### PR TITLE
feat: ordered availability+auth agent selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,15 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   in `src/proposal.js` from the actual text; the synthesis model's own figures are ignored.
 - **acpx is alpha.** All model invocation is isolated behind `src/acpx.js` so an upstream
   CLI change has one blast radius. v1 uses plain `exec` and named sessions only; acpx flows
-  are deferred until they are stable upstream.
+  are deferred until they are stable upstream. The one sanctioned exception is the
+  per-harness native status table in `src/agents.js` (`claude auth status`, `opencode models`).
+- **Agent auto-pick is probe-then-verify, never probe-only.** `src/agents.js` walks each
+  role's ladder with a zero-token probe, but the claude adapter cannot be pre-verified by
+  acpx (sessions succeed while logged out), so every real call runs under
+  `AgentResolver.withFallthrough`, which demotes a candidate on a classifiable failure
+  (`classifyAcpxFailure`). Reasoning effort is a per-adapter session option
+  (`EFFORT_OPTION_KEYS`), so effortful calls always go through `sessionPrompt`. Verdicts
+  cache in `.backpass/agent-probe-cache.json`.
 - Cursor IDE support is deliberately deferred to v1.1 (`--include-cursor-ide`, best effort);
   see the header of `src/discovery/adapters/cursor-ide.js` for why.
 

--- a/README.md
+++ b/README.md
@@ -233,18 +233,38 @@ with `--theme dark|light` or `"theme"` in `.backpassrc.json`.
 
 ### Two-tier models
 
-Cheap analysis, smart synthesis. Both go through acpx, so you pick from the harnesses you
-already have.
+Cheap analysis, smart synthesis. Both go through acpx, so backpass uses the harnesses you
+already have - and by default it works out which ones those are. Each pass has an ordered
+ladder of candidates, and the first one that is installed, logged in, and serves the model
+wins:
+
+| pass      | effort | 1st                                    | 2nd                          | 3rd                               |
+| --------- | ------ | -------------------------------------- | ---------------------------- | --------------------------------- |
+| analysis  | medium | `gpt-5.6-luna` via pi, opencode, codex | `claude-sonnet-5` via claude | `grok-4.6` via pi, opencode, grok |
+| synthesis | high   | `gpt-5.6-sol` via pi, opencode, codex  | `claude-opus-5` via claude   | `grok-4.6` via pi, opencode, grok |
+
+Each candidate is checked with a ~1.5s zero-token acpx probe (claude via `claude auth status`,
+because its adapter accepts sessions while logged out); verdicts are cached in
+`.backpass/agent-probe-cache.json` for 12h (30min for negatives) and re-probed with `--force`.
+The probe is a filter, not a promise: if the chosen harness answers `AUTH_REQUIRED` or rejects
+the model mid-run, backpass falls through to the next candidate and says so. When a whole
+ladder is exhausted the error lists every candidate with what to run to fix it.
+
+Bare model ids are resolved against what each adapter advertises (`openai-codex/gpt-5.6-luna`
+on pi, `openai/gpt-5.6-luna` on opencode, `gpt-5.6-luna` on codex), so nothing is hardcoded
+per harness. Ladders are ordinary config - reorder or shorten them under `"ladders"`.
+
+Pinning an agent skips its ladder entirely:
 
 ```sh
 backpass \
-  --analysis-agent codex  --analysis-model gpt-5.2       --analysis-effort low \
+  --analysis-agent codex  --analysis-model gpt-5.5        --analysis-effort low \
   --synthesis-agent claude --synthesis-model claude-opus-5 --synthesis-effort high
 ```
 
-Model ids pass straight through to acpx - there is no hardcoded model list to go stale.
-If an adapter does not advertise reasoning effort, backpass says so in the run report
-rather than pretending it applied.
+`--no-auto-agent` pins the pre-ladder defaults (codex / claude). If an adapter does not
+advertise reasoning effort, backpass says so in the run report rather than pretending it
+applied.
 
 ### Configuration
 
@@ -258,8 +278,20 @@ CLI flags on top:
   "skillsDir": ".claude/skills",
   "maxEditsPerRun": 5,
   "minGapEvidence": 2,
