### PR TITLE
fix: print tier token accounting once, in order, with real acpx usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   second full file is warned about, never silently ignored or double-written.
 - **Never trust model-reported numbers.** Token deltas and budget projections are measured
   in `src/proposal.js` from the actual text; the synthesis model's own figures are ignored.
+  Usage accounting comes only from acpx's `[acpx] tokens:` stderr line, which acpx prints
+  when the ACP adapter returns usage (codex, claude do; pi does not). Records are
+  `{ agent, usage|null }` (`usageRecord` in `src/acpx.js`) and `src/commands/usage.js` is
+  the one place that prints them - never `n/a`: nothing when no call ran, the harness by
+  name when it stayed silent.
 - **acpx is alpha.** All model invocation is isolated behind `src/acpx.js` so an upstream
   CLI change has one blast radius. v1 uses plain `exec` and named sessions only; acpx flows
   are deferred until they are stable upstream. The one sanctioned exception is the

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -335,12 +335,32 @@ function firstLine(text) {
   return (text || "").split("\n").find((l) => l.trim()) || "";
 }
 
-/** Sum acpx usage records for cost visibility (design section 9). */
+/**
+ * Per-call usage accounting (design section 9).
+ *
+ * acpx prints its `[acpx] tokens:` line only when the ACP adapter returns `usage` in
+ * the `session/prompt` result. codex and claude do; pi does not (its result is a bare
+ * `{ stopReason }`), so a pi-backed pass legitimately has nothing to report. A record
+ * therefore keeps the harness next to the (possibly null) usage, so the report can say
+ * *who* stayed silent instead of printing a meaningless "n/a".
+ *
+ * @typedef {{ agent: string, usage: Record<string, number> | null }} UsageRecord
+ */
+
+/** @returns {UsageRecord} */
+export function usageRecord(agent, result) {
+  return { agent, usage: result?.usage || null };
+}
+
+/** Sum the usage maps of the records that reported one. */
 export function sumUsage(records) {
   const total = {};
-  for (const usage of records) {
-    if (!usage) continue;
-    for (const [key, value] of Object.entries(usage)) total[key] = (total[key] || 0) + value;
+  for (const record of records) {
+    const usage = record?.usage ?? record;
+    if (!usage || typeof usage !== "object") continue;
+    for (const [key, value] of Object.entries(usage)) {
+      if (Number.isFinite(value)) total[key] = (total[key] || 0) + value;
+    }
   }
   return total;
 }
@@ -350,4 +370,24 @@ export function formatUsage(usage) {
   return Object.entries(usage)
     .map(([k, v]) => `${k}=${v.toLocaleString("en-US")}`)
     .join(" ");
+}
+
+/**
+ * Describe a pass's usage for the report, or null when the pass made no model calls
+ * (everything cached, or a different command ran it) - the caller then prints nothing.
+ *
+ * @param {(UsageRecord | null | undefined)[]} records
+ * @returns {string | null}
+ */
+export function describeUsage(records) {
+  const calls = (records || []).filter((r) => r && typeof r === "object" && "agent" in r);
+  if (!calls.length) return null;
+  const reported = calls.filter((r) => r.usage && Object.keys(r.usage).length);
+  if (!reported.length) {
+    const agents = [...new Set(calls.map((r) => r.agent))].join(", ");
+    return `not reported by ${agents}`;
+  }
+  const text = formatUsage(sumUsage(reported));
+  if (reported.length === calls.length) return text;
+  return `${text} (${reported.length} of ${calls.length} calls reported)`;
 }

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { execOneShot, extractJson, sessionPrompt } from "./acpx.js";
+import { execOneShot, extractJson, sessionPrompt, usageRecord } from "./acpx.js";
 import { distill } from "./distill.js";
 import { readTranscript } from "./discovery/index.js";
 import { renderInstructionIndex } from "./memory.js";
@@ -126,7 +126,9 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
   fs.mkdirSync(path.dirname(promptFile), { recursive: true });
   fs.writeFileSync(promptFile, prompt);
 
+  let ranWith = null;
   const result = await config.agents.withFallthrough("analysis", async (pick) => {
+    ranWith = pick.agent;
     const call = {
       agent: pick.agent,
       model: pick.model,
@@ -155,7 +157,7 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
   return {
     status: "ok",
     evidence: sanitizeEvidence(parsed),
-    usage: result.usage,
+    usage: usageRecord(ranWith, result),
     distilled,
   };
 }

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,9 +1,9 @@
 import { analyzeTranscripts } from "../analyze.js";
 import { UserError, color, info, json, out, warn } from "../logger.js";
 import { resolveMemoryFiles } from "../memory.js";
-import { sumUsage, formatUsage } from "../acpx.js";
 import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
+import { printUsage } from "./usage.js";
 
 /**
  * The memory file a run optimizes: the first configured file that exists (AGENTS.md by
@@ -78,10 +78,9 @@ export async function cmdAnalyze(ctx) {
     `  ${summary.analyzed} newly analyzed · ${summary.cached} cached · ` +
       `${summary.skipped} skipped (too short) · ${summary.failed} failed`,
   );
-  const usage = sumUsage(summary.usage);
-  out(`  tier-1 tokens: ${formatUsage(usage)}`);
   if (summary.failed) {
     out(color.dim("  failed transcripts are listed by `backpass status` and retried next run"));
   }
+  printUsage({ tier1: summary.usage });
   return 0;
 }

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -3,9 +3,9 @@ import { synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
-import { formatUsage, sumUsage } from "../acpx.js";
 import { emitProgress } from "../progress.js";
 import { primaryMemoryFile } from "./analyze.js";
+import { printUsage } from "./usage.js";
 import { discoverForRun } from "./scan.js";
 
 export async function foldForRun(ctx, memoryFile) {
@@ -52,7 +52,12 @@ export async function runProposal(ctx, precomputed = null) {
   return { proposal, summary, memoryFile: file };
 }
 
-export function printProposal(proposal, { applied = false } = {}) {
+/**
+ * @param {object} proposal
+ * @param {{ applied?: boolean, analysisUsage?: import("../acpx.js").UsageRecord[] }} [options]
+ *   `analysisUsage` is the tier-1 accounting of the same run, when the caller ran it.
+ */
+export function printProposal(proposal, { applied = false, analysisUsage = [] } = {}) {
   out("");
   out(
     `${color.bold("proposal")} · ${proposal.repo.name} · ${proposal.memoryFile.path} · ` +
@@ -86,9 +91,7 @@ export function printProposal(proposal, { applied = false } = {}) {
 
   for (const note of proposal.notes || []) out(color.dim(`  note: ${note}`));
 
-  const usage = sumUsage(proposal.usage || []);
-  out("");
-  out(color.dim(`  tier-2 tokens: ${formatUsage(usage)}`));
+  printUsage({ tier1: analysisUsage, tier2: proposal.usage || [] });
   if (applied) return;
   out("");
   out("Review and apply with `backpass apply` (nothing has been written).");

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,5 +1,4 @@
 import { UserError, color, info, json, out } from "../logger.js";
-import { formatUsage, sumUsage } from "../acpx.js";
 import { ProposalViolation } from "../proposal.js";
 import { runAnalysis } from "./analyze.js";
 import { bootstrapJson, bootstrapRun, printBootstrap } from "./bootstrap.js";
@@ -78,12 +77,7 @@ export async function cmdRun(ctx) {
       return 0;
     }
 
-    printProposal(proposal);
-
-    const tier1 = sumUsage(analysis.summary?.usage || []);
-    const tier2 = sumUsage(proposal.usage || []);
-    out(color.dim(`  tier-1 tokens: ${formatUsage(tier1)}`));
-    out(color.dim(`  tier-2 tokens: ${formatUsage(tier2)}`));
+    printProposal(proposal, { analysisUsage: analysis.summary?.usage || [] });
     return 0;
   } catch (err) {
     tui?.stop();

--- a/src/commands/usage.js
+++ b/src/commands/usage.js
@@ -1,0 +1,25 @@
+import { describeUsage } from "../acpx.js";
+import { color, out } from "../logger.js";
+
+/**
+ * Print the model-usage accounting for a run, one line per pass that actually made
+ * calls: tier-1 (the per-transcript analysis pass) then tier-2 (synthesis). This is the
+ * only place that prints these lines - `run` and `propose` both end in `printProposal`,
+ * and `analyze` prints just its own tier through the same helper - so the accounting
+ * appears exactly once, in order, before the apply hint.
+ *
+ * A pass that made no calls this run (all evidence cached, or analysis ran in an earlier
+ * command) prints nothing rather than a meaningless "n/a"; a pass whose harness returned
+ * no usage says so by name (see `describeUsage`).
+ *
+ * @param {{ tier1?: import("../acpx.js").UsageRecord[], tier2?: import("../acpx.js").UsageRecord[] }} usage
+ */
+export function printUsage({ tier1 = [], tier2 = [] } = {}) {
+  const lines = [
+    ["tier-1", describeUsage(tier1)],
+    ["tier-2", describeUsage(tier2)],
+  ].filter(([, text]) => text);
+  if (!lines.length) return;
+  out("");
+  for (const [tier, text] of lines) out(color.dim(`  ${tier} tokens: ${text}`));
+}

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { extractJson, sessionPrompt } from "./acpx.js";
+import { extractJson, sessionPrompt, usageRecord } from "./acpx.js";
 import { renderEvidenceForPrompt } from "./fold.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt } from "./prompts.js";
@@ -144,7 +144,9 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     // A classifiable failure (not logged in, model rejected, adapter missing) falls
     // through to the next ladder candidate; the switch is recorded in the notes so the
     // proposal's provenance is visible.
+    let ranWith = pick.agent;
     const result = await config.agents.withFallthrough("synthesis", async (current) => {
+      ranWith = current.agent;
       if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
       return sessionPrompt({
         agent: current.agent,
@@ -157,7 +159,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       });
     });
 
-    if (result.usage) usage.push(result.usage);
+    usage.push(usageRecord(ranWith, result));
     // The same adapter limitation is reported on every attempt; say it once.
     for (const note of result.notes || []) {
       if (notes.includes(note)) continue;

--- a/test/usage-output.test.js
+++ b/test/usage-output.test.js
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * A stand-in acpx: answers on stdout and prints the per-run accounting line on stderr
+ * exactly as the real `--format quiet` does for a harness that reports usage (codex,
+ * claude). With FAKE_ACPX_SILENT set it behaves like pi, whose ACP result carries no
+ * usage, so acpx prints no line at all.
+ */
+const fakeAcpxDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fake-acpx-"));
+const fakeAcpx = path.join(fakeAcpxDir, "acpx");
+fs.writeFileSync(
+  fakeAcpx,
+  [
+    "#!/bin/sh",
+    "printf '{\"ok\":true}\\n'",
+    'if [ -z "$FAKE_ACPX_SILENT" ]; then',
+    '  echo "[acpx] tokens: input=14585 output=5 cache_read=11008 total=25598" >&2',
+    "fi",
+    "exit 0",
+    "",
+  ].join("\n"),
+);
+fs.chmodSync(fakeAcpx, 0o755);
+process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+
+const { execOneShot, describeUsage, usageRecord, sumUsage } = await import("../src/acpx.js");
+const { printProposal } = await import("../src/commands/propose.js");
+const { printUsage } = await import("../src/commands/usage.js");
+
+function captureStdout(fn) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+}
+
+function proposalWith(usage) {
+  return {
+    repo: { name: "demo" },
+    memoryFile: { path: "AGENTS.md" },
+    edits: [],
+    notes: [],
+    stats: { transcripts: 2, positive: 1, negative: 0, gapClusters: 0 },
+    budget: { current: 100, projected: 100, capTokens: 5000, utilization: 0.02, withinBudget: true, mode: "cap" },
+    usage,
+  };
+}
+
+const promptFile = path.join(fakeAcpxDir, "prompt.md");
+fs.writeFileSync(promptFile, "hello");
+
+test("a harness that reports usage through acpx yields a numeric record", async () => {
+  delete process.env.FAKE_ACPX_SILENT;
+  const result = await execOneShot({ agent: "codex", promptFile, cwd: fakeAcpxDir, timeoutSeconds: 5 });
+  const record = usageRecord("codex", result);
+  assert.deepEqual(record, { agent: "codex", usage: { input: 14585, output: 5, cache_read: 11008, total: 25598 } });
+  assert.equal(describeUsage([record, record]), "input=29,170 output=10 cache_read=22,016 total=51,196");
+});
+
+test("a harness that reports nothing (pi) is named instead of printing n/a", async () => {
+  process.env.FAKE_ACPX_SILENT = "1";
+  try {
+    const result = await execOneShot({ agent: "pi", promptFile, cwd: fakeAcpxDir, timeoutSeconds: 5 });
+    const record = usageRecord("pi", result);
+    assert.deepEqual(record, { agent: "pi", usage: null });
+    assert.equal(describeUsage([record]), "not reported by pi");
+  } finally {
+    delete process.env.FAKE_ACPX_SILENT;
+  }
+});
+
+test("describeUsage: no calls means nothing to say; a partial report says how partial", () => {
+  assert.equal(describeUsage([]), null);
+  assert.equal(describeUsage(undefined), null);
+  const codex = { agent: "codex", usage: { input: 10, output: 2 } };
+  const pi = { agent: "pi", usage: null };
+  assert.equal(describeUsage([codex, pi]), "input=10 output=2 (1 of 2 calls reported)");
+  assert.deepEqual(sumUsage([codex, pi, null]), { input: 10, output: 2 });
+});
+
+test("a full run prints tier-1 then tier-2 exactly once, before the apply hint", () => {
+  const analysisUsage = [
+    { agent: "codex", usage: { input: 100, output: 10 } },
+    { agent: "codex", usage: { input: 200, output: 20 } },
+  ];
+  const proposal = proposalWith([{ agent: "codex", usage: { input: 5000, output: 300 } }]);
+  const lines = captureStdout(() => printProposal(proposal, { analysisUsage }));
+
+  const tier1 = lines.findIndex((l) => l.includes("tier-1 tokens:"));
+  const tier2 = lines.findIndex((l) => l.includes("tier-2 tokens:"));
+  const apply = lines.findIndex((l) => l.startsWith("Review and apply"));
+  assert.equal(lines.filter((l) => l.includes("tier-1 tokens:")).length, 1);
+  assert.equal(lines.filter((l) => l.includes("tier-2 tokens:")).length, 1);
+  assert.ok(tier1 < tier2 && tier2 < apply, `order was tier1=${tier1} tier2=${tier2} apply=${apply}`);
+  assert.match(lines[tier1], /tier-1 tokens: input=300 output=30$/);
+  assert.match(lines[tier2], /tier-2 tokens: input=5,000 output=300$/);
+  assert.ok(!lines.some((l) => l.includes("n/a")));
+});
+
+test("standalone propose prints only the synthesis tier, and never n/a", () => {
+  const proposal = proposalWith([{ agent: "claude", usage: { input: 1, output: 2, total: 3 } }]);
+  const lines = captureStdout(() => printProposal(proposal));
+  assert.ok(!lines.some((l) => l.includes("tier-1 tokens:")));
+  assert.equal(lines.filter((l) => l.includes("tier-2 tokens:")).length, 1);
+  assert.ok(
+    lines.findIndex((l) => l.includes("tier-2 tokens:")) < lines.findIndex((l) => l.startsWith("Review and apply")),
+  );
+  assert.ok(!lines.some((l) => l.includes("n/a")));
+});
+
+test("a pi-backed run names the silent harness and an applied proposal skips the hint", () => {
+  const proposal = proposalWith([{ agent: "pi", usage: null }]);
+  const lines = captureStdout(() =>
+    printProposal(proposal, { applied: true, analysisUsage: [{ agent: "pi", usage: null }] }),
+  );
+  assert.deepEqual(
+    lines.filter((l) => l.includes("tokens:")).map((l) => l.trim()),
+    ["tier-1 tokens: not reported by pi", "tier-2 tokens: not reported by pi"],
+  );
+  assert.ok(!lines.some((l) => l.startsWith("Review and apply")));
+});
+
+test("with no model calls at all, no accounting line is printed", () => {
+  assert.deepEqual(
+    captureStdout(() => printUsage({ tier1: [], tier2: [] })),
+    [],
+  );
+  const lines = captureStdout(() => printProposal(proposalWith([])));
+  assert.ok(!lines.some((l) => l.includes("tokens:")));
+  assert.ok(!lines.some((l) => l.includes("n/a")));
+});


### PR DESCRIPTION
## The bug

`printProposal` printed a `tier-2 tokens:` line and then the `Review and apply` hint, and `cmdRun` printed `tier-1` + `tier-2` again after it. A default run (reproduced end-to-end on this repo's own transcripts) showed:

```
  tier-2 tokens: n/a

Review and apply with `backpass apply` (nothing has been written).
  tier-1 tokens: n/a
  tier-2 tokens: n/a
```

## Part 1: single source of truth

`printProposal` now owns the accounting through a new `src/commands/usage.js` (`printUsage`): tier-1 then tier-2, exactly once, before the apply hint. `run` passes its analysis usage in; standalone `propose` shows only the synthesis tier (analysis ran in an earlier command, so there is nothing of this run to report); `analyze` prints just tier-1 through the same helper. `run.js` no longer prints any tier line.

## Part 2: path taken - wired to real numbers

**acpx does report usage.** Tested concretely against acpx 0.13.0: under `--format quiet` (what backpass uses) it writes `[acpx] tokens: input=… output=… cache_read=… total=…` to stderr for both `exec` one-shots and `-s <session>` prompts, and `parseTokenLine` already parses it. In acpx's source (`formatUsageLine` in `dist/output-*.js`) the line is emitted iff the ACP `session/prompt` result carries `usage`:

- **codex**: result has `usage:{inputTokens,cachedReadTokens,outputTokens,totalTokens,…}` -> line printed
- **claude**: same -> line printed
- **pi**: result is a bare `{"stopReason":"end_turn"}` -> no line, nothing to parse

The `n/a` in the report was the pi case: auto-pick chose pi on this machine. So the plumbing was already right for harnesses that report; what was wrong was the presentation. Usage records now carry the harness (`usageRecord(agent, result)` -> `{ agent, usage|null }`), and `describeUsage` yields:

- real summed numbers when calls reported (with `(N of M calls reported)` if mixed)
- `not reported by pi` when calls ran but the harness returned no usage - named, not `n/a`
- nothing at all (line omitted) when the pass made no calls (all cached / skipped)

`n/a` is never printed on any path.

### E2E after the fix

```
# codex analysis + codex synthesis
  tier-1 tokens: input=22,450 output=1,794 cache_read=11,008 total=35,252
  tier-2 tokens: input=17,417 output=185 cache_read=11,008 total=28,610
Review and apply with `backpass apply` (nothing has been written).

# default auto-pick (pi)
  tier-1 tokens: not reported by pi
  tier-2 tokens: not reported by pi

# standalone propose (synthesis=codex)
  tier-2 tokens: input=17,478 output=781 cache_read=11,008 total=29,267
```

## Tests

`test/usage-output.test.js` runs `execOneShot` against a fake `acpx` binary (`BACKPASS_ACPX_BIN`) that prints the real stderr line (or stays silent like pi), and asserts the printed report: tier-1 before tier-2, each once, both before `Review and apply`, no `n/a`, silent harness named, no line when no calls ran. `pnpm run check` (lint, format, typecheck, 154 tests) is green.
