### PR TITLE
feat: slim the starter memory to a Learnings section and target it in bootstrap synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,8 @@ pointer-aware:
   CLAUDE.md untouched, and warns each run until you consolidate: move CLAUDE.md's content
   into AGENTS.md and make CLAUDE.md the one-line pointer.
 - A repo with **no memory file** is bootstrapped on the first `backpass` run: a starter
-  AGENTS.md (purpose, detected orientation such as the package manager and check
-  commands, baseline conventions, a `## Maintaining this file` section) plus a CLAUDE.md
-  pointer. The starter is then run through the ordinary backward pass, so recurring gaps
+  AGENTS.md (purpose, an empty `## Learnings` section, a `## Maintaining this file`
+  section) plus a CLAUDE.md pointer. The starter is then run through the ordinary backward pass, so recurring gaps
   from your real transcripts become its first evidence-backed instructions. With no
   transcripts it is seeded from defaults alone and says so. Bootstrap only ever creates
   files; review it with `git diff`.

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 
 import { parseMemoryUnits } from "./memory.js";
@@ -8,12 +7,12 @@ import { estimateTokens } from "./tokens.js";
 /**
  * The starter memory file backpass seeds when a repo has none.
  *
- * Bootstrap = sensible defaults + the normal backward pass. The defaults here are the
- * skeleton every good memory file shares (purpose, orientation, conventions, a
- * self-governance section); what the repo's own transcripts teach is layered on top by
- * the same analyze -> fold -> synthesize pipeline a normal run uses, with this text
- * standing in as the "current weights". Whatever is deterministically detectable from
- * the checkout (package manager, check commands) is filled in; nothing is guessed.
+ * Bootstrap = a minimal skeleton + the normal backward pass. The skeleton is deliberately
+ * tiny (purpose, an empty `## Learnings` section, a self-governance section): every
+ * starter line is paid on every session, so nothing generic is pre-filled. What the
+ * repo's own transcripts teach is layered on top by the same analyze -> fold ->
+ * synthesize pipeline a normal run uses, with this text standing in as the "current
+ * weights"; evidence-backed entries land under `## Learnings`.
  *
  * The canonical file is AGENTS.md; CLAUDE.md is the `@AGENTS.md` pointer so both harness
  * families read one source of truth. Writing happens in `src/apply/writer.js`.
@@ -47,108 +46,14 @@ Prefer rewriting or pruning existing entries over appending new ones.
 When updating this file, preserve this bar for all agents and keep entries concise.
 `;
 
-const LOCKFILES = [
-  ["pnpm-lock.yaml", "pnpm"],
-  ["yarn.lock", "yarn"],
-  ["bun.lockb", "bun"],
-  ["bun.lock", "bun"],
-  ["package-lock.json", "npm"],
-];
-
-const SCRIPT_LABELS = [
-  ["check", "the full local gate"],
-  ["test", "tests"],
-  ["lint", "lint"],
-  ["typecheck", "type checks"],
-  ["build", "the build"],
-  ["format:check", "formatting"],
-];
-
-/** What the checkout itself says, without reading transcripts or calling a model. */
-export function detectRepoFacts(root) {
-  const facts = { packageManager: null, scripts: [], readme: null };
-  const exists = (name) => fs.existsSync(path.join(root, name));
-
-  for (const [file, manager] of LOCKFILES) {
-    if (exists(file)) {
-      facts.packageManager = manager;
-      break;
-    }
-  }
-
-  const pkgPath = path.join(root, "package.json");
-  if (exists("package.json")) {
-    try {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-      if (!facts.packageManager && pkg.packageManager) {
-        facts.packageManager = String(pkg.packageManager).split("@")[0];
-      }
-      const scripts = pkg.scripts && typeof pkg.scripts === "object" ? pkg.scripts : {};
-      for (const [name, label] of SCRIPT_LABELS) {
-        if (typeof scripts[name] === "string") facts.scripts.push({ name, label });
-      }
-      if (!facts.packageManager) facts.packageManager = "npm";
-    } catch {
-      // An unparseable package.json is not a bootstrap problem; the defaults stay generic.
-    }
-  }
-
-  for (const name of ["README.md", "README", "readme.md"]) {
-    if (exists(name)) {
-      facts.readme = name;
-      break;
-    }
-  }
-  return facts;
-}
-
-function runCommand(manager, script) {
-  if (!manager || manager === "npm") return `npm run ${script}`;
-  return `${manager} run ${script}`;
-}
-
 /** Render the default AGENTS.md for a repo. Deterministic for a given checkout. */
