### PR TITLE
feat: bootstrap AGENTS.md when none exists; pointer-aware memory resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   (`src/tui/render.js`) so it is testable as text.
 - **`src/apply/writer.js` is the only module that writes to the repo.** Keep it that way -
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
+  Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
+  writes without the apply gate, and it only ever creates files, never overwrites.
+- **Memory resolution is pointer-aware** (`resolveMemoryFiles` in `src/memory.js`): the
+  first configured file is canonical, a `@AGENTS.md`-only CLAUDE.md is a pointer, and a
+  second full file is warned about, never silently ignored or double-written.
 - **Never trust model-reported numbers.** Token deltas and budget projections are measured
   in `src/proposal.js` from the actual text; the synthesis model's own figures are ignored.
 - **acpx is alpha.** All model invocation is isolated behind `src/acpx.js` so an upstream

--- a/README.md
+++ b/README.md
@@ -203,6 +203,25 @@ backpass apply --no-ui     # same decision, in the terminal
 backpass apply --dry-run   # show what would be written
 ```
 
+### 9. Which file is the weights
+
+`memoryFiles` is an ordered list (default `["AGENTS.md", "CLAUDE.md"]`); the first one
+that exists is the file a run optimizes, so **AGENTS.md is canonical**. Resolution is
+pointer-aware:
+
+- `CLAUDE.md` containing only `@AGENTS.md` (the standard import) is a pointer: optimizing
+  AGENTS.md covers both harness families and the pointer stays valid. Nothing to report.
+- Two separate full files are a divergence hazard. backpass optimizes AGENTS.md, leaves
+  CLAUDE.md untouched, and warns each run until you consolidate: move CLAUDE.md's content
+  into AGENTS.md and make CLAUDE.md the one-line pointer.
+- A repo with **no memory file** is bootstrapped on the first `backpass` run: a starter
+  AGENTS.md (purpose, detected orientation such as the package manager and check
+  commands, baseline conventions, a `## Maintaining this file` section) plus a CLAUDE.md
+  pointer. The starter is then run through the ordinary backward pass, so recurring gaps
+  from your real transcripts become its first evidence-backed instructions. With no
+  transcripts it is seeded from defaults alone and says so. Bootstrap only ever creates
+  files; review it with `git diff`.
+
 ## CLI Reference
 
 | Command            | What it does                                                  |

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -72,3 +72,22 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
   return results;
 }
