### PR TITLE
fix: exclude .backpass/ from git on every command, not only init

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,13 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { CONFIG_FILENAME, STATE_DIRNAME, initialConfig, repoConfigPath } from "../config.js";
+import { CONFIG_FILENAME, initialConfig, repoConfigPath } from "../config.js";
 import { color, info, out, warn } from "../logger.js";
 import { loadMemoryFiles } from "../memory.js";
 import { ensureLocalExclude } from "../repo.js";
+import { STATE_EXCLUDE_LINE as EXCLUDE_LINE } from "../state.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
-
-const EXCLUDE_LINE = `${STATE_DIRNAME}/`;
 
 export async function cmdInit({ repo, config, flags }) {
   const target = repoConfigPath(repo.root);

--- a/src/state.js
+++ b/src/state.js
@@ -4,10 +4,15 @@ import crypto from "node:crypto";
 
 import { STATE_DIRNAME } from "./config.js";
 import { warn } from "./logger.js";
+import { ensureLocalExclude } from "./repo.js";
+
+/** The line every command writes to the repo's local git exclude for the state dir. */
+export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
 
 /**
  * All mutable run state lives in a `.backpass/` directory, kept out of git via the
- * repo's local exclude (`.git/info/exclude`, written by `backpass init`) rather than
+ * repo's local exclude (`.git/info/exclude`, written idempotently by `ensure()` on every
+ * command, so a plain `backpass` run with no prior `init` is excluded too) rather than
  * the tracked `.gitignore`:
  *
  *   scan-cache.json        path+mtime+size -> association verdict (design section 2.2)
@@ -30,9 +35,14 @@ export class State {
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
   }
 
+  /**
+   * Creates the state dir and excludes it from git in the same step. The exclude is
+   * local-only and fail-soft: a non-git directory is silently left alone.
+   */
   ensure() {
     fs.mkdirSync(this.evidenceDir, { recursive: true });
     fs.mkdirSync(this.applyDir, { recursive: true });
+    this.exclude = ensureLocalExclude(path.dirname(this.root), STATE_EXCLUDE_LINE);
     return this;
   }
 

--- a/test/state-exclude.test.js
+++ b/test/state-exclude.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { State } from "../src/state.js";
+
+function git(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+function initRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-state-"));
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  return dir;
+}
+
+test("creating the state dir without a prior `init` excludes .backpass/ from git", () => {
+  const dir = initRepo();
+  fs.writeFileSync(path.join(dir, "AGENTS.md"), "# memory\n");
+
+  const state = new State(dir).ensure();
+  state.writeScanCache({ version: 1, entries: {} });
+
+  assert.equal(state.exclude.status, "added");
+  const exclude = fs.readFileSync(path.join(dir, ".git", "info", "exclude"), "utf8");
+  assert.match(exclude, /^\.backpass\/$/m);
+  assert.equal(fs.existsSync(path.join(dir, ".gitignore")), false, "tracked .gitignore is untouched");
+
+  const status = git(["status", "--porcelain", "--untracked-files=all"], dir);
+  assert.doesNotMatch(status, /\.backpass/, `state dir leaked into git status:\n${status}`);
+  assert.match(status, /AGENTS\.md/, "user memory files are still visible to git");
+});
+
+test("ensure() is idempotent alongside `init` - the exclude line is written once", () => {
+  const dir = initRepo();
+
+  new State(dir).ensure();
+  const second = new State(dir).ensure();
+
+  assert.equal(second.exclude.status, "present");
+  const lines = fs
+    .readFileSync(path.join(dir, ".git", "info", "exclude"), "utf8")
+    .split("\n")
+    .filter((l) => l.trim() === ".backpass/");
+  assert.equal(lines.length, 1);
+});
+
+test("ensure() outside a git repo creates the state dir and does not throw", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-nogit-"));
+
+  const state = new State(dir).ensure();
+
+  assert.equal(state.exclude.status, "no-git");
+  assert.ok(fs.existsSync(state.evidenceDir));
+});


### PR DESCRIPTION
## Bug
The default `backpass` run creates `.backpass/` but only `backpass init` called `ensureLocalExclude()`, so users who never ran `init` saw `.backpass/` untracked in `git status`.

## Fix
- `State.ensure()` (the single creation site for the state dir, used by every command via `src/cli.js`) now calls `ensureLocalExclude(root, ".backpass/")`. Idempotent, local-only (`.git/info/exclude`, never the tracked `.gitignore`), fail-soft outside a git repo.
- `init` reuses the shared `STATE_EXCLUDE_LINE` constant; running it after a plain run leaves exactly one exclude line.

## Tests
`test/state-exclude.test.js`: run without prior init excludes `.backpass/` (exclude file + `git status`), `AGENTS.md` remains visible, idempotence, non-git case. `pnpm run check` green (142 tests).

Verified E2E in a fresh repo via `bin/backpass.js scan` then `init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)