### PR TITLE
feat: adaptive per-run edit cap that scales with budget overage in shrink mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,10 @@ sessions (default 2) are dropped. One bad session never rewrites the weights.
 A single high-reasoning call turns the folded evidence into concrete edits: ADD, REMOVE,
 REWRITE, or EXTRACT→SKILL. Then mechanical gates run, and they are not negotiable:
 
-- at most `maxEditsPerRun` edits (the learning rate)
+- at most `maxEditsPerRun` edits (the learning rate). By default the cap is adaptive: 5
+  when the file is near or under budget, and in a shrink plan (file over budget) one edit
+  per ~40 tokens of overage, capped at 20, so badly overgrown files recover in fewer runs.
+  An explicit `--max-edits` or config value always pins it.
 - new instructions need evidence from `minGapEvidence` distinct sessions
 - every edit carries a verbatim quote
 - the post-edit file must fit the budget
@@ -294,7 +297,7 @@ CLI flags on top:
   "memoryFiles": ["AGENTS.md"],
   "budgetTokens": 5000,
   "skillsDir": ".agents/skills",
-  "maxEditsPerRun": 5,
+  "maxEditsPerRun": null,
   "minGapEvidence": 2,
   "analysis": { "agent": null, "model": null, "effort": null },
   "synthesis": { "agent": null, "model": null, "effort": null },

--- a/src/cli.js
+++ b/src/cli.js
@@ -100,7 +100,7 @@ MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
 
 BUDGET AND SHAPE
   --budget <tokens>        always-loaded budget per memory file         [5000]
-  --max-edits <n>          edits per run - the learning rate            [5]
+  --max-edits <n>          edits per run - the learning rate            [adaptive]
   --min-gap-evidence <n>   sessions needed before a new instruction     [2]
   --memory-file <path>     memory file to optimize (repeatable)
   --skills-dir <path>      where skill extractions are written          [.agents/skills]

