### PR TITLE
fix: exclude .backpass/ via .git/info/exclude, not tracked .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ you have already authenticated.
 
 ```sh
 cd your-repo
-backpass init      # write .backpassrc.json, gitignore .backpass/
+backpass init      # write .backpassrc.json, exclude .backpass/ via .git/info/exclude
 backpass           # scan → analyze → propose (never writes)
 backpass apply     # review each edit, accept or reject, then write
 ```
@@ -213,7 +213,7 @@ backpass apply --dry-run   # show what would be written
 | `backpass propose` | tier-2 synthesis from cached evidence                         |
 | `backpass apply`   | review and write the accepted edits                           |
 | `backpass status`  | cache state, failed transcripts, budget bars                  |
-| `backpass init`    | write `.backpassrc.json`, gitignore `.backpass/`              |
+| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally        |
 
 Run `backpass --help` for the full flag list.
 
@@ -272,7 +272,8 @@ CLI flags on top:
 
 ### State
 
-Everything mutable lives in a gitignored `.backpass/`:
+Everything mutable lives in `.backpass/`, kept out of git via the repo's local exclude
+(`.git/info/exclude`, written by `backpass init`) rather than the tracked `.gitignore`:
 
 ```
 .backpass/

--- a/src/cli.js
+++ b/src/cli.js
@@ -71,7 +71,7 @@ COMMANDS
   propose    tier-2 pass: one high-reasoning call turning folded evidence into edits
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar
-  init       write .backpassrc.json and gitignore .backpass/
+  init       write .backpassrc.json and exclude .backpass/ via .git/info/exclude
 
 DISCOVERY
   --since <dur>            only sessions newer than this (30d, 12h, 2w, all)  [30d]

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -2,11 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { CONFIG_FILENAME, STATE_DIRNAME, initialConfig, repoConfigPath } from "../config.js";
-import { color, info, out } from "../logger.js";
+import { color, info, out, warn } from "../logger.js";
 import { loadMemoryFiles } from "../memory.js";
+import { ensureLocalExclude } from "../repo.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 
-const GITIGNORE_LINE = `${STATE_DIRNAME}/`;
+const EXCLUDE_LINE = `${STATE_DIRNAME}/`;
 
 export async function cmdInit({ repo, config, flags }) {
   const target = repoConfigPath(repo.root);
@@ -24,12 +25,17 @@ export async function cmdInit({ repo, config, flags }) {
     info(`${color.green("·")} wrote ${CONFIG_FILENAME}`);
   }
 
+  const exclude = ensureLocalExclude(repo.root, EXCLUDE_LINE);
+  if (exclude.status === "added") {
+    info(`${color.green("·")} added ${EXCLUDE_LINE} to .git/info/exclude (local, never committed)`);
+  } else if (exclude.status === "no-git") {
+    info(`${color.yellow("·")} no git dir found - skipped excluding ${EXCLUDE_LINE}`);
+  }
+
   const gitignore = path.join(repo.root, ".gitignore");
-  const current = fs.existsSync(gitignore) ? fs.readFileSync(gitignore, "utf8") : "";
-  if (!current.split("\n").some((l) => l.trim() === GITIGNORE_LINE)) {
-    const separator = current && !current.endsWith("\n") ? "\n" : "";
-    fs.appendFileSync(gitignore, `${separator}${GITIGNORE_LINE}\n`);
-    info(`${color.green("·")} added ${GITIGNORE_LINE} to .gitignore`);
+  const gitignoreLines = fs.existsSync(gitignore) ? fs.readFileSync(gitignore, "utf8").split("\n") : [];
+  if (gitignoreLines.some((l) => l.trim() === EXCLUDE_LINE)) {
+    warn(`.gitignore already lists ${EXCLUDE_LINE} from an older backpass - remove it any time, it's redundant now`);
   }
 
   const files = loadMemoryFiles(repo.root, seed.memoryFiles);