-  "analysis": { "agent": "codex", "model": "gpt-5.2", "effort": "low" },
-  "synthesis": { "agent": "claude", "model": "claude-opus-5", "effort": "high" },
+  "analysis": { "agent": null, "model": null, "effort": null },
+  "synthesis": { "agent": null, "model": null, "effort": null },
+  "ladders": {
+    "analysis": [
+      { "model": "gpt-5.6-luna", "agents": ["pi", "opencode", "codex"] },
+      { "model": "claude-sonnet-5", "agents": ["claude"] },
+      { "model": "grok-4.6", "agents": ["pi", "opencode", "grok"] }
+    ],
+    "synthesis": [
+      { "model": "gpt-5.6-sol", "agents": ["pi", "opencode", "codex"] },
+      { "model": "claude-opus-5", "agents": ["claude"] },
+      { "model": "grok-4.6", "agents": ["pi", "opencode", "grok"] }
+    ]
+  },
   "discovery": {
     "harnesses": ["claude", "codex", "pi", "opencode", "grok", "cursor"],
     "since": "30d",
@@ -281,6 +313,7 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence/<id>.json     per-transcript analysis
   evidence-summary.json  folded evidence
   proposal.json          the latest synthesis
+  agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them
   apply/apply.html       the rendered review surface
 ```

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -1,6 +1,5 @@
-import { spawn } from "node:child_process";
-
 import { warn } from "./logger.js";
+import { runCapture } from "./subprocess.js";
 
 /**
  * The acpx execution layer (design section 4).
@@ -16,13 +15,40 @@ import { warn } from "./logger.js";
 
 export const ACPX_BIN = process.env.BACKPASS_ACPX_BIN || "acpx";
 
+/**
+ * backpass's user-facing harness names versus acpx's agent registry. The only
+ * mismatch today is grok: backpass calls the harness `grok` everywhere (config,
+ * discovery, --harness) while acpx registers it as `grok-build`. Translate at this
+ * boundary only, so the user never has to know.
+ */
+const ACPX_AGENT_NAMES = { grok: "grok-build" };
+
+export function acpxAgentName(agent) {
+  return ACPX_AGENT_NAMES[agent] || agent;
+}
+
+/**
+ * The session config-option id each adapter uses for reasoning effort. There is no
+ * shared ACP name for it and `acpx status` does not expose config options, so this
+ * small table is measured (see the ordered-defaults design report) rather than
+ * derived. Adapters absent here (grok, opencode) advertise no effort option at all;
+ * effort is then skipped with a report note, never silently.
+ */
+export const EFFORT_OPTION_KEYS = { codex: "reasoning_effort", claude: "effort", pi: "thought_level" };
+
+export function effortOptionKey(agent) {
+  return EFFORT_OPTION_KEYS[agent] || null;
+}
+
 export class AcpxError extends Error {
-  constructor(message, { stdout = "", stderr = "", code = null } = {}) {
+  constructor(message, { stdout = "", stderr = "", code = null, timedOut = false, spawnError = null } = {}) {
     super(message);
     this.name = "AcpxError";
     this.stdout = stdout;
     this.stderr = stderr;
     this.code = code;
+    this.timedOut = timedOut;
+    this.spawnError = spawnError;
   }
 }
 
@@ -30,39 +56,36 @@ export class AcpxError extends Error {
  * @param {string[]} args
  * @param {{ timeoutMs?: number, cwd?: string, input?: string }} [options]
  */
-function run(args, { timeoutMs, cwd, input } = {}) {
-  return new Promise((resolve) => {
-    const child = spawn(ACPX_BIN, args, { cwd, stdio: ["pipe", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
+function run(args, options = {}) {
+  return runCapture(ACPX_BIN, args, options);
+}
 
-    const timer = timeoutMs
-      ? setTimeout(() => {
-          timedOut = true;
-          child.kill("SIGTERM");
-          setTimeout(() => child.kill("SIGKILL"), 5000).unref();
-        }, timeoutMs)
-      : null;
+function notFoundError(result) {
+  return new AcpxError(`acpx not found on PATH (looked for "${ACPX_BIN}")`, result);
+}
 
-    child.stdout.on("data", (d) => {
-      stdout += d;
-    });
-    child.stderr.on("data", (d) => {
-      stderr += d;
-    });
-    child.on("error", (err) => {
-      if (timer) clearTimeout(timer);
-      resolve({ code: null, stdout, stderr: `${stderr}${err.message}`, spawnError: err });
-    });
-    child.on("close", (code) => {
-      if (timer) clearTimeout(timer);
-      resolve({ code, stdout, stderr, timedOut });
-    });
-
-    if (input !== undefined) child.stdin.end(input);
-    else child.stdin.end();
-  });
+/**
+ * Availability verdicts for a failed acpx call. Only a *classifiable* failure is a
+ * reason to drop a candidate and fall through to the next one; anything else (a
+ * timeout on a long prompt, garbage output) stays a plain error so a run never
+ * silently switches models after real work has started.
+ *
+ * acpx reports these on stderr as `[acpx] error: RUNTIME AUTH_REQUIRED ...` and
+ * `Cannot apply --model "x": the ACP agent did not advertise that model`.
+ *
+ * @param {{ stderr?: string, spawnError?: { code?: string } | null, timedOut?: boolean }} failure
+ * @returns {"unauthenticated" | "model-unavailable" | "unreachable" | null}
+ */
+export function classifyAcpxFailure(failure) {
+  if (!failure) return null;
+  if (failure.spawnError?.code === "ENOENT") return "unreachable";
+  const text = failure.stderr || "";
+  if (/AUTH_REQUIRED|authentication required/i.test(text)) return "unauthenticated";
+  if (/did not advertise that model/i.test(text)) return "model-unavailable";
+  if (/\b(ENOENT|command not found|not found on PATH|failed to spawn|spawn .* ENOENT)\b/i.test(text)) {
+    return "unreachable";
+  }
+  return null;
 }
 
 /** acpx prints a per-run accounting line: `[acpx] tokens: input=10 output=47 ... total=34194`. */
@@ -130,6 +153,57 @@ function baseArgs({ cwd, model, timeoutSeconds, approveReads, suppressReads }) {
   return args;
 }
 
+/** `acpx --version`, used to key the probe cache. Null when acpx is missing. */
+export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
+  const result = await run(["--version"], { timeoutMs });
+  if (result.code !== 0) return null;
+  const line = firstLine(result.stdout);
+  return line || null;
+}
+
+/**
+ * Zero-token availability probe: spawn the adapter, handshake, create a session,
+ * read what it advertises, close it. For codex / pi / grok, `sessions new` is a
+ * real auth gate (ACP -32000); for claude it is not, which is why `src/agents.js`
+ * checks `claude auth status` before ever calling this.
+ *
+ * @returns {Promise<{ verdict: "ok" | "unauthenticated" | "model-unavailable" | "unreachable" | "timeout",
+ *   detail: string, availableModels: string[] }>}
+ */
+export async function probeSession({ agent, sessionName, cwd = undefined, timeoutMs = 20_000 }) {
+  const acpxAgent = acpxAgentName(agent);
+  const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs, cwd });
+  if (created.spawnError?.code === "ENOENT") throw notFoundError(created);
+  if (created.timedOut) {
+    return {
+      verdict: "timeout",
+      detail: `probe timed out after ${Math.round(timeoutMs / 1000)}s`,
+      availableModels: [],
+    };
+  }
+  if (created.code !== 0) {
+    const verdict = classifyAcpxFailure(created) || "unreachable";
+    return { verdict, detail: firstLine(created.stderr) || `exit ${created.code}`, availableModels: [] };
+  }
+
+  try {
+    const status = await run(["--format", "json", acpxAgent, "status", "-s", sessionName], { timeoutMs, cwd });
+    let availableModels = [];
+    if (status.code === 0) {
+      try {
+        const parsed = JSON.parse(status.stdout.trim().split("\n").at(-1) || "{}");
+        if (Array.isArray(parsed.availableModels)) availableModels = parsed.availableModels.map(String);
+      } catch {
+        // Leave the list empty; the caller decides whether it needs one.
+      }
+    }
+    return { verdict: "ok", detail: "", availableModels };
+  } finally {
+    const closed = await run([acpxAgent, "sessions", "close", sessionName], { timeoutMs, cwd });
+    if (closed.code !== 0) warn(`could not close acpx probe session ${sessionName}`);
+  }
+}
+
 /**
  * Tier 1 - one-shot analysis call (design section 5).
  *
@@ -150,16 +224,14 @@ export async function execOneShot({
     ...baseArgs({ cwd, model, timeoutSeconds, approveReads, suppressReads }),
     "--prompt-retries",
     String(promptRetries),
-    agent,
+    acpxAgentName(agent),
     "exec",
     "--file",
     promptFile,
   ];
 
   const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd });
-  if (result.spawnError && result.spawnError.code === "ENOENT") {
-    throw new AcpxError(`acpx not found on PATH (looked for "${ACPX_BIN}")`, { stderr: result.stderr });
-  }
+  if (result.spawnError && result.spawnError.code === "ENOENT") throw notFoundError(result);
   if (result.timedOut) {
     throw new AcpxError(`acpx ${agent} exec timed out after ${timeoutSeconds}s`, result);
   }
@@ -172,11 +244,13 @@ export async function execOneShot({
 }
 
 /**
- * Tier 2 - synthesis through a named session (design section 5).
+ * A prompt through a short-lived named session (design section 5).
  *
- * acpx documents both `set model` and `set reasoning_effort` on sessions, so the big
- * high-reasoning pass runs there. Adapters that do not advertise a reasoning-effort
- * config option skip that step with a report line - never silently.
+ * Reasoning effort is a session config option on every adapter that has one, and
+ * `exec` cannot set it - so any call that wants effort applied goes through here:
+ * the synthesis pass always, and the analysis pass whenever an effort is configured.
+ * Adapters that do not advertise an effort option skip that step with a report line -
+ * never silently.
  */
 export async function sessionPrompt({
   agent,
@@ -186,23 +260,29 @@ export async function sessionPrompt({
   promptFile,
   cwd,
   timeoutSeconds = 900,
+  promptRetries = 1,
   approveReads = true,
   suppressReads = true,
 }) {
   const notes = [];
-  const created = await run([agent, "sessions", "new", "--name", sessionName], { timeoutMs: 60_000, cwd });
-  if (created.spawnError && created.spawnError.code === "ENOENT") {
-    throw new AcpxError(`acpx not found on PATH (looked for "${ACPX_BIN}")`, created);
-  }
+  const acpxAgent = acpxAgentName(agent);
+  const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs: 60_000, cwd });
+  if (created.spawnError && created.spawnError.code === "ENOENT") throw notFoundError(created);
   if (created.code !== 0) {
+    // An auth or spawn failure must surface as such so the caller can fall through.
+    if (classifyAcpxFailure(created)) {
+      throw new AcpxError(`acpx ${agent} session create failed: ${firstLine(created.stderr)}`, created);
+    }
     // No session support for this adapter: fall back to a one-shot, and say so.
     notes.push(`session unsupported for ${agent}; fell back to exec one-shot`);
+    if (effort) notes.push(`${agent} cannot set effort without a session; ran without effort=${effort}`);
     const fallback = await execOneShot({
       agent,
       model,
       promptFile,
       cwd,
       timeoutSeconds,
+      promptRetries,
       approveReads,
       suppressReads,
     });
@@ -211,22 +291,29 @@ export async function sessionPrompt({
 
   try {
     if (model) {
-      const set = await run([agent, "-s", sessionName, "set", "model", model], { timeoutMs: 60_000, cwd });
-      if (set.code !== 0) notes.push(`could not set model=${model} on ${agent}: ${firstLine(set.stderr)}`);
+      const set = await run([acpxAgent, "-s", sessionName, "set", "model", model], { timeoutMs: 60_000, cwd });
+      if (set.code !== 0) {
+        if (classifyAcpxFailure(set) === "model-unavailable") {
+          throw new AcpxError(`acpx ${agent} rejected model ${model}: ${firstLine(set.stderr)}`, set);
+        }
+        notes.push(`could not set model=${model} on ${agent}: ${firstLine(set.stderr)}`);
+      }
     }
     if (effort) {
-      const set = await run([agent, "-s", sessionName, "set", "reasoning_effort", effort], {
-        timeoutMs: 60_000,
-        cwd,
-      });
-      if (set.code !== 0) {
-        notes.push(`${agent} does not advertise reasoning_effort; ran without effort=${effort}`);
+      const key = effortOptionKey(agent);
+      const set = key
+        ? await run([acpxAgent, "-s", sessionName, "set", key, effort], { timeoutMs: 60_000, cwd })
+        : null;
+      if (!set || set.code !== 0) {
+        notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${effort}`);
       }
     }
 
     const args = [
       ...baseArgs({ cwd, model: null, timeoutSeconds, approveReads, suppressReads }),
-      agent,
+      "--prompt-retries",
+      String(promptRetries),
+      acpxAgent,
       "-s",
       sessionName,
       "--file",
@@ -239,7 +326,7 @@ export async function sessionPrompt({
     const combined = `${result.stdout}\n${result.stderr}`;
     return { text: stripAcpxNoise(result.stdout), usage: parseTokenLine(combined), raw: result.stdout, notes };
   } finally {
-    const closed = await run([agent, "sessions", "close", sessionName], { timeoutMs: 30_000, cwd });
+    const closed = await run([acpxAgent, "sessions", "close", sessionName], { timeoutMs: 30_000, cwd });
     if (closed.code !== 0) warn(`could not close acpx session ${sessionName}`);
   }
 }

--- a/src/agents.js
+++ b/src/agents.js
@@ -1,0 +1,389 @@
+import { UserError, color, info, warn } from "./logger.js";
+import { DEFAULT_EFFORT, LEGACY_DEFAULT_AGENTS } from "./config.js";
+import { AcpxError, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
+import { runCapture } from "./subprocess.js";
+
+/**
+ * Ordered agent selection (the ordered-defaults design, section 8).
+ *
+ * Each role (analysis, synthesis) has a ladder of candidates - a model id served by a
+ * few harnesses, in preference order. This module walks the ladder and picks the first
+ * candidate that is installed, authenticated, and serves the model, using a ~1.5s
+ * zero-token probe per candidate. The probe is a *filter*, not a guarantee: the first
+ * real call is the decider, and a classifiable failure there (AUTH_REQUIRED, model
+ * rejected, adapter missing) demotes the candidate and falls through to the next one.
+ *
+ * All model invocation still goes through `src/acpx.js`. The one documented exception
+ * is `NATIVE_PROBES` below: the claude adapter creates sessions happily while logged
+ * out and only fails at prompt time, so its login state has to come from the harness's
+ * own `claude auth status`. opencode's ACP session has been seen to wedge for minutes
+ * on a large profile, so `opencode models` answers first and the ACP probe is capped.
+ *
+ * Verdicts are cached in `.backpass/agent-probe-cache.json` (12h for ok, 30min for
+ * negatives, invalidated on an acpx version change) and memoized for the run.
+ */
+
+const OK_TTL_MS = 12 * 60 * 60 * 1000;
+const NEGATIVE_TTL_MS = 30 * 60 * 1000;
+const NATIVE_TIMEOUT_MS = 5_000;
+const PROBE_TIMEOUT_MS = 20_000;
+const PROBE_TIMEOUT_BY_AGENT = { opencode: 10_000 };
+
+/** Adapters whose model list is open-ended: any id is forwarded, none can be verified. */
+const TRUSTING_MODEL_AGENTS = new Set(["claude"]);
+
+export const VERDICT_LABELS = {
+  ok: "ok",
+  unauthenticated: "not logged in",
+  "model-unavailable": "model not advertised",
+  unreachable: "not installed / not spawnable",
+  timeout: "probe timed out",
+};
+
+const LOGIN_HINTS = {
+  codex: "codex login",
+  claude: "claude auth login",
+  grok: "grok login",
+  opencode: "opencode auth login",
+  pi: "pi login",
+};
+
+/**
+ * Per-harness native status commands. Each returns a verdict or null (inconclusive, so
+ * the acpx probe decides). See the module header for why this table exists at all.
+ */
+const NATIVE_PROBES = {
+  async claude({ model }) {
+    const result = await runCapture("claude", ["auth", "status"], { timeoutMs: NATIVE_TIMEOUT_MS });
+    if (result.spawnError?.code === "ENOENT") {
+      return { verdict: "unreachable", detail: "claude CLI not found on PATH", resolvedModel: model };
+    }
+    let parsed = null;
+    try {
+      parsed = JSON.parse(result.stdout.trim());
+    } catch {
+      // Not the JSON we expect; let the acpx probe have a look.
+    }
+    if (parsed && typeof parsed.loggedIn === "boolean") {
+      if (!parsed.loggedIn) return { verdict: "unauthenticated", detail: "claude auth status: loggedIn=false" };
+      return null;
+    }
+    if (result.code !== 0) {
+      return { verdict: "unreachable", detail: firstLine(result.stderr) || `claude auth status exit ${result.code}` };
+    }
+    return null;
+  },
+  async opencode({ model }) {
+    const result = await runCapture("opencode", ["models"], { timeoutMs: NATIVE_TIMEOUT_MS });
+    if (result.spawnError?.code === "ENOENT") {
+      return { verdict: "unreachable", detail: "opencode CLI not found on PATH" };
+    }
+    if (result.timedOut || result.code !== 0) return null;
+    const advertised = result.stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const resolved = resolveModelId(model, advertised);
+    if (!resolved.id) {
+      return {
+        verdict: "model-unavailable",
+        detail: resolved.ambiguous
+          ? `ambiguous in \`opencode models\`: ${resolved.ambiguous.join(", ")}`
+          : "absent from `opencode models` (provider not logged in?)",
+      };
+    }
+    return null;
+  },
+};
+
+function firstLine(text) {
+  return (text || "").split("\n").find((l) => l.trim()) || "";
+}
+
+/**
+ * Match a bare model id against what an adapter advertises (design section 4.1):
+ * exact, then a unique last-`/`-segment match (`openai-codex/x`, `xai/x`), then a
+ * unique `x[...]` variant. Segment *equality* is deliberate: `gpt-5.6-luna-fast`
+ * must not satisfy `gpt-5.6-luna`. More than one survivor is a non-match, reported.
+ *
+ * @returns {{ id: string | null, ambiguous?: string[] }}
+ */
+export function resolveModelId(bareId, advertised) {
+  if (advertised.includes(bareId)) return { id: bareId };
+  const bySegment = advertised.filter((id) => id.split("/").at(-1) === bareId);
+  if (bySegment.length === 1) return { id: bySegment[0] };
+  if (bySegment.length > 1) return { id: null, ambiguous: bySegment };
+  const byVariant = advertised.filter((id) => id.startsWith(`${bareId}[`));
+  if (byVariant.length === 1) return { id: byVariant[0] };
+  if (byVariant.length > 1) return { id: null, ambiguous: byVariant };
+  return { id: null };
+}
+
+/** Flatten a ladder model-outer / harness-inner into `{ model, agent }` candidates. */
+export function flattenLadder(ladder) {
+  return ladder.flatMap((rung) => rung.agents.map((agent) => ({ model: rung.model, agent })));
+}
+
+export function candidateKey({ agent, model }) {
+  return `${agent}|${model}`;
+}
+
+/**
+ * Probe one candidate end to end: native status command first (when one exists),
+ * then the zero-token acpx session probe, then model-id resolution.
+ *
+ * @param {{ agent: string, model: string }} candidate
+ * @param {{ cwd?: string, sessionName?: string,
+ *   probeSession?: (args: { agent: string, sessionName: string, cwd?: string, timeoutMs?: number }) =>
+ *     Promise<{ verdict: string, detail: string, availableModels?: string[] }> }} [options]
+ * @returns {Promise<{ verdict: string, detail: string, resolvedModel: string | null }>}
+ */
+export async function probeCandidate(candidate, options = {}) {
+  const { cwd, sessionName, probeSession: probe = probeSession } = options;
+  const { agent, model } = candidate;
+  const native = NATIVE_PROBES[agent];
+  if (native) {
+    const early = await native(candidate);
+    if (early) return { resolvedModel: null, ...early };
+  }
+
+  const result = await probe({
+    agent,
+    sessionName,
+    cwd,
+    timeoutMs: PROBE_TIMEOUT_BY_AGENT[agent] || PROBE_TIMEOUT_MS,
+  });
+  if (result.verdict !== "ok") return { verdict: result.verdict, detail: result.detail, resolvedModel: null };
+
+  if (TRUSTING_MODEL_AGENTS.has(agent)) {
+    return { verdict: "ok", detail: "model accepted on faith; the first real call verifies it", resolvedModel: model };
+  }
+  const resolved = resolveModelId(model, result.availableModels || []);
+  if (!resolved.id) {
+    const detail = resolved.ambiguous
+      ? `ambiguous among advertised ids: ${resolved.ambiguous.join(", ")}`
+      : result.availableModels?.length
+        ? `not among ${result.availableModels.length} advertised model(s)`
+        : "adapter advertised no models";
+    return { verdict: "model-unavailable", detail, resolvedModel: null };
+  }
+  return { verdict: "ok", detail: "", resolvedModel: resolved.id };
+}
+
+/**
+ * A cache entry is fresh when it is within its TTL and was recorded against the same
+ * acpx version. Negatives expire fast: "I just logged in" is the common repair.
+ */
+export function isProbeEntryFresh(entry, { now = Date.now() } = {}) {
+  if (!entry || !entry.checkedAt) return false;
+  const age = now - Date.parse(entry.checkedAt);
+  if (!Number.isFinite(age) || age < 0) return false;
+  return age < (entry.verdict === "ok" ? OK_TTL_MS : NEGATIVE_TTL_MS);
+}
+
+function hintFor(agent, verdict) {
+  if (verdict === "unauthenticated" && LOGIN_HINTS[agent]) return `-> run: ${LOGIN_HINTS[agent]}`;
+  if (verdict === "unreachable") return `-> install the ${agent} CLI`;
+  return "";
+}
+
+/**
+ * Resolves the agent for each role once per run and owns the fall-through state.
+ *
+ * `resolve(role)` returns `{ agent, model, effort, pinned, reason }`. The analysis and
+ * synthesis stages call it lazily, so read-only commands (`scan`, `status`) never probe.
+ * `demote(role, pick, verdict)` records a mid-run classifiable failure; the next
+ * `resolve(role)` walks on from the following candidate.
+ */
+export class AgentResolver {
+  /**
+   * @param {object} config
+   * @param {{ state?: { readProbeCache: Function, writeProbeCache: Function }, cwd?: string,
+   *   bypassCache?: boolean, probeCandidate?: Function, acpxVersion?: Function, now?: () => number }} [deps]
+   */
+  constructor(config, deps = {}) {
+    this.config = config;
+    this.state = deps.state || null;
+    this.cwd = deps.cwd;
+    this.bypassCache = Boolean(deps.bypassCache);
+    this.probeCandidate = deps.probeCandidate || probeCandidate;
+    this.acpxVersion = deps.acpxVersion || acpxVersion;
+    this.now = deps.now || (() => Date.now());
+    /** In-process memo for the run: key -> { verdict, detail, resolvedModel, checkedAt }. */
+    this.memo = new Map();
+    /** Probes in flight, so parallel analysis workers never double-probe a candidate. */
+    this.inflight = new Map();
+    this.picks = {};
+    this.cache = null;
+    this.version = undefined;
+    this.probeCount = 0;
+  }
+
+  async loadCache() {
+    if (this.cache) return this.cache;
+    if (this.version === undefined) this.version = await this.acpxVersion();
+    const stored = this.state ? this.state.readProbeCache() : { version: 1, acpxVersion: null, entries: {} };
+    if (stored.acpxVersion !== this.version) stored.entries = {};
+    stored.acpxVersion = this.version;
+    this.cache = stored;
+    return stored;
+  }
+
+  saveCache() {
+    if (this.state && this.cache) this.state.writeProbeCache(this.cache);
+  }
+
+  async verdictFor(candidate) {
+    const key = candidateKey(candidate);
+    if (this.memo.has(key)) return this.memo.get(key);
+    if (this.inflight.has(key)) return this.inflight.get(key);
+    const pending = this.probeAndRecord(candidate, key).finally(() => this.inflight.delete(key));
+    this.inflight.set(key, pending);
+    return pending;
+  }
+
+  async probeAndRecord(candidate, key) {
+    const cache = await this.loadCache();
+    const cached = cache.entries[key];
+    if (!this.bypassCache && isProbeEntryFresh(cached, { now: this.now() })) {
+      this.memo.set(key, { ...cached, cached: true });
+      return this.memo.get(key);
+    }
+
+    this.probeCount += 1;
+    const sessionName = `backpass-probe-${process.pid}-${this.probeCount}`;
+    const result = await this.probeCandidate(candidate, { cwd: this.cwd, sessionName });
+    const entry = {
+      verdict: result.verdict,
+      detail: result.detail || "",
+      resolvedModel: result.resolvedModel || null,
+      checkedAt: new Date(this.now()).toISOString(),
+    };
+    cache.entries[key] = entry;
+    this.memo.set(key, entry);
+    this.saveCache();
+    return entry;
+  }
+
+  /** The candidates for a role, in order, as `{ agent, model }`. */
+  ladder(role) {
+    return flattenLadder(this.config.ladders[role]);
+  }
+
+  pinned(role) {
+    const explicit = this.config[role];
+    if (explicit.agent) {
+      return { agent: explicit.agent, model: explicit.model || null, pinned: true, reason: "configured" };
+    }
+    if (this.config.autoAgent === false) {
+      return { agent: LEGACY_DEFAULT_AGENTS[role], model: null, pinned: true, reason: "--no-auto-agent" };
+    }
+    return null;
+  }
+
+  /**
+   * @param {"analysis" | "synthesis"} role
+   * @returns {Promise<{ agent: string, model: string | null, ladderModel?: string, effort: string | null, pinned: boolean, reason: string }>}
+   */
+  async resolve(role) {
+    if (this.picks[role]) return this.picks[role];
+    const effort = this.config[role].effort || DEFAULT_EFFORT[role];
+
+    const pinned = this.pinned(role);
+    if (pinned) {
+      this.picks[role] = { ...pinned, effort };
+      return this.picks[role];
+    }
+
+    const trail = [];
+    for (const candidate of this.ladder(role)) {
+      let entry;
+      try {
+        entry = await this.verdictFor(candidate);
+      } catch (err) {
+        // acpx itself is missing: one clean error, not one per candidate.
+        if (err instanceof AcpxError) throw new UserError(err.message, "install acpx (npm i -g acpx) and retry");
+        throw err;
+      }
+      trail.push({ ...candidate, ...entry });
+      if (entry.verdict === "ok") {
+        this.picks[role] = {
+          agent: candidate.agent,
+          model: entry.resolvedModel || candidate.model,
+          ladderModel: candidate.model,
+          effort,
+          pinned: false,
+          reason: describeTrail(trail),
+        };
+        this.announce(role, this.picks[role], trail);
+        return this.picks[role];
+      }
+    }
+    throw exhaustedError(role, trail);
+  }
+
+  announce(role, pick, trail) {
+    const losers = trail.filter((t) => t.verdict !== "ok");
+    const cached = trail.at(-1)?.cached ? color.dim(" (cached)") : "";
+    info(`${color.cyan("·")} ${role}: ${pick.agent} (${pick.model}) effort=${pick.effort}${cached}`);
+    for (const t of losers) {
+      info(color.dim(`    skipped ${t.agent}/${t.model}: ${VERDICT_LABELS[t.verdict] || t.verdict}`));
+    }
+  }
+
+  /**
+   * Record a classifiable mid-run failure for the chosen candidate. Returns true when
+   * there is something to fall through to (the next `resolve(role)` walks on), false
+   * when the pick was pinned by the user - then the error is theirs to see.
+   */
+  async demote(role, pick, verdict, detail = "") {
+    if (pick.pinned) return false;
+    const key = candidateKey({ agent: pick.agent, model: pick.ladderModel });
+    if (this.memo.get(key)?.verdict === "ok") {
+      // First worker to see the failure records it; the rest just re-resolve.
+      const entry = { verdict, detail, resolvedModel: null, checkedAt: new Date(this.now()).toISOString() };
+      this.memo.set(key, entry);
+      const cache = await this.loadCache();
+      cache.entries[key] = entry;
+      this.saveCache();
+      warn(`${role}: ${pick.agent} (${pick.model}) ${VERDICT_LABELS[verdict] || verdict} mid-run; falling through`);
+    }
+    if (this.picks[role] === pick) delete this.picks[role];
+    return true;
+  }
+
+  /**
+   * Run `fn(pick)` for a role, falling through the ladder on classifiable failures.
+   * Unclassifiable errors (a timeout on real work, garbage output) propagate unchanged.
+   */
+  async withFallthrough(role, fn) {
+    for (;;) {
+      const pick = await this.resolve(role);
+      try {
+        return await fn(pick);
+      } catch (err) {
+        const verdict = err instanceof AcpxError ? classifyAcpxFailure(err) : null;
+        if (!verdict || !(await this.demote(role, pick, verdict, err.message))) throw err;
+      }
+    }
+  }
+}
+
+function describeTrail(trail) {
+  const losers = trail.filter((t) => t.verdict !== "ok");
+  if (!losers.length) return "first candidate in the ladder";
+  return `after skipping ${losers.map((t) => `${t.agent}/${t.model} (${VERDICT_LABELS[t.verdict] || t.verdict})`).join(", ")}`;
+}
+
+function exhaustedError(role, trail) {
+  const width = Math.max(...trail.map((t) => t.model.length));
+  const lines = trail.map((t) => {
+    const label = VERDICT_LABELS[t.verdict] || t.verdict;
+    const hint = hintFor(t.agent, t.verdict);
+    return `  ${t.model.padEnd(width)}  ${t.agent.padEnd(9)} ${label}${t.detail ? ` (${t.detail})` : ""}${hint ? `  ${hint}` : ""}`;
+  });
+  return new UserError(
+    `no available agent for the ${role} pass\n\n${lines.join("\n")}`,
+    `log in to one of the harnesses above, or pin one explicitly: backpass --${role}-agent <agent> --${role}-model <id>`,
+  );
+}

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { execOneShot, extractJson } from "./acpx.js";
+import { execOneShot, extractJson, sessionPrompt } from "./acpx.js";
 import { distill } from "./distill.js";
 import { readTranscript } from "./discovery/index.js";
 import { renderInstructionIndex } from "./memory.js";
@@ -21,6 +21,16 @@ import { color, info, warn } from "./logger.js";
 
 const MIN_ASSISTANT_TURNS = 4;
 const MIN_TOOL_CALLS = 3;
+
+let callCounter = 0;
+const seenNotes = new Set();
+
+/** The same adapter limitation would repeat once per transcript; say it once per run. */
+function noteOnce(note) {
+  if (seenNotes.has(note)) return;
+  seenNotes.add(note);
+  warn(note);
+}
 
 /** Evidence items without a verbatim quote are dropped - the rubric's central rule. */
 export function sanitizeEvidence(parsed) {
@@ -99,14 +109,26 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
   fs.mkdirSync(path.dirname(promptFile), { recursive: true });
   fs.writeFileSync(promptFile, prompt);
 
-  const result = await execOneShot({
-    agent: config.analysis.agent,
-    model: config.analysis.model,
-    promptFile,
-    cwd: repo.root,
-    timeoutSeconds: config.timeoutSeconds,
-    promptRetries: config.promptRetries,
+  const result = await config.agents.withFallthrough("analysis", async (pick) => {
+    const call = {
+      agent: pick.agent,
+      model: pick.model,
+      promptFile,
+      cwd: repo.root,
+      timeoutSeconds: config.timeoutSeconds,
+      promptRetries: config.promptRetries,
+    };
+    // Effort is a session config option, so an effortful analysis call needs a
+    // (fresh, per-transcript) session; without effort the plain one-shot is cheaper.
+    if (!pick.effort) return execOneShot(call);
+    callCounter += 1;
+    return sessionPrompt({
+      ...call,
+      effort: pick.effort,
+      sessionName: `backpass-analysis-${process.pid}-${slot}-${callCounter}`,
+    });
   });
+  for (const note of result.notes || []) noteOnce(note);
 
   const parsed = extractJson(result.text);
   if (!parsed) {
@@ -155,23 +177,26 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
     pending.push(transcript);
   }
 
+  if (!pending.length) {
+    emitProgress("analyze:start", { pending: 0, cached: summary.cached, total: transcripts.length, jobs: config.jobs });
+    emitProgress("analyze:done", summary);
+    return summary;
+  }
+
+  // Resolve (and, on the first run, probe) before the fan-out so the pick is announced once.
+  const pick = await config.agents.resolve("analysis");
   emitProgress("analyze:start", {
     pending: pending.length,
     cached: summary.cached,
     total: transcripts.length,
     jobs: config.jobs,
-    agent: config.analysis.agent,
-    model: config.analysis.model,
+    agent: pick.agent,
+    model: pick.model,
   });
 
-  if (!pending.length) {
-    emitProgress("analyze:done", summary);
-    return summary;
-  }
-
   info(
-    `${color.cyan("·")} analyzing ${pending.length} transcript(s) with ${config.analysis.agent}` +
-      `${config.analysis.model ? ` (${config.analysis.model})` : ""} at jobs=${config.jobs}`,
+    `${color.cyan("·")} analyzing ${pending.length} transcript(s) with ${pick.agent}` +
+      `${pick.model ? ` (${pick.model})` : ""}${pick.effort ? ` effort=${pick.effort}` : ""} at jobs=${config.jobs}`,
   );
 
   let done = 0;

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ import { UserError, fail, setQuiet } from "./logger.js";
 import { loadConfig } from "./config.js";
 import { resolveRepo } from "./repo.js";
 import { State } from "./state.js";
+import { AgentResolver } from "./agents.js";
 
 import { cmdInit } from "./commands/init.js";
 import { cmdScan } from "./commands/scan.js";
@@ -50,6 +51,7 @@ const OPTIONS = {
 
   "dry-run": { type: "boolean" },
   "no-ui": { type: "boolean" },
+  "no-auto-agent": { type: "boolean" },
   force: { type: "boolean" },
   limit: { type: "string" },
   theme: { type: "string" },
@@ -82,12 +84,18 @@ DISCOVERY
   --limit <n>              analyze at most N transcripts this run
 
 MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
-  --analysis-agent <a>     acpx agent for the per-transcript pass       [codex]
-  --analysis-model <id>    model id for the analysis pass
-  --analysis-effort <e>    reasoning effort, when the adapter advertises it
-  --synthesis-agent <a>    acpx agent for the final proposal pass       [claude]
-  --synthesis-model <id>   model id for the synthesis pass
+  By default each pass auto-picks the first harness in its ladder that is installed,
+  logged in, and serves the model (a ~1.5s zero-token probe per candidate, cached):
+    analysis   gpt-5.6-luna via pi, opencode, codex  >  claude-sonnet-5 via claude  >  grok-4.6 via pi, opencode, grok
+    synthesis  gpt-5.6-sol  via pi, opencode, codex  >  claude-opus-5  via claude  >  grok-4.6 via pi, opencode, grok
+  Setting an agent pins that pass and skips its ladder.
+  --analysis-agent <a>     acpx agent for the per-transcript pass       [auto]
+  --analysis-model <id>    model id for the analysis pass (needs --analysis-agent)
+  --analysis-effort <e>    reasoning effort, when the adapter advertises it  [medium]
+  --synthesis-agent <a>    acpx agent for the final proposal pass       [auto]
+  --synthesis-model <id>   model id for the synthesis pass (needs --synthesis-agent)
   --synthesis-effort <e>   reasoning effort for synthesis               [high]
+  --no-auto-agent          skip the ladders and pin codex / claude (the pre-0.2 defaults)
   --jobs <n>               parallel analysis calls                      [4]
 
 BUDGET AND SHAPE
@@ -100,7 +108,8 @@ BUDGET AND SHAPE
 APPLY
   --no-ui                  terminal accept/reject instead of the Lavish surface
   --dry-run                show what would be written, write nothing
-  --force                  re-analyze transcripts that already have fresh evidence
+  --force                  re-analyze transcripts that already have fresh evidence,
+                           and re-probe agents instead of trusting the probe cache
 
 OTHER
   --theme <mode>           live progress ink set: auto, dark, or light    [auto]
@@ -116,7 +125,7 @@ or below 60 columns - stdout and --json output are identical either way.
 EXAMPLES
   backpass                                  a full run, ending with a proposal
   backpass scan --since 7d --strict         what would be analyzed, deterministic only
-  backpass --analysis-model gpt-5.2 --synthesis-model claude-opus-5
+  backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
 `;
 
@@ -148,6 +157,7 @@ function overridesFrom(values) {
   if (values["synthesis-agent"]) overrides.synthesis.agent = values["synthesis-agent"];
   if (values["synthesis-model"]) overrides.synthesis.model = values["synthesis-model"];
   if (values["synthesis-effort"]) overrides.synthesis.effort = values["synthesis-effort"];
+  if (values["no-auto-agent"]) overrides.autoAgent = false;
 
   for (const key of ["discovery", "analysis", "synthesis"]) {
     if (!Object.keys(overrides[key]).length) delete overrides[key];
@@ -205,6 +215,11 @@ export async function main(argv) {
     const repo = resolveRepo(process.cwd());
     const config = loadConfig(repo.root, overridesFrom(values));
     config.state = new State(repo.root).ensure();
+    config.agents = new AgentResolver(config, {
+      state: config.state,
+      cwd: repo.root,
+      bypassCache: Boolean(values.force),
+    });
 
     const ctx = {
       repo,

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -6,6 +6,8 @@ import { loadMemoryFiles } from "../memory.js";
 import { loadSkills, resolveOverflowTarget } from "../skills.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 import { table } from "./scan.js";
+import { DEFAULT_EFFORT } from "../config.js";
+import { candidateKey, isProbeEntryFresh } from "../agents.js";
 
 export async function cmdStatus(ctx) {
   const { repo, config } = ctx;
@@ -105,12 +107,28 @@ export async function cmdStatus(ctx) {
   }
 
   out("");
-  out(
-    color.dim(
-      `models: analysis ${config.analysis.agent}${config.analysis.model ? `/${config.analysis.model}` : ""} · ` +
-        `synthesis ${config.synthesis.agent}${config.synthesis.model ? `/${config.synthesis.model}` : ""}` +
-        `${config.synthesis.effort ? ` (effort ${config.synthesis.effort})` : ""}`,
-    ),
-  );
+  out(color.dim("MODELS"));
+  for (const role of ["analysis", "synthesis"]) out(`  ${role.padEnd(10)}      ${describeRole(config, role)}`);
   return 0;
+}
+
+/**
+ * The pick for a role without probing: a pinned agent as configured, otherwise the
+ * ladder with whatever the probe cache already knows. `status` must stay instant.
+ */
+function describeRole(config, role) {
+  const pinned = config.agents.pinned(role);
+  const effort = config[role].effort || DEFAULT_EFFORT[role];
+  if (pinned) {
+    return `${pinned.agent}${pinned.model ? `/${pinned.model}` : ""} (effort ${effort}, ${pinned.reason})`;
+  }
+  const cache = config.state.readProbeCache();
+  for (const candidate of config.agents.ladder(role)) {
+    const entry = cache.entries[candidateKey(candidate)];
+    if (!isProbeEntryFresh(entry)) continue;
+    if (entry.verdict === "ok") {
+      return `${candidate.agent}/${entry.resolvedModel || candidate.model} (effort ${effort}, auto - probed ${entry.checkedAt.slice(0, 16).replace("T", " ")})`;
+    }
+  }
+  return color.dim(`auto - ${config.agents.ladder(role).length} candidates, none probed yet (effort ${effort})`);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -11,14 +11,48 @@ export const ALL_HARNESSES = ["claude", "codex", "pi", "opencode", "grok", "curs
 /** Cursor IDE is deferred to v1.1 and only ever runs behind --include-cursor-ide. */
 export const OPT_IN_HARNESSES = ["cursor-ide"];
 
+/**
+ * The ordered candidate ladders behind the auto-pick (ordered-defaults design, section 8.2).
+ * Each rung is one model id served by several harnesses in preference order; rungs are
+ * flattened model-outer / harness-inner, and the first candidate that is installed,
+ * authenticated, and serves the model wins. Model ids are the bare ids the vendors use;
+ * per-harness spellings (`openai-codex/...`, `openai/...`, `xai/...`) are resolved at
+ * probe time against what the adapter advertises - never hard-coded. Ladders live in
+ * config so a user can reorder or shorten them in `.backpassrc.json` without a release.
+ */
+export const DEFAULT_LADDERS = {
+  analysis: [
+    { model: "gpt-5.6-luna", agents: ["pi", "opencode", "codex"] },
+    { model: "claude-sonnet-5", agents: ["claude"] },
+    { model: "grok-4.6", agents: ["pi", "opencode", "grok"] },
+  ],
+  synthesis: [
+    { model: "gpt-5.6-sol", agents: ["pi", "opencode", "codex"] },
+    { model: "claude-opus-5", agents: ["claude"] },
+    { model: "grok-4.6", agents: ["pi", "opencode", "grok"] },
+  ],
+};
+
+/** Applied to a role whenever no layer set an effort, auto-picked or pinned. */
+export const DEFAULT_EFFORT = { analysis: "medium", synthesis: "high" };
+
+/** What `--no-auto-agent` pins: the pre-ladder fixed defaults. */
+export const LEGACY_DEFAULT_AGENTS = { analysis: "codex", synthesis: "claude" };
+
 export const DEFAULT_CONFIG = {
   memoryFiles: ["AGENTS.md", "CLAUDE.md"],
   budgetTokens: 5000,
   skillsDir: ".claude/skills",
   maxEditsPerRun: 5,
   minGapEvidence: 2,
-  analysis: { agent: "codex", model: null, effort: null },
-  synthesis: { agent: "claude", model: null, effort: "high" },
+  /**
+   * `agent: null` means auto-pick from `ladders[role]`; `effort: null` means
+   * `DEFAULT_EFFORT[role]`. Setting `agent` pins the role and skips the ladder.
+   */
+  analysis: { agent: null, model: null, effort: null },
+  synthesis: { agent: null, model: null, effort: null },
+  autoAgent: true,
+  ladders: DEFAULT_LADDERS,
   discovery: {
     harnesses: ALL_HARNESSES,
     since: "30d",
@@ -105,6 +139,23 @@ function validate(config) {
   if (!Number.isInteger(config.jobs) || config.jobs < 1) {
     throw new UserError("config.jobs must be an integer >= 1");
   }
+  for (const role of ["analysis", "synthesis"]) {
+    if (config[role].model && !config[role].agent) {
+      throw new UserError(
+        `config.${role}.model is set but config.${role}.agent is not`,
+        `set --${role}-agent too, or leave both unset to auto-pick from the ladder`,
+      );
+    }
+    const ladder = config.ladders?.[role];
+    if (!Array.isArray(ladder) || ladder.length === 0) {
+      throw new UserError(`config.ladders.${role} must be a non-empty array of { model, agents } rungs`);
+    }
+    for (const rung of ladder) {
+      if (!rung || typeof rung.model !== "string" || !Array.isArray(rung.agents) || !rung.agents.length) {
+        throw new UserError(`config.ladders.${role} rungs must look like { "model": "<id>", "agents": ["<harness>"] }`);
+      }
+    }
+  }
   if (!["auto", "dark", "light"].includes(config.theme)) {
     throw new UserError(`config.theme must be "auto", "dark", or "light" (got "${config.theme}")`);
   }
@@ -148,8 +199,9 @@ export function initialConfig() {
     skillsDir: DEFAULT_CONFIG.skillsDir,
     maxEditsPerRun: DEFAULT_CONFIG.maxEditsPerRun,
     minGapEvidence: DEFAULT_CONFIG.minGapEvidence,
-    analysis: { agent: "codex", model: null, effort: "low" },
-    synthesis: { agent: "claude", model: null, effort: "high" },
+    // Agents stay unset so the ladder auto-pick keeps applying to initialized repos.
+    analysis: { agent: null, model: null, effort: null },
+    synthesis: { agent: null, model: null, effort: null },
     discovery: { harnesses: ALL_HARNESSES, since: "30d", worktreeGlobs: [], minUserTurns: 2 },
     jobs: DEFAULT_CONFIG.jobs,
   };

--- a/src/state.js
+++ b/src/state.js
@@ -15,6 +15,7 @@ import { warn } from "./logger.js";
  *   evidence-summary.json  folded evidence (stage 2)
  *   proposal.json          latest tier-2 synthesis (stage 3)
  *   rejections.json        edits the human rejected, and the evidence weight behind them
+ *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -26,6 +27,7 @@ export class State {
     this.summaryPath = path.join(this.root, "evidence-summary.json");
     this.proposalPath = path.join(this.root, "proposal.json");
     this.rejectionsPath = path.join(this.root, "rejections.json");
+    this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
   }
 
   ensure() {
@@ -104,6 +106,15 @@ export class State {
 
   writeRejections(rejections) {
     this.writeJsonFile(this.rejectionsPath, rejections);
+  }
+
+  readProbeCache() {
+    const value = this.readJsonFile(this.probeCachePath, null);
+    return value && value.version === 1 ? value : { version: 1, acpxVersion: null, entries: {} };
+  }
+
+  writeProbeCache(cache) {
+    this.writeJsonFile(this.probeCachePath, cache);
   }
 }
 

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -1,0 +1,47 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Spawn a command, capture both streams, and resolve (never reject) with a
+ * uniform result. Shared by the acpx boundary (`src/acpx.js`) and the native
+ * harness probes (`src/agents.js`), so every subprocess in backpass is killed the
+ * same way on timeout and reports a spawn failure the same way.
+ *
+ * @param {string} bin
+ * @param {string[]} args
+ * @param {{ timeoutMs?: number, cwd?: string, input?: string }} [options]
+ * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: NodeJS.ErrnoException }>}
+ */
+export function runCapture(bin, args, { timeoutMs, cwd, input } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { cwd, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+          setTimeout(() => child.kill("SIGKILL"), 5000).unref();
+        }, timeoutMs)
+      : null;
+
+    child.stdout.on("data", (d) => {
+      stdout += d;
+    });
+    child.stderr.on("data", (d) => {
+      stderr += d;
+    });
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      resolve({ code: null, stdout, stderr: `${stderr}${err.message}`, spawnError: err });
+    });
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut });
+    });
+
+    if (input !== undefined) child.stdin.end(input);
+    else child.stdin.end();
+  });
+}

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -119,16 +119,17 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     const promptFile = path.join(promptDir, `synthesis-${attempt}.md`);
     fs.writeFileSync(promptFile, prompt);
 
+    const pick = await config.agents.resolve("synthesis");
     info(
-      `${color.cyan("·")} synthesizing with ${config.synthesis.agent}` +
-        `${config.synthesis.model ? ` (${config.synthesis.model})` : ""}` +
-        `${config.synthesis.effort ? ` effort=${config.synthesis.effort}` : ""}` +
+      `${color.cyan("·")} synthesizing with ${pick.agent}` +
+        `${pick.model ? ` (${pick.model})` : ""}` +
+        `${pick.effort ? ` effort=${pick.effort}` : ""}` +
         `${attempt > 1 ? " [re-prompt]" : ""}`,
     );
     emitProgress("synth:start", {
-      agent: config.synthesis.agent,
-      model: config.synthesis.model,
-      effort: config.synthesis.effort,
+      agent: pick.agent,
+      model: pick.model,
+      effort: pick.effort,
       attempt,
       sessionName: `backpass-synth-${process.pid}`,
       gapClusters: summary.totals.gapClusters,
@@ -136,14 +137,20 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       suppressed: Object.keys(rejections.entries || {}).length,
     });
 
-    const result = await sessionPrompt({
-      agent: config.synthesis.agent,
-      model: config.synthesis.model,
-      effort: config.synthesis.effort,
-      sessionName: `backpass-synth-${process.pid}`,
-      promptFile,
-      cwd: repo.root,
-      timeoutSeconds: Math.max(config.timeoutSeconds, 900),
+    // A classifiable failure (not logged in, model rejected, adapter missing) falls
+    // through to the next ladder candidate; the switch is recorded in the notes so the
+    // proposal's provenance is visible.
+    const result = await config.agents.withFallthrough("synthesis", async (current) => {
+      if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
+      return sessionPrompt({
+        agent: current.agent,
+        model: current.model,
+        effort: current.effort,
+        sessionName: `backpass-synth-${process.pid}`,
+        promptFile,
+        cwd: repo.root,
+        timeoutSeconds: Math.max(config.timeoutSeconds, 900),
+      });
     });
 
     if (result.usage) usage.push(result.usage);

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -1,0 +1,447 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AgentResolver,
+  candidateKey,
+  flattenLadder,
+  isProbeEntryFresh,
+  probeCandidate,
+  resolveModelId,
+} from "../src/agents.js";
+import { AcpxError, acpxAgentName, classifyAcpxFailure, effortOptionKey } from "../src/acpx.js";
+import { DEFAULT_LADDERS, loadConfig } from "../src/config.js";
+import { UserError, setQuiet } from "../src/logger.js";
+
+setQuiet(true);
+
+/** In-memory stand-in for `State`'s probe cache. */
+function memoryState(initial = { version: 1, acpxVersion: "0.13.0", entries: {} }) {
+  let cache = structuredClone(initial);
+  return {
+    readProbeCache: () => structuredClone(cache),
+    writeProbeCache: (value) => {
+      cache = structuredClone(value);
+    },
+    get cache() {
+      return cache;
+    },
+  };
+}
+
+/**
+ * A scripted probe: `verdicts` maps "agent|model" to the probe outcome. Unlisted
+ * candidates read as not installed. Every probe is recorded so tests can assert on
+ * the walk order and on caching.
+ */
+function scriptedProbe(verdicts) {
+  const calls = [];
+  const probe = async (candidate) => {
+    calls.push(candidateKey(candidate));
+    const v = verdicts[candidateKey(candidate)];
+    if (!v) return { verdict: "unreachable", detail: "not installed", resolvedModel: null };
+    if (typeof v === "string") return { verdict: v, detail: "", resolvedModel: null };
+    return { verdict: "ok", detail: "", resolvedModel: candidate.model, ...v };
+  };
+  return { probe, calls };
+}
+
+/**
+ * @param {Record<string, any>} verdicts
+ * @param {{ config?: any, state?: ReturnType<typeof memoryState>, now?: () => number,
+ *   bypassCache?: boolean, acpxVersion?: () => Promise<string | null> }} [options]
+ */
+function resolverWith(verdicts, { config = loadConfig(tmpRepo()), state = memoryState(), ...deps } = {}) {
+  const { probe, calls } = scriptedProbe(verdicts);
+  const resolver = new AgentResolver(config, {
+    state,
+    probeCandidate: probe,
+    acpxVersion: async () => "0.13.0",
+    ...deps,
+  });
+  return { resolver, calls, state };
+}
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CONFIG_FILENAME } from "../src/config.js";
+
+function tmpRepo(config) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-agents-"));
+  if (config) fs.writeFileSync(path.join(dir, CONFIG_FILENAME), JSON.stringify(config));
+  return dir;
+}
+
+function authRequired(agent) {
+  return new AcpxError(`acpx ${agent} session prompt failed (exit 1)`, {
+    stderr: "[acpx] error: RUNTIME AUTH_REQUIRED Authentication required\n",
+    code: 1,
+  });
+}
+
+test("the ladders flatten model-outer, harness-inner, in the captain's order", () => {
+  assert.deepEqual(
+    flattenLadder(DEFAULT_LADDERS.analysis).map((c) => `${c.model}@${c.agent}`),
+    [
+      "gpt-5.6-luna@pi",
+      "gpt-5.6-luna@opencode",
+      "gpt-5.6-luna@codex",
+      "claude-sonnet-5@claude",
+      "grok-4.6@pi",
+      "grok-4.6@opencode",
+      "grok-4.6@grok",
+    ],
+  );
+  assert.equal(flattenLadder(DEFAULT_LADDERS.synthesis)[0].model, "gpt-5.6-sol");
+  assert.equal(flattenLadder(DEFAULT_LADDERS.synthesis)[3].model, "claude-opus-5");
+});
+
+test("ordered selection picks the first available+authed candidate per role", async () => {
+  const { resolver, calls } = resolverWith({
+    "pi|gpt-5.6-luna": "unauthenticated",
+    "opencode|gpt-5.6-luna": "model-unavailable",
+    "codex|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" },
+    "pi|gpt-5.6-sol": "timeout",
+    "opencode|gpt-5.6-sol": "model-unavailable",
+    "codex|gpt-5.6-sol": "unauthenticated",
+    "claude|claude-opus-5": { resolvedModel: "claude-opus-5" },
+  });
+
+  const analysis = await resolver.resolve("analysis");
+  assert.equal(analysis.agent, "codex");
+  assert.equal(analysis.model, "gpt-5.6-luna");
+  assert.equal(analysis.effort, "medium", "analysis defaults to medium effort");
+  assert.equal(analysis.pinned, false);
+  assert.match(analysis.reason, /pi\/gpt-5.6-luna \(not logged in\)/);
+
+  const synthesis = await resolver.resolve("synthesis");
+  assert.equal(synthesis.agent, "claude");
+  assert.equal(synthesis.model, "claude-opus-5");
+  assert.equal(synthesis.effort, "high", "synthesis defaults to high effort");
+
+  assert.deepEqual(
+    calls,
+    [
+      "pi|gpt-5.6-luna",
+      "opencode|gpt-5.6-luna",
+      "codex|gpt-5.6-luna",
+      "pi|gpt-5.6-sol",
+      "opencode|gpt-5.6-sol",
+      "codex|gpt-5.6-sol",
+      "claude|claude-opus-5",
+    ],
+    "the walk stops at the first ok and never probes lower rungs",
+  );
+});
+
+test("the resolved model id is the adapter's spelling, never the bare id", async () => {
+  const { resolver } = resolverWith({ "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" } });
+  const pick = await resolver.resolve("analysis");
+  assert.equal(pick.agent, "pi");
+  assert.equal(pick.model, "openai-codex/gpt-5.6-luna");
+  assert.equal(pick.ladderModel, "gpt-5.6-luna");
+});
+
+test("claude is decided by `claude auth status`, not by the acpx session probe", async () => {
+  // The acpx probe for claude always says ok (a logged-out claude still creates a
+  // session). Run the real native check against a fake `claude` on PATH and assert
+  // the verdict comes from it.
+  const bin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fakebin-"));
+  const script = path.join(bin, "claude");
+  const marker = path.join(bin, "acpx-probe-was-called");
+  fs.writeFileSync(
+    script,
+    `#!/bin/sh\nif [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo '{"loggedIn": false, "authMethod": "none"}'; exit 1; fi\nexit 2\n`,
+  );
+  fs.chmodSync(script, 0o755);
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${bin}${path.delimiter}${oldPath}`;
+  try {
+    let acpxProbed = false;
+    const verdict = await probeCandidate(
+      { agent: "claude", model: "claude-sonnet-5" },
+      {
+        sessionName: "t",
+        probeSession: async () => {
+          acpxProbed = true;
+          fs.writeFileSync(marker, "");
+          return { verdict: "ok", detail: "", availableModels: ["default", "sonnet", "opus[1m]"] };
+        },
+      },
+    );
+    assert.equal(verdict.verdict, "unauthenticated");
+    assert.match(verdict.detail, /loggedIn=false/);
+    assert.equal(acpxProbed, false, "a logged-out claude never reaches the (false-positive) acpx probe");
+
+    // Logged in: the native check passes, the acpx probe runs, and the model is taken on faith.
+    fs.writeFileSync(
+      script,
+      `#!/bin/sh\nif [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo '{"loggedIn": true, "authMethod": "claude.ai"}'; exit 0; fi\nexit 2\n`,
+    );
+    const ok = await probeCandidate(
+      { agent: "claude", model: "claude-sonnet-5" },
+      {
+        sessionName: "t",
+        probeSession: async () => ({ verdict: "ok", detail: "", availableModels: ["default", "sonnet"] }),
+      },
+    );
+    assert.equal(ok.verdict, "ok");
+    assert.equal(ok.resolvedModel, "claude-sonnet-5", "claude forwards any id; it is not matched against the list");
+  } finally {
+    process.env.PATH = oldPath;
+  }
+});
+
+test("non-claude candidates resolve the bare id against the advertised list", async () => {
+  const piLike = async () => ({
+    verdict: "ok",
+    detail: "",
+    availableModels: ["kimi-coding/k3", "openai-codex/gpt-5.6-luna", "openai-codex/gpt-5.6-sol", "xai/grok-4.6"],
+  });
+  const luna = await probeCandidate({ agent: "pi", model: "gpt-5.6-luna" }, { sessionName: "t", probeSession: piLike });
+  assert.deepEqual([luna.verdict, luna.resolvedModel], ["ok", "openai-codex/gpt-5.6-luna"]);
+
+  const missing = await probeCandidate(
+    { agent: "pi", model: "claude-opus-5" },
+    { sessionName: "t", probeSession: piLike },
+  );
+  assert.equal(missing.verdict, "model-unavailable");
+
+  const unauth = await probeCandidate(
+    { agent: "codex", model: "gpt-5.6-luna" },
+    {
+      sessionName: "t",
+      probeSession: async () => ({
+        verdict: "unauthenticated",
+        detail: "Authentication required",
+        availableModels: [],
+      }),
+    },
+  );
+  assert.equal(unauth.verdict, "unauthenticated");
+});
+
+test("AUTH_REQUIRED mid-run falls through to the next candidate", async () => {
+  const { resolver, calls, state } = resolverWith({
+    "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" },
+    "opencode|gpt-5.6-luna": "model-unavailable",
+    "codex|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" },
+  });
+
+  const attempts = [];
+  const result = await resolver.withFallthrough("analysis", async (pick) => {
+    attempts.push(`${pick.agent}/${pick.model}`);
+    if (pick.agent === "pi") throw authRequired("pi");
+    return "evidence";
+  });
+
+  assert.equal(result, "evidence");
+  assert.deepEqual(attempts, ["pi/openai-codex/gpt-5.6-luna", "codex/gpt-5.6-luna"]);
+  assert.deepEqual(calls, ["pi|gpt-5.6-luna", "opencode|gpt-5.6-luna", "codex|gpt-5.6-luna"]);
+  assert.equal(state.cache.entries["pi|gpt-5.6-luna"].verdict, "unauthenticated", "the failure is remembered");
+  assert.equal((await resolver.resolve("analysis")).agent, "codex", "later calls in the run stay on the fallback");
+});
+
+test("parallel workers failing on the same candidate fall through once, together", async () => {
+  const { resolver } = resolverWith({
+    "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" },
+    "codex|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" },
+  });
+  const picks = [];
+  await Promise.all(
+    [1, 2, 3].map(() =>
+      resolver.withFallthrough("analysis", async (pick) => {
+        picks.push(pick.agent);
+        if (pick.agent === "pi") throw authRequired("pi");
+        return "ok";
+      }),
+    ),
+  );
+  assert.deepEqual(picks.filter((p) => p === "codex").length, 3);
+  assert.equal(resolver.probeCount, 3, "pi, opencode, codex - probed once each despite three workers");
+});
+
+test("only classifiable failures fall through; real-work errors propagate unchanged", async () => {
+  const { resolver } = resolverWith({
+    "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" },
+    "codex|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" },
+  });
+  const timeout = new AcpxError("acpx pi session prompt timed out after 300s", { timedOut: true, stderr: "" });
+  await assert.rejects(
+    resolver.withFallthrough("analysis", async () => {
+      throw timeout;
+    }),
+    (err) => err === timeout,
+  );
+  assert.equal((await resolver.resolve("analysis")).agent, "pi", "a timeout on real work does not demote");
+  await assert.rejects(
+    resolver.withFallthrough("analysis", async () => {
+      throw new Error("analysis returned no parseable JSON");
+    }),
+    /no parseable JSON/,
+  );
+});
+
+test("explicit config or CLI flags pin the role and skip the ladder entirely", async () => {
+  const config = loadConfig(tmpRepo({ analysis: { agent: "grok" } }), {
+    synthesis: { agent: "claude", model: "claude-opus-5", effort: "max" },
+  });
+  const { resolver, calls } = resolverWith({}, { config });
+
+  const analysis = await resolver.resolve("analysis");
+  assert.deepEqual(
+    { agent: analysis.agent, model: analysis.model, effort: analysis.effort, pinned: analysis.pinned },
+    { agent: "grok", model: null, effort: "medium", pinned: true },
+  );
+  const synthesis = await resolver.resolve("synthesis");
+  assert.deepEqual(
+    { agent: synthesis.agent, model: synthesis.model, effort: synthesis.effort, pinned: synthesis.pinned },
+    { agent: "claude", model: "claude-opus-5", effort: "max", pinned: true },
+  );
+  assert.deepEqual(calls, [], "nothing was probed");
+
+  // A pinned agent is the user's decision: an auth failure surfaces, it does not fall through.
+  await assert.rejects(
+    resolver.withFallthrough("synthesis", async () => {
+      throw authRequired("claude");
+    }),
+    AcpxError,
+  );
+});
+
+test("--no-auto-agent pins the pre-ladder defaults", async () => {
+  const config = loadConfig(tmpRepo(), { autoAgent: false });
+  const { resolver, calls } = resolverWith({}, { config });
+  assert.equal((await resolver.resolve("analysis")).agent, "codex");
+  assert.equal((await resolver.resolve("synthesis")).agent, "claude");
+  assert.equal((await resolver.resolve("synthesis")).effort, "high");
+  assert.deepEqual(calls, []);
+});
+
+test("an exhausted ladder fails with one actionable error listing every candidate", async () => {
+  const { resolver } = resolverWith({
+    "pi|gpt-5.6-sol": "unauthenticated",
+    "codex|gpt-5.6-sol": "unauthenticated",
+    "claude|claude-opus-5": "unauthenticated",
+    "grok|grok-4.6": "timeout",
+  });
+  await assert.rejects(
+    () => resolver.resolve("synthesis"),
+    (err) => {
+      assert.ok(err instanceof UserError);
+      assert.match(err.message, /no available agent for the synthesis pass/);
+      for (const line of [
+        /gpt-5.6-sol\s+pi\s+not logged in.*pi login/,
+        /gpt-5.6-sol\s+opencode\s+not installed/,
+        /gpt-5.6-sol\s+codex\s+not logged in.*codex login/,
+        /claude-opus-5\s+claude\s+not logged in.*claude auth login/,
+        /grok-4.6\s+grok\s+probe timed out/,
+      ]) {
+        assert.match(err.message, line);
+      }
+      assert.match(err.hint, /--synthesis-agent <agent> --synthesis-model <id>/);
+      return true;
+    },
+  );
+});
+
+test("a missing acpx is reported once, not once per candidate", async () => {
+  const config = loadConfig(tmpRepo());
+  let probes = 0;
+  const resolver = new AgentResolver(config, {
+    state: memoryState(),
+    acpxVersion: async () => null,
+    probeCandidate: async () => {
+      probes += 1;
+      throw new AcpxError('acpx not found on PATH (looked for "acpx")');
+    },
+  });
+  await assert.rejects(
+    () => resolver.resolve("analysis"),
+    (err) => err instanceof UserError && /acpx not found/.test(err.message),
+  );
+  assert.equal(probes, 1);
+});
+
+test("probe verdicts are cached with TTLs and invalidated on an acpx version change", async () => {
+  let now = Date.parse("2026-08-22T00:00:00Z");
+  const state = memoryState();
+  const verdicts = {
+    "pi|gpt-5.6-luna": "unauthenticated",
+    "opencode|gpt-5.6-luna": { resolvedModel: "openai/gpt-5.6-luna" },
+  };
+
+  const first = resolverWith(verdicts, { state, now: () => now });
+  assert.equal((await first.resolver.resolve("analysis")).agent, "opencode");
+  assert.equal(first.calls.length, 2);
+
+  // 10 minutes later: both verdicts are fresh, nothing is probed.
+  now += 10 * 60 * 1000;
+  const second = resolverWith(verdicts, { state, now: () => now });
+  assert.equal((await second.resolver.resolve("analysis")).agent, "opencode");
+  assert.deepEqual(second.calls, []);
+
+  // 45 minutes later: the negative expired (30min) and is re-probed; the ok (12h) is not.
+  now += 35 * 60 * 1000;
+  const third = resolverWith(
+    { ...verdicts, "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" } },
+    {
+      state,
+      now: () => now,
+    },
+  );
+  assert.equal((await third.resolver.resolve("analysis")).agent, "pi", "logging in is picked up within 30min");
+  assert.deepEqual(third.calls, ["pi|gpt-5.6-luna"]);
+
+  // --force bypasses the cache.
+  const forced = resolverWith(verdicts, { state, now: () => now, bypassCache: true });
+  await forced.resolver.resolve("analysis");
+  assert.ok(forced.calls.length >= 1);
+
+  // A new acpx drops every entry.
+  const upgraded = resolverWith(verdicts, { state, now: () => now, acpxVersion: async () => "0.14.0" });
+  await upgraded.resolver.resolve("analysis");
+  assert.deepEqual(upgraded.calls, ["pi|gpt-5.6-luna", "opencode|gpt-5.6-luna"]);
+  assert.equal(state.cache.acpxVersion, "0.14.0");
+
+  assert.equal(isProbeEntryFresh(null), false);
+  assert.equal(isProbeEntryFresh({ verdict: "ok", checkedAt: "garbage" }), false);
+});
+
+test("bare model ids resolve by segment equality, never by prefix", () => {
+  const opencode = ["opencode/free", "openai/gpt-5.6-luna", "openai/gpt-5.6-luna-fast", "openai/gpt-5.6-sol"];
+  assert.equal(resolveModelId("gpt-5.6-luna", opencode).id, "openai/gpt-5.6-luna");
+  assert.equal(resolveModelId("gpt-5.6-sol", opencode).id, "openai/gpt-5.6-sol");
+  assert.equal(resolveModelId("gpt-5.6-terra", opencode).id, null);
+  assert.equal(resolveModelId("gpt-5.6-luna", ["gpt-5.6-luna", "gpt-5.5"]).id, "gpt-5.6-luna");
+  assert.equal(resolveModelId("opus", ["default", "opus[1m]", "sonnet"]).id, "opus[1m]");
+  const ambiguous = resolveModelId("grok-4.6", ["xai/grok-4.6", "other/grok-4.6"]);
+  assert.equal(ambiguous.id, null);
+  assert.deepEqual(ambiguous.ambiguous, ["xai/grok-4.6", "other/grok-4.6"]);
+});
+
+test("acpx failure classification and the per-adapter tables", () => {
+  assert.equal(
+    classifyAcpxFailure({ stderr: "[acpx] error: RUNTIME AUTH_REQUIRED Authentication required" }),
+    "unauthenticated",
+  );
+  assert.equal(
+    classifyAcpxFailure({ stderr: "Authentication required\nhint: run `acpx config show`" }),
+    "unauthenticated",
+  );
+  assert.equal(
+    classifyAcpxFailure({ stderr: 'Cannot apply --model "x": the ACP agent did not advertise that model.' }),
+    "model-unavailable",
+  );
+  assert.equal(classifyAcpxFailure({ spawnError: { code: "ENOENT" } }), "unreachable");
+  assert.equal(classifyAcpxFailure({ stderr: "[acpx] error: TIMEOUT prompt exceeded 300s" }), null);
+  assert.equal(classifyAcpxFailure({ stderr: "" }), null);
+
+  assert.equal(acpxAgentName("grok"), "grok-build", "backpass's grok is acpx's grok-build");
+  assert.equal(acpxAgentName("codex"), "codex");
+  assert.equal(effortOptionKey("codex"), "reasoning_effort");
+  assert.equal(effortOptionKey("claude"), "effort");
+  assert.equal(effortOptionKey("pi"), "thought_level");
+  assert.equal(effortOptionKey("grok"), null);
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -25,6 +25,31 @@ test("the defaults match the approved design", () => {
   assert.equal(config.discovery.since, "30d");
   assert.deepEqual(config.discovery.harnesses, ["claude", "codex", "pi", "opencode", "grok", "cursor"]);
   assert.ok(!config.discovery.harnesses.includes("cursor-ide"), "Cursor IDE is deferred to v1.1");
+  assert.deepEqual(config.analysis, { agent: null, model: null, effort: null }, "agents are auto-picked by default");
+  assert.deepEqual(config.synthesis, { agent: null, model: null, effort: null });
+  assert.equal(config.autoAgent, true);
+  assert.deepEqual(
+    config.ladders.analysis.map((r) => r.model),
+    ["gpt-5.6-luna", "claude-sonnet-5", "grok-4.6"],
+  );
+  assert.deepEqual(
+    config.ladders.synthesis.map((r) => r.model),
+    ["gpt-5.6-sol", "claude-opus-5", "grok-4.6"],
+  );
+});
+
+test("a model without an agent is rejected rather than half-auto-picked", () => {
+  assert.throws(() => loadConfig(tempRepo({ synthesis: { model: "claude-opus-5" } })), UserError);
+  const ok = loadConfig(tempRepo({ synthesis: { agent: "claude", model: "claude-opus-5" } }));
+  assert.equal(ok.synthesis.agent, "claude");
+});
+
+test("ladders are user-editable and validated", () => {
+  const config = loadConfig(tempRepo({ ladders: { analysis: [{ model: "gpt-5.5", agents: ["codex"] }] } }));
+  assert.deepEqual(config.ladders.analysis, [{ model: "gpt-5.5", agents: ["codex"] }]);
+  assert.equal(config.ladders.synthesis.length, 3, "the other role keeps its default ladder");
+  assert.throws(() => loadConfig(tempRepo({ ladders: { analysis: [] } })), UserError);
+  assert.throws(() => loadConfig(tempRepo({ ladders: { synthesis: [{ model: "x" }] } })), UserError);
 });
 
 test("repo config overrides defaults, and CLI flags override both", () => {
@@ -33,7 +58,7 @@ test("repo config overrides defaults, and CLI flags override both", () => {
   const fromFile = loadConfig(dir);
   assert.equal(fromFile.budgetTokens, 3000);
   assert.equal(fromFile.analysis.agent, "pi");
-  assert.equal(fromFile.synthesis.agent, "claude", "untouched defaults survive a partial override");
+  assert.equal(fromFile.synthesis.agent, null, "untouched defaults survive a partial override (null = auto-pick)");
 
   const withFlags = loadConfig(dir, { budgetTokens: 8000, analysis: { model: "gpt-5.2" } });
   assert.equal(withFlags.budgetTokens, 8000);


### PR DESCRIPTION
Implements the captain-approved ordered-defaults design (feasibility report `backpass-ordered-agent-defaults-feasibility-s1`). Replaces the hard `analysis=codex` / `synthesis=claude` defaults with ordered availability+auth selection.

## Ladders (captain's order, in `DEFAULT_LADDERS`, user-editable under `"ladders"`)

- **analysis** (effort medium): `gpt-5.6-luna` via pi > opencode > codex, then `claude-sonnet-5` via claude, then `grok-4.6` via pi > opencode > grok
- **synthesis** (effort high): `gpt-5.6-sol` via pi > opencode > codex, then `claude-opus-5` via claude, then `grok-4.6` via pi > opencode > grok

## Mechanism

- `src/agents.js` (new): `AgentResolver` walks the ladder with `probeCandidate` - native status first (`claude auth status` JSON `loggedIn`; `opencode models`), then the zero-token acpx `sessions new` / `status --format json` / `sessions close` probe (`probeSession` in `src/acpx.js`, 20s cap, 10s for opencode which wedges on large profiles).
- **Model ids** resolve at probe time against `availableModels` with the report's 4-rule matcher (exact, unique last-segment, unique `[variant]`, else unavailable; `-fast` never matches). Claude is the only "trusting" adapter: id passed through, verified by the first real call.
- **Mid-run fall-through**: every real call runs under `withFallthrough(role, fn)`; `classifyAcpxFailure` turns `AUTH_REQUIRED` / model-rejected / ENOENT into a demotion and the next candidate is used. Timeouts on real work and parse errors propagate unchanged (never silently switch models after real work). Pinned picks never fall through.
- **Caching**: `.backpass/agent-probe-cache.json`, 12h for ok, 30min for negatives, dropped on acpx version change, in-process memo + in-flight dedupe across `--jobs` workers, `--force` bypasses.
- **Exhaustion**: `UserError` listing every candidate, its verdict, and the login command to run.
- **Precedence unchanged**: `agent` set in any layer pins the role; `--no-auto-agent` pins the old codex/claude pair. `backpass init` no longer writes agents, so initialized repos keep the ladder. `model` without `agent` is now rejected (half-auto).
- `grok` -> `grok-build` translated at the acpx boundary (`acpxAgentName`).

## Deviations from the report, and why

- **Effort key is a small static table** (`EFFORT_OPTION_KEYS`: codex `reasoning_effort`, claude `effort`, pi `thought_level`) rather than read from config options: `acpx --format json status` exposes `availableModels` but no config options (verified live). This fixes report bug (2): synthesis on claude now actually gets `effort=high`.
- **Analysis effort uses a fresh session per transcript** (not one long-lived session per worker) so no transcript's context bleeds into the next; the report's bug (1) (`--analysis-effort` never applied) is fixed by routing effortful analysis through `sessionPrompt`.
- **Harness CLI version invalidation skipped** (acpx version only) to keep the probe cheap; negatives expire in 30min anyway.
- `backpass status` shows the pick from the cache without probing, so it stays instant.

## Verification

- `pnpm run check` green: lint, prettier, tsc, 128 tests (17 new in `test/agents.test.js`, all offline - probes mocked, the claude path exercised against a fake `claude` on PATH).
- Live zero-token probe of all 11 ladder candidates on this Mac matched the report: pi resolves `openai-codex/...`, opencode demoted on the 10s timeout, grok via `grok-build`, claude accepted on faith.
- Real E2E `backpass analyze --limit 1`: auto-picked `pi (openai-codex/gpt-5.6-luna) effort=medium`, evidence written, cache file created, no leaked acpx sessions.

Not published; release go/no-go stays with the captain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