--- a/src/config.js
+++ b/src/config.js
@@ -43,7 +43,8 @@ export const DEFAULT_CONFIG = {
   memoryFiles: ["AGENTS.md", "CLAUDE.md"],
   budgetTokens: 5000,
   skillsDir: ".agents/skills",
-  maxEditsPerRun: 5,
+  /** `null` means adaptive: see `effectiveMaxEdits` in proposal.js. An integer pins it. */
+  maxEditsPerRun: null,
   minGapEvidence: 2,
   /**
    * `agent: null` means auto-pick from `ladders[role]`; `effort: null` means
@@ -130,8 +131,8 @@ function validate(config) {
   if (!Number.isFinite(config.budgetTokens) || config.budgetTokens <= 0) {
     throw new UserError("config.budgetTokens must be a positive number");
   }
-  if (!Number.isInteger(config.maxEditsPerRun) || config.maxEditsPerRun <= 0) {
-    throw new UserError("config.maxEditsPerRun must be a positive integer");
+  if (config.maxEditsPerRun !== null && (!Number.isInteger(config.maxEditsPerRun) || config.maxEditsPerRun <= 0)) {
+    throw new UserError("config.maxEditsPerRun must be a positive integer, or null for the adaptive cap");
   }
   if (!Number.isInteger(config.minGapEvidence) || config.minGapEvidence < 1) {
     throw new UserError("config.minGapEvidence must be an integer >= 1");
@@ -197,7 +198,7 @@ export function initialConfig() {
     memoryFiles: ["AGENTS.md"],
     budgetTokens: DEFAULT_CONFIG.budgetTokens,
     skillsDir: DEFAULT_CONFIG.skillsDir,
-    maxEditsPerRun: DEFAULT_CONFIG.maxEditsPerRun,
+    // maxEditsPerRun stays unset so the adaptive cap applies; set it to pin a number.
     minGapEvidence: DEFAULT_CONFIG.minGapEvidence,
     // Agents stay unset so the ladder auto-pick keeps applying to initialized repos.
     analysis: { agent: null, model: null, effort: null },

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -18,6 +18,26 @@ import { budgetStatus, estimateTokens } from "./tokens.js";
 
 export const EDIT_KINDS = ["add", "remove", "rewrite", "extract"];
 
+/**
+ * The per-run edit cap is adaptive (design section 6). Near or under budget it is the
+ * gentle learning rate: DEFAULT_MAX_EDITS small, reviewable steps. A file that is over
+ * budget needs a shrink plan, and a flat cap would stretch that plan across many runs,
+ * so the allowance scales with the overage: one edit per SHRINK_EDIT_TOKENS of overage,
+ * never below the default and never above SHRINK_MAX_EDITS, which keeps a single apply
+ * review manageable. An explicit `maxEditsPerRun` (flag or config) always wins.
+ */
+export const DEFAULT_MAX_EDITS = 5;
+export const SHRINK_MAX_EDITS = 20;
+/** A typical memory-file instruction removal or tightening trims about this many tokens. */
+export const SHRINK_EDIT_TOKENS = 40;
+
+export function effectiveMaxEdits(memoryFile, config) {
+  if (Number.isInteger(config.maxEditsPerRun) && config.maxEditsPerRun > 0) return config.maxEditsPerRun;
+  const overage = memoryFile.tokens - config.budgetTokens;
+  if (overage <= 0) return DEFAULT_MAX_EDITS;
+  return Math.min(SHRINK_MAX_EDITS, Math.max(DEFAULT_MAX_EDITS, Math.ceil(overage / SHRINK_EDIT_TOKENS)));
+}
+
 export class ProposalViolation extends Error {
   constructor(message, violations) {
     super(message);
@@ -135,10 +155,9 @@ export function buildProposal(rawResult, context) {
   const rawEdits = Array.isArray(rawResult?.edits) ? rawResult.edits : [];
   const edits = rawEdits.map((raw, i) => normalizeEdit(raw, i, { memoryPath: memoryFile.path }));
 
-  if (edits.length > config.maxEditsPerRun) {
-    violations.push(
-      `proposed ${edits.length} edits but the per-run cap is ${config.maxEditsPerRun} (the learning rate)`,
-    );
+  const maxEdits = effectiveMaxEdits(memoryFile, config);
+  if (edits.length > maxEdits) {
+    violations.push(`proposed ${edits.length} edits but the per-run cap is ${maxEdits} (the learning rate)`);
   }
 
   const accepted = [];
@@ -250,7 +269,7 @@ export function buildProposal(rawResult, context) {
     budget,
     config: {
       budgetTokens: config.budgetTokens,
-      maxEditsPerRun: config.maxEditsPerRun,
+      maxEditsPerRun: maxEdits,
       minGapEvidence: config.minGapEvidence,
       skillsDir: config.skillsDir,
       analysis: config.analysis,

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -5,7 +5,7 @@ import { extractJson, sessionPrompt } from "./acpx.js";
 import { renderEvidenceForPrompt } from "./fold.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt } from "./prompts.js";
-import { buildProposal, ProposalViolation } from "./proposal.js";
+import { buildProposal, effectiveMaxEdits, ProposalViolation } from "./proposal.js";
 import { loadSkills, renderSkillIndex, resolveOverflowTarget } from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
@@ -21,13 +21,13 @@ import { color, info, warn } from "./logger.js";
  * saves the rejected proposal rather than quietly trimming it (design section 6).
  */
 
-function budgetRule(memoryFile, config) {
+function budgetRule(memoryFile, config, maxEdits) {
   const remaining = config.budgetTokens - memoryFile.tokens;
   if (remaining <= 0) {
     return (
       `This file is ALREADY ${Math.abs(remaining)} tokens OVER budget, so this run is a SHRINK ` +
       `PLAN. You are NOT expected to reach ${config.budgetTokens} tokens in one run - the ` +
-      `${config.maxEditsPerRun}-edit cap makes that impossible and later runs continue the work. ` +
+      `${maxEdits}-edit cap for this run makes that impossible and later runs continue the work. ` +
       `What is required is real progress: the edit set MUST be net-negative, so lead with the ` +
       `highest-cost instructions that have no positive evidence, and with skill extractions of ` +
       `long narrow sections. Any addition must name the removal that pays for it. Make the ` +
@@ -75,6 +75,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   for (const w of overflow.warnings) warn(w);
   const skillFiles = loadSkills(repo.root, overflow.dir);
   const harnessCounts = harnessCountsOf(transcripts);
+  const maxEdits = effectiveMaxEdits(memoryFile, config);
 
   const values = {
     REPO_NAME: repo.name,
@@ -88,13 +89,13 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     CURRENT_TOKENS: String(memoryFile.tokens),
     BUDGET_TOKENS: String(config.budgetTokens),
     BUDGET_STATE: budgetState(memoryFile, config),
-    BUDGET_RULE: budgetRule(memoryFile, config),
+    BUDGET_RULE: budgetRule(memoryFile, config, maxEdits),
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
     SKILLS_DIR: overflow.dir,
     SKILL_INDEX: renderSkillIndex(skillFiles),
     EVIDENCE: renderEvidenceForPrompt(summary),
     REJECTIONS: renderRejections(rejections),
-    MAX_EDITS: String(config.maxEditsPerRun),
+    MAX_EDITS: String(maxEdits),
     MIN_GAP_EVIDENCE: String(config.minGapEvidence),
   };
 
@@ -133,6 +134,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       model: pick.model,
       effort: pick.effort,
       attempt,
+      maxEdits,
       sessionName: `backpass-synth-${process.pid}`,
       gapClusters: summary.totals.gapClusters,
       instructions: summary.instructions.length,

--- a/src/tui/index.js
+++ b/src/tui/index.js
@@ -12,6 +12,7 @@
  *  - all motion stops and the region is erased the moment the run ends
  */
 
+import { DEFAULT_MAX_EDITS } from "../proposal.js";
 import { clearProgressSink, setProgressSink } from "../progress.js";
 import { setLoggerSink } from "../logger.js";
 import { colorDepth, detectBackground, tuiEligible } from "./term.js";
@@ -38,7 +39,7 @@ export async function startTui(ctx, { stderr = process.stderr } = {}) {
       repoName: ctx.repo.name,
       worktrees: ctx.repo.worktrees?.length || 1,
       since: ctx.config.discovery.since,
-      maxEdits: ctx.config.maxEditsPerRun,
+      maxEdits: ctx.config.maxEditsPerRun ?? DEFAULT_MAX_EDITS,
     },
   });
   tui.start();
@@ -219,6 +220,7 @@ export function reduceEvent(state, event, data, now = Date.now()) {
       s.model = data.model;
       s.effort = data.effort;
       s.attempt = data.attempt;
+      if (data.maxEdits) state.meta.maxEdits = data.maxEdits;
       s.sessionName = data.sessionName;
       s.gapClusters = data.gapClusters;
       s.instructions = data.instructions;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -19,7 +19,7 @@ function tempRepo(config) {
 test("the defaults match the approved design", () => {
   const config = loadConfig(tempRepo());
   assert.equal(config.budgetTokens, 5000);
-  assert.equal(config.maxEditsPerRun, 5);
+  assert.equal(config.maxEditsPerRun, null, "the edit cap is adaptive unless pinned");
   assert.equal(config.minGapEvidence, 2);
   assert.equal(config.jobs, 4);
   assert.equal(config.discovery.since, "30d");

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -4,7 +4,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { applyEdit, buildProposal, projectWithDecisions } from "../src/proposal.js";
+import {
+  applyEdit,
+  buildProposal,
+  DEFAULT_MAX_EDITS,
+  effectiveMaxEdits,
+  projectWithDecisions,
+  SHRINK_EDIT_TOKENS,
+  SHRINK_MAX_EDITS,
+} from "../src/proposal.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
@@ -539,4 +547,68 @@ test("a file within budget keeps the strict cap gate", () => {
   );
   assert.equal(proposal.budget.mode, "cap");
   assert.equal(proposal.budget.startedOverBudget, false);
+});
+
+function rawEdits(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    kind: "remove",
+    title: `remove rule ${i + 1}`,
+    find: `- rule ${i + 1}`,
+    replace: "",
+    rationale: "no positive evidence",
+    evidence: QUOTE,
+    transcripts: 3,
+  }));
+}
+
+function overBudgetFile(overage, budgetTokens = 200) {
+  const rules = [];
+  let text = "";
+  let i = 0;
+  while (estimateTokens(text) < budgetTokens + overage) {
+    i += 1;
+    rules.push(`- rule ${i} keeps the file long enough to sit over the budget line`);
+    text = `# Long memory\n\n${rules.join("\n")}\n`;
+  }
+  return memoryFile(text);
+}
+
+test("cap mode keeps the gentle default edit cap", () => {
+  const ctx = context({ config: { ...context().config, maxEditsPerRun: null } });
+  assert.equal(effectiveMaxEdits(ctx.memoryFile, ctx.config), DEFAULT_MAX_EDITS);
+});
+
+test("shrink mode scales the edit cap to the overage, up to the ceiling", () => {
+  const config = { ...context().config, budgetTokens: 200, maxEditsPerRun: null };
+  const modest = overBudgetFile(400, 200);
+  const modestCap = effectiveMaxEdits(modest, config);
+  assert.ok(modestCap > DEFAULT_MAX_EDITS, `a 400-token overage should allow more than ${DEFAULT_MAX_EDITS} edits`);
+  assert.ok(modestCap < SHRINK_MAX_EDITS, "a modest overage should not hit the ceiling");
+  assert.equal(modestCap, Math.ceil((modest.tokens - 200) / SHRINK_EDIT_TOKENS));
+
+  const large = overBudgetFile(5000, 200);
+  assert.equal(effectiveMaxEdits(large, config), SHRINK_MAX_EDITS);
+});
+
+test("an explicit maxEditsPerRun wins over the adaptive cap in both modes", () => {
+  const config = { ...context().config, budgetTokens: 200, maxEditsPerRun: 3 };
+  assert.equal(effectiveMaxEdits(overBudgetFile(5000, 200), config), 3);
+  assert.equal(effectiveMaxEdits(memoryFile(), config), 3);
+});
+
+test("the cap-exceeded violation fires above the effective adaptive cap, not the flat default", () => {
+  const file = overBudgetFile(400, 200);
+  const config = { ...context().config, budgetTokens: 200, maxEditsPerRun: null };
+  const cap = effectiveMaxEdits(file, config);
+  assert.ok(cap > DEFAULT_MAX_EDITS);
+
+  const within = buildProposal({ edits: rawEdits(cap) }, context({ memoryFile: file, config }));
+  assert.ok(!within.violations.some((v) => v.includes("per-run cap")), within.violations.join("\n"));
+  assert.equal(within.proposal.config.maxEditsPerRun, cap, "the proposal records the effective cap");
+
+  const above = buildProposal({ edits: rawEdits(cap + 1) }, context({ memoryFile: file, config }));
+  assert.ok(
+    above.violations.some((v) => v.includes(`per-run cap is ${cap}`)),
+    above.violations.join("\n"),
+  );
 });


### PR DESCRIPTION
## What

Replaces the flat `maxEditsPerRun = 5` with an adaptive per-run edit cap. `effectiveMaxEdits(memoryFile, config)` in `src/proposal.js` is the single source of truth:

- **Cap mode** (file near/under budget): the gentle default of **5** - the steady learning rate.
- **Shrink mode** (file over budget): `clamp(ceil(overage / 40), 5, 20)`.
- **Explicit override always wins**: an integer `--max-edits` or `maxEditsPerRun` in either config layer pins the cap. The default config value is now `null` (= adaptive); `backpass init` no longer writes a fixed number so initialized repos get the adaptive behavior.

The effective number is threaded through everywhere the cap is used: the cap-exceeded gate and the proposal's recorded `config.maxEditsPerRun`, the `MAX_EDITS` prompt variable and the shrink-plan note in `src/synthesize.js`, and the TUI synthesize header (via a `maxEdits` field on `synth:start`). Apply stays human-gated and unchanged.

## Why these numbers

- **40 tokens per edit**: a typical shrink edit removes or tightens one instruction bullet; in real AGENTS.md files those run ~25-60 tokens, so 40 is a conservative middle. This means a 200-token overage still gets the default 5, a 400-token overage gets 10, and 800+ saturates.
- **Ceiling 20**: apply review is per-edit accept/reject. 20 edits is at the edge of what one person reviews carefully in a sitting; beyond that a second run is cheaper than a rubber-stamped review. The floor is the default 5 so shrink mode is never stricter than cap mode.

## Tests

- cap mode keeps the gentle default
- shrink mode: a modest overage allows more than 5 and matches the formula; a large overage hits the ceiling
- explicit `maxEditsPerRun` wins in both modes
- the cap-exceeded violation fires only above the effective cap, and the proposal records that cap
- config default is `null`; validation still rejects non-positive or non-integer pins

`pnpm run check` is green (lint, format, typecheck, 151 tests).