### PR TITLE
feat: live progress TUI for the default run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `src/discovery/adapters/` is pinned by a golden fixture in `test/fixtures/`. When a
   harness changes its on-disk shape, fix the adapter and update its fixture together.
   Adapters must stay fail-soft: an unreadable store warns and is skipped, never throws.
+- **The live progress view is an enhancement layer, never a dependency.** Pipeline stages
+  emit events through `src/progress.js`; `src/tui/` renders them on stderr during the
+  default run and buffers/replays the plain logger lines on teardown. Every path must
+  behave identically when it is inactive (non-TTY, CI, NO_COLOR, --quiet, --json) - plain
+  line output on stderr and clean stdout are the contract. Rendering logic stays pure
+  (`src/tui/render.js`) so it is testable as text.
 - **`src/apply/writer.js` is the only module that writes to the repo.** Keep it that way -
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
 - **Never trust model-reported numbers.** Token deltas and budget projections are measured

--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ backpass apply --dry-run   # show what would be written
 
 Run `backpass --help` for the full flag list.
 
+### Live progress
+
+On an interactive terminal the default run renders a live progress view: the budget gauge,
+a stage rail (discover → analyze → fold → synthesize), per-store discovery counts, one lane
+per analysis job with its distillation receipt, and a running evidence tally. It draws to
+stderr only and collapses into the plain line summary when the run ends, so scrollback and
+piped output are identical to a run without it.
+
+The view never gets in the way of automation: no TTY, `NO_COLOR`, `CI`, `--quiet`, `--json`,
+or a terminal under 60 columns all mean plain lines, unchanged. Truecolor terminals get the
+backpass theme; everything else falls back to the nearest ANSI-16 colors. The ink set adapts
+to light backgrounds automatically (queried via OSC 11, `COLORFGBG` as fallback); force one
+with `--theme dark|light` or `"theme"` in `.backpassrc.json`.
+
 ### Two-tier models
 
 Cheap analysis, smart synthesis. Both go through acpx, so you pick from the harnesses you

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -7,6 +7,7 @@ import { readTranscript } from "./discovery/index.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt } from "./prompts.js";
 import { evidenceKey, isEvidenceFresh, safeFileName } from "./state.js";
+import { emitProgress } from "./progress.js";
 import { color, info, warn } from "./logger.js";
 
 /**
@@ -57,12 +58,22 @@ function promptPathFor(state, transcript) {
   return path.join(state.applyDir, "..", "prompts", `${safeFileName(transcript.id)}.md`);
 }
 
-async function analyzeOne({ transcript, memoryFile, config, repo }) {
+async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
   const raw = await readTranscript(transcript);
   const distilled = distill(raw.events, {
     ...transcript,
     model: raw.model,
     rawPath: raw.rawPath,
+  });
+
+  emitProgress("analyze:lane", {
+    slot,
+    harness: transcript.harness,
+    id: transcript.nativeId,
+    title: transcript.title || transcript.nativeId,
+    phase: "model",
+    rawBytes: transcript.bytes,
+    distilledBytes: Buffer.byteLength(distilled.trace, "utf8"),
   });
 
   // Triviality filter. `minUserTurns` is the knob, but a session is only truly trivial
@@ -110,16 +121,20 @@ async function analyzeOne({ transcript, memoryFile, config, repo }) {
   };
 }
 
-/** Bounded-concurrency worker pool - the design's `--jobs N` fan-out. */
+/**
+ * Bounded-concurrency worker pool - the design's `--jobs N` fan-out.
+ * The worker also receives its runner slot so the progress view can show one
+ * lane per job.
+ */
 async function pool(items, limit, worker) {
   const results = new Array(items.length);
   let cursor = 0;
-  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async (_, slot) => {
     for (;;) {
       const index = cursor;
       cursor += 1;
       if (index >= items.length) return;
-      results[index] = await worker(items[index], index);
+      results[index] = await worker(items[index], index, slot);
     }
   });
   await Promise.all(runners);
@@ -140,7 +155,19 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
     pending.push(transcript);
   }
 
-  if (!pending.length) return summary;
+  emitProgress("analyze:start", {
+    pending: pending.length,
+    cached: summary.cached,
+    total: transcripts.length,
+    jobs: config.jobs,
+    agent: config.analysis.agent,
+    model: config.analysis.model,
+  });
+
+  if (!pending.length) {
+    emitProgress("analyze:done", summary);
+    return summary;
+  }
 
   info(
     `${color.cyan("·")} analyzing ${pending.length} transcript(s) with ${config.analysis.agent}` +
@@ -148,7 +175,8 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
   );
 
   let done = 0;