--- a/src/repo.js
+++ b/src/repo.js
@@ -68,6 +68,35 @@ function listRemotes(root) {
 }
 
 /**
+ * Ensure `line` is present in this repo's *local* git exclude file
+ * (`.git/info/exclude`) - never a tracked file the user owns. The path is
+ * resolved via `git rev-parse --git-path info/exclude` rather than assumed,
+ * since in a worktree or submodule `.git` is a file, not a directory, and
+ * `info/exclude` lives in the shared common git dir. Idempotent: a line
+ * already present is left alone.
+ *
+ * Returns `{ status: "added" | "present" | "no-git", path? }`.
+ */
+export function ensureLocalExclude(root, line) {
+  let excludePath;
+  try {
+    excludePath = git(["rev-parse", "--git-path", "info/exclude"], root);
+  } catch {
+    return { status: "no-git" };
+  }
+  const resolved = path.isAbsolute(excludePath) ? excludePath : path.join(root, excludePath);
+
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  const current = fs.existsSync(resolved) ? fs.readFileSync(resolved, "utf8") : "";
+  if (current.split("\n").some((l) => l.trim() === line)) {
+    return { status: "present", path: resolved };
+  }
+  const separator = current && !current.endsWith("\n") ? "\n" : "";
+  fs.appendFileSync(resolved, `${separator}${line}\n`);
+  return { status: "added", path: resolved };
+}
+
+/**
  * Repo identity used by every discovery adapter.
  * `commonDir` distinguishes worktrees of the same repository.
  */