+
+/**
+ * Seed a repo that has no memory file: the canonical file plus the pointer. Each file
+ * is created only if absent - bootstrap never overwrites, so a pre-existing file (say a
+ * CLAUDE.md the user wrote while a run was in flight) is reported, not replaced.
+ */
+export function writeBootstrapFiles(repoRoot, files) {
+  const results = { written: [], skipped: [] };
+  for (const { path: relative, text } of files) {
+    const absolute = path.join(repoRoot, relative);
+    if (fs.existsSync(absolute)) {
+      results.skipped.push({ file: relative, reason: "already exists" });
+      continue;
+    }
+    fs.writeFileSync(absolute, text, { flag: "wx" });
+    results.written.push({ file: relative, bytes: Buffer.byteLength(text, "utf8") });
+  }
+  return results;
+}

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,0 +1,169 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { parseMemoryUnits } from "./memory.js";
+import { sha256 } from "./state.js";
+import { estimateTokens } from "./tokens.js";
+
+/**
+ * The starter memory file backpass seeds when a repo has none.
+ *
+ * Bootstrap = sensible defaults + the normal backward pass. The defaults here are the
+ * skeleton every good memory file shares (purpose, orientation, conventions, a
+ * self-governance section); what the repo's own transcripts teach is layered on top by
+ * the same analyze -> fold -> synthesize pipeline a normal run uses, with this text
+ * standing in as the "current weights". Whatever is deterministically detectable from
+ * the checkout (package manager, check commands) is filled in; nothing is guessed.
+ *
+ * The canonical file is AGENTS.md; CLAUDE.md is the `@AGENTS.md` pointer so both harness
+ * families read one source of truth. Writing happens in `src/apply/writer.js`.
+ */
+
+export const CANONICAL_MEMORY_FILE = "AGENTS.md";
+export const POINTER_MEMORY_FILE = "CLAUDE.md";
+
+/** The convention's two-line pointer form; `isPointerTo` recognizes it round-trip. */
+export function renderPointer(target = CANONICAL_MEMORY_FILE) {
+  return `<!-- Points Claude at ${target} via import; edit ${target}, not this file. -->\n@${target}\n`;
+}
+
+/**
+ * What a bootstrap creates for a config: the canonical file is the first configured
+ * memory file (a user override still wins), and CLAUDE.md becomes a pointer to it unless
+ * CLAUDE.md itself is the canonical file.
+ */
+export function bootstrapTargets(memoryFiles) {
+  const canonical = memoryFiles[0] || CANONICAL_MEMORY_FILE;
+  const pointer =
+    path.basename(canonical) === POINTER_MEMORY_FILE && path.dirname(canonical) === "." ? null : POINTER_MEMORY_FILE;
+  return { canonical, pointer };
+}
+
+export const MAINTAINING_SECTION = `## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.
+`;
+
+const LOCKFILES = [
+  ["pnpm-lock.yaml", "pnpm"],
+  ["yarn.lock", "yarn"],
+  ["bun.lockb", "bun"],
+  ["bun.lock", "bun"],
+  ["package-lock.json", "npm"],
+];
+
+const SCRIPT_LABELS = [
+  ["check", "the full local gate"],
+  ["test", "tests"],
+  ["lint", "lint"],
+  ["typecheck", "type checks"],
+  ["build", "the build"],
+  ["format:check", "formatting"],
+];
+
+/** What the checkout itself says, without reading transcripts or calling a model. */
+export function detectRepoFacts(root) {
+  const facts = { packageManager: null, scripts: [], readme: null };
+  const exists = (name) => fs.existsSync(path.join(root, name));
+
+  for (const [file, manager] of LOCKFILES) {
+    if (exists(file)) {
+      facts.packageManager = manager;
+      break;
+    }
+  }
+
+  const pkgPath = path.join(root, "package.json");
+  if (exists("package.json")) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      if (!facts.packageManager && pkg.packageManager) {
+        facts.packageManager = String(pkg.packageManager).split("@")[0];
+      }
+      const scripts = pkg.scripts && typeof pkg.scripts === "object" ? pkg.scripts : {};
+      for (const [name, label] of SCRIPT_LABELS) {
+        if (typeof scripts[name] === "string") facts.scripts.push({ name, label });
+      }
+      if (!facts.packageManager) facts.packageManager = "npm";
+    } catch {
+      // An unparseable package.json is not a bootstrap problem; the defaults stay generic.
+    }
+  }
+
+  for (const name of ["README.md", "README", "readme.md"]) {
+    if (exists(name)) {
+      facts.readme = name;
+      break;
+    }
+  }
+  return facts;
+}
+
+function runCommand(manager, script) {
+  if (!manager || manager === "npm") return `npm run ${script}`;
+  return `${manager} run ${script}`;
+}
+
+/** Render the default AGENTS.md for a repo. Deterministic for a given checkout. */
+export function renderStarterMemory({ repo, facts = detectRepoFacts(repo.root) }) {
+  if (!facts) facts = detectRepoFacts(repo.root);
+  const orientation = [];
+  if (facts.readme) orientation.push(`- \`${facts.readme}\` documents the user-facing surface; start there.`);
+  if (facts.packageManager) {
+    orientation.push(`- ${facts.packageManager} is the package manager; do not switch it or add a second lockfile.`);
+  }
+  if (facts.scripts.length) {
+    const gate = facts.scripts.find((s) => s.name === "check") || facts.scripts[0];
+    const others = facts.scripts
+      .filter((s) => s !== gate)
+      .map((s) => `\`${runCommand(facts.packageManager, s.name)}\` (${s.label})`)
+      .join(", ");
+    orientation.push(
+      `- \`${runCommand(facts.packageManager, gate.name)}\` runs ${gate.label}${others ? `; also ${others}` : ""}. ` +
+        "Run it before declaring work done.",
+    );
+  }
+  if (!orientation.length) {
+    orientation.push("- Read the top-level README and directory layout before changing anything.");
+  }
+
+  return `# Project agent memory
+
+${repo.name}: this file is the always-loaded memory for agents working in this repo.
+It is kept short on purpose - every line here is paid on every session.
+
+## Orientation
+
+${orientation.join("\n")}
+
+## Conventions
+
+- Read the surrounding code and follow its existing patterns before adding new ones.
+- Reproduce a bug end to end before fixing it, then keep the reproduction as a test.
+- Run the project's checks (lint, tests, types) before declaring work done; fix what
+  they report even when it is unrelated to the task.
+- Never hand-edit generated files (lockfiles, changelogs, build output).
+- Keep changes scoped to the task; call out follow-ups instead of silently widening scope.
+
+## Sharp edges
+
+- None recorded yet. backpass adds evidence-backed entries here from real sessions.
+
+${MAINTAINING_SECTION}`;
+}
+
+/** An in-memory memory file object in the shape `readMemoryFile` returns, never on disk. */
+export function starterMemoryFile(repo, relativePath = CANONICAL_MEMORY_FILE, facts = null) {
+  const text = renderStarterMemory({ repo, facts });
+  return {
+    path: relativePath,
+    absolute: path.join(repo.root, relativePath),
+    text,
+    hash: `sha256:${sha256(text).slice(0, 16)}`,
+    tokens: estimateTokens(text),
+    units: parseMemoryUnits(text),
+  };
+}

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,20 +1,36 @@
 import { analyzeTranscripts } from "../analyze.js";
-import { UserError, color, info, json, out } from "../logger.js";
-import { loadMemoryFiles, memorySetHash } from "../memory.js";
+import { UserError, color, info, json, out, warn } from "../logger.js";
+import { resolveMemoryFiles } from "../memory.js";
 import { sumUsage, formatUsage } from "../acpx.js";
 import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
 
-/** The memory file a run optimizes: the first configured file that exists. */
+/**
+ * The memory file a run optimizes: the first configured file that exists (AGENTS.md by
+ * default - canonical). Resolution is pointer-aware: a CLAUDE.md that is just
+ * `@AGENTS.md` is covered by optimizing AGENTS.md and needs no mention. A second file
+ * with its own content is NOT updated - that would either be ignored silently or
+ * double-written into divergence - so the run says so and recommends consolidating.
+ *
+ * When no configured file exists, `backpass` (the default run) bootstraps one; every
+ * other command fails with a pointer to that.
+ */
 export function primaryMemoryFile(repo, config) {
-  const files = loadMemoryFiles(repo.root, config.memoryFiles);
-  if (!files.length) {
+  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles);
+  if (!resolved.primary) {
     throw new UserError(
       `no memory file found (looked for ${config.memoryFiles.join(", ")})`,
-      "create an AGENTS.md, or set memoryFiles in .backpassrc.json",
+      "run `backpass` to bootstrap an AGENTS.md, or set memoryFiles in .backpassrc.json",
     );
   }
-  return { file: files[0], all: files, hash: memorySetHash(files) };
+  for (const other of resolved.separate) {
+    warn(
+      `${other.path} is a separate memory file and will NOT be updated - only ${resolved.primary.path} is optimized. ` +
+        `To cover both, consolidate: move its content into ${resolved.primary.path} and make ${other.path} a pointer ` +
+        `(a single line: @${resolved.primary.path}).`,
+    );
+  }
+  return { file: resolved.primary, all: resolved.all, hash: resolved.hash, resolved };
 }
 
 export async function runAnalysis(ctx) {

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -24,6 +24,12 @@ export async function cmdApply(ctx) {
       "run `backpass propose` again",
     );
   }