-export function renderStarterMemory({ repo, facts = detectRepoFacts(repo.root) }) {
-  if (!facts) facts = detectRepoFacts(repo.root);
-  const orientation = [];
-  if (facts.readme) orientation.push(`- \`${facts.readme}\` documents the user-facing surface; start there.`);
-  if (facts.packageManager) {
-    orientation.push(`- ${facts.packageManager} is the package manager; do not switch it or add a second lockfile.`);
-  }
-  if (facts.scripts.length) {
-    const gate = facts.scripts.find((s) => s.name === "check") || facts.scripts[0];
-    const others = facts.scripts
-      .filter((s) => s !== gate)
-      .map((s) => `\`${runCommand(facts.packageManager, s.name)}\` (${s.label})`)
-      .join(", ");
-    orientation.push(
-      `- \`${runCommand(facts.packageManager, gate.name)}\` runs ${gate.label}${others ? `; also ${others}` : ""}. ` +
-        "Run it before declaring work done.",
-    );
-  }
-  if (!orientation.length) {
-    orientation.push("- Read the top-level README and directory layout before changing anything.");
-  }
-
+export function renderStarterMemory({ repo }) {
   return `# Project agent memory
 
 ${repo.name}: this file is the always-loaded memory for agents working in this repo.
 It is kept short on purpose - every line here is paid on every session.
 
-## Orientation
-
-${orientation.join("\n")}
-
-## Conventions
-
-- Read the surrounding code and follow its existing patterns before adding new ones.
-- Reproduce a bug end to end before fixing it, then keep the reproduction as a test.
-- Run the project's checks (lint, tests, types) before declaring work done; fix what
-  they report even when it is unrelated to the task.
-- Never hand-edit generated files (lockfiles, changelogs, build output).
-- Keep changes scoped to the task; call out follow-ups instead of silently widening scope.
-
-## Sharp edges
+## Learnings
 
 - None recorded yet. backpass adds evidence-backed entries here from real sessions.
 
@@ -156,8 +61,8 @@ ${MAINTAINING_SECTION}`;
 }
 
 /** An in-memory memory file object in the shape `readMemoryFile` returns, never on disk. */
-export function starterMemoryFile(repo, relativePath = CANONICAL_MEMORY_FILE, facts = null) {
-  const text = renderStarterMemory({ repo, facts });
+export function starterMemoryFile(repo, relativePath = CANONICAL_MEMORY_FILE) {
+  const text = renderStarterMemory({ repo });
   return {
     path: relativePath,
     absolute: path.join(repo.root, relativePath),

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -12,7 +12,7 @@ import { foldForRun, printProposal } from "./propose.js";
 /**
  * Bootstrap: the default run when the repo has no memory file at all.
  *
- * Instead of failing, backpass seeds a starter AGENTS.md (sensible defaults, see
+ * Instead of failing, backpass seeds a starter AGENTS.md (a minimal skeleton, see
  * `src/bootstrap.js`) plus a CLAUDE.md pointer, then runs the ordinary backward pass with
  * the starter as the current weights: the transcripts' gaps and recurring mistakes
  * become the first evidence-backed instructions. Every edit of that first proposal is
@@ -27,8 +27,8 @@ import { foldForRun, printProposal } from "./propose.js";
 const BOOTSTRAP_RUN_NOTE =
   "This memory file was just seeded from generic defaults and has never steered a session, " +
   "so the evidence is gaps and mistakes only. Turn recurring gaps into concrete instructions " +
-  "(`add` under the matching section, `## Sharp edges` for project-specific traps, replacing " +
-  "the placeholder bullet there) and `rewrite` any default the evidence contradicts. " +
+  "(`add` under `## Learnings`, replacing the placeholder bullet there; never create a new " +
+  "section for them) and `rewrite` any default the evidence contradicts. " +
   "Skip anything a single session suggests.";
 
 /**

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { bootstrapRun } from "../src/commands/bootstrap.js";
-import { detectRepoFacts, renderPointer, renderStarterMemory } from "../src/bootstrap.js";
+import { renderPointer, renderStarterMemory } from "../src/bootstrap.js";
 import { loadConfig } from "../src/config.js";
 import { setLoggerSink } from "../src/logger.js";
 import { isPointerTo, parseMemoryUnits } from "../src/memory.js";
@@ -97,26 +97,26 @@ function withSink(fn) {
   );
 }
 
-test("starter memory is a real file: purpose, detected facts, conventions, and self-governance", () => {
+test("starter memory is the minimal skeleton: purpose, an empty Learnings section, self-governance", () => {
   const repo = makeRepo({
     "package.json": JSON.stringify({ name: "demo", scripts: { check: "x", test: "y" } }),
     "pnpm-lock.yaml": "",
     "README.md": "# demo",
   });
-  const facts = detectRepoFacts(repo.root);
-  assert.equal(facts.packageManager, "pnpm");
-  const text = renderStarterMemory({ repo, facts });
+  const text = renderStarterMemory({ repo });
   assert.match(text, /^# Project agent memory/);
   assert.match(text, /demo-repo/);
-  assert.match(text, /`pnpm run check` runs the full local gate/);
-  assert.match(text, /`README.md` documents/);
-  assert.match(text, /## Conventions/);
-  assert.match(text, /## Maintaining this file/);
-  assert.ok(parseMemoryUnits(text).length >= 8, "the starter is not a stub");
+  const headings = text.split("\n").filter((l) => l.startsWith("## "));
+  assert.deepEqual(headings, ["## Learnings", "## Maintaining this file"]);
+  assert.match(
+    text,
+    /## Learnings\n\n- None recorded yet\. backpass adds evidence-backed entries here from real sessions\./,
+  );
+  assert.doesNotMatch(text, /Sharp edges|Orientation|Conventions|pnpm|README/);
+  assert.ok(parseMemoryUnits(text).length >= 3, "the starter parses into memory units");
 
-  const bare = renderStarterMemory({ repo: makeRepo(), facts: detectRepoFacts(makeRepo().root) });
-  assert.match(bare, /Read the top-level README/);
-  assert.match(bare, /## Maintaining this file/);
+  // Deterministic: the checkout's contents no longer change the starter.
+  assert.equal(renderStarterMemory({ repo: makeRepo() }), text);
 });
 
 test("no memory file and no transcripts: seeds AGENTS.md from defaults plus a CLAUDE.md pointer", async () => {
@@ -157,10 +157,20 @@ test("with transcripts: analysis gaps become the first evidence-backed instructi
     ["AGENTS.md"],
   );
 
+  assert.match(captured.runNote, /`## Learnings`/);
+  assert.doesNotMatch(captured.runNote, /Sharp edges/);
+
   const agents = fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8");
   assert.match(agents, /scratch database/);
   assert.doesNotMatch(agents, /None recorded yet/);
   assert.match(agents, /## Maintaining this file/);
+  // The entry landed inside ## Learnings, not in a new or renamed section.
+  const learnings = agents.slice(agents.indexOf("## Learnings"), agents.indexOf("## Maintaining this file"));
+  assert.match(learnings, /^- Run migrations only against a scratch database/m);
+  assert.deepEqual(
+    agents.split("\n").filter((l) => l.startsWith("## ")),
+    ["## Learnings", "## Maintaining this file"],
+  );
   assert.equal(fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8"), renderPointer("AGENTS.md"));
 
   // The applied proposal is marked so `backpass apply` cannot replay it onto the new file.


### PR DESCRIPTION
## What

Slims the starter memory `renderStarterMemory` seeds for a repo with no memory file, and carries the `Sharp edges` -> `Learnings` rename through the pipeline.

- Starter structure is now header/intro -> `## Learnings` (placeholder line kept) -> `## Maintaining this file`. `## Orientation` and `## Conventions` are gone.
- `detectRepoFacts` had no caller outside the template and its test, so it is removed along with the `facts` plumbing in `starterMemoryFile`.
- `## Sharp edges` was named in exactly one place outside the template: `BOOTSTRAP_RUN_NOTE` in `src/commands/bootstrap.js`, the run note that tells synthesis where to put evidence-backed entries. It now says `## Learnings` and explicitly forbids creating a new section. The prompts under `src/prompts/` never named the section, and proposal placement (`src/proposal.js`) is `anchor`/`find` based, so nothing else needed to change. README's bootstrap description is updated.

## Tests

- `test/bootstrap.test.js`: starter test asserts the exact `##` heading list, the placeholder under `## Learnings`, no Orientation/Conventions/Sharp edges/detected facts, and that the starter is deterministic regardless of checkout contents.
- The with-transcripts bootstrap test now asserts the run note names `## Learnings`, the evidence-backed entry lands inside `## Learnings`, and the resulting file's headings are exactly `## Learnings`, `## Maintaining this file` (no duplicate or renamed section).
- `pnpm install` + `pnpm run check` (lint, format, typecheck, 142 tests) green.

## End-to-end verification

Real run with real models, fully isolated: a scratch `HOME` whose `.claude/projects/` held three synthetic Claude Code transcripts (same recurring mistake: running jest in a `node:test` repo) tied to a scratch git repo with no memory file; auth dirs symlinked so acpx agents authenticate.

`backpass --no-ui` in that repo: bootstrap wrote the new starter, analysis ran on pi/gpt-5.6-luna, synthesis on pi/gpt-5.6-sol, and the proposal was one `add` edit with `find` = the `## Learnings` placeholder line. Resulting AGENTS.md:

```
## Learnings

- Run tests with `npm test` (`node:test`); never use Jest.

## Maintaining this file
```

No `Sharp edges`, no new section.

Caveat worth knowing: on the first attempt the three real analysis outputs were paraphrases (`Inspect package.json ... before choosing a test command` vs `Before running tests, inspect package.json ... instead of assuming Jest`), and `src/fold.js`'s bigram similarity at 0.45 did not cluster them, so all three were dropped as singletons and nothing was proposed. To exercise the synthesis placement I normalized the cached evidence records' `proposedInstruction` to one string so the fold clustered them (3 sessions), then re-ran the bootstrap. The fold's sensitivity to paraphrase is a pre-existing issue, independent of this change, and deserves its own follow-up.