--- a/src/state.js
+++ b/src/state.js
@@ -6,7 +6,9 @@ import { STATE_DIRNAME } from "./config.js";
 import { warn } from "./logger.js";
 
 /**
- * All mutable run state lives in a gitignored `.backpass/` directory:
+ * All mutable run state lives in a `.backpass/` directory, kept out of git via the
+ * repo's local exclude (`.git/info/exclude`, written by `backpass init`) rather than
+ * the tracked `.gitignore`:
  *
  *   scan-cache.json        path+mtime+size -> association verdict (design section 2.2)
  *   evidence/<id>.json     per-transcript tier-1 analysis output (design section 3)

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { cmdInit } from "../src/commands/init.js";
+import { loadConfig } from "../src/config.js";
+
+function git(args, cwd) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function initRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-init-"));
+  git(["init", "-q"], dir);
+  git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  return dir;
+}
+
+async function runInit(dir, flags = {}) {
+  const repo = { root: dir, realRoot: dir, name: path.basename(dir), worktrees: [dir], remotes: [] };
+  const config = loadConfig(dir);
+  return cmdInit({ repo, config, flags });
+}
+
+test("init excludes .backpass/ via .git/info/exclude and never touches a tracked .gitignore", async () => {
+  const dir = initRepo();
+
+  await runInit(dir);
+
+  const excludePath = path.join(dir, ".git", "info", "exclude");
+  assert.match(fs.readFileSync(excludePath, "utf8"), /^\.backpass\/$/m);
+  assert.equal(fs.existsSync(path.join(dir, ".gitignore")), false);
+});
+
+test("running init twice does not duplicate the exclude line", async () => {
+  const dir = initRepo();
+
+  await runInit(dir);
+  await runInit(dir, { force: true });
+
+  const excludePath = path.join(dir, ".git", "info", "exclude");
+  const lines = fs
+    .readFileSync(excludePath, "utf8")
+    .split("\n")
+    .filter((l) => l.trim() === ".backpass/");
+  assert.equal(lines.length, 1);
+});
+
+test("a non-git directory is handled gracefully: no error, no .gitignore created", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-init-nongit-"));
+
+  await assert.doesNotReject(() => runInit(dir));
+
+  assert.equal(fs.existsSync(path.join(dir, ".gitignore")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".git")), false);
+});
+
+test("a tracked .gitignore that already lists .backpass/ (from an older backpass) is left untouched", async () => {
+  const dir = initRepo();
+  fs.writeFileSync(path.join(dir, ".gitignore"), "node_modules/\n.backpass/\n");
+  const before = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+
+  await runInit(dir);
+
+  assert.equal(fs.readFileSync(path.join(dir, ".gitignore"), "utf8"), before, "the tracked file is never rewritten");
+  // The local exclude is still the source of truth going forward.
+  const excludePath = path.join(dir, ".git", "info", "exclude");
+  assert.match(fs.readFileSync(excludePath, "utf8"), /^\.backpass\/$/m);
+});

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -14,7 +14,10 @@ function git(args, cwd) {
 
 function initRepo() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-init-"));
-  git(["init", "-q"], dir);
+  git(["init", "-q", "-b", "main"], dir);
+  // CI runners have no global git identity - configure one locally so the commit below works.
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
   git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
   return dir;
 }

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { ensureLocalExclude } from "../src/repo.js";
+
+function git(args, cwd) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function tempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function initRepo() {
+  const dir = tempDir("backpass-repo-");
+  git(["init", "-q"], dir);
+  git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  return dir;
+}
+
+test("writes the line to .git/info/exclude, not a tracked .gitignore", () => {
+  const dir = initRepo();
+
+  const result = ensureLocalExclude(dir, ".backpass/");
+
+  assert.equal(result.status, "added");
+  const excludePath = path.join(dir, ".git", "info", "exclude");
+  assert.equal(result.path, excludePath);
+  assert.match(fs.readFileSync(excludePath, "utf8"), /^\.backpass\/$/m);
+  assert.equal(fs.existsSync(path.join(dir, ".gitignore")), false, "no tracked .gitignore is created");
+});
+
+test("is idempotent - a second call does not duplicate the line", () => {
+  const dir = initRepo();
+
+  ensureLocalExclude(dir, ".backpass/");
+  const second = ensureLocalExclude(dir, ".backpass/");
+
+  assert.equal(second.status, "present");
+  const excludePath = path.join(dir, ".git", "info", "exclude");
+  const lines = fs
+    .readFileSync(excludePath, "utf8")
+    .split("\n")
+    .filter((l) => l.trim() === ".backpass/");
+  assert.equal(lines.length, 1);
+});
+
+test("resolves the exclude path via `git rev-parse --git-path info/exclude` in a worktree", () => {
+  const dir = initRepo();
+  const worktree = tempDir("backpass-worktree-");
+  fs.rmdirSync(worktree); // `git worktree add` requires the target not to exist yet
+  git(["worktree", "add", "-q", worktree, "-b", "backpass-test-branch"], dir);
+
+  const result = ensureLocalExclude(worktree, ".backpass/");
+
+  assert.equal(result.status, "added");
+  // The worktree's own `.git` is a file, not a directory - the real exclude file
+  // lives in the *common* git dir, which only `--git-path` (not a hardcoded
+  // `<root>/.git/info/exclude`) resolves correctly.
+  assert.ok(fs.statSync(path.join(worktree, ".git")).isFile(), "worktree .git is a file");
+  assert.equal(fs.existsSync(path.join(worktree, ".git", "info", "exclude")), false);
+  const commonExclude = path.join(dir, ".git", "info", "exclude");
+  assert.equal(result.path, fs.realpathSync(commonExclude));
+  assert.match(fs.readFileSync(commonExclude, "utf8"), /^\.backpass\/$/m);
+});
+
+test("a non-git directory is skipped gracefully, without creating anything", () => {
+  const dir = tempDir("backpass-nongit-");
+
+  const result = ensureLocalExclude(dir, ".backpass/");
+
+  assert.equal(result.status, "no-git");
+  assert.equal(fs.existsSync(path.join(dir, ".git")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".gitignore")), false);
+});

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -17,7 +17,10 @@ function tempDir(prefix) {
 
 function initRepo() {
   const dir = tempDir("backpass-repo-");
-  git(["init", "-q"], dir);
+  git(["init", "-q", "-b", "main"], dir);
+  // CI runners have no global git identity - configure one locally so the commit below works.
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
   git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
   return dir;
 }


### PR DESCRIPTION
## Problem

`backpass init` appended `.backpass/` to the repo's **tracked** `.gitignore`,
modifying a file the user owns - it showed up in their diff and they had to
commit it just to keep backpass's per-clone state dir out of git.

## Fix

`init` now writes `.backpass/` to the repo's **local** git exclude
(`.git/info/exclude`) instead of touching any tracked file:

- The exclude path is resolved via `git rev-parse --git-path info/exclude`,
  never hardcoded as `<root>/.git/info/exclude` - this is required in a
  worktree or submodule, where `.git` is a file, not a directory, and the
  real exclude file lives in the shared common git dir.
- Idempotent: a second `init` never duplicates the line.
- A non-git directory is skipped gracefully with a one-line note - no error,
  no `.gitignore` created.
- A tracked `.gitignore` that already lists `.backpass/` from an older
  backpass version is left untouched (it's the user's file to remove), with
  a one-line note so they know it's now redundant.

Updated the CLI help, README, and the `src/state.js` header comment to
describe the local-exclude behavior accurately.

## Tests

Added `test/repo.test.js` (unit-level, covering `ensureLocalExclude`
directly, including a real `git worktree add` to prove the path resolution
works when `.git` is a file) and `test/init.test.js` (`cmdInit`-level,
covering the same scenarios end to end): writes to `.git/info/exclude` and
never touches `.gitignore`, idempotency, worktree path resolution via
`--git-path` rather than a hardcoded path, graceful non-git handling, and a
pre-existing tracked `.gitignore` entry left untouched.

`pnpm run check` (lint, format, typecheck, tests) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