-  await pool(pending, config.jobs, async (transcript) => {
+  const evidenceTotals = { positive: 0, negative: 0, gaps: 0 };
+  await pool(pending, config.jobs, async (transcript, _index, slot) => {
     const base = {
       transcript: {
         harness: transcript.harness,
@@ -165,8 +193,16 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
       analyzedAt: new Date().toISOString(),
     };
 
+    emitProgress("analyze:lane", {
+      slot,
+      harness: transcript.harness,
+      id: transcript.nativeId,
+      title: transcript.title || transcript.nativeId,
+      phase: "distill",
+    });
+
     try {
-      const result = await analyzeOne({ transcript, memoryFile, config, repo });
+      const result = await analyzeOne({ transcript, memoryFile, config, repo, slot });
       if (result.status === "skipped") {
         summary.skipped += 1;
         state.writeEvidence(transcript.id, { ...base, status: "skipped", reason: result.reason });
@@ -179,6 +215,10 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
           stats: result.distilled.stats,
           ...result.evidence,
         });
+        evidenceTotals.positive += result.evidence.positive.length;
+        evidenceTotals.negative += result.evidence.negative.length;
+        evidenceTotals.gaps += result.evidence.gaps.length;
+        emitProgress("analyze:evidence", { ...evidenceTotals });
       }
     } catch (err) {
       // Per-transcript fail-soft: recorded, listed by `backpass status`, retried next run.
@@ -187,11 +227,19 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
       state.writeEvidence(transcript.id, { ...base, status: "failed", error: err.message });
     } finally {
       done += 1;
+      emitProgress("analyze:tick", {
+        slot,
+        done,
+        ok: summary.analyzed,
+        skipped: summary.skipped,
+        failed: summary.failed,
+      });
       if (done % 10 === 0 || done === pending.length) {
         info(`${color.dim(`  ${done}/${pending.length} analyzed`)}`);
       }
     }
   });
 
+  emitProgress("analyze:done", summary);
   return summary;
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -52,6 +52,7 @@ const OPTIONS = {
   "no-ui": { type: "boolean" },
   force: { type: "boolean" },
   limit: { type: "string" },
+  theme: { type: "string" },
 };
 
 const HELP = `backpass v${VERSION} - gradient descent for your agent memory
@@ -102,10 +103,15 @@ APPLY
   --force                  re-analyze transcripts that already have fresh evidence
 
 OTHER
+  --theme <mode>           live progress ink set: auto, dark, or light    [auto]
   --json                   machine-readable output on stdout
-  -q, --quiet              suppress progress output
+  -q, --quiet              suppress progress output (also disables the live view)
   -h, --help               this help
   -v, --version            print version
+
+The default run renders a live progress view on an interactive terminal. It draws
+to stderr only and falls back to plain lines when piped, in CI, under NO_COLOR,
+or below 60 columns - stdout and --json output are identical either way.
 
 EXAMPLES
   backpass                                  a full run, ending with a proposal
@@ -134,6 +140,7 @@ function overridesFrom(values) {
   }
   if (values["memory-file"]?.length) overrides.memoryFiles = values["memory-file"];
   if (values["skills-dir"]) overrides.skillsDir = values["skills-dir"];
+  if (values.theme) overrides.theme = values.theme;
 
   if (values["analysis-agent"]) overrides.analysis.agent = values["analysis-agent"];
   if (values["analysis-model"]) overrides.analysis.model = values["analysis-model"];

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -2,6 +2,7 @@ import { analyzeTranscripts } from "../analyze.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { loadMemoryFiles, memorySetHash } from "../memory.js";
 import { sumUsage, formatUsage } from "../acpx.js";
+import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
 
 /** The memory file a run optimizes: the first configured file that exists. */
@@ -19,6 +20,13 @@ export function primaryMemoryFile(repo, config) {
 export async function runAnalysis(ctx) {
   const { repo, config } = ctx;
   const { file, hash } = primaryMemoryFile(repo, config);
+  // Deterministic by design: tokens and units come from parsing the file, no model.
+  emitProgress("memory", {
+    path: file.path,
+    tokens: file.tokens,
+    budget: config.budgetTokens,
+    units: file.units.length,
+  });
   const { transcripts, perHarness } = await discoverForRun(ctx);
 
   if (!transcripts.length) {

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -4,6 +4,7 @@ import { ProposalViolation } from "../proposal.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { formatUsage, sumUsage } from "../acpx.js";
+import { emitProgress } from "../progress.js";
 import { primaryMemoryFile } from "./analyze.js";
 import { discoverForRun } from "./scan.js";
 
@@ -21,8 +22,16 @@ export async function runProposal(ctx, precomputed = null) {
   const { file } = precomputed || primaryMemoryFile(repo, config);
   const transcripts = precomputed?.transcripts || (await discoverForRun(ctx)).transcripts;
 
+  const foldStarted = Date.now();
   const summary = await foldForRun(ctx, file);
   config.state.writeSummary(summary);
+  emitProgress("fold:done", {
+    instructions: summary.instructions.length,
+    clustersFound: summary.totals.gapClusters + summary.totals.droppedGapSingletons,
+    clustersKept: summary.totals.gapClusters,
+    minGapEvidence: config.minGapEvidence,
+    ms: Date.now() - foldStarted,
+  });
 
   if (!summary.analyzedSessions) {
     throw new UserError(

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,6 +4,7 @@ import { ProposalViolation } from "../proposal.js";
 import { runAnalysis } from "./analyze.js";
 import { printProposal, runProposal } from "./propose.js";
 import { budgetBar, formatTokens } from "../tokens.js";
+import { startTui } from "../tui/index.js";
 
 /**
  * The default command: one full backward pass.
@@ -11,47 +12,54 @@ import { budgetBar, formatTokens } from "../tokens.js";
  *   discover -> distill -> analyze (cheap, fanned out) -> fold -> synthesize (one big call)
  *
  * It never writes. Applying is a separate, human-gated step.
+ *
+ * On an eligible terminal a live progress view renders the run on stderr; it
+ * collapses back into the plain lines below before anything is printed to
+ * stdout, so piped and logged output is unchanged.
  */
 export async function cmdRun(ctx) {
   const { repo, config } = ctx;
-
-  info(
-    `${color.bold("backpass")} ${color.dim(
-      `v${ctx.version} · ${repo.name} · budget ${formatTokens(config.budgetTokens)} tok · since ${config.discovery.since}`,
-    )}`,
-  );
-
-  const analysis = await runAnalysis(ctx);
-
-  if (!analysis.transcripts.length) {
-    out("");
-    out("No agent transcripts are associated with this repo yet.");
-    out(
-      color.dim(
-        "  `backpass scan --since all` widens the time window; --include-cursor-ide adds the Cursor IDE store.",
-      ),
-    );
-    return 0;
-  }
-
-  const budget = budgetBar({
-    utilization: analysis.file.tokens / config.budgetTokens,
-    withinBudget: analysis.file.tokens <= config.budgetTokens,
-  });
-  info(
-    `${color.cyan("·")} ${analysis.file.path}: ${budget} ${formatTokens(analysis.file.tokens)} / ` +
-      `${formatTokens(config.budgetTokens)} tok · ${analysis.file.units.length} instructions`,
-  );
-
-  if (analysis.summary) {
-    info(
-      `${color.cyan("·")} evidence: ${analysis.summary.analyzed} new · ${analysis.summary.cached} cached · ` +
-        `${analysis.summary.skipped} too short · ${analysis.summary.failed} failed`,
-    );
-  }
+  const tui = await startTui(ctx);
 
   try {
+    info(
+      `${color.bold("backpass")} ${color.dim(
+        `v${ctx.version} · ${repo.name} · budget ${formatTokens(config.budgetTokens)} tok · since ${config.discovery.since}`,
+      )}`,
+    );
+
+    const analysis = await runAnalysis(ctx);
+
+    if (!analysis.transcripts.length) {
+      tui?.stop();
+      out("");
+      out("No agent transcripts are associated with this repo yet.");
+      out(
+        color.dim(
+          "  `backpass scan --since all` widens the time window; --include-cursor-ide adds the Cursor IDE store.",
+        ),
+      );
+      return 0;
+    }
+
+    const budget = budgetBar({
+      utilization: analysis.file.tokens / config.budgetTokens,
+      withinBudget: analysis.file.tokens <= config.budgetTokens,
+    });
+    info(
+      `${color.cyan("·")} ${analysis.file.path}: ${budget} ${formatTokens(analysis.file.tokens)} / ` +
+        `${formatTokens(config.budgetTokens)} tok · ${analysis.file.units.length} instructions`,
+    );
+
+    if (analysis.summary) {
+      info(
+        `${color.cyan("·")} evidence: ${analysis.summary.analyzed} new · ${analysis.summary.cached} cached · ` +
+          `${analysis.summary.skipped} too short · ${analysis.summary.failed} failed`,
+      );
+    }
+
     const { proposal } = await runProposal(ctx, analysis);
+    tui?.stop();
 
     if (ctx.flags.json) {
       json(proposal);
@@ -66,6 +74,7 @@ export async function cmdRun(ctx) {
     out(color.dim(`  tier-2 tokens: ${formatUsage(tier2)}`));
     return 0;
   } catch (err) {
+    tui?.stop();
     if (err instanceof ProposalViolation) {
       info("");
       for (const violation of err.violations) info(`  ${color.red("x")} ${violation}`);
@@ -74,5 +83,7 @@ export async function cmdRun(ctx) {
       throw new UserError(err.message, "try a stronger synthesis model, or raise --budget / --max-edits");
     }
     throw err;
+  } finally {
+    tui?.stop();
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,8 @@ export const DEFAULT_CONFIG = {
   jobs: 4,
   timeoutSeconds: 300,
   promptRetries: 1,
+  /** Live progress ink set: "auto" queries the terminal background, or force "dark" / "light". */
+  theme: "auto",
 };
 
 function userConfigPath() {
@@ -102,6 +104,9 @@ function validate(config) {
   }
   if (!Number.isInteger(config.jobs) || config.jobs < 1) {
     throw new UserError("config.jobs must be an integer >= 1");
+  }
+  if (!["auto", "dark", "light"].includes(config.theme)) {
+    throw new UserError(`config.theme must be "auto", "dark", or "light" (got "${config.theme}")`);
   }
   const known = new Set([...ALL_HARNESSES, ...OPT_IN_HARNESSES]);
   for (const h of config.discovery.harnesses) {

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -8,6 +8,7 @@ import * as cursorIde from "./adapters/cursor-ide.js";
 
 import { associate, passesStrict } from "./association.js";
 import { sinceCutoff } from "../config.js";
+import { emitProgress } from "../progress.js";
 import { warn } from "../logger.js";
 
 export const ADAPTERS = {
@@ -47,6 +48,8 @@ export async function discoverTranscripts({ repo, config, strict = false, harnes
   const perHarness = {};
   let cacheDirty = false;
 
+  emitProgress("discover:start", { harnesses: selected.filter((h) => getAdapter(h)) });
+
   for (const harness of selected) {
     const adapter = getAdapter(harness);
     if (!adapter) {
@@ -56,6 +59,7 @@ export async function discoverTranscripts({ repo, config, strict = false, harnes
 
     const stats = { scanned: 0, matched: 0, cached: 0, skipped: 0, error: null };
     perHarness[harness] = stats;
+    emitProgress("discover:harness:start", { harness });
 
     try {
       const found = adapter.discover
@@ -73,16 +77,34 @@ export async function discoverTranscripts({ repo, config, strict = false, harnes
           });
       transcripts.push(...found);
       stats.matched = found.length;
+      emitProgress("discover:harness:done", {
+        harness,
+        scanned: stats.scanned,
+        cached: stats.cached,
+        matched: stats.matched,
+        tiers: tierCounts(found),
+      });
     } catch (err) {
       stats.error = err.message;
       warn(`${harness}: transcript store unreadable (${err.message}) - harness skipped`);
+      emitProgress("discover:harness:done", { harness, error: err.message });
     }
   }
 
   if (cacheDirty) config.state.writeScanCache(cache);
 
   transcripts.sort((a, b) => (b.mtimeMs || 0) - (a.mtimeMs || 0));
+  emitProgress("discover:done", { total: transcripts.length });
   return { transcripts, perHarness, cutoffMs };
+}
+
+function tierCounts(found) {
+  const tiers = {};
+  for (const transcript of found) {
+    const tier = transcript.association?.tier;
+    if (tier) tiers[tier] = (tiers[tier] || 0) + 1;
+  }
+  return tiers;
 }
 
 async function discoverDirect(adapter, { repo, config, cutoffMs, strict, stats }) {
@@ -109,6 +131,16 @@ function discoverFiles(adapter, { repo, config, cutoffMs, strict, stats, cache, 
   for (const candidate of candidates) {
     if (cutoffMs && candidate.mtimeMs < cutoffMs) continue;
     stats.scanned += 1;
+    // Large stores (codex holds 10k+ session files) get a live scan tick; the
+    // classify loop is synchronous, so this is the only paint opportunity.
+    if (stats.scanned % 25 === 0) {
+      emitProgress("discover:harness:tick", {
+        harness: adapter.name,
+        scanned: stats.scanned,
+        total: candidates.length,
+        matched: out.length,
+      });
+    }
 
     const cacheKey = `${adapter.name}:${candidate.key}`;
     const cached = cache.entries[cacheKey];

--- a/src/logger.js
+++ b/src/logger.js
@@ -14,14 +14,29 @@ export const color = {
 };
 
 let quiet = false;
+let sink = null;
 
 export function setQuiet(value) {
   quiet = Boolean(value);
 }
 
+/**
+ * While the live progress view owns stderr, progress lines are diverted here,
+ * buffered, and replayed verbatim on teardown - so scrollback after a TUI run
+ * is byte-identical to a run without one. Pass null to restore direct output.
+ */
+export function setLoggerSink(fn) {
+  sink = fn;
+}
+
 /** Human-facing progress and diagnostics go to stderr so stdout stays pipeable. */
 export function info(...args) {
-  if (!quiet) console.error(...args);
+  if (quiet) return;
+  if (sink) {
+    sink(args.join(" "));
+    return;
+  }
+  console.error(...args);
 }
 
 export function step(label, detail = "") {
@@ -29,7 +44,12 @@ export function step(label, detail = "") {
 }
 
 export function warn(message) {
-  console.error(`${color.yellow("warn")} ${message}`);
+  const line = `${color.yellow("warn")} ${message}`;
+  if (sink) {
+    sink(line);
+    return;
+  }
+  console.error(line);
 }
 
 export function fail(message) {

--- a/src/progress.js
+++ b/src/progress.js
@@ -1,0 +1,29 @@
+/**
+ * Progress event bus between the pipeline and the live progress view.
+ *
+ * Pipeline stages emit structured events through `emitProgress`; they are dropped
+ * unless a renderer registered a sink. This keeps every stage free of rendering
+ * concerns and guarantees that runs without a TTY behave exactly as before -
+ * the events simply go nowhere.
+ */
+
+let sink = null;
+
+/** Register the single active sink (the TUI controller). */
+export function setProgressSink(fn) {
+  sink = fn;
+}
+
+export function clearProgressSink() {
+  sink = null;
+}
+
+/** Emit one progress event. A throwing sink must never break the pipeline. */
+export function emitProgress(event, data = {}) {
+  if (!sink) return;
+  try {
+    sink(event, data);
+  } catch {
+    // Rendering is best-effort; the run itself is what matters.
+  }
+}

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -8,6 +8,7 @@ import { renderPrompt } from "./prompts.js";
 import { buildProposal, ProposalViolation } from "./proposal.js";
 import { loadSkills, renderSkillIndex, resolveOverflowTarget } from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
+import { emitProgress } from "./progress.js";
 import { color, info, warn } from "./logger.js";
 
 /**
@@ -124,6 +125,16 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
         `${config.synthesis.effort ? ` effort=${config.synthesis.effort}` : ""}` +
         `${attempt > 1 ? " [re-prompt]" : ""}`,
     );
+    emitProgress("synth:start", {
+      agent: config.synthesis.agent,
+      model: config.synthesis.model,
+      effort: config.synthesis.effort,
+      attempt,
+      sessionName: `backpass-synth-${process.pid}`,
+      gapClusters: summary.totals.gapClusters,
+      instructions: summary.instructions.length,
+      suppressed: Object.keys(rejections.entries || {}).length,
+    });
 
     const result = await sessionPrompt({
       agent: config.synthesis.agent,
@@ -152,6 +163,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
         proposal.notes = [...proposal.notes, ...notes];
         proposal.usage = usage;
         proposal.overflowTarget = overflow;
+        emitProgress("synth:done", { edits: proposal.edits.length, attempt });
         return { proposal, violations: [] };
       }
       lastViolations = violations;
@@ -165,6 +177,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
 
     if (attempt === 1) {
       warn(`synthesis violated ${lastViolations.length} gate(s); re-prompting once with the exact violations`);
+      emitProgress("synth:violations", { attempt, violations: lastViolations });
       prompt = `${renderPrompt("synthesis", values)}\n\n## Your previous answer was rejected\n\nIt violated these hard rules. Fix every one of them and return the corrected JSON object only.\n\n${lastViolations
         .map((v) => `- ${v}`)
         .join("\n")}\n`;

--- a/src/tui/index.js
+++ b/src/tui/index.js
@@ -1,0 +1,329 @@
+/**
+ * The live progress view controller: owns the stderr repaint region during the
+ * default run, reduces pipeline progress events into render state, and tears
+ * itself down into today's plain line output.
+ *
+ * Contract (approved design, section "behavior"):
+ *  - stderr only; stdout and --json are untouched
+ *  - eligibility-gated: no TTY, NO_COLOR, CI, --quiet, --json, or a terminal
+ *    narrower than 60 columns means the TUI never starts and nothing changes
+ *  - while active, logger progress lines are buffered and replayed verbatim on
+ *    teardown, so scrollback ends up exactly as it does without the TUI
+ *  - all motion stops and the region is erased the moment the run ends
+ */
+
+import { clearProgressSink, setProgressSink } from "../progress.js";
+import { setLoggerSink } from "../logger.js";
+import { colorDepth, detectBackground, tuiEligible } from "./term.js";
+import { makeTheme } from "./theme.js";
+import { SPINNER_INTERVAL_MS, renderFrame, spinnerFrame } from "./render.js";
+
+/**
+ * Start the live view for one run. Returns null when the terminal is not
+ * eligible - callers treat that as "no TUI" and change nothing.
+ */
+export async function startTui(ctx, { stderr = process.stderr } = {}) {
+  if (!tuiEligible({ stderr, quiet: Boolean(ctx.flags.quiet), json: Boolean(ctx.flags.json) })) return null;
+
+  const depth = colorDepth({ stderr });
+  const preference = ctx.config.theme || "auto";
+  const background = preference === "auto" ? await detectBackground({ stderr }) : preference;
+  const theme = makeTheme({ depth, background });
+
+  const tui = new Tui({
+    theme,
+    stderr,
+    meta: {
+      version: ctx.version,
+      repoName: ctx.repo.name,
+      worktrees: ctx.repo.worktrees?.length || 1,
+      since: ctx.config.discovery.since,
+      maxEdits: ctx.config.maxEditsPerRun,
+    },
+  });
+  tui.start();
+  return tui;
+}
+
+export function initialState(meta) {
+  return {
+    meta,
+    memory: null,
+    discover: {
+      status: "pending",
+      startedAt: null,
+      endedAt: null,
+      order: [],
+      harnesses: {},
+      totalMatched: 0,
+      storesOk: 0,
+      storesTotal: 0,
+      files: 0,
+      newFiles: 0,
+    },
+    analyze: {
+      status: "pending",
+      startedAt: null,
+      endedAt: null,
+      total: 0,
+      pending: 0,
+      done: 0,
+      ok: 0,
+      skipped: 0,
+      failed: 0,
+      cached: 0,
+      jobs: 0,
+      agent: null,
+      model: null,
+      lanes: [],
+      evidence: { positive: 0, negative: 0, gaps: 0 },
+    },
+    fold: {
+      status: "pending",
+      startedAt: null,
+      endedAt: null,
+      instructions: 0,
+      clustersFound: 0,
+      clustersKept: 0,
+      minGapEvidence: 2,
+    },
+    synthesize: {
+      status: "pending",
+      startedAt: null,
+      endedAt: null,
+      agent: null,
+      model: null,
+      effort: null,
+      attempt: 0,
+      sessionName: null,
+      gapClusters: 0,
+      instructions: 0,
+      suppressed: 0,
+      violations: [],
+      edits: 0,
+    },
+  };
+}
+
+/** Reduce one progress event into the render state. Exported for tests. */
+export function reduceEvent(state, event, data, now = Date.now()) {
+  const { discover: d, analyze: a, fold: f, synthesize: s } = state;
+
+  switch (event) {
+    case "memory":
+      state.memory = { path: data.path, tokens: data.tokens, budget: data.budget, units: data.units };
+      break;
+
+    case "discover:start":
+      d.status = "active";
+      d.startedAt = now;
+      d.order = data.harnesses;
+      d.storesTotal = data.harnesses.length;
+      for (const harness of data.harnesses) {
+        d.harnesses[harness] = {
+          status: "pending",
+          scanned: 0,
+          total: 0,
+          matched: 0,
+          newCount: 0,
+          tiers: {},
+          error: null,
+        };
+      }
+      break;
+    case "discover:harness:start":
+      d.harnesses[data.harness].status = "scanning";
+      break;
+    case "discover:harness:tick": {
+      const h = d.harnesses[data.harness];
+      h.scanned = data.scanned;
+      h.total = data.total;
+      h.matched = data.matched;
+      d.totalMatched = Object.values(d.harnesses).reduce((sum, row) => sum + row.matched, 0);
+      break;
+    }
+    case "discover:harness:done": {
+      const h = d.harnesses[data.harness];
+      if (data.error) {
+        h.status = "error";
+        h.error = data.error;
+      } else {
+        h.status = "done";
+        h.scanned = data.scanned;
+        h.matched = data.matched;
+        h.newCount = Math.max(data.scanned - (data.cached || 0), 0);
+        h.tiers = data.tiers || {};
+        d.storesOk += 1;
+        d.files += data.scanned;
+        d.newFiles += h.newCount;
+      }
+      d.totalMatched = Object.values(d.harnesses).reduce((sum, row) => sum + row.matched, 0);
+      break;
+    }
+    case "discover:done":
+      d.status = "done";
+      d.endedAt = now;
+      d.totalMatched = data.total;
+      break;
+
+    case "analyze:start":
+      a.status = "active";
+      a.startedAt = now;
+      a.total = data.total;
+      a.pending = data.pending;
+      a.cached = data.cached;
+      a.jobs = data.jobs;
+      a.agent = data.agent;
+      a.model = data.model;
+      a.lanes = new Array(Math.max(Math.min(data.jobs, data.pending), 0)).fill(null);
+      break;
+    case "analyze:lane": {
+      const existing = a.lanes[data.slot] || { startedAt: now };
+      a.lanes[data.slot] = { ...existing, ...data, startedAt: data.phase === "distill" ? now : existing.startedAt };
+      break;
+    }
+    case "analyze:tick":
+      a.done = data.done;
+      a.ok = data.ok;
+      a.skipped = data.skipped;
+      a.failed = data.failed;
+      a.lanes[data.slot] = null;
+      break;
+    case "analyze:evidence":
+      a.evidence = { positive: data.positive, negative: data.negative, gaps: data.gaps };
+      break;
+    case "analyze:done":
+      a.status = "done";
+      a.endedAt = now;
+      a.ok = data.analyzed;
+      a.cached = data.cached;
+      a.skipped = data.skipped;
+      a.failed = data.failed;
+      a.lanes = [];
+      break;
+
+    case "fold:done":
+      f.status = "done";
+      f.startedAt = now - (data.ms || 0);
+      f.endedAt = now;
+      f.instructions = data.instructions;
+      f.clustersFound = data.clustersFound;
+      f.clustersKept = data.clustersKept;
+      f.minGapEvidence = data.minGapEvidence;
+      break;
+
+    case "synth:start":
+      s.status = "active";
+      s.startedAt = now;
+      s.agent = data.agent;
+      s.model = data.model;
+      s.effort = data.effort;
+      s.attempt = data.attempt;
+      s.sessionName = data.sessionName;
+      s.gapClusters = data.gapClusters;
+      s.instructions = data.instructions;
+      s.suppressed = data.suppressed;
+      break;
+    case "synth:violations":
+      s.violations = data.violations || [];
+      break;
+    case "synth:done":
+      s.status = "done";
+      s.endedAt = now;
+      s.edits = data.edits;
+      break;
+  }
+  return state;
+}
+
+const PAINT_THROTTLE_MS = 40;
+
+class Tui {
+  constructor({ theme, stderr, meta }) {
+    this.theme = theme;
+    this.stderr = stderr;
+    this.state = initialState(meta);
+    this.buffered = [];
+    this.painted = 0;
+    this.lastPaint = 0;
+    this.stopped = false;
+    this.timer = null;
+    this.onEvent = this.onEvent.bind(this);
+    this.onResize = () => this.paint(true);
+    this.onSigint = () => {
+      this.stop();
+      process.exit(130);
+    };
+    this.onSigterm = () => {
+      this.stop();
+      process.exit(143);
+    };
+    this.onExit = () => {
+      if (!this.stopped) this.stderr.write("\x1b[?25h");
+    };
+  }
+
+  start() {
+    setProgressSink(this.onEvent);
+    // Progress lines keep being produced for scrollback; they are buffered here
+    // and replayed verbatim on teardown so the collapsed output is identical to
+    // a run without the TUI.
+    setLoggerSink((line) => this.buffered.push(line));
+    this.stderr.write("\x1b[?25l");
+    this.timer = setInterval(() => this.paint(), SPINNER_INTERVAL_MS);
+    this.stderr.on("resize", this.onResize);
+    process.on("SIGINT", this.onSigint);
+    process.on("SIGTERM", this.onSigterm);
+    process.once("exit", this.onExit);
+    this.paint(true);
+  }
+
+  onEvent(event, data) {
+    reduceEvent(this.state, event, data);
+    this.paint();
+  }
+
+  paint(force = false) {
+    if (this.stopped) return;
+    const now = Date.now();
+    if (!force && now - this.lastPaint < PAINT_THROTTLE_MS) return;
+    this.lastPaint = now;
+
+    const lines = renderFrame(this.state, {
+      width: this.stderr.columns || 80,
+      theme: this.theme,
+      now,
+      spin: spinnerFrame(now),
+    });
+
+    let out = "\x1b[?2026h";
+    if (this.painted > 0) out += `\x1b[${this.painted}A`;
+    out += "\r";
+    for (const line of lines) out += `\x1b[2K${line}\n`;
+    if (this.painted > lines.length) out += "\x1b[0J";
+    out += "\x1b[?2026l";
+    this.stderr.write(out);
+    this.painted = lines.length;
+  }
+
+  /** Idempotent teardown: erase the region, restore the cursor, replay buffered lines. */
+  stop() {
+    if (this.stopped) return;
+    this.stopped = true;
+    clearInterval(this.timer);
+    clearProgressSink();
+    setLoggerSink(null);
+    this.stderr.off("resize", this.onResize);
+    process.off("SIGINT", this.onSigint);
+    process.off("SIGTERM", this.onSigterm);
+
+    let out = "";
+    if (this.painted > 0) out += `\x1b[${this.painted}A\r\x1b[0J`;
+    out += "\x1b[?25h";
+    this.stderr.write(out);
+    this.painted = 0;
+
+    for (const line of this.buffered) this.stderr.write(`${line}\n`);
+    this.buffered = [];
+  }
+}

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -1,0 +1,468 @@
+/**
+ * Pure rendering for the live progress view: (state, options) -> lines.
+ *
+ * Everything here is deterministic - no timers, no terminal, no I/O - which is
+ * what makes the layout testable as plain text (depth-0 theme). The visual
+ * contract is the captain-approved mock: prompt echo is the shell's, then a
+ * bordered run header with the budget gauge, a four-stage rail, one detail
+ * panel for the stage currently spending time, and a hint footer.
+ *
+ * Layout rules from the approved behavior contract:
+ *  - never wider than the terminal (lines are truncated, never wrapped)
+ *  - below NARROW_COLUMNS the right-hand column (timers, notes) is dropped
+ *  - every number shown is measured by backpass, never model-reported
+ */
+
+import { NARROW_COLUMNS } from "./term.js";
+
+export const SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏";
+export const SPINNER_INTERVAL_MS = 80;
+
+/** The frame glyph for a wall-clock instant - even cadence however paints are driven. */
+export function spinnerFrame(now) {
+  return SPINNER_FRAMES[Math.floor(now / SPINNER_INTERVAL_MS) % SPINNER_FRAMES.length];
+}
+
+const MAX_WIDTH = 110;
+
+const HARNESS_HUES = {
+  claude: "peach",
+  codex: "green",
+  pi: "purple",
+  opencode: "mint",
+  grok: "magenta",
+  cursor: "blue",
+  "cursor-ide": "blue",
+};
+
+const TIER_LABELS = { 1: "ran in this repo", 2: "git remote match", 3: "path match (best-effort)" };
+
+// eslint-disable-next-line no-control-regex -- matching ANSI SGR escapes is the point
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+export function stripAnsi(text) {
+  return String(text).replace(ANSI_PATTERN, "");
+}
+
+export function visibleWidth(text) {
+  return [...stripAnsi(text)].length;
+}
+
+/** Truncate a painted line to `width` visible cells, preserving escapes and reset. */
+export function clipLine(line, width) {
+  if (visibleWidth(line) <= width) return line;
+  let out = "";
+  let used = 0;
+  let sawEscape = false;
+  // eslint-disable-next-line no-control-regex -- splitting on ANSI SGR escapes is the point
+  const parts = String(line).split(/(\x1b\[[0-9;]*m)/);
+  for (const part of parts) {
+    if (part.startsWith("\x1b[")) {
+      out += part;
+      sawEscape = true;
+      continue;
+    }
+    for (const ch of part) {
+      if (used >= width - 1) return sawEscape ? `${out}\x1b[0m…` : `${out}…`;
+      out += ch;
+      used += 1;
+    }
+  }
+  return out;
+}
+
+/** Pad a plain string to `width` characters; longer strings get an ellipsis. */
+export function fitPlain(text, width, align = "left") {
+  const chars = [...String(text)];
+  if (chars.length > width) return width > 0 ? `${chars.slice(0, Math.max(width - 1, 0)).join("")}…` : "";
+  const pad = " ".repeat(width - chars.length);
+  return align === "right" ? pad + chars.join("") : chars.join("") + pad;
+}
+
+/** Pad an already painted string to `width` visible cells. */
+export function padVis(text, width, align = "left") {
+  const missing = width - visibleWidth(text);
+  if (missing <= 0) return text;
+  const pad = " ".repeat(missing);
+  return align === "right" ? pad + text : text + pad;
+}
+
+/** Left content with right-aligned content; the right side is dropped when it cannot fit. */
+export function lr(left, right, width) {
+  if (!right) return left;
+  const gap = width - visibleWidth(left) - visibleWidth(right);
+  if (gap < 2) return left;
+  return left + " ".repeat(gap) + right;
+}
+
+export function formatCount(n) {
+  return Number(n || 0).toLocaleString("en-US");
+}
+
+export function formatBytes(n) {
+  const bytes = Number(n) || 0;
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+/** m:ss for anything from a second up; bare milliseconds below that (fold is instant). */
+export function formatElapsed(ms) {
+  const value = Math.max(0, Math.round(Number(ms) || 0));
+  if (value < 1000) return `${value}ms`;
+  const seconds = Math.floor(value / 1000);
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+/** ▰▱ progress cells; the gradient marks descent, `!!` marks over-budget (as budgetBar does). */
+export function gaugeBar(theme, ratio, cells) {
+  const value = Number.isFinite(ratio) ? Math.max(ratio, 0) : 0;
+  const over = value > 1;
+  const filled = Math.min(cells, Math.round(value * cells));
+  const overflow = over ? Math.min(cells - Math.min(filled, cells - 2), 2) : 0;
+  const solid = over ? cells - overflow : filled;
+  const empty = Math.max(cells - solid - overflow, 0);
+  return (
+    theme.gradient("▰".repeat(solid)) +
+    (overflow ? theme.paint("!".repeat(overflow), "red", { bold: true }) : "") +
+    theme.paint("▱".repeat(empty), "faint")
+  );
+}
+
+function stageElapsed(stage, now) {
+  if (!stage?.startedAt) return null;
+  return formatElapsed((stage.endedAt || now) - stage.startedAt);
+}
+
+function tierLabel(tiers = {}) {
+  let best = null;
+  for (const tier of [1, 2, 3]) {
+    if ((tiers[tier] || 0) > (tiers[best] || 0)) best = tier;
+  }
+  return best ? TIER_LABELS[best] : "";
+}
+
+function headerLines(state, theme, width, spin) {
+  const inner = width - 4;
+  const border = (text) => theme.paint(text, "faint");
+  const lines = [border(`╭${"─".repeat(width - 2)}╮`)];
+
+  const brand = `${theme.gradient("∇", { bold: true })} ${theme.paint("backpass", "text", { bold: true })} ${theme.paint(`v${state.meta.version}`, "faint")}`;
+  const contextParts = [state.meta.repoName];
+  if (state.meta.worktrees > 1) contextParts.push(`${state.meta.worktrees} worktrees`);
+  contextParts.push(`since ${state.meta.since}`);
+  lines.push(wrapBox(lr(brand, theme.paint(contextParts.join(" · "), "dim"), inner), inner, border));
+
+  const memory = state.memory;
+  if (memory) {
+    const ratio = memory.tokens / memory.budget;
+    const cells = state.narrow ? 16 : 24;
+    const over = memory.tokens > memory.budget;
+    const left =
+      `${theme.paint(memory.path, "dim")}  ${gaugeBar(theme, ratio, cells)}  ` +
+      `${theme.paint(formatCount(memory.tokens), over ? "red" : "mint")} ${theme.paint("/", "faint")} ${theme.paint(`${formatCount(memory.budget)} tok`, "text")}`;
+    const right = over
+      ? `${theme.paint("OVER", "red", { bold: true })}${theme.paint(" · shrink plan", "faint")}`
+      : theme.paint(`${formatCount(memory.units)} instructions · budget ${Math.round(ratio * 100)}%`, "faint");
+    lines.push(wrapBox(lr(left, right, inner), inner, border));
+  } else {
+    lines.push(wrapBox(theme.paint(`reading memory file${spin ? "…" : ""}`, "faint"), inner, border));
+  }
+
+  lines.push(border(`╰${"─".repeat(width - 2)}╯`));
+  return lines;
+}
+
+function wrapBox(content, inner, border) {
+  return `${border("│")} ${padVis(clipLine(content, inner), inner)} ${border("│")}`;
+}
+
+function mark(theme, status, spin) {
+  if (status === "active") return theme.paint(spin, "mint");
+  if (status === "done") return theme.paint("✓", "mint");
+  if (status === "error") return theme.paint("!", "yellow");
+  return theme.paint("○", "faint");
+}
+
+function railLine(theme, state, name, summary, stage, width, spin) {
+  const status = stage?.status || "pending";
+  const label =
+    status === "pending"
+      ? theme.paint(fitPlain(name, 11), "faint")
+      : theme.paint(fitPlain(name, 11), "text", { bold: status === "active" });
+  const left = ` ${mark(theme, status, spin)} ${label}${summary || ""}`;
+  const elapsed = state.narrow ? null : stageElapsed(stage, state.now);
+  return lr(left, elapsed ? theme.paint(elapsed, "faint") : null, width);
+}
+
+function discoverSummary(theme, d) {
+  if (!d || d.status === "pending") return "";
+  if (d.status === "active") {
+    return theme.paint(
+      `scanning ${d.storesTotal} local stores · ${formatCount(d.totalMatched)} sessions from this repo so far`,
+      "dim",
+    );
+  }
+  const parts = [`${formatCount(d.totalMatched)} sessions from this repo`, `${d.storesOk}/${d.storesTotal} stores`];
+  if (d.files) parts.push(`${formatCount(d.files)} files, ${formatCount(d.newFiles)} new`);
+  return theme.paint(parts.join(" · "), "dim");
+}
+
+function analyzeSummary(theme, a, narrow) {
+  if (!a || a.status === "pending") return "";
+  if (a.status === "active") {
+    const bar = gaugeBar(theme, a.pending ? a.done / a.pending : 1, narrow ? 10 : 14);
+    return `${bar} ${theme.paint(`${a.done}/${a.pending}`, "text", { bold: true })} ${theme.paint(
+      `· ${a.cached} already analyzed · jobs ${a.jobs}`,
+      "dim",
+    )}`;
+  }
+  return theme.paint(`${a.ok} ok · ${a.skipped} skipped · ${a.failed} failed · ${a.cached} reused`, "dim");
+}
+
+function foldSummary(theme, f) {
+  if (!f || f.status !== "done") return "";
+  return (
+    theme.paint(`${f.instructions} instructions scored · ${f.clustersFound} gaps → `, "dim") +
+    theme.paint(`${f.clustersKept} clusters kept`, "text") +
+    theme.paint(` (seen in ≥${f.minGapEvidence} sessions)`, "faint")
+  );
+}
+
+function synthSummary(theme, s) {
+  if (!s || s.status === "pending") return "";
+  const model = [s.agent, s.model].filter(Boolean).join(" · ");
+  const effort = s.effort ? ` · effort ${s.effort}` : "";
+  if (s.status === "done") return theme.paint(`${s.edits} edit(s) · passed validation`, "dim");
+  if (s.attempt > 1) {
+    return (
+      theme.paint("re-prompt ", "dim") + theme.paint("1 of 1", "yellow") + theme.paint(` · ${model}${effort}`, "dim")
+    );
+  }
+  return theme.paint(`one call · ${model}${effort}`, "dim");
+}
+
+function sectionRule(theme, name, description, width) {
+  const left = `${theme.paint("──", "faint")} ${theme.paint(name, "text", { bold: true })}${theme.paint(` · ${description} `, "faint")}`;
+  const remaining = width - visibleWidth(left);
+  return left + theme.paint("─".repeat(Math.max(remaining, 0)), "faint");
+}
+
+function harnessDot(theme, harness) {
+  return theme.paint("●", HARNESS_HUES[harness] || "blue");
+}
+
+function discoverDetail(state, theme, width, spin) {
+  const d = state.discover;
+  const lines = [sectionRule(theme, "discover", "local stores only · nothing leaves this machine", width)];
+  const countWidth = 15;
+  const howWidth = 25;
+  const activityWidth = width - 2 - 2 - 11 - countWidth - (state.narrow ? 0 : howWidth) - 4;
+
+  for (const harness of d.order) {
+    const h = d.harnesses[harness];
+    const dot = harnessDot(theme, harness);
+    const name = theme.paint(fitPlain(harness, 10), "text");
+
+    let activity;
+    let count;
+    let how = theme.paint(fitPlain(tierLabel(h.tiers), howWidth, "right"), "faint");
+    if (h.status === "error") {
+      activity = theme.paint(fitPlain("store unreadable · harness skipped, run continues", activityWidth), "yellow");
+      count = theme.paint(fitPlain("–", countWidth, "right"), "faint");
+      how = theme.paint(fitPlain("fail-soft", howWidth, "right"), "faint");
+    } else if (h.status === "scanning") {
+      const showBar = (h.total || 0) >= 500;
+      const text = showBar
+        ? `${formatCount(h.scanned)}/${formatCount(h.total)} sessions`
+        : `${formatCount(h.scanned)} sessions`;
+      const bar = showBar ? `${gaugeBar(theme, h.total ? h.scanned / h.total : 0, state.narrow ? 8 : 10)} ` : "";
+      activity = bar + theme.paint(fitPlain(text, activityWidth - (showBar ? (state.narrow ? 9 : 11) : 0)), "dim");
+      count = padVis(
+        `${theme.paint(formatCount(h.matched), "text", { bold: true })} ${theme.paint("so far", "faint")}`,
+        countWidth,
+        "right",
+      );
+    } else {
+      const scanned = `${formatCount(h.scanned)} sessions`;
+      const fresh = h.newCount > 0 || h.scanned > 0 ? ` · ${formatCount(h.newCount)} new` : "";
+      const query = harness === "opencode" ? "1 sqlite query" : `${scanned}${fresh}`;
+      activity = theme.paint(fitPlain(query, activityWidth), "dim");
+      count = padVis(
+        `${theme.paint(formatCount(h.matched), "text", { bold: true })} ${theme.paint("this repo", "faint")}`,
+        countWidth,
+        "right",
+      );
+    }
+
+    const glyph =
+      h.status === "scanning" ? theme.paint(spin, "mint") : mark(theme, h.status === "error" ? "error" : "done", spin);
+    const row = ` ${glyph} ${dot} ${name}${activity}${count}${state.narrow ? "" : how}`;
+    lines.push(row);
+  }
+
+  lines.push("");
+  lines.push(theme.paint("new = not seen by a previous scan · re-scans only read new or changed files", "faint"));
+  return lines;
+}
+
+/** Outcome counters with parentheticals that shrink until the line fits. */
+function countersLine(a, theme, width) {
+  const build = (skippedNote, failedNote, reusedNote) =>
+    ` ${theme.paint(String(a.ok), "mint")} ${theme.paint("ok", "dim")} ${theme.paint("·", "faint")} ` +
+    `${theme.paint(String(a.skipped), "text")} ${theme.paint("skipped", "dim")}${skippedNote ? ` ${theme.paint(skippedNote, "faint")}` : ""} ${theme.paint("·", "faint")} ` +
+    `${theme.paint(String(a.failed), "yellow")} ${theme.paint("failed", "dim")}${failedNote ? ` ${theme.paint(failedNote, "faint")}` : ""} ${theme.paint("·", "faint")} ` +
+    `${theme.paint(String(a.cached), "blue")} ${theme.paint("reused", "dim")}${reusedNote ? ` ${theme.paint(reusedNote, "faint")}` : ""}`;
+
+  const variants = [
+    build("(trivial session)", "(will retry)", "(analyzed in an earlier run)"),
+    build("(trivial)", "(will retry)", "(earlier run)"),
+    build(null, null, null),
+  ];
+  return variants.find((line) => visibleWidth(line) <= width) || variants[variants.length - 1];
+}
+
+function analyzeDetail(state, theme, width, spin) {
+  const a = state.analyze;
+  const model = [a.agent, a.model].filter(Boolean).join(" · ");
+  const lines = [sectionRule(theme, "analyze", `one cheap call per transcript · ${model}`, width)];
+
+  const receiptWidth = 27;
+  const timeWidth = 6;
+  const titleWidth = Math.max(width - 2 - 2 - 2 - 11 - 10 - receiptWidth - (state.narrow ? 0 : timeWidth) - 7, 10);
+
+  a.lanes.forEach((lane, index) => {
+    if (!lane) return;
+    const receipt =
+      lane.phase === "model"
+        ? padVis(
+            `${theme.paint("distilled", "faint")} ${theme.paint(formatBytes(lane.rawBytes), "dim")} ${theme.paint("▸", "faint")} ${theme.paint(formatBytes(lane.distilledBytes), "dim")}`,
+            receiptWidth,
+            "right",
+          )
+        : theme.paint(fitPlain("distilling…", receiptWidth, "right"), "faint");
+    const elapsed = state.narrow
+      ? ""
+      : theme.paint(fitPlain(formatElapsed(state.now - lane.startedAt), timeWidth, "right"), "faint");
+    lines.push(
+      ` ${theme.paint(spin, "mint")} ${theme.paint(String(index + 1), "faint")} ${harnessDot(theme, lane.harness)} ` +
+        `${theme.paint(fitPlain(lane.harness, 9), "text")}${theme.paint(fitPlain(lane.id, 10), "faint")} ` +
+        `${theme.paint(fitPlain(lane.title, titleWidth), "dim")} ${receipt}${elapsed}`,
+    );
+  });
+
+  lines.push("");
+  lines.push(countersLine(a, theme, width));
+  const evidence =
+    ` ${theme.paint("evidence so far", "dim")}   ${theme.paint(`✓ ${a.evidence.positive}`, "mint")} ${theme.paint("helped", "faint")}` +
+    `   ${theme.paint(`✗ ${a.evidence.negative}`, "red")} ${theme.paint("violated", "faint")}` +
+    `   ${theme.paint(`◆ ${a.evidence.gaps}`, "yellow")} ${theme.paint("gaps", "faint")}`;
+  lines.push(
+    lr(evidence, state.narrow ? null : theme.paint("claims without a verbatim quote are dropped", "faint"), width),
+  );
+  return lines;
+}
+
+function synthesizeDetail(state, theme, width, spin) {
+  const s = state.synthesize;
+  const lines = [sectionRule(theme, "synthesize", `folded evidence → at most ${state.meta.maxEdits} edits`, width)];
+
+  if (s.attempt > 1 && s.violations.length) {
+    lines.push(
+      ` ${theme.paint("!", "yellow")} ${theme.paint(`synthesis violated ${s.violations.length} gate(s)`, "text")} ${theme.paint("· re-prompting once with the exact breaches", "dim")}`,
+    );
+    for (const violation of s.violations.slice(0, 4)) {
+      lines.push(`    ${theme.paint("✗", "red")} ${theme.paint(clipPlain(violation, width - 8), "dim")}`);
+    }
+  }
+
+  lines.push(
+    lr(
+      ` ${theme.paint(spin, "mint")} weighing ${s.gapClusters} gap clusters + ${s.instructions} instruction records against the budget…`,
+      state.narrow || !s.sessionName ? null : theme.paint(`session ${s.sessionName}`, "faint"),
+      width,
+    ),
+  );
+
+  if (s.suppressed > 0) {
+    lines.push("");
+    lines.push(
+      theme.paint(
+        `${s.suppressed} previously rejected edit(s) suppressed · re-proposed only on materially new evidence`,
+        "faint",
+      ),
+    );
+  }
+  return lines;
+}
+
+function clipPlain(text, width) {
+  return fitPlain(String(text), width).trimEnd();
+}
+
+/** The active detail panel: the stage currently spending time, else the latest one. */
+function activePanel(state) {
+  if (state.synthesize.status === "active") return "synthesize";
+  if (state.analyze.status === "active") return "analyze";
+  if (state.discover.status === "active") return "discover";
+  if (state.synthesize.status === "done") return "synthesize";
+  if (state.analyze.status === "done") return "analyze";
+  if (state.discover.status === "done") return "discover";
+  return null;
+}
+
+/**
+ * Render one frame. `state` is the controller's reduced event state; options
+ * carry the terminal width, theme, wall-clock, and current spinner glyph.
+ */
+export function renderFrame(state, { width, theme, now, spin }) {
+  const cols = Math.max(Math.min(width || 80, MAX_WIDTH), 40);
+  const frameState = { ...state, now, narrow: (width || 80) < NARROW_COLUMNS };
+
+  const lines = [];
+  lines.push(...headerLines(frameState, theme, cols, spin));
+
+  lines.push(
+    railLine(
+      theme,
+      frameState,
+      "discover",
+      discoverSummary(theme, frameState.discover),
+      frameState.discover,
+      cols,
+      spin,
+    ),
+  );
+  lines.push(
+    railLine(
+      theme,
+      frameState,
+      "analyze",
+      analyzeSummary(theme, frameState.analyze, frameState.narrow),
+      frameState.analyze,
+      cols,
+      spin,
+    ),
+  );
+  lines.push(railLine(theme, frameState, "fold", foldSummary(theme, frameState.fold), frameState.fold, cols, spin));
+  lines.push(
+    railLine(
+      theme,
+      frameState,
+      "synthesize",
+      synthSummary(theme, frameState.synthesize),
+      frameState.synthesize,
+      cols,
+      spin,
+    ),
+  );
+  lines.push("");
+
+  const panel = activePanel(frameState);
+  if (panel === "discover") lines.push(...discoverDetail(frameState, theme, cols, spin));
+  if (panel === "analyze") lines.push(...analyzeDetail(frameState, theme, cols, spin));
+  if (panel === "synthesize") lines.push(...synthesizeDetail(frameState, theme, cols, spin));
+
+  return lines.map((line) => clipLine(line, cols).trimEnd());
+}

--- a/src/tui/term.js
+++ b/src/tui/term.js
@@ -1,0 +1,130 @@
+/**
+ * Terminal capability detection for the live progress view.
+ *
+ * Three questions are answered here, all decided in the approved design review:
+ *
+ *  1. Is a live view appropriate at all? (TTY, not CI, no NO_COLOR, wide enough)
+ *  2. How much color can we emit? Truecolor gets the house theme; anything else
+ *     falls back to the nearest ANSI-16 colors.
+ *  3. Is the background dark or light? Queried via OSC 11 (~50ms budget) with
+ *     COLORFGBG as fallback; unknown assumes dark. A config key / --theme flag
+ *     can force either.
+ */
+
+/** Minimum columns below which the TUI does not start and plain lines are used. */
+export const MIN_COLUMNS = 60;
+
+/** Columns below which the right-hand column (timers, notes) is dropped. */
+export const NARROW_COLUMNS = 84;
+
+/**
+ * @param {object} [options]
+ * @param {Record<string, string | undefined>} [options.env]
+ * @param {{ isTTY?: boolean, columns?: number }} [options.stderr]
+ * @param {boolean} [options.quiet]
+ * @param {boolean} [options.json]
+ */
+export function tuiEligible({ env = process.env, stderr = process.stderr, quiet = false, json = false } = {}) {
+  if (quiet || json) return false;
+  if (!stderr.isTTY) return false;
+  if (env.NO_COLOR !== undefined) return false;
+  if (env.CI) return false;
+  if ((env.TERM || "") === "dumb") return false;
+  if ((stderr.columns || 80) < MIN_COLUMNS) return false;
+  return true;
+}
+
+/**
+ * 24 for truecolor terminals, 4 for everything else (ANSI-16), 0 when color is off.
+ * @param {object} [options]
+ * @param {Record<string, string | undefined>} [options.env]
+ * @param {{ isTTY?: boolean }} [options.stderr]
+ */
+export function colorDepth({ env = process.env, stderr = process.stderr } = {}) {
+  if (env.NO_COLOR !== undefined || !stderr.isTTY) return 0;
+  const colorterm = (env.COLORTERM || "").toLowerCase();
+  if (colorterm.includes("truecolor") || colorterm.includes("24bit")) return 24;
+  return 4;
+}
+
+/**
+ * Classify a COLORFGBG value like "15;0" (fg;bg). By rxvt convention the last
+ * field is the background color index: 0-6 and 8 are dark, 7 and 9-15 light.
+ */
+export function backgroundFromColorFgBg(value) {
+  if (!value) return null;
+  const parts = String(value).split(";");
+  const bg = Number(parts[parts.length - 1]);
+  if (!Number.isInteger(bg) || bg < 0 || bg > 255) return null;
+  return bg === 7 || bg >= 9 ? "light" : "dark";
+}
+
+/**
+ * Classify an OSC 11 response like `\x1b]11;rgb:0b0b/0e0e/1414\x07`.
+ * Channels may be 1-4 hex digits per the XParseColor spec.
+ */
+export function backgroundFromOscResponse(text) {
+  const match = /\]11;rgb:([0-9a-f]{1,4})\/([0-9a-f]{1,4})\/([0-9a-f]{1,4})/i.exec(String(text || ""));
+  if (!match) return null;
+  const channel = (hex) => parseInt(hex, 16) / (16 ** hex.length - 1);
+  const [r, g, b] = [match[1], match[2], match[3]].map(channel);
+  const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luma > 0.5 ? "light" : "dark";
+}
+
+/**
+ * Ask the terminal for its background color. Resolves "dark" | "light".
+ * Never rejects; any failure falls back to COLORFGBG, then dark.
+ */
+export function detectBackground({
+  env = process.env,
+  stdin = process.stdin,
+  stderr = process.stderr,
+  timeoutMs = 50,
+} = {}) {
+  const fallback = backgroundFromColorFgBg(env.COLORFGBG) || "dark";
+
+  if (!stdin.isTTY || typeof stdin.setRawMode !== "function" || !stderr.isTTY) {
+    return Promise.resolve(fallback);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let response = "";
+    const wasRaw = stdin.isRaw === true;
+
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdin.off("data", onData);
+      try {
+        if (!wasRaw) stdin.setRawMode(false);
+        stdin.pause();
+      } catch {
+        // Terminal state restoration is best-effort.
+      }
+      resolve(value);
+    };
+
+    const onData = (chunk) => {
+      response += chunk.toString("utf8");
+      const parsed = backgroundFromOscResponse(response);
+      if (parsed) finish(parsed);
+      // A terminator without a parseable color means the terminal answered
+      // something we do not understand - stop waiting.
+      else if (response.includes("\x07") || response.includes("\x1b\\")) finish(fallback);
+    };
+
+    const timer = setTimeout(() => finish(fallback), timeoutMs);
+
+    try {
+      stdin.setRawMode(true);
+      stdin.on("data", onData);
+      stdin.resume();
+      stderr.write("\x1b]11;?\x07");
+    } catch {
+      finish(fallback);
+    }
+  });
+}

--- a/src/tui/theme.js
+++ b/src/tui/theme.js
@@ -1,0 +1,111 @@
+/**
+ * The backpass house theme for the live progress view.
+ *
+ * One theme, two ink sets (captain-approved design): the palette from the apply
+ * surface for dark backgrounds, and a darkened twin tuned for paper-white. On
+ * truecolor terminals the exact hex inks are emitted; otherwise each ink maps to
+ * its nearest ANSI-16 color, which inherits the user's own palette.
+ *
+ * The mint->blue "descent gradient" is the brand mark and is reserved for
+ * exactly two things: the nabla wordmark and active progress fills.
+ */
+
+export const INKS = {
+  dark: {
+    text: "#d9dfea",
+    dim: "#8a93a5",
+    faint: "#5a6375",
+    mint: "#4fe3c1",
+    blue: "#6ea8ff",
+    yellow: "#ffc857",
+    red: "#ff5d73",
+    purple: "#b18aff",
+    peach: "#ff9e64",
+    green: "#9ece6a",
+    magenta: "#e05fbc",
+  },
+  light: {
+    text: "#2a3140",
+    dim: "#5b6478",
+    faint: "#939cae",
+    mint: "#0a8a72",
+    blue: "#2b62d9",
+    yellow: "#8f6606",
+    red: "#c22b47",
+    purple: "#6f42c8",
+    peach: "#b25a10",
+    green: "#4e7a17",
+    magenta: "#ab3184",
+  },
+};
+
+/** Nearest ANSI-16 foreground SGR code per ink. `null` means the default fg. */
+export const ANSI16 = {
+  text: null,
+  dim: "90",
+  faint: "90",
+  mint: "96",
+  blue: "94",
+  yellow: "93",
+  red: "91",
+  purple: "95",
+  peach: "33",
+  green: "92",
+  magenta: "95",
+};
+
+export function hexToRgb(hex) {
+  const value = hex.replace("#", "");
+  return [parseInt(value.slice(0, 2), 16), parseInt(value.slice(2, 4), 16), parseInt(value.slice(4, 6), 16)];
+}
+
+const RESET = "\x1b[0m";
+
+/**
+ * Build a theme for one terminal. `depth` 24 emits hex inks, 4 emits ANSI-16,
+ * and 0 emits no escapes at all - which is what the render tests use, so the
+ * rendered layout is asserted as plain text.
+ */
+export function makeTheme({ depth = 24, background = "dark" } = {}) {
+  const inks = INKS[background] || INKS.dark;
+
+  const open = (ink, bold) => {
+    if (depth === 0) return "";
+    const parts = [];
+    if (bold) parts.push("1");
+    if (depth === 24) {
+      const [r, g, b] = hexToRgb(inks[ink] || inks.text);
+      parts.push(`38;2;${r};${g};${b}`);
+    } else if (ANSI16[ink]) {
+      parts.push(ANSI16[ink]);
+    }
+    return parts.length ? `\x1b[${parts.join(";")}m` : "";
+  };
+
+  const paint = (text, ink = "text", { bold = false } = {}) => {
+    const prefix = open(ink, bold);
+    return prefix ? `${prefix}${text}${RESET}` : String(text);
+  };
+
+  /** Per-character mint->blue interpolation; solid mint below truecolor. */
+  const gradient = (text, { bold = false } = {}) => {
+    const value = String(text);
+    if (depth === 0) return value;
+    if (depth !== 24) return paint(value, "mint", { bold });
+    const from = hexToRgb(inks.mint);
+    const to = hexToRgb(inks.blue);
+    const chars = [...value];
+    const steps = Math.max(chars.length - 1, 1);
+    return (
+      chars
+        .map((ch, i) => {
+          const t = i / steps;
+          const rgb = from.map((f, c) => Math.round(f + (to[c] - f) * t));
+          return `\x1b[${bold ? "1;" : ""}38;2;${rgb[0]};${rgb[1]};${rgb[2]}m${ch}`;
+        })
+        .join("") + RESET
+    );
+  };
+
+  return { depth, background, inks, paint, gradient };
+}

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -1,0 +1,349 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  clipLine,
+  fitPlain,
+  formatBytes,
+  formatCount,
+  formatElapsed,
+  gaugeBar,
+  lr,
+  renderFrame,
+  spinnerFrame,
+  stripAnsi,
+  visibleWidth,
+  SPINNER_FRAMES,
+} from "../src/tui/render.js";
+import { initialState, reduceEvent } from "../src/tui/index.js";
+import { makeTheme } from "../src/tui/theme.js";
+
+const plain = makeTheme({ depth: 0 });
+const T0 = Date.parse("2026-08-21T10:00:00Z");
+
+function baseMeta() {
+  return { version: "1.1.0", repoName: "eddies-wallet", worktrees: 3, since: "30d", maxEdits: 5 };
+}
+
+/** Replay one event script into a fresh state, advancing the clock per step. */
+function stateAfter(events) {
+  const state = initialState(baseMeta());
+  events.forEach(([event, data], index) => reduceEvent(state, event, data, T0 + index * 1000));
+  return state;
+}
+
+function render(state, { width = 110, now = T0 + 60_000 } = {}) {
+  return renderFrame(state, { width, theme: plain, now, spin: "⠸" });
+}
+
+// ---------- text helpers ----------
+
+test("visibleWidth ignores ANSI escapes", () => {
+  assert.equal(visibleWidth("\x1b[38;2;1;2;3mabc\x1b[0m"), 3);
+  assert.equal(stripAnsi("\x1b[1mx\x1b[0m"), "x");
+});
+
+test("clipLine truncates by visible cells and keeps escapes intact", () => {
+  const painted = `\x1b[31m${"a".repeat(20)}\x1b[0m`;
+  const clipped = clipLine(painted, 10);
+  assert.equal(visibleWidth(clipped), 10);
+  assert.ok(stripAnsi(clipped).endsWith("…"));
+  assert.equal(clipLine("short", 10), "short");
+});
+
+test("fitPlain pads and ellipsizes", () => {
+  assert.equal(fitPlain("ab", 4), "ab  ");
+  assert.equal(fitPlain("ab", 4, "right"), "  ab");
+  assert.equal(fitPlain("abcdef", 4), "abc…");
+});
+
+test("lr right-aligns and drops the right side when it cannot fit", () => {
+  assert.equal(lr("left", "right", 20), "left" + " ".repeat(11) + "right");
+  assert.equal(lr("a-very-long-left-side", "right", 22), "a-very-long-left-side");
+});
+
+test("formatters produce the mock's vocabulary", () => {
+  assert.equal(formatBytes(1.9 * 1024 * 1024), "1.9 MB");
+  assert.equal(formatBytes(412 * 1024), "412.0 KB");
+  assert.equal(formatBytes(83), "83 B");
+  assert.equal(formatElapsed(12), "12ms");
+  assert.equal(formatElapsed(4000), "0:04");
+  assert.equal(formatElapsed(245_000), "4:05");
+  assert.equal(formatCount(10317), "10,317");
+});
+
+test("gaugeBar fills by ratio and marks overflow with !!", () => {
+  assert.equal(gaugeBar(plain, 0.5, 10), "▰▰▰▰▰▱▱▱▱▱");
+  assert.equal(gaugeBar(plain, 0, 10), "▱".repeat(10));
+  assert.equal(gaugeBar(plain, 1, 10), "▰".repeat(10));
+  assert.equal(gaugeBar(plain, 1.04, 10), "▰".repeat(8) + "!!");
+});
+
+test("spinner cycles through the braille frames on an 80ms cadence", () => {
+  assert.equal(spinnerFrame(0), SPINNER_FRAMES[0]);
+  assert.equal(spinnerFrame(80), SPINNER_FRAMES[1]);
+  assert.equal(spinnerFrame(80 * SPINNER_FRAMES.length), SPINNER_FRAMES[0]);
+});
+
+// ---------- event reduction ----------
+
+test("discovery events accumulate per-harness rows and totals", () => {
+  const state = stateAfter([
+    ["discover:start", { harnesses: ["claude", "codex", "pi"] }],
+    ["discover:harness:start", { harness: "claude" }],
+    ["discover:harness:done", { harness: "claude", scanned: 214, cached: 131, matched: 38, tiers: { 1: 36, 2: 2 } }],
+    ["discover:harness:start", { harness: "codex" }],
+    ["discover:harness:tick", { harness: "codex", scanned: 8912, total: 10317, matched: 9 }],
+  ]);
+
+  assert.equal(state.discover.status, "active");
+  assert.equal(state.discover.harnesses.claude.status, "done");
+  assert.equal(state.discover.harnesses.claude.newCount, 83);
+  assert.equal(state.discover.harnesses.codex.status, "scanning");
+  assert.equal(state.discover.totalMatched, 47);
+  assert.equal(state.discover.storesOk, 1);
+});
+
+test("an unreadable store becomes an error row, not a failed run", () => {
+  const state = stateAfter([
+    ["discover:start", { harnesses: ["pi"] }],
+    ["discover:harness:start", { harness: "pi" }],
+    ["discover:harness:done", { harness: "pi", error: "ENOENT" }],
+    ["discover:done", { total: 0 }],
+  ]);
+  assert.equal(state.discover.harnesses.pi.status, "error");
+  assert.equal(state.discover.storesOk, 0);
+  assert.equal(state.discover.status, "done");
+});
+
+test("analyze events drive lanes, counters, and the running evidence tally", () => {
+  const state = stateAfter([
+    ["analyze:start", { pending: 25, cached: 33, total: 58, jobs: 4, agent: "codex", model: "gpt-5.2-mini" }],
+    ["analyze:lane", { slot: 0, harness: "claude", id: "7c1f39aa", title: "refactor wallet sync", phase: "distill" }],
+    [
+      "analyze:lane",
+      {
+        slot: 0,
+        harness: "claude",
+        id: "7c1f39aa",
+        title: "refactor wallet sync",
+        phase: "model",
+        rawBytes: 1_990_000,
+        distilledBytes: 12_700,
+      },
+    ],
+    ["analyze:evidence", { positive: 4, negative: 1, gaps: 2 }],
+    ["analyze:tick", { slot: 0, done: 1, ok: 1, skipped: 0, failed: 0 }],
+  ]);
+
+  assert.equal(state.analyze.status, "active");
+  assert.equal(state.analyze.lanes.length, 4);
+  assert.equal(state.analyze.lanes[0], null);
+  assert.equal(state.analyze.done, 1);
+  assert.deepEqual(state.analyze.evidence, { positive: 4, negative: 1, gaps: 2 });
+});
+
+test("fold and synthesis events settle the tail stages", () => {
+  const state = stateAfter([
+    ["fold:done", { instructions: 24, clustersFound: 9, clustersKept: 4, minGapEvidence: 2, ms: 12 }],
+    [
+      "synth:start",
+      {
+        agent: "claude",
+        model: "claude-opus-5",
+        effort: "high",
+        attempt: 1,
+        sessionName: "backpass-synth-1",
+        gapClusters: 4,
+        instructions: 24,
+        suppressed: 1,
+      },
+    ],
+    ["synth:violations", { attempt: 1, violations: ["projected file is 5,180 tok"] }],
+    [
+      "synth:start",
+      { agent: "claude", model: "claude-opus-5", effort: "high", attempt: 2, sessionName: "backpass-synth-1" },
+    ],
+  ]);
+
+  assert.equal(state.fold.status, "done");
+  assert.equal(state.fold.clustersKept, 4);
+  assert.equal(state.synthesize.attempt, 2);
+  assert.deepEqual(state.synthesize.violations, ["projected file is 5,180 tok"]);
+});
+
+// ---------- full frames ----------
+
+const DISCOVERY_SCRIPT = [
+  ["memory", { path: "AGENTS.md", tokens: 2412, budget: 5000, units: 63 }],
+  ["discover:start", { harnesses: ["claude", "codex", "opencode", "grok", "pi"] }],
+  ["discover:harness:start", { harness: "claude" }],
+  ["discover:harness:done", { harness: "claude", scanned: 214, cached: 131, matched: 38, tiers: { 1: 36, 2: 2 } }],
+  ["discover:harness:start", { harness: "codex" }],
+  ["discover:harness:tick", { harness: "codex", scanned: 8912, total: 10317, matched: 9 }],
+  ["discover:harness:start", { harness: "opencode" }],
+  ["discover:harness:done", { harness: "opencode", scanned: 4, cached: 0, matched: 4, tiers: { 1: 4 } }],
+  ["discover:harness:start", { harness: "grok" }],
+  ["discover:harness:done", { harness: "grok", scanned: 41, cached: 36, matched: 3, tiers: { 2: 3 } }],
+  ["discover:harness:start", { harness: "pi" }],
+  ["discover:harness:done", { harness: "pi", error: "store unreadable" }],
+];
+
+test("discovery frame: header gauge, rail, per-harness rows, plain-language labels", () => {
+  const lines = render(stateAfter(DISCOVERY_SCRIPT));
+  const text = lines.join("\n");
+
+  assert.ok(text.includes("∇ backpass v1.1.0"));
+  assert.ok(text.includes("eddies-wallet · 3 worktrees · since 30d"));
+  assert.ok(text.includes("2,412 / 5,000 tok"));
+  assert.ok(text.includes("63 instructions · budget 48%"));
+  assert.ok(text.includes("sessions from this repo so far"));
+  assert.ok(text.includes("214 sessions · 83 new"));
+  assert.ok(text.includes("38 this repo"));
+  assert.ok(text.includes("ran in this repo"));
+  assert.ok(text.includes("git remote match"));
+  assert.ok(text.includes("8,912/10,317 sessions"));
+  assert.ok(text.includes("9 so far"));
+  assert.ok(text.includes("1 sqlite query"));
+  assert.ok(text.includes("store unreadable · harness skipped, run continues"));
+  assert.ok(text.includes("fail-soft"));
+  assert.ok(text.includes("new = not seen by a previous scan"));
+  // The forbidden jargon from the design review must never resurface.
+  assert.ok(!text.includes("tier"));
+  assert.ok(!text.includes("rollout"));
+  assert.ok(!/\bmatched\b/.test(text));
+});
+
+test("every line fits the terminal and the header box is intact", () => {
+  for (const width of [100, 80, 62]) {
+    const lines = render(stateAfter(DISCOVERY_SCRIPT), { width });
+    for (const line of lines) {
+      assert.ok(visibleWidth(line) <= Math.min(width, 110), `line overflows at width ${width}: ${stripAnsi(line)}`);
+    }
+    assert.ok(stripAnsi(lines[0]).startsWith("╭"));
+    assert.ok(stripAnsi(lines[3]).startsWith("╰"));
+  }
+});
+
+const ANALYZE_SCRIPT = [
+  ...DISCOVERY_SCRIPT,
+  ["discover:harness:done", { harness: "codex", scanned: 10317, cached: 9893, matched: 11, tiers: { 2: 11 } }],
+  ["discover:done", { total: 53 }],
+  ["analyze:start", { pending: 25, cached: 33, total: 58, jobs: 4, agent: "codex", model: "gpt-5.2-mini" }],
+  [
+    "analyze:lane",
+    { slot: 0, harness: "claude", id: "7c1f39aa", title: "refactor wallet sync engine", phase: "distill" },
+  ],
+  [
+    "analyze:lane",
+    {
+      slot: 1,
+      harness: "grok",
+      id: "51a7ff08",
+      title: "add csv export",
+      phase: "model",
+      rawBytes: 640_000,
+      distilledBytes: 8_400,
+    },
+  ],
+  ["analyze:evidence", { positive: 61, negative: 14, gaps: 22 }],
+  ["analyze:tick", { slot: 2, done: 18, ok: 16, skipped: 1, failed: 1 }],
+];
+
+test("analyze frame: pool bar, lanes with distill receipts, counters, evidence tally", () => {
+  const lines = render(stateAfter(ANALYZE_SCRIPT));
+  const text = lines.join("\n");
+
+  assert.ok(text.includes("18/25"));
+  assert.ok(text.includes("33 already analyzed · jobs 4"));
+  assert.ok(text.includes("one cheap call per transcript · codex · gpt-5.2-mini"));
+  assert.ok(text.includes("distilling…"));
+  assert.ok(text.includes("distilled 625.0 KB ▸ 8.2 KB"));
+  assert.ok(text.includes("16 ok"));
+  assert.ok(text.includes("skipped (trivial session)"));
+  assert.ok(text.includes("failed (will retry)"));
+  assert.ok(text.includes("33 reused (analyzed in an earlier run)"));
+  assert.ok(text.includes("✓ 61 helped"));
+  assert.ok(text.includes("✗ 14 violated"));
+  assert.ok(text.includes("◆ 22 gaps"));
+  assert.ok(text.includes("claims without a verbatim quote are dropped"));
+  assert.ok(text.includes("53 sessions from this repo"));
+});
+
+const SYNTH_SCRIPT = [
+  ...ANALYZE_SCRIPT,
+  ["analyze:done", { total: 58, analyzed: 23, cached: 33, skipped: 1, failed: 1 }],
+  ["fold:done", { instructions: 24, clustersFound: 9, clustersKept: 4, minGapEvidence: 2, ms: 12 }],
+  [
+    "synth:start",
+    {
+      agent: "claude",
+      model: "claude-opus-5",
+      effort: "high",
+      attempt: 1,
+      sessionName: "backpass-synth-84121",
+      gapClusters: 4,
+      instructions: 24,
+      suppressed: 1,
+    },
+  ],
+];
+
+test("synthesis frame: fold rail line, sparse panel, suppression note - no gates checklist", () => {
+  const lines = render(stateAfter(SYNTH_SCRIPT));
+  const text = lines.join("\n");
+
+  assert.ok(text.includes("23 ok · 1 skipped · 1 failed · 33 reused"));
+  assert.ok(text.includes("24 instructions scored · 9 gaps → 4 clusters kept (seen in ≥2 sessions)"));
+  assert.ok(text.includes("one call · claude · claude-opus-5 · effort high"));
+  assert.ok(text.includes("folded evidence → at most 5 edits"));
+  assert.ok(text.includes("weighing 4 gap clusters + 24 instruction records against the budget…"));
+  assert.ok(text.includes("session backpass-synth-84121"));
+  assert.ok(text.includes("1 previously rejected edit(s) suppressed"));
+  // Gates only surface when one fails (decided in review).
+  assert.ok(!text.includes("gates"));
+});
+
+test("a gate violation renders the exact breaches and the re-prompt marker", () => {
+  const lines = render(
+    stateAfter([
+      ...SYNTH_SCRIPT,
+      ["synth:violations", { attempt: 1, violations: ["E2 adds an instruction with evidence from 1 session"] }],
+      [
+        "synth:start",
+        { agent: "claude", model: "claude-opus-5", effort: "high", attempt: 2, sessionName: "backpass-synth-84121" },
+      ],
+    ]),
+  );
+  const text = lines.join("\n");
+
+  assert.ok(text.includes("synthesis violated 1 gate(s)"));
+  assert.ok(text.includes("re-prompting once with the exact breaches"));
+  assert.ok(text.includes("✗ E2 adds an instruction with evidence from 1 session"));
+  assert.ok(text.includes("re-prompt 1 of 1"));
+});
+
+test("an over-budget file flips the header gauge into shrink-plan mode", () => {
+  const lines = render(
+    stateAfter([
+      ["memory", { path: "AGENTS.md", tokens: 5214, budget: 5000, units: 71 }],
+      ["discover:start", { harnesses: ["claude"] }],
+    ]),
+  );
+  const text = lines.join("\n");
+
+  assert.ok(text.includes("!!"));
+  assert.ok(text.includes("5,214 / 5,000 tok"));
+  assert.ok(text.includes("OVER · shrink plan"));
+});
+
+test("narrow terminals drop the right-hand column", () => {
+  const wide = render(stateAfter(SYNTH_SCRIPT), { width: 110 });
+  const narrow = render(stateAfter(SYNTH_SCRIPT), { width: 70 });
+
+  assert.ok(wide.join("\n").includes("session backpass-synth-84121"));
+  assert.ok(!narrow.join("\n").includes("session backpass-synth-84121"));
+  for (const line of narrow) {
+    assert.ok(visibleWidth(line) <= 70, `narrow line overflows: ${stripAnsi(line)}`);
+  }
+});

--- a/test/tui-theme.test.js
+++ b/test/tui-theme.test.js
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ANSI16, INKS, hexToRgb, makeTheme } from "../src/tui/theme.js";
+import { backgroundFromColorFgBg, backgroundFromOscResponse, colorDepth, tuiEligible } from "../src/tui/term.js";
+
+test("hexToRgb parses the house inks", () => {
+  assert.deepEqual(hexToRgb("#4fe3c1"), [79, 227, 193]);
+  assert.deepEqual(hexToRgb("#0a8a72"), [10, 138, 114]);
+});
+
+test("truecolor theme emits exact hex inks", () => {
+  const theme = makeTheme({ depth: 24, background: "dark" });
+  assert.equal(theme.paint("ok", "mint"), "\x1b[38;2;79;227;193mok\x1b[0m");
+  assert.equal(theme.paint("hot", "red", { bold: true }), "\x1b[1;38;2;255;93;115mhot\x1b[0m");
+});
+
+test("light background swaps to the descent-light ink set", () => {
+  const theme = makeTheme({ depth: 24, background: "light" });
+  const [r, g, b] = hexToRgb(INKS.light.mint);
+  assert.equal(theme.paint("ok", "mint"), `\x1b[38;2;${r};${g};${b}mok\x1b[0m`);
+});
+
+test("ANSI-16 fallback maps each ink to its nearest classic color", () => {
+  const theme = makeTheme({ depth: 4, background: "dark" });
+  assert.equal(theme.paint("ok", "mint"), `\x1b[${ANSI16.mint}mok\x1b[0m`);
+  assert.equal(theme.paint("dim", "faint"), `\x1b[${ANSI16.faint}mdim\x1b[0m`);
+  // "text" is the terminal's own default foreground - no escape at all.
+  assert.equal(theme.paint("plain", "text"), "plain");
+  assert.equal(theme.paint("plain", "text", { bold: true }), "\x1b[1mplain\x1b[0m");
+});
+
+test("depth 0 renders plain text - the layout-test mode", () => {
+  const theme = makeTheme({ depth: 0 });
+  assert.equal(theme.paint("plain", "mint", { bold: true }), "plain");
+  assert.equal(theme.gradient("▰▰▰"), "▰▰▰");
+});
+
+test("gradient interpolates mint to blue per character in truecolor", () => {
+  const theme = makeTheme({ depth: 24, background: "dark" });
+  const painted = theme.gradient("ab");
+  const [mr, mg, mb] = hexToRgb(INKS.dark.mint);
+  const [br, bg, bb] = hexToRgb(INKS.dark.blue);
+  assert.ok(painted.startsWith(`\x1b[38;2;${mr};${mg};${mb}ma`));
+  assert.ok(painted.includes(`\x1b[38;2;${br};${bg};${bb}mb`));
+  assert.ok(painted.endsWith("\x1b[0m"));
+});
+
+test("gradient collapses to solid mint below truecolor", () => {
+  const theme = makeTheme({ depth: 4, background: "dark" });
+  assert.equal(theme.gradient("▰▰"), `\x1b[${ANSI16.mint}m▰▰\x1b[0m`);
+});
+
+test("colorDepth follows COLORTERM and NO_COLOR", () => {
+  const tty = { isTTY: true };
+  assert.equal(colorDepth({ env: { COLORTERM: "truecolor" }, stderr: tty }), 24);
+  assert.equal(colorDepth({ env: { COLORTERM: "24bit" }, stderr: tty }), 24);
+  assert.equal(colorDepth({ env: {}, stderr: tty }), 4);
+  assert.equal(colorDepth({ env: { NO_COLOR: "1", COLORTERM: "truecolor" }, stderr: tty }), 0);
+  assert.equal(colorDepth({ env: { COLORTERM: "truecolor" }, stderr: { isTTY: false } }), 0);
+});
+
+test("tuiEligible gates on TTY, CI, NO_COLOR, quiet, json, and width", () => {
+  const wide = { isTTY: true, columns: 120 };
+  assert.equal(tuiEligible({ env: {}, stderr: wide }), true);
+  assert.equal(tuiEligible({ env: {}, stderr: { isTTY: false, columns: 120 } }), false);
+  assert.equal(tuiEligible({ env: { CI: "1" }, stderr: wide }), false);
+  assert.equal(tuiEligible({ env: { NO_COLOR: "" }, stderr: wide }), false);
+  assert.equal(tuiEligible({ env: { TERM: "dumb" }, stderr: wide }), false);
+  assert.equal(tuiEligible({ env: {}, stderr: wide, quiet: true }), false);
+  assert.equal(tuiEligible({ env: {}, stderr: wide, json: true }), false);
+  assert.equal(tuiEligible({ env: {}, stderr: { isTTY: true, columns: 50 } }), false);
+});
+
+test("COLORFGBG classifies dark and light backgrounds", () => {
+  assert.equal(backgroundFromColorFgBg("15;0"), "dark");
+  assert.equal(backgroundFromColorFgBg("0;15"), "light");
+  assert.equal(backgroundFromColorFgBg("12;8"), "dark");
+  assert.equal(backgroundFromColorFgBg("0;default;7"), "light");
+  assert.equal(backgroundFromColorFgBg(""), null);
+  assert.equal(backgroundFromColorFgBg("nonsense"), null);
+});
+
+test("OSC 11 responses classify by luminance", () => {
+  assert.equal(backgroundFromOscResponse("\x1b]11;rgb:0b0b/0e0e/1414\x07"), "dark");
+  assert.equal(backgroundFromOscResponse("\x1b]11;rgb:f7f7/f9f9/fcfc\x07"), "light");
+  assert.equal(backgroundFromOscResponse("\x1b]11;rgb:ff/ff/ff\x1b\\"), "light");
+  assert.equal(backgroundFromOscResponse("garbage"), null);
+});


### PR DESCRIPTION
Implements the captain-approved progress TUI design from the `backpass-tui-mock-r1` review (spec: `~/fm-homes/mini-default/data/backpass-tui-mock-r1/report.md` + the approved mock `backpass-tui-mock-approved.html`).

## What the default run looks like now

On an interactive terminal, `backpass` renders a live region on stderr: the run header box with the budget gauge (mint→blue descent gradient), the `discover → analyze → fold → synthesize` stage rail, and one detail panel for the stage currently spending time - per-store discovery rows with plain-language association labels ("ran in this repo" / "git remote match"), one lane per analysis job with its distillation receipt (`distilled 1.9 MB ▸ 12.4 KB`), a running evidence tally, and the synthesis panel including gate-violation re-prompt states. On exit the region collapses and the buffered plain logger lines are replayed verbatim, so scrollback is identical to a run without the TUI.

## Design decisions honored (all captain-settled in review)

- **Palette**: house theme in truecolor, nearest ANSI-16 fallback otherwise
- **Motion**: braille spinners at 80ms, timers, bars advance on real progress only
- **Light terminals**: descent-light ink set, auto-selected via OSC 11 query with `COLORFGBG` fallback; `--theme dark|light` / `"theme"` config key force either
- **No jargon**: sessions (not rollouts), "N this repo" (not matched), "N new" (not cache %), no tier-1/tier-2 anywhere in the TUI
- Gates surface only when one fails; the header is fully deterministic

## Architecture

- `src/progress.js` - tiny event bus; stages emit structured events that go nowhere unless a renderer attached (zero behavior change for every non-TTY path)
- `src/tui/term.js` - eligibility (TTY, no CI/NO_COLOR/--quiet/--json/dumb/<60 cols), color depth, background detection
- `src/tui/theme.js` - both ink sets, ANSI-16 mapping, per-character gradient
- `src/tui/render.js` - pure `(state, opts) → lines`, fully testable as plain text
- `src/tui/index.js` - event reducer + repaint controller (synchronized-update escapes, resize, SIGINT-safe teardown, logger-line buffering/replay)
- Emit sites: `discovery/index.js` (per-harness scan progress incl. live tick for 10k+ file stores), `analyze.js` (pool slots → lanes, outcome counters, evidence tally), `commands/propose.js` (fold), `synthesize.js` (attempts + violations), `commands/analyze.js` (deterministic memory stats)

Zero runtime dependencies kept - the repaint engine is ~90 lines of ANSI on stderr; stdout and `--json` are untouched.

## Testing

- 26 new tests (`test/tui-theme.test.js`, `test/tui-render.test.js`) cover the pure layers: capability gates, background classification, ink sets and gradient, ANSI-aware clipping/width helpers, the event reducer, and full rendered frames for every mock state (discovery, fan-out, synthesis, gate violation, over-budget shrink mode, narrow terminals). No model, network, or TTY in tests; `pnpm run check` green (lint, format, typecheck, 103 tests).
- E2E smoke under a pseudo-TTY: a replayed-event run of the real controller (gradient bar, repaints, teardown byte-verified) and the real CLI (`backpass --harness pi --since 1h`), confirming the TUI paints, collapses, restores the cursor, and leaves exactly today's plain output in scrollback; the same command without a TTY is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