+  if (proposal.appliedAt) {
+    throw new UserError(
+      `the last proposal was already applied by ${proposal.appliedBy || "a previous apply"} (${proposal.appliedAt})`,
+      "run `backpass` again to produce a fresh one",
+    );
+  }
   if (!proposal.edits.length) {
     out("The last run proposed no edits. Nothing to apply.");
     return 0;

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -1,0 +1,172 @@
+import { analyzeTranscripts } from "../analyze.js";
+import { applyDecisions, writeBootstrapFiles } from "../apply/writer.js";
+import { bootstrapTargets, renderPointer, starterMemoryFile } from "../bootstrap.js";
+import { color, info, json, out, warn } from "../logger.js";
+import { emitProgress } from "../progress.js";
+import { ProposalViolation } from "../proposal.js";
+import { synthesizeProposal } from "../synthesize.js";
+import { budgetBar, formatTokens } from "../tokens.js";
+import { discoverForRun } from "./scan.js";
+import { foldForRun, printProposal } from "./propose.js";
+
+/**
+ * Bootstrap: the default run when the repo has no memory file at all.
+ *
+ * Instead of failing, backpass seeds a starter AGENTS.md (sensible defaults, see
+ * `src/bootstrap.js`) plus a CLAUDE.md pointer, then runs the ordinary backward pass with
+ * the starter as the current weights: the transcripts' gaps and recurring mistakes
+ * become the first evidence-backed instructions. Every edit of that first proposal is
+ * applied directly - the file is brand new, so there is nothing to protect with the
+ * human gate and `git diff` is the review. Later runs go through the normal
+ * propose -> apply flow.
+ *
+ * Safety: files are only ever created, never overwritten, and a failure anywhere after
+ * the seed still leaves a valid defaults-only memory file behind.
+ */
+
+const BOOTSTRAP_RUN_NOTE =
+  "This memory file was just seeded from generic defaults and has never steered a session, " +
+  "so the evidence is gaps and mistakes only. Turn recurring gaps into concrete instructions " +
+  "(`add` under the matching section, `## Sharp edges` for project-specific traps, replacing " +
+  "the placeholder bullet there) and `rewrite` any default the evidence contradicts. " +
+  "Skip anything a single session suggests.";
+
+/**
+ * `deps` exists so the flow is testable offline: the three model/disk-facing stages
+ * default to the real pipeline and can be swapped for fakes.
+ */
+export async function bootstrapRun(ctx, deps = {}) {
+  const { repo, config } = ctx;
+  const discover = deps.discover || discoverForRun;
+  const analyze = deps.analyze || analyzeTranscripts;
+  const synthesize = deps.synthesize || synthesizeProposal;
+  const { canonical, pointer } = bootstrapTargets(config.memoryFiles);
+
+  const { transcripts, perHarness } = await discover(ctx);
+  info(
+    `${color.yellow("·")} no memory file found (looked for ${config.memoryFiles.join(", ")}) - ` +
+      `bootstrapping ${canonical} from ${transcripts.length} transcript(s) + defaults`,
+  );
+
+  const starter = starterMemoryFile(repo, canonical);
+  const seed = [{ path: canonical, text: starter.text }];
+  if (pointer) seed.push({ path: pointer, text: renderPointer(canonical) });
+  const seeded = writeBootstrapFiles(repo.root, seed);
+  for (const w of seeded.written) info(`${color.green("·")} wrote ${w.file}`);
+  for (const s of seeded.skipped) warn(`${s.file} ${s.reason} - left untouched`);
+
+  emitProgress("memory", {
+    path: starter.path,
+    tokens: starter.tokens,
+    budget: config.budgetTokens,
+    units: starter.units.length,
+  });
+
+  const result = {
+    bootstrap: true,
+    seededFrom: "defaults",
+    files: seeded,
+    memoryFile: canonical,
+    transcripts: transcripts.length,
+    perHarness,
+    summary: null,
+    proposal: null,
+    applied: null,
+  };
+
+  if (!transcripts.length) return result;
+
+  result.summary = await analyze({
+    transcripts,
+    memoryFile: starter,
+    config,
+    repo,
+    memoryHash: starter.hash,
+    force: Boolean(ctx.flags.force),
+  });
+  info(
+    `${color.cyan("·")} evidence: ${result.summary.analyzed} new · ${result.summary.cached} cached · ` +
+      `${result.summary.skipped} too short · ${result.summary.failed} failed`,
+  );
+
+  const folded = await foldForRun(ctx, starter);
+  config.state.writeSummary(folded);
+  emitProgress("fold:done", {
+    instructions: folded.instructions.length,
+    clustersFound: folded.totals.gapClusters + folded.totals.droppedGapSingletons,
+    clustersKept: folded.totals.gapClusters,
+    minGapEvidence: config.minGapEvidence,
+    ms: 0,
+  });
+  if (!folded.analyzedSessions) return result;
+
+  try {
+    const { proposal } = await synthesize({
+      memoryFile: starter,
+      summary: folded,
+      config,
+      repo,
+      transcripts,
+      runNote: BOOTSTRAP_RUN_NOTE,
+    });
+    const decisions = Object.fromEntries(proposal.edits.map((e) => [e.id, "accepted"]));
+    const applied = applyDecisions({ proposal, decisions, repo, state: config.state, config });
+    proposal.appliedAt = new Date().toISOString();
+    proposal.appliedBy = "bootstrap";
+    config.state.writeProposal(proposal);
+    result.proposal = proposal;
+    result.applied = applied;
+    if (proposal.edits.length) result.seededFrom = "transcripts + defaults";
+  } catch (err) {
+    if (!(err instanceof ProposalViolation)) throw err;
+    // The seed is already on disk, so a bad synthesis degrades to defaults-only.
+    for (const violation of err.violations) warn(violation);
+    warn("synthesis failed its gates; the memory file stays defaults-only this run");
+  }
+  return result;
+}
+
+export function printBootstrap(result, config) {
+  out("");
+  const files = result.files.written.map((w) => w.file).join(" + ");
+  out(`${color.bold("bootstrapped")} ${files || "nothing"} ${color.dim(`(seeded from ${result.seededFrom})`)}`);
+  for (const s of result.files.skipped) out(`  ${color.yellow("kept")} ${s.file} (${s.reason})`);
+
+  if (!result.transcripts) {
+    out("  no transcripts associated with this repo yet - the defaults stand until later runs find some");
+    out(color.dim("  `backpass scan --since all` widens the time window"));
+  } else if (!result.proposal) {
+    out(`  ${result.transcripts} transcript(s) found, but none produced usable evidence; defaults stand`);
+  } else {
+    printProposal(result.proposal, { applied: true });
+    for (const w of result.applied.written) {
+      out(`  ${color.green("wrote")} ${w.file} (${w.edits.join(", ")})`);
+      if (w.budget) {
+        out(
+          `    budget ${budgetBar(w.budget)} ${formatTokens(w.budget.current)} -> ` +
+            `${formatTokens(w.budget.projected)} / ${formatTokens(w.budget.capTokens)} tok`,
+        );
+      }
+    }
+    for (const s of result.applied.skills) out(`  ${color.green("wrote")} ${s.path} (new skill)`);
+    for (const f of result.applied.failed) {
+      out(`  ${color.red("failed")} ${f.file}${f.edit ? ` (${f.edit})` : ""}: ${f.error}`);
+    }
+  }
+  out("");
+  out(
+    `Review with \`git diff\`; later runs keep refining under the ${formatTokens(config.budgetTokens)}-token budget.`,
+  );
+}
+
+export function bootstrapJson(result) {
+  json({
+    bootstrap: true,
+    seededFrom: result.seededFrom,
+    memoryFile: result.memoryFile,
+    files: result.files,
+    transcripts: result.transcripts,
+    proposal: result.proposal,
+    applied: result.applied,
+  });
+}

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -41,7 +41,9 @@ export async function cmdInit({ repo, config, flags }) {
   const files = loadMemoryFiles(repo.root, seed.memoryFiles);
   out("");
   if (!files.length) {
-    out(`No memory file found yet. Create one of ${seed.memoryFiles.join(", ")} and run \`backpass\`.`);
+    out(
+      `No memory file found yet. \`backpass\` will bootstrap ${seed.memoryFiles[0]} (+ a CLAUDE.md pointer) from your transcripts and defaults.`,
+    );
     return 0;
   }
   for (const file of files) {

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -52,7 +52,7 @@ export async function runProposal(ctx, precomputed = null) {
   return { proposal, summary, memoryFile: file };
 }
 
-export function printProposal(proposal) {
+export function printProposal(proposal, { applied = false } = {}) {
   out("");
   out(
     `${color.bold("proposal")} · ${proposal.repo.name} · ${proposal.memoryFile.path} · ` +
@@ -89,6 +89,7 @@ export function printProposal(proposal) {
   const usage = sumUsage(proposal.usage || []);
   out("");
   out(color.dim(`  tier-2 tokens: ${formatUsage(usage)}`));
+  if (applied) return;
   out("");
   out("Review and apply with `backpass apply` (nothing has been written).");
 }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -2,16 +2,20 @@ import { UserError, color, info, json, out } from "../logger.js";
 import { formatUsage, sumUsage } from "../acpx.js";
 import { ProposalViolation } from "../proposal.js";
 import { runAnalysis } from "./analyze.js";
+import { bootstrapJson, bootstrapRun, printBootstrap } from "./bootstrap.js";
 import { printProposal, runProposal } from "./propose.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { startTui } from "../tui/index.js";
+import { resolveMemoryFiles } from "../memory.js";
 
 /**
  * The default command: one full backward pass.
  *
  *   discover -> distill -> analyze (cheap, fanned out) -> fold -> synthesize (one big call)
  *
- * It never writes. Applying is a separate, human-gated step.
+ * It never writes - with one exception: a repo with no memory file at all is
+ * bootstrapped (`./bootstrap.js`), which only ever creates files. Otherwise applying
+ * is a separate, human-gated step.
  *
  * On an eligible terminal a live progress view renders the run on stderr; it
  * collapses back into the plain lines below before anything is printed to
@@ -27,6 +31,14 @@ export async function cmdRun(ctx) {
         `v${ctx.version} · ${repo.name} · budget ${formatTokens(config.budgetTokens)} tok · since ${config.discovery.since}`,
       )}`,
     );
+
+    if (!resolveMemoryFiles(repo.root, config.memoryFiles).primary) {
+      const result = await bootstrapRun(ctx);
+      tui?.stop();
+      if (ctx.flags.json) bootstrapJson(result);
+      else printBootstrap(result, config);
+      return 0;
+    }
 
     const analysis = await runAnalysis(ctx);
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { color, json, out } from "../logger.js";
-import { loadMemoryFiles } from "../memory.js";
+import { resolveMemoryFiles } from "../memory.js";
 import { loadSkills, resolveOverflowTarget } from "../skills.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 import { table } from "./scan.js";
@@ -13,7 +13,8 @@ export async function cmdStatus(ctx) {
   const { repo, config } = ctx;
   const state = config.state;
 
-  const files = loadMemoryFiles(repo.root, config.memoryFiles);
+  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles);
+  const files = resolved.all;
   const evidence = state.listEvidence();
   const counts = { ok: 0, failed: 0, skipped: 0 };
   for (const e of evidence) counts[e.status] = (counts[e.status] || 0) + 1;
@@ -29,6 +30,8 @@ export async function cmdStatus(ctx) {
     path: file.path,
     ...budgetStatus(file.text, null, config.budgetTokens),
     instructions: file.units.length,
+    pointerTo: resolved.pointers.includes(file) ? resolved.primary.path : null,
+    separate: resolved.separate.includes(file),
   }));
 
   if (ctx.flags.json) {
@@ -51,7 +54,13 @@ export async function cmdStatus(ctx) {
   out(color.dim("BUDGET (always-loaded)"));
   if (!budgets.length) out("  no memory file found");
   for (const b of budgets) {
-    const state_ = b.withinBudget ? "" : color.red(` ${b.over} OVER`);
+    if (b.pointerTo) {
+      out(`  ${b.path.padEnd(14)} ${color.dim(`pointer to ${b.pointerTo}`)}`);
+      continue;
+    }
+    const state_ =
+      (b.withinBudget ? "" : color.red(` ${b.over} OVER`)) +
+      (b.separate ? color.yellow(" separate - not optimized") : "");
     out(
       `  ${b.path.padEnd(14)} ${budgetBar(b)} ${formatTokens(b.current)} / ${formatTokens(b.capTokens)} tok` +
         ` · ${b.instructions} instructions${state_}`,

--- a/src/memory.js
+++ b/src/memory.js
@@ -194,3 +194,44 @@ export function reanchor(reference, file, threshold = 0.6) {
   if (best && bestScore >= threshold) return { unit: best, match: "fuzzy", score: bestScore };
   return { unit: null, match: "stale", score: bestScore };
 }
+
+/**
+ * Pointer detection. The convention for covering both harness families without
+ * duplicating content is a canonical AGENTS.md plus a CLAUDE.md that only contains the
+ * `@AGENTS.md` import (Claude Code inlines it at load time). Such a file carries no
+ * instructions of its own, so optimizing the target is fully correct and the pointer
+ * stays valid afterwards.
+ *
+ * A file is a pointer to `target` when, ignoring blank lines and HTML comments, its
+ * only content is the import line (`@AGENTS.md` or `@./AGENTS.md`).
+ */
+export function isPointerTo(text, target) {
+  const lines = text
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length !== 1) return false;
+  const ref = lines[0].replace(/^@\.\//, "@");
+  return ref === `@${target}`;
+}
+
+/**
+ * Resolve the memory file a run optimizes from the configured order.
+ *
+ *   primary   the first configured file that exists (null when none does)
+ *   pointers  other configured files that are pointers to the primary - silently fine
+ *   separate  other configured files with their own content - NOT updated by a run;
+ *             the caller warns so divergence is never silent
+ *
+ * The weights hash still covers every existing file, as before, so cached evidence
+ * survives this resolution unchanged.
+ */
+export function resolveMemoryFiles(repoRoot, memoryFiles) {
+  const files = loadMemoryFiles(repoRoot, memoryFiles);
+  if (!files.length) return { primary: null, all: files, pointers: [], separate: [], hash: null };
+  const [primary, ...others] = files;
+  const pointers = others.filter((f) => isPointerTo(f.text, primary.path));
+  const separate = others.filter((f) => !pointers.includes(f));
+  return { primary, all: files, pointers, separate, hash: memorySetHash(files) };
+}

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -6,6 +6,7 @@ edits - one gradient step on the weights, not a rewrite.
 ## Repository
 
 {{REPO_NAME}} - {{TRANSCRIPT_COUNT}} sessions analyzed across {{HARNESS_SUMMARY}}.
+{{RUN_NOTE}}
 
 ## Current memory file: {{MEMORY_PATH}}
 

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -68,7 +68,7 @@ function harnessCountsOf(transcripts) {
   return counts;
 }
 
-export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts }) {
+export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
   const state = config.state;
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
@@ -78,6 +78,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   const values = {
     REPO_NAME: repo.name,
     TRANSCRIPT_COUNT: String(summary.analyzedSessions),
+    RUN_NOTE: runNote,
     HARNESS_SUMMARY:
       Object.entries(harnessCounts)
         .map(([h, n]) => `${h} ${n}`)

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,0 +1,198 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { bootstrapRun } from "../src/commands/bootstrap.js";
+import { detectRepoFacts, renderPointer, renderStarterMemory } from "../src/bootstrap.js";
+import { loadConfig } from "../src/config.js";
+import { setLoggerSink } from "../src/logger.js";
+import { isPointerTo, parseMemoryUnits } from "../src/memory.js";
+import { State } from "../src/state.js";
+
+function makeRepo(files = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-bootstrap-"));
+  for (const [name, text] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), text);
+  return { root: dir, realRoot: dir, name: "demo-repo", worktrees: [dir], remotes: [] };
+}
+
+function makeCtx(repo, overrides = {}) {
+  const config = loadConfig(repo.root, overrides);
+  config.state = new State(repo.root).ensure();
+  return { repo, config, flags: {}, version: "test" };
+}
+
+function transcript(id) {
+  return { id, nativeId: id, harness: "claude", path: `/x/${id}.jsonl`, mtimeMs: 1, bytes: 10, startedAt: 1 };
+}
+
+const discoverNone = async () => ({ transcripts: [], perHarness: {} });
+const discoverTwo = async () => ({ transcripts: [transcript("s1"), transcript("s2")], perHarness: { claude: {} } });
+
+/** Stands in for the tier-1 model: every session reports the same gap against the starter. */
+function fakeAnalyze({ transcripts, memoryFile, config, memoryHash }) {
+  for (const t of transcripts) {
+    config.state.writeEvidence(t.id, {
+      status: "ok",
+      transcript: { id: t.id, harness: t.harness, startedAt: t.startedAt },
+      memoryHash,
+      memoryPath: memoryFile.path,
+      positive: [],
+      negative: [],
+      gaps: [
+        {
+          mistake: "ran migrations against the shared db",
+          proposedInstruction: "Run migrations only against a scratch database.",
+          recurrenceRisk: "high",
+          quote: "applied the migration to prod-db",
+        },
+      ],
+    });
+  }
+  return { total: transcripts.length, analyzed: transcripts.length, cached: 0, skipped: 0, failed: 0, usage: [] };
+}
+
+function fakeSynthesize(captured) {
+  return async ({ memoryFile, summary, runNote }) => {
+    captured.runNote = runNote;
+    captured.gapClusters = summary.totals.gapClusters;
+    const { buildProposal } = await import("../src/proposal.js");
+    const { proposal, violations } = buildProposal(
+      {
+        edits: [
+          {
+            kind: "rewrite",
+            file: memoryFile.path,
+            title: "record the migration trap",
+            find: "- None recorded yet. backpass adds evidence-backed entries here from real sessions.",
+            replace: "- Run migrations only against a scratch database, never the shared one.",
+            evidence: [
+              { polarity: "negative", text: "applied the migration to prod-db", source: "claude · s1" },
+              { polarity: "negative", text: "applied the migration to prod-db", source: "claude · s2" },
+            ],
+            transcripts: 2,
+          },
+        ],
+      },
+      { memoryFile, config: captured.config, repo: captured.repo, summary },
+    );
+    assert.deepEqual(violations, []);
+    return { proposal, violations };
+  };
+}
+
+function withSink(fn) {
+  const lines = [];
+  setLoggerSink((l) => lines.push(l));
+  return fn().then(
+    (r) => {
+      setLoggerSink(null);
+      return { result: r, lines };
+    },
+    (e) => {
+      setLoggerSink(null);
+      throw e;
+    },
+  );
+}
+
+test("starter memory is a real file: purpose, detected facts, conventions, and self-governance", () => {
+  const repo = makeRepo({
+    "package.json": JSON.stringify({ name: "demo", scripts: { check: "x", test: "y" } }),
+    "pnpm-lock.yaml": "",
+    "README.md": "# demo",
+  });
+  const facts = detectRepoFacts(repo.root);
+  assert.equal(facts.packageManager, "pnpm");
+  const text = renderStarterMemory({ repo, facts });
+  assert.match(text, /^# Project agent memory/);
+  assert.match(text, /demo-repo/);
+  assert.match(text, /`pnpm run check` runs the full local gate/);
+  assert.match(text, /`README.md` documents/);
+  assert.match(text, /## Conventions/);
+  assert.match(text, /## Maintaining this file/);
+  assert.ok(parseMemoryUnits(text).length >= 8, "the starter is not a stub");
+
+  const bare = renderStarterMemory({ repo: makeRepo(), facts: detectRepoFacts(makeRepo().root) });
+  assert.match(bare, /Read the top-level README/);
+  assert.match(bare, /## Maintaining this file/);
+});
+
+test("no memory file and no transcripts: seeds AGENTS.md from defaults plus a CLAUDE.md pointer", async () => {
+  const repo = makeRepo();
+  const ctx = makeCtx(repo);
+  const { result, lines } = await withSink(() => bootstrapRun(ctx, { discover: discoverNone }));
+
+  assert.equal(result.seededFrom, "defaults");
+  assert.deepEqual(
+    result.files.written.map((w) => w.file),
+    ["AGENTS.md", "CLAUDE.md"],
+  );
+  assert.ok(
+    lines.some((l) => /no memory file found.*bootstrapping AGENTS\.md from 0 transcript\(s\) \+ defaults/.test(l)),
+  );
+
+  const agents = fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8");
+  assert.match(agents, /## Maintaining this file/);
+  const claude = fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8");
+  assert.equal(claude, renderPointer("AGENTS.md"));
+  assert.equal(isPointerTo(claude, "AGENTS.md"), true);
+});
+
+test("with transcripts: analysis gaps become the first evidence-backed instruction", async () => {
+  const repo = makeRepo();
+  const ctx = makeCtx(repo);
+  const captured = { config: ctx.config, repo };
+  const { result, lines } = await withSink(() =>
+    bootstrapRun(ctx, { discover: discoverTwo, analyze: fakeAnalyze, synthesize: fakeSynthesize(captured) }),
+  );
+
+  assert.ok(lines.some((l) => /bootstrapping AGENTS\.md from 2 transcript\(s\) \+ defaults/.test(l)));
+  assert.match(captured.runNote, /seeded from generic defaults/);
+  assert.equal(captured.gapClusters, 1, "the two sessions' gaps folded into one cluster");
+  assert.equal(result.seededFrom, "transcripts + defaults");
+  assert.deepEqual(
+    result.applied.written.map((w) => w.file),
+    ["AGENTS.md"],
+  );
+
+  const agents = fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8");
+  assert.match(agents, /scratch database/);
+  assert.doesNotMatch(agents, /None recorded yet/);
+  assert.match(agents, /## Maintaining this file/);
+  assert.equal(fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8"), renderPointer("AGENTS.md"));
+
+  // The applied proposal is marked so `backpass apply` cannot replay it onto the new file.
+  const saved = ctx.config.state.readProposal();
+  assert.equal(saved.appliedBy, "bootstrap");
+  assert.ok(saved.appliedAt);
+});
+
+test("bootstrap never overwrites: a CLAUDE.md that appears is kept, only the missing file is created", async () => {
+  const repo = makeRepo({ "CLAUDE.md": "# mine\n" });
+  // Config looks only for AGENTS.md, so there is "no memory file" yet CLAUDE.md exists on disk.
+  const ctx = makeCtx(repo, { memoryFiles: ["AGENTS.md"] });
+  const { result } = await withSink(() => bootstrapRun(ctx, { discover: discoverNone }));
+
+  assert.deepEqual(
+    result.files.written.map((w) => w.file),
+    ["AGENTS.md"],
+  );
+  assert.deepEqual(result.files.skipped, [{ file: "CLAUDE.md", reason: "already exists" }]);
+  assert.equal(fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8"), "# mine\n");
+});
+
+test("a memoryFiles override bootstraps that path, with CLAUDE.md pointing at it", async () => {
+  const repo = makeRepo();
+  fs.mkdirSync(path.join(repo.root, "docs"));
+  const ctx = makeCtx(repo, { memoryFiles: ["docs/AGENTS.md"] });
+  const { result } = await withSink(() => bootstrapRun(ctx, { discover: discoverNone }));
+
+  assert.deepEqual(
+    result.files.written.map((w) => w.file),
+    ["docs/AGENTS.md", "CLAUDE.md"],
+  );
+  const claude = fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8");
+  assert.equal(isPointerTo(claude, "docs/AGENTS.md"), true);
+});

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -1,0 +1,137 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { primaryMemoryFile } from "../src/commands/analyze.js";
+import { applyDecisions } from "../src/apply/writer.js";
+import { loadConfig } from "../src/config.js";
+import { setLoggerSink } from "../src/logger.js";
+import { isPointerTo, resolveMemoryFiles } from "../src/memory.js";
+import { buildProposal } from "../src/proposal.js";
+import { State } from "../src/state.js";
+import { renderPointer } from "../src/bootstrap.js";
+
+const AGENTS = "# Memory\n\n## Rules\n\n- Run the tests before pushing.\n- Never edit generated files.\n";
+const SEPARATE_CLAUDE = "# Claude notes\n\n- Prefer bun over npm.\n";
+
+function repoWith(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-memres-"));
+  for (const [name, text] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), text);
+  return { root: dir, realRoot: dir, name: path.basename(dir), worktrees: [dir], remotes: [] };
+}
+
+function captureWarnings(fn) {
+  const lines = [];
+  setLoggerSink((line) => lines.push(line));
+  try {
+    return { result: fn(), warnings: lines.filter((l) => l.includes("warn")) };
+  } finally {
+    setLoggerSink(null);
+  }
+}
+
+/** One evidence-backed edit against AGENTS.md, pushed through the real writer. */
+function applyOneEdit(repo, config) {
+  const { file } = primaryMemoryFile(repo, config);
+  const summary = {
+    analyzedSessions: 2,
+    instructions: [],
+    gaps: [],
+    totals: { positive: 0, negative: 2, gapClusters: 0 },
+  };
+  const { proposal, violations } = buildProposal(
+    {
+      edits: [
+        {
+          kind: "rewrite",
+          file: file.path,
+          title: "tighten",
+          find: "- Run the tests before pushing.",
+          replace: "- Run the full test suite before pushing.",
+          evidence: [{ polarity: "negative", text: "skipped tests", source: "claude · s1 · turn 2" }],
+          transcripts: 2,
+        },
+      ],
+    },
+    { memoryFile: file, config, repo, summary },
+  );
+  assert.deepEqual(violations, []);
+  const state = new State(repo.root).ensure();
+  return applyDecisions({ proposal, decisions: { e1: "accepted" }, repo, state, config });
+}
+
+test("isPointerTo accepts the @AGENTS.md import forms and nothing else", () => {
+  assert.equal(isPointerTo("@AGENTS.md\n", "AGENTS.md"), true);
+  assert.equal(isPointerTo("@./AGENTS.md", "AGENTS.md"), true);
+  assert.equal(isPointerTo(renderPointer("AGENTS.md"), "AGENTS.md"), true);
+  assert.equal(isPointerTo("\n<!-- c -->\n\n@AGENTS.md\n\n", "AGENTS.md"), true);
+  assert.equal(isPointerTo("@AGENTS.md\n- plus a real rule\n", "AGENTS.md"), false);
+  assert.equal(isPointerTo("@docs/AGENTS.md", "AGENTS.md"), false);
+  assert.equal(isPointerTo(SEPARATE_CLAUDE, "AGENTS.md"), false);
+  assert.equal(isPointerTo("", "AGENTS.md"), false);
+});
+
+test("CLAUDE.md as a pointer resolves AGENTS.md silently and only AGENTS.md is written", () => {
+  const repo = repoWith({ "AGENTS.md": AGENTS, "CLAUDE.md": renderPointer("AGENTS.md") });
+  const config = loadConfig(repo.root);
+
+  const { result, warnings } = captureWarnings(() => primaryMemoryFile(repo, config));
+  assert.equal(result.file.path, "AGENTS.md");
+  assert.deepEqual(warnings, []);
+  assert.equal(result.resolved.pointers.length, 1);
+  assert.equal(result.resolved.separate.length, 0);
+
+  const written = applyOneEdit(repo, config);
+  assert.deepEqual(
+    written.written.map((w) => w.file),
+    ["AGENTS.md"],
+  );
+  assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /full test suite/);
+  assert.equal(fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8"), renderPointer("AGENTS.md"));
+});
+
+test("two separate full files: AGENTS.md is optimized, CLAUDE.md is left alone with a consolidate warning", () => {
+  const repo = repoWith({ "AGENTS.md": AGENTS, "CLAUDE.md": SEPARATE_CLAUDE });
+  const config = loadConfig(repo.root);
+
+  const { result, warnings } = captureWarnings(() => primaryMemoryFile(repo, config));
+  assert.equal(result.file.path, "AGENTS.md");
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /CLAUDE\.md is a separate memory file and will NOT be updated/);
+  assert.match(warnings[0], /@AGENTS\.md/);
+
+  const written = applyOneEdit(repo, config);
+  assert.deepEqual(
+    written.written.map((w) => w.file),
+    ["AGENTS.md"],
+  );
+  assert.equal(fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8"), SEPARATE_CLAUDE);
+});
+
+test("a single AGENTS.md or a single CLAUDE.md resolves as before, without warnings", () => {
+  for (const name of ["AGENTS.md", "CLAUDE.md"]) {
+    const repo = repoWith({ [name]: AGENTS });
+    const { result, warnings } = captureWarnings(() => primaryMemoryFile(repo, loadConfig(repo.root)));
+    assert.equal(result.file.path, name);
+    assert.deepEqual(warnings, []);
+    assert.equal(result.all.length, 1);
+  }
+});
+
+test("a configured memoryFiles override still picks its own primary", () => {
+  const repo = repoWith({ "AGENTS.md": AGENTS });
+  fs.mkdirSync(path.join(repo.root, "docs"), { recursive: true });
+  fs.writeFileSync(path.join(repo.root, "docs", "MEMORY.md"), AGENTS);
+  const config = loadConfig(repo.root, { memoryFiles: ["docs/MEMORY.md"] });
+  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles);
+  assert.equal(resolved.primary.path, "docs/MEMORY.md");
+  assert.equal(resolved.all.length, 1);
+});
+
+test("no memory file: primaryMemoryFile fails with a pointer to bootstrap", () => {
+  const repo = repoWith({});
+  assert.throws(() => primaryMemoryFile(repo, loadConfig(repo.root)), /no memory file found/);
+  assert.equal(resolveMemoryFiles(repo.root, ["AGENTS.md", "CLAUDE.md"]).primary, null);
+});


### PR DESCRIPTION
## Summary

One coherent memory-handling change in two parts.

**Part 1 - bootstrap when no memory file exists.** `backpass` no longer fails with "no memory file found". It logs `no memory file found (looked for AGENTS.md, CLAUDE.md) - bootstrapping AGENTS.md from N transcript(s) + defaults`, creates:

- `AGENTS.md` - a starter with purpose, an Orientation section filled from deterministic repo facts (package manager from lockfile, `check`/`test`/`lint`/... scripts from package.json, README pointer), baseline Conventions, a Sharp edges placeholder, and the canonical `## Maintaining this file` section (`src/bootstrap.js`)
- `CLAUDE.md` - the standard two-line `@AGENTS.md` pointer

and then runs the ordinary analyze -> fold -> synthesize pass with the starter as the current weights (the synthesis prompt gets a bootstrap note via a new `{{RUN_NOTE}}` token). The first proposal is applied directly through `src/apply/writer.js` - the file is brand new, so `git diff` is the review; the saved proposal is stamped `appliedBy: bootstrap` so `backpass apply` refuses to replay it. With no transcripts (or no usable evidence) the files are seeded from defaults and the output says so (`seeded from defaults`). Bootstrap only ever creates files (`wx` flag + existence check); an existing file is reported as `kept`, never overwritten. `config.memoryFiles[0]` still decides the canonical path.

**Part 2 - pointer-aware resolution.** `resolveMemoryFiles` (`src/memory.js`) keeps the first configured file canonical (AGENTS.md) and classifies the others:

- a CLAUDE.md whose only content is `@AGENTS.md` / `@./AGENTS.md` (comments and blank lines ignored) is a *pointer*: optimizing AGENTS.md is fully correct, no output
- a CLAUDE.md with its own content is *separate*: AGENTS.md is optimized and a `warn` says CLAUDE.md will NOT be updated and recommends consolidating it into a pointer. `backpass status` marks pointers (`pointer to AGENTS.md`) and separate files (`separate - not optimized`).

Single-AGENTS.md and single-CLAUDE.md behavior is unchanged, and the weights hash still covers all existing files so cached evidence survives.

## Open design choice for the captain (not assumed)

The both-separate-files policy here is **warn, optimize AGENTS.md only**. The alternative - updating both separate files each run - is a different policy (it risks divergence as edits are accepted on one and rejected on the other). If you would rather both files be updated, say so and that becomes a follow-up; this PR deliberately does not pick it silently.

A second, smaller call worth a glance: bootstrap applies its first proposal **without** the apply gate, on the grounds that a newly created file has nothing to protect. If you prefer "seed defaults, then leave the proposal for `backpass apply`", that is a two-line change in `src/commands/bootstrap.js`.

## Tests

- `test/bootstrap.test.js`: starter content (facts, conventions, self-governance, not a stub); no-file + no-transcripts seeds defaults + pointer; with transcripts the folded gap becomes the first instruction via the real fold/buildProposal/writer path (model stages injected); never overwrites an existing CLAUDE.md; `memoryFiles` override bootstraps that path with a pointer to it.
- `test/memory-resolution.test.js`: pointer detection; pointer CLAUDE.md -> AGENTS.md resolved, no warning, only AGENTS.md written; two separate files -> consolidate warning, CLAUDE.md byte-identical; single-file cases unchanged; override wins.
- `pnpm run check` (lint, format, typecheck, 139 tests) green. Also smoke-tested the real CLI in a fresh repo with an empty HOME: bootstrap, second run, and `status` for the pointer and separate cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
