### PR TITLE
fix: write generated skills to .agents/skills with a .claude/skills symlink and non-invocable frontmatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
+- **Skills only count if a harness loads them.** Extractions target `.agents/skills` with
+  `.claude/skills -> ../.agents/skills` as a symlink (`ensureSkillsLayout` in
+  `src/skills.js`, run at write time); a bare `skills/` dir is never auto-detected and a
+  real `.claude/skills` directory is warned about, never replaced.
 - **Memory resolution is pointer-aware** (`resolveMemoryFiles` in `src/memory.js`): the
   first configured file is canonical, a `@AGENTS.md`-only CLAUDE.md is a pointer, and a
   second full file is warned about, never silently ignored or double-written.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ CLI flags on top:
 {
   "memoryFiles": ["AGENTS.md"],
   "budgetTokens": 5000,
-  "skillsDir": ".claude/skills",
+  "skillsDir": ".agents/skills",
   "maxEditsPerRun": 5,
   "minGapEvidence": 2,
   "analysis": { "agent": null, "model": null, "effort": null },

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -18,7 +18,14 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   const rejected = proposal.edits.filter((e) => decisions[e.id] === "rejected");
 
   const byFile = new Map();
-  const results = { written: [], skills: [], failed: [], accepted: accepted.length, rejected: rejected.length };
+  const results = {
+    written: [],
+    skills: [],
+    failed: [],
+    warnings: [],
+    accepted: accepted.length,
+    rejected: rejected.length,
+  };
 
   for (const edit of accepted) {
     if (!byFile.has(edit.file)) byFile.set(edit.file, []);
@@ -56,8 +63,9 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   for (const edit of accepted) {
     if (edit.kind !== "extract" || !edit.skill) continue;
     try {
-      if (!dryRun) writeSkill(repo.root, edit.skill);
-      results.skills.push({ path: edit.skill.path, dryRun });
+      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
+      results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
+      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {
       results.failed.push({ file: edit.skill.path, edit: edit.id, error: err.message });
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -103,7 +103,7 @@ BUDGET AND SHAPE
   --max-edits <n>          edits per run - the learning rate            [5]
   --min-gap-evidence <n>   sessions needed before a new instruction     [2]
   --memory-file <path>     memory file to optimize (repeatable)
-  --skills-dir <path>      where skill extractions are written          [.claude/skills]
+  --skills-dir <path>      where skill extractions are written          [.agents/skills]
 
 APPLY
   --no-ui                  terminal accept/reject instead of the Lavish surface

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -1,4 +1,4 @@
-import { UserError, color, info, json, out } from "../logger.js";
+import { UserError, color, info, json, out, warn } from "../logger.js";
 import { applyDecisions } from "../apply/writer.js";
 import { closeApplySurface, openApplySurface, pollDecisions, renderApplySurface } from "../apply/lavish.js";
 import { reviewInTerminal } from "../apply/terminal.js";
@@ -85,7 +85,11 @@ export async function cmdApply(ctx) {
       );
     }
   }
-  for (const skill of results.skills) out(`  ${color.green("wrote")} ${skill.path} (new skill)`);
+  for (const skill of results.skills) {
+    out(`  ${color.green("wrote")} ${skill.path} (new skill)`);
+    for (const created of skill.created || []) out(color.dim(`    created ${created}`));
+  }
+  for (const warning of results.warnings || []) warn(warning);
   for (const failure of results.failed) {
     out(`  ${color.red("failed")} ${failure.file}${failure.edit ? ` (${failure.edit})` : ""}: ${failure.error}`);
   }

--- a/src/config.js
+++ b/src/config.js
@@ -42,7 +42,7 @@ export const LEGACY_DEFAULT_AGENTS = { analysis: "codex", synthesis: "claude" };
 export const DEFAULT_CONFIG = {
   memoryFiles: ["AGENTS.md", "CLAUDE.md"],
   budgetTokens: 5000,
-  skillsDir: ".claude/skills",
+  skillsDir: ".agents/skills",
   maxEditsPerRun: 5,
   minGapEvidence: 2,
   /**

--- a/src/skills.js
+++ b/src/skills.js
@@ -90,7 +90,17 @@ export function renderSkillIndex(skills) {
 /** Serialize a skill draft to the common SKILL.md shape. */
 export function renderSkillFile(skill) {
   const description = skill.description.replace(/\n+/g, " ").trim();
-  return `---\nname: ${skill.name}\ndescription: ${description}\n---\n\n${skill.body.trim()}\n`;
+  // Generated skills are reference material that fires on its description, never a
+  // slash-command: mark them non-invocable and internal so harnesses keep them out of
+  // the user-facing command list.
+  const frontmatter = [
+    `name: ${skill.name}`,
+    `description: ${description}`,
+    "user-invocable: false",
+    "metadata:",
+    "  internal: true",
+  ].join("\n");
+  return `---\n${frontmatter}\n---\n\n${skill.body.trim()}\n`;
 }
 
 /**
@@ -109,24 +119,88 @@ export function extractionBudgetEffect(edit) {
   };
 }
 
+/** Where agents actually auto-load skills from: the AGENTS.md convention. */
+export const CANONICAL_SKILLS_DIR = ".agents/skills";
+/** Claude reads this path; it is kept as a symlink into the canonical dir, never a copy. */
+export const CLAUDE_SKILLS_LINK = ".claude/skills";
+export const CLAUDE_SKILLS_LINK_TARGET = path.posix.join("..", CANONICAL_SKILLS_DIR);
+
 /**
- * Repos with no skills convention get `docs/` extraction plus a pointer line instead
- * (design section 7, format note). Detected rather than configured so the common case
- * needs no setup.
+ * Pick the directory skill extractions target.
+ *
+ * Skills only pay off if the harness loads them, so the answer is the canonical
+ * `.agents/skills` (mirrored to `.claude/skills` by symlink) unless the user explicitly
+ * configured another directory that already exists. The bare `skills/` dir is an
+ * installer/public convention that no harness auto-loads, so it is never auto-detected -
+ * it is only honored when named in the config. Resolution is read-only; the layout is
+ * created at write time (`ensureSkillsLayout`), which keeps every pre-apply stage
+ * side-effect free.
  */
-export function resolveOverflowTarget(repoRoot, skillsDir) {
-  if (fs.existsSync(path.join(repoRoot, skillsDir))) return { kind: "skills", dir: skillsDir };
-  for (const candidate of [".claude/skills", ".agents/skills", "skills"]) {
-    if (fs.existsSync(path.join(repoRoot, candidate))) return { kind: "skills", dir: candidate };
+export function resolveOverflowTarget(repoRoot, skillsDir = CANONICAL_SKILLS_DIR) {
+  const warnings = [];
+  const claude = inspectClaudeSkillsLink(repoRoot);
+  if (claude.state === "dir") warnings.push(claudeSkillsDirWarning());
+
+  const explicit = skillsDir && skillsDir !== CANONICAL_SKILLS_DIR && skillsDir !== CLAUDE_SKILLS_LINK;
+  if (explicit && fs.existsSync(path.join(repoRoot, skillsDir))) {
+    return { kind: "skills", dir: skillsDir, warnings };
   }
-  if (fs.existsSync(path.join(repoRoot, "docs"))) return { kind: "docs", dir: "docs" };
-  return { kind: "skills", dir: skillsDir };
+  return { kind: "skills", dir: CANONICAL_SKILLS_DIR, warnings };
 }
 
-/** Write an accepted skill extraction to disk. */
+function claudeSkillsDirWarning() {
+  return (
+    `${CLAUDE_SKILLS_LINK} is a real directory, not a symlink to ${CLAUDE_SKILLS_LINK_TARGET}; ` +
+    `left untouched. Claude will not see skills written to ${CANONICAL_SKILLS_DIR} until you ` +
+    `merge it in and replace it with the symlink (ln -s ${CLAUDE_SKILLS_LINK_TARGET} ${CLAUDE_SKILLS_LINK}).`
+  );
+}
+
+function inspectClaudeSkillsLink(repoRoot) {
+  let stat;
+  try {
+    stat = fs.lstatSync(path.join(repoRoot, CLAUDE_SKILLS_LINK));
+  } catch {
+    return { state: "missing" };
+  }
+  if (stat.isSymbolicLink()) return { state: "symlink" };
+  if (stat.isDirectory()) return { state: "dir" };
+  return { state: "other" };
+}
+
+/**
+ * Create the canonical skills dir and the `.claude/skills -> ../.agents/skills` symlink
+ * so both harness families load the same files with no duplication. An existing
+ * `.claude/skills` is never clobbered: a symlink (to anywhere) is left as is, and a real
+ * directory is reported so the user can merge it by hand.
+ */
+export function ensureSkillsLayout(repoRoot) {
+  const created = [];
+  const warnings = [];
+  const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
+  if (!fs.existsSync(canonical)) {
+    fs.mkdirSync(canonical, { recursive: true });
+    created.push(CANONICAL_SKILLS_DIR);
+  }
+
+  const claude = inspectClaudeSkillsLink(repoRoot);
+  if (claude.state === "missing") {
+    const link = path.join(repoRoot, CLAUDE_SKILLS_LINK);
+    fs.mkdirSync(path.dirname(link), { recursive: true });
+    fs.symlinkSync(CLAUDE_SKILLS_LINK_TARGET, link, "dir");
+    created.push(`${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`);
+  } else if (claude.state === "dir") {
+    warnings.push(claudeSkillsDirWarning());
+  }
+  return { created, warnings };
+}
+
+/** Write an accepted skill extraction to disk, setting up the load layout on first use. */
 export function writeSkill(repoRoot, skill) {
+  const inCanonical = skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`);
+  const layout = inCanonical ? ensureSkillsLayout(repoRoot) : { created: [], warnings: [] };
   const target = path.join(repoRoot, skill.path);
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.writeFileSync(target, renderSkillFile(skill));
-  return target;
+  return { target, ...layout };
 }

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -72,6 +72,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   const state = config.state;
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
+  for (const w of overflow.warnings) warn(w);
   const skillFiles = loadSkills(repo.root, overflow.dir);
   const harnessCounts = harnessCountsOf(transcripts);
 

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -1,0 +1,175 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  CANONICAL_SKILLS_DIR,
+  CLAUDE_SKILLS_LINK,
+  CLAUDE_SKILLS_LINK_TARGET,
+  ensureSkillsLayout,
+  loadSkills,
+  parseFrontmatter,
+  renderSkillFile,
+  resolveOverflowTarget,
+  writeSkill,
+} from "../src/skills.js";
+import { applyDecisions } from "../src/apply/writer.js";
+import { DEFAULT_CONFIG } from "../src/config.js";
+
+function tmpRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "backpass-skills-"));
+}
+
+const SKILL = {
+  name: "release-signing",
+  description: "Use when signing a release\nor rotating the signing key.",
+  body: "# Release signing\n\n1. Fetch the key.\n2. Sign the tarball.\n",
+  path: `${CANONICAL_SKILLS_DIR}/release-signing/SKILL.md`,
+};
+
+test("the default skills dir is the auto-loaded .agents/skills", () => {
+  assert.equal(DEFAULT_CONFIG.skillsDir, CANONICAL_SKILLS_DIR);
+});
+
+test("generated SKILL.md frontmatter marks the skill non-invocable and internal", () => {
+  const text = renderSkillFile(SKILL);
+  const lines = text.split("\n");
+  assert.equal(lines[0], "---");
+  assert.ok(lines.includes("user-invocable: false"), text);
+  const metadataAt = lines.indexOf("metadata:");
+  assert.ok(metadataAt > 0, text);
+  assert.equal(lines[metadataAt + 1], "  internal: true");
+  assert.equal(lines[metadataAt + 2], "---");
+  const frontmatter = parseFrontmatter(text);
+  assert.equal(frontmatter.name, "release-signing");
+  assert.equal(frontmatter.description, "Use when signing a release or rotating the signing key.");
+  assert.equal(frontmatter["user-invocable"], "false");
+  assert.ok(text.endsWith("2. Sign the tarball.\n"));
+});
+
+test("writeSkill lands in .agents/skills and links .claude/skills to it", () => {
+  const root = tmpRepo();
+  const result = writeSkill(root, SKILL);
+
+  const canonical = path.join(root, CANONICAL_SKILLS_DIR, "release-signing", "SKILL.md");
+  assert.equal(result.target, canonical);
+  assert.ok(fs.existsSync(canonical));
+  assert.ok(!fs.existsSync(path.join(root, "skills")));
+
+  const link = path.join(root, CLAUDE_SKILLS_LINK);
+  assert.ok(fs.lstatSync(link).isSymbolicLink());
+  assert.equal(fs.readlinkSync(link), CLAUDE_SKILLS_LINK_TARGET);
+  assert.equal(fs.readFileSync(path.join(link, "release-signing", "SKILL.md"), "utf8"), renderSkillFile(SKILL));
+  assert.deepEqual(result.created, [CANONICAL_SKILLS_DIR, `${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`]);
+  assert.deepEqual(result.warnings, []);
+
+  // Both harness views index the same single file.
+  assert.deepEqual(
+    loadSkills(root, CLAUDE_SKILLS_LINK).map((s) => s.name),
+    loadSkills(root, CANONICAL_SKILLS_DIR).map((s) => s.name),
+  );
+
+  const again = writeSkill(root, SKILL);
+  assert.deepEqual(again.created, []);
+});
+
+test("resolveOverflowTarget prefers .agents/skills and never auto-picks bare skills/", () => {
+  const empty = tmpRepo();
+  assert.deepEqual(resolveOverflowTarget(empty), { kind: "skills", dir: CANONICAL_SKILLS_DIR, warnings: [] });
+  assert.equal(resolveOverflowTarget(empty, ".claude/skills").dir, CANONICAL_SKILLS_DIR);
+
+  const bare = tmpRepo();
+  fs.mkdirSync(path.join(bare, "skills"));
+  fs.mkdirSync(path.join(bare, "docs"));
+  assert.equal(resolveOverflowTarget(bare).dir, CANONICAL_SKILLS_DIR);
+  assert.equal(resolveOverflowTarget(bare, ".claude/skills").dir, CANONICAL_SKILLS_DIR);
+
+  // An explicitly configured directory that exists is the user's call.
+  assert.equal(resolveOverflowTarget(bare, "skills").dir, "skills");
+  // ...but one that does not exist falls back to the canonical dir.
+  assert.equal(resolveOverflowTarget(bare, "nope/skills").dir, CANONICAL_SKILLS_DIR);
+});
+
+test("ensureSkillsLayout creates the dir and symlink when none exists and is idempotent", () => {
+  const root = tmpRepo();
+  const first = ensureSkillsLayout(root);
+  assert.ok(fs.statSync(path.join(root, CANONICAL_SKILLS_DIR)).isDirectory());
+  assert.equal(fs.readlinkSync(path.join(root, CLAUDE_SKILLS_LINK)), CLAUDE_SKILLS_LINK_TARGET);
+  assert.equal(first.created.length, 2);
+  assert.deepEqual(ensureSkillsLayout(root), { created: [], warnings: [] });
+});
+
+test("an existing .claude/skills symlink is left alone even if it points elsewhere", () => {
+  const root = tmpRepo();
+  fs.mkdirSync(path.join(root, ".claude"));
+  fs.mkdirSync(path.join(root, "custom-skills"));
+  fs.symlinkSync("../custom-skills", path.join(root, CLAUDE_SKILLS_LINK), "dir");
+  const result = ensureSkillsLayout(root);
+  assert.equal(fs.readlinkSync(path.join(root, CLAUDE_SKILLS_LINK)), "../custom-skills");
+  assert.deepEqual(result.created, [CANONICAL_SKILLS_DIR]);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("a real .claude/skills directory is warned about and never clobbered", () => {
+  const root = tmpRepo();
+  const existing = path.join(root, CLAUDE_SKILLS_LINK, "hand-written", "SKILL.md");
+  fs.mkdirSync(path.dirname(existing), { recursive: true });
+  fs.writeFileSync(existing, "---\nname: hand-written\ndescription: keep me\n---\n\nbody\n");
+
+  const resolved = resolveOverflowTarget(root);
+  assert.equal(resolved.dir, CANONICAL_SKILLS_DIR);
+  assert.equal(resolved.warnings.length, 1);
+  assert.match(resolved.warnings[0], /\.claude\/skills is a real directory/);
+
+  const result = writeSkill(root, SKILL);
+  assert.equal(result.warnings.length, 1);
+  assert.match(result.warnings[0], /left untouched/);
+  assert.ok(fs.lstatSync(path.join(root, CLAUDE_SKILLS_LINK)).isDirectory());
+  assert.ok(!fs.lstatSync(path.join(root, CLAUDE_SKILLS_LINK)).isSymbolicLink());
+  assert.equal(fs.readFileSync(existing, "utf8").includes("keep me"), true);
+  assert.ok(!fs.existsSync(path.join(root, CLAUDE_SKILLS_LINK, "release-signing")));
+  assert.ok(fs.existsSync(path.join(root, CANONICAL_SKILLS_DIR, "release-signing", "SKILL.md")));
+});
+
+test("applyDecisions writes accepted extractions through the skills layout and surfaces warnings", () => {
+  const root = tmpRepo();
+  fs.writeFileSync(path.join(root, "AGENTS.md"), "# Memory\n\n- Sign releases with the key.\n");
+  const edit = {
+    id: "e1",
+    kind: "extract",
+    file: "AGENTS.md",
+    find: "- Sign releases with the key.",
+    replace: "- Release signing: see the release-signing skill.",
+    skill: SKILL,
+  };
+  const proposal = { memoryFile: { path: "AGENTS.md" }, edits: [edit] };
+  const state = { readRejections: () => [], writeRejections: () => {} };
+
+  const dry = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted" },
+    repo: { root },
+    state,
+    config: { budgetTokens: 5000 },
+    dryRun: true,
+  });
+  assert.ok(!fs.existsSync(path.join(root, CANONICAL_SKILLS_DIR)));
+  assert.deepEqual(dry.skills, [{ path: SKILL.path, dryRun: true, created: [] }]);
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted" },
+    repo: { root },
+    state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.equal(results.failed.length, 0);
+  assert.deepEqual(results.warnings, []);
+  assert.deepEqual(results.skills[0].created, [
+    CANONICAL_SKILLS_DIR,
+    `${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`,
+  ]);
+  assert.ok(fs.existsSync(path.join(root, CLAUDE_SKILLS_LINK, "release-signing", "SKILL.md")));
+});


### PR DESCRIPTION
## Problem

1. `backpass apply` wrote extracted skills where `resolveOverflowTarget` pointed, which could silently be the bare `./skills/` dir - a public/installer convention no harness auto-loads.
2. Generated `SKILL.md` files looked like user-invocable slash-commands.

## Fix

- Default `skillsDir` is now `.agents/skills` (canonical, AGENTS.md convention). `resolveOverflowTarget` returns it unless the user explicitly configured a different, existing dir; bare `skills/` is never auto-detected. A configured `.claude/skills` is treated as the canonical dir (it is the symlink).
- `writeSkill` runs `ensureSkillsLayout` first: creates `.agents/skills` if missing and `.claude/skills -> ../.agents/skills` as a symlink so Claude and AGENTS.md-family harnesses load one copy.
- If `.claude/skills` is already a real directory, it is left untouched and a warning is surfaced (from synthesis and from `apply` output). An existing symlink pointing elsewhere is also left alone.
- `renderSkillFile` emits `user-invocable: false` and `metadata:\n  internal: true`.
- README / CLI help / config default updated; AGENTS.md gains a sharp-edge note.

Note: resolution stays read-only and the layout is created at write time (from `src/apply/writer.js`), keeping the "writer.js is the only module that writes" invariant; `status` and `synthesize` only resolve.

## Tests

`test/skills.test.js` covers: default dir, frontmatter, canonical write + symlink creation, resolution preference (never bare `skills/`), idempotent layout creation, foreign symlink left alone, real-dir warn-and-don't-clobber, and `applyDecisions` end to end (dry-run writes nothing). `pnpm run check` green (155 tests).