### PR TITLE
feat: drop raw transcript ids from the analyze progress table

### DIFF
--- a/src/analyze.js
+++ b/src/analyze.js
@@ -97,7 +97,9 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
     id: transcript.nativeId,
     title: transcriptLabel(transcript),
     phase: "model",
-    rawBytes: transcript.bytes,
+    // Measure the input distill actually consumed, not `transcript.bytes`: that is a
+    // discovery stat() size, which is a directory or 0 for several harnesses.
+    rawBytes: Buffer.byteLength(JSON.stringify(raw.events), "utf8"),
     distilledBytes: Buffer.byteLength(distilled.trace, "utf8"),
   });
 

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -64,6 +64,21 @@ export function sanitizeEvidence(parsed) {
   return clean;
 }
 
+/**
+ * Human-facing label for a transcript in progress output. Never a raw session ID: a
+ * transcript with no title falls back to its session date/time, then to "(untitled)".
+ */
+export function transcriptLabel(transcript) {
+  if (transcript.title) return transcript.title;
+  const at = Number(transcript.startedAt);
+  if (Number.isFinite(at) && at > 0) {
+    const d = new Date(at);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `session ${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+  return "(untitled)";
+}
+
 function promptPathFor(state, transcript) {
   return path.join(state.applyDir, "..", "prompts", `${safeFileName(transcript.id)}.md`);
 }
@@ -80,7 +95,7 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
     slot,
     harness: transcript.harness,
     id: transcript.nativeId,
-    title: transcript.title || transcript.nativeId,
+    title: transcriptLabel(transcript),
     phase: "model",
     rawBytes: transcript.bytes,
     distilledBytes: Buffer.byteLength(distilled.trace, "utf8"),
@@ -222,7 +237,7 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
       slot,
       harness: transcript.harness,
       id: transcript.nativeId,
-      title: transcript.title || transcript.nativeId,
+      title: transcriptLabel(transcript),
       phase: "distill",
     });
 
@@ -248,7 +263,7 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
     } catch (err) {
       // Per-transcript fail-soft: recorded, listed by `backpass status`, retried next run.
       summary.failed += 1;
-      warn(`${transcript.harness} ${transcript.nativeId}: ${err.message}`);
+      warn(`${transcript.harness} ${transcriptLabel(transcript)}: ${err.message}`);
       state.writeEvidence(transcript.id, { ...base, status: "failed", error: err.message });
     } finally {
       done += 1;

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -354,12 +354,10 @@ function analyzeDetail(state, theme, width, spin) {
 
   lines.push("");
   lines.push(countersLine(a, theme, width));
-  const evidence =
-    ` ${theme.paint("evidence so far", "dim")}   ${theme.paint(`✓ ${a.evidence.positive}`, "mint")} ${theme.paint("helped", "faint")}` +
-    `   ${theme.paint(`✗ ${a.evidence.negative}`, "red")} ${theme.paint("violated", "faint")}` +
-    `   ${theme.paint(`◆ ${a.evidence.gaps}`, "yellow")} ${theme.paint("gaps", "faint")}`;
   lines.push(
-    lr(evidence, state.narrow ? null : theme.paint("claims without a verbatim quote are dropped", "faint"), width),
+    ` ${theme.paint("evidence so far", "dim")}   ${theme.paint(`✓ ${a.evidence.positive}`, "mint")} ${theme.paint("helped", "faint")}` +
+      `   ${theme.paint(`✗ ${a.evidence.negative}`, "red")} ${theme.paint("violated", "faint")}` +
+      `   ${theme.paint(`◆ ${a.evidence.gaps}`, "yellow")} ${theme.paint("gaps", "faint")}`,
   );
   return lines;
 }

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -330,7 +330,7 @@ function analyzeDetail(state, theme, width, spin) {
 
   const receiptWidth = 27;
   const timeWidth = 6;
-  const titleWidth = Math.max(width - 2 - 2 - 2 - 11 - 10 - receiptWidth - (state.narrow ? 0 : timeWidth) - 7, 10);
+  const titleWidth = Math.max(width - 2 - 2 - 2 - 11 - receiptWidth - (state.narrow ? 0 : timeWidth) - 7, 10);
 
   a.lanes.forEach((lane, index) => {
     if (!lane) return;
@@ -347,7 +347,7 @@ function analyzeDetail(state, theme, width, spin) {
       : theme.paint(fitPlain(formatElapsed(state.now - lane.startedAt), timeWidth, "right"), "faint");
     lines.push(
       ` ${theme.paint(spin, "mint")} ${theme.paint(String(index + 1), "faint")} ${harnessDot(theme, lane.harness)} ` +
-        `${theme.paint(fitPlain(lane.harness, 9), "text")}${theme.paint(fitPlain(lane.id, 10), "faint")} ` +
+        `${theme.paint(fitPlain(lane.harness, 9), "text")} ` +
         `${theme.paint(fitPlain(lane.title, titleWidth), "dim")} ${receipt}${elapsed}`,
     );
   });

--- a/test/analyze-label.test.js
+++ b/test/analyze-label.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { transcriptLabel } from "../src/analyze.js";
+
+const uuid = "0f3b6a2e-9d1c-4e7a-b8c5-1d2e3f4a5b6c";
+
+test("transcriptLabel prefers the real title", () => {
+  assert.equal(
+    transcriptLabel({ nativeId: uuid, title: "refactor wallet sync", startedAt: 1 }),
+    "refactor wallet sync",
+  );
+});
+
+test("transcriptLabel falls back to the session date/time, never the id", () => {
+  const startedAt = new Date(2026, 7, 21, 14, 3).getTime();
+  const label = transcriptLabel({ nativeId: uuid, title: "", startedAt });
+  assert.equal(label, "session 2026-08-21 14:03");
+  assert.ok(!label.includes(uuid.slice(0, 8)));
+});
+
+test("transcriptLabel falls back to (untitled) without a title or a start time", () => {
+  assert.equal(transcriptLabel({ nativeId: uuid, title: null, startedAt: null }), "(untitled)");
+  assert.equal(transcriptLabel({ nativeId: uuid, startedAt: 0 }), "(untitled)");
+});

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -270,6 +270,31 @@ test("analyze frame: pool bar, lanes with distill receipts, counters, evidence t
   assert.ok(text.includes("53 sessions from this repo"));
 });
 
+test("analyze frame: lane rows show the human title and never the transcript id", () => {
+  const lines = render(stateAfter(ANALYZE_SCRIPT));
+  const text = lines.join("\n");
+
+  assert.ok(text.includes("refactor wallet sync engine"));
+  assert.ok(text.includes("add csv export"));
+  assert.ok(!text.includes("7c1f39aa"));
+  assert.ok(!text.includes("51a7ff08"));
+});
+
+test("analyze frame: a lane whose title is a clean fallback still carries no id", () => {
+  const uuid = "0f3b6a2e-9d1c-4e7a-b8c5-1d2e3f4a5b6c";
+  const script = [
+    ...ANALYZE_SCRIPT,
+    ["analyze:lane", { slot: 2, harness: "codex", id: uuid, title: "session 2026-08-21 14:03", phase: "distill" }],
+    ["analyze:lane", { slot: 3, harness: "codex", id: uuid, title: "(untitled)", phase: "distill" }],
+  ];
+  const text = render(stateAfter(script)).join("\n");
+
+  assert.ok(text.includes("session 2026-08-21 14:03"));
+  assert.ok(text.includes("(untitled)"));
+  assert.ok(!text.includes(uuid));
+  assert.ok(!text.includes(uuid.slice(0, 8)));
+});
+
 const SYNTH_SCRIPT = [
   ...ANALYZE_SCRIPT,
   ["analyze:done", { total: 58, analyzed: 23, cached: 33, skipped: 1, failed: 1 }],

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -266,7 +266,7 @@ test("analyze frame: pool bar, lanes with distill receipts, counters, evidence t
   assert.ok(text.includes("✓ 61 helped"));
   assert.ok(text.includes("✗ 14 violated"));
   assert.ok(text.includes("◆ 22 gaps"));
-  assert.ok(text.includes("claims without a verbatim quote are dropped"));
+  assert.ok(!text.includes("claims without a verbatim quote are dropped"));
   assert.ok(text.includes("53 sessions from this repo"));
 });
 


### PR DESCRIPTION
## Summary
Three display cleanups in the analyze progress view.

### 1. No raw transcript ids
- Remove the truncated-id column from the analyze progress table (`src/tui/render.js`) and give its width to the title column.
- Add `transcriptLabel()` in `src/analyze.js`: real title, else `session YYYY-MM-DD HH:MM` from `startedAt`, else `(untitled)`. No path falls back to the native UUID anymore. The per-transcript failure warning uses the same label.
- The plain-lines (non-TTY) analyze path only prints counts and never showed ids; `--json`, evidence records and `backpass scan` keep their ids (machine contract unchanged).

### 2. Truthful `distilled <raw> ▸ <distilled>` receipt
Root cause of receipts reading backwards (e.g. `distilled 203 B ▸ 28.4 KB`): `rawBytes` was `transcript.bytes`, which is the discovery-time `stat().size` of whatever the adapter enumerated. For claude/codex/pi that is the JSONL file, but for cursor-cli and grok it is the session *directory* (a few hundred bytes) and for opencode and cursor-ide it is hard-coded `0`. Meanwhile `distilledBytes` measured the real distilled trace, so the two numbers never described the same content. `rawBytes` now measures the serialized normalized events that `distill()` actually consumed, so the receipt reads big -> small for every harness.

### 3. Remove the footnote
Dropped the faint `claims without a verbatim quote are dropped` line under the evidence tally.

## Tests
- Render tests assert lane rows show titles and contain no id, including the date/time and `(untitled)` fallbacks, and that the footnote is gone.
- New `test/analyze-label.test.js` covers the fallback order.
- `pnpm run check` green (lint, format, typecheck, 147 tests).