### PR TITLE
feat: cap analyzed transcripts with a recency-weighted sample (--max-transcripts, --seed)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 ## Orientation
 
 - `README.md` documents the user-facing surface; `src/cli.js` is the authoritative flag list.
-- The pipeline is one stage per module, in order: `src/discovery/` -> `src/distill.js` ->
+- The pipeline is one stage per module, in order: `src/discovery/` -> `src/sample.js` (cap) -> `src/distill.js` ->
   `src/analyze.js` -> `src/fold.js` -> `src/synthesize.js` -> `src/proposal.js` -> `src/apply/`.
   Each module's header comment explains its role; read those before changing a stage.
 - Zero runtime dependencies, ESM, no build step. Node >= 22.5 (for `node:sqlite`).

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ open the original when - and only when - a specific claim needs it.
 
 ### 3. Analysis - one cheap call per transcript
 
+Analysis costs one call per transcript, so the set is capped first: past `maxTranscripts`
+(default 100, `--max-transcripts`) a **recency-weighted sample** is analyzed instead of
+everything. Each transcript's weight halves every `sampleHalfLife` (default 14d), and the
+sample is drawn without replacement, so recent sessions are almost always kept and old
+ones stay represented in proportion. When this happens the run says so on stderr
+(`discovered 340 transcript(s), analyzing a recency-weighted sample of 100`); pass
+`--max-transcripts all` to analyze every transcript, or `--seed <n>` to reproduce a sample.
+
 Each distilled trace goes to a cheap model with the memory file and a rubric. It returns
 strict JSON: which instructions helped, which were violated, and what mistakes no current
 instruction covers.
@@ -299,6 +307,8 @@ CLI flags on top:
   "skillsDir": ".agents/skills",
   "maxEditsPerRun": null,
   "minGapEvidence": 2,
+  "maxTranscripts": 100,
+  "sampleHalfLife": "14d",
   "analysis": { "agent": null, "model": null, "effort": null },
   "synthesis": { "agent": null, "model": null, "effort": null },
   "ladders": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,7 @@ import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 
 import { UserError, fail, setQuiet } from "./logger.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, parseMaxTranscripts } from "./config.js";
 import { resolveRepo } from "./repo.js";
 import { State } from "./state.js";
 import { AgentResolver } from "./agents.js";
@@ -38,6 +38,8 @@ const OPTIONS = {
 
   budget: { type: "string" },
   "max-edits": { type: "string" },
+  "max-transcripts": { type: "string" },
+  seed: { type: "string" },
   "min-gap-evidence": { type: "string" },
   "memory-file": { type: "string", multiple: true },
   "skills-dir": { type: "string" },
@@ -81,7 +83,10 @@ DISCOVERY
                            (claude, codex, pi, opencode, grok, cursor)
   --strict                 deterministic associations only (tiers 1 and 2)
   --include-cursor-ide     also scan the Cursor IDE store (best-effort, v1.1 preview)
-  --limit <n>              analyze at most N transcripts this run
+  --limit <n>              analyze at most N transcripts this run (newest first)
+  --max-transcripts <n>    cap per run; past it a recency-weighted random sample
+                           is analyzed. 0 or "all" disables the cap          [100]
+  --seed <n>               make the transcript sample reproducible
 
 MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
   By default each pass auto-picks the first harness in its ladder that is installed,
@@ -144,6 +149,10 @@ function overridesFrom(values) {
   if (values.jobs) overrides.jobs = toInt(values.jobs, "--jobs");
   if (values.budget) overrides.budgetTokens = toInt(values.budget, "--budget");
   if (values["max-edits"]) overrides.maxEditsPerRun = toInt(values["max-edits"], "--max-edits");
+  if (values["max-transcripts"] !== undefined) {
+    overrides.maxTranscripts = parseMaxTranscripts(values["max-transcripts"], "--max-transcripts");
+  }
+  if (values.seed !== undefined) overrides.seed = toSeed(values.seed);
   if (values["min-gap-evidence"]) {
     overrides.minGapEvidence = toInt(values["min-gap-evidence"], "--min-gap-evidence");
   }
@@ -168,6 +177,12 @@ function overridesFrom(values) {
 function toInt(value, flag) {
   const n = Number(value);
   if (!Number.isInteger(n) || n <= 0) throw new UserError(`${flag} must be a positive integer (got "${value}")`);
+  return n;
+}
+
+function toSeed(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n)) throw new UserError(`--seed must be an integer (got "${value}")`);
   return n;
 }
 

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -4,6 +4,7 @@ import { resolveMemoryFiles } from "../memory.js";
 import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
 import { printUsage } from "./usage.js";
+import { capTranscripts } from "../sample.js";
 
 /**
  * The memory file a run optimizes: the first configured file that exists (AGENTS.md by
@@ -43,7 +44,8 @@ export async function runAnalysis(ctx) {
     budget: config.budgetTokens,
     units: file.units.length,
   });
-  const { transcripts, perHarness } = await discoverForRun(ctx);
+  // The cap bounds the expensive per-transcript calls; cached evidence is reused as usual.
+  const { transcripts, perHarness } = capTranscripts(await discoverForRun(ctx), config);
 
   if (!transcripts.length) {
     info(`${color.yellow("·")} no transcripts associated with this repo`);

--- a/src/config.js
+++ b/src/config.js
@@ -47,6 +47,14 @@ export const DEFAULT_CONFIG = {
   maxEditsPerRun: null,
   minGapEvidence: 2,
   /**
+   * Cap on transcripts analyzed per run; past it a recency-weighted sample is drawn
+   * (`src/sample.js`). `0` or "all" disables the cap. `sampleHalfLife` is the age at
+   * which a transcript's sampling weight halves; `seed` makes the sample reproducible.
+   */
+  maxTranscripts: 100,
+  sampleHalfLife: "14d",
+  seed: null,
+  /**
    * `agent: null` means auto-pick from `ladders[role]`; `effort: null` means
    * `DEFAULT_EFFORT[role]`. Setting `agent` pins the role and skips the ladder.
    */
@@ -119,6 +127,19 @@ export function parseSince(since) {
   return n * ms;
 }
 
+/** Normalize a user-facing cap: `0`, `all`, null, or undefined disables it. */
+export function parseMaxTranscripts(value, flag = "maxTranscripts") {
+  if (value === null || value === undefined || value === "all" || value === "0" || value === 0) return null;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new UserError(
+      `${flag} must be a non-negative integer or "all" (got "${value}")`,
+      'use a positive integer, or 0 / "all" to analyze every transcript',
+    );
+  }
+  return n;
+}
+
 export function sinceCutoff(since, now = Date.now()) {
   const window = parseSince(since);
   return window === null ? null : now - window;
@@ -136,6 +157,13 @@ function validate(config) {
   }
   if (!Number.isInteger(config.minGapEvidence) || config.minGapEvidence < 1) {
     throw new UserError("config.minGapEvidence must be an integer >= 1");
+  }
+  config.maxTranscripts = parseMaxTranscripts(config.maxTranscripts, "config.maxTranscripts");
+  if (parseSince(config.sampleHalfLife) === null) {
+    throw new UserError(`config.sampleHalfLife must be a duration like 14d (got "${config.sampleHalfLife}")`);
+  }
+  if (config.seed !== null && !Number.isInteger(config.seed)) {
+    throw new UserError("config.seed must be an integer or null");
   }
   if (!Number.isInteger(config.jobs) || config.jobs < 1) {
     throw new UserError("config.jobs must be an integer >= 1");
@@ -200,6 +228,7 @@ export function initialConfig() {
     skillsDir: DEFAULT_CONFIG.skillsDir,
     // maxEditsPerRun stays unset so the adaptive cap applies; set it to pin a number.
     minGapEvidence: DEFAULT_CONFIG.minGapEvidence,
+    maxTranscripts: DEFAULT_CONFIG.maxTranscripts,
     // Agents stay unset so the ladder auto-pick keeps applying to initialized repos.
     analysis: { agent: null, model: null, effort: null },
     synthesis: { agent: null, model: null, effort: null },

--- a/src/sample.js
+++ b/src/sample.js
@@ -1,0 +1,99 @@
+import { parseMaxTranscripts, parseSince } from "./config.js";
+import { color, info } from "./logger.js";
+
+/**
+ * Recency-weighted capping of the discovered transcript set.
+ *
+ * Analysis costs one model call per transcript, so a repo with a long history (or a
+ * `--since all` run) needs a bound. A plain "newest N" cut would silently erase the
+ * older history; instead, when discovery exceeds `maxTranscripts` we draw a weighted
+ * sample WITHOUT replacement where each transcript's weight decays exponentially with
+ * its age: weight = 2^(-age / halfLife). Recent sessions are almost always kept, old
+ * ones are still represented in proportion to their weight.
+ *
+ * Sampling uses the Efraimidis-Spirakis one-pass scheme: key = -ln(u) / weight with
+ * u ~ U(0, 1), keep the N smallest keys. That is exactly weighted sampling without
+ * replacement (an exponential race with rate = weight), needs no rejection loop, and is
+ * O(n log n). The RNG is a seedable splitmix32 so runs are reproducible with `--seed`.
+ *
+ * This module is pure: it never touches the cache, so evidence for a sampled transcript
+ * is reused by the analyzer exactly as before.
+ */
+
+export const DEFAULT_SAMPLE_HALF_LIFE = "14d";
+
+/** splitmix32: small, seedable, and uniform enough for sampling keys. */
+export function seededRandom(seed) {
+  let state = Number(seed) >>> 0 || 0x9e3779b9;
+  return () => {
+    state = (state + 0x9e3779b9) | 0;
+    let t = state ^ (state >>> 16);
+    t = Math.imul(t, 0x21f0aaad);
+    t ^= t >>> 15;
+    t = Math.imul(t, 0x735a2d97);
+    t ^= t >>> 15;
+    return (t >>> 0) / 4294967296;
+  };
+}
+
+/** Epoch ms a transcript is dated to: the session start, else the file mtime. */
+export function transcriptTime(transcript) {
+  const at = Number(transcript.startedAt);
+  if (Number.isFinite(at) && at > 0) return at;
+  const mtime = Number(transcript.mtimeMs);
+  return Number.isFinite(mtime) && mtime > 0 ? mtime : null;
+}
+
+/** 2^(-age / halfLife), clamped so an undated or ancient transcript still has a chance. */
+export function recencyWeight(transcript, { now, halfLifeMs }) {
+  const at = transcriptTime(transcript);
+  if (at === null) return 1e-9;
+  const age = Math.max(0, now - at);
+  return Math.max(1e-9, Math.pow(2, -age / halfLifeMs));
+}
+
+/**
+ * Weighted sample without replacement of `count` transcripts. Returns the kept
+ * transcripts in their original (newest-first) order so downstream output is stable.
+ */
+/**
+ * @param {object[]} transcripts
+ * @param {number | null} count
+ * @param {{ seed?: number, now?: number, halfLife?: string }} [options]
+ */
+export function sampleTranscripts(
+  transcripts,
+  count,
+  { seed, now = Date.now(), halfLife = DEFAULT_SAMPLE_HALF_LIFE } = {},
+) {
+  if (count === null || transcripts.length <= count) return transcripts;
+  const random = seededRandom(seed ?? Math.floor(Math.random() * 0xffffffff));
+  const halfLifeMs = parseSince(halfLife) ?? Infinity;
+  const keyed = transcripts.map((transcript, index) => {
+    const u = random() || Number.EPSILON;
+    return { index, key: -Math.log(u) / recencyWeight(transcript, { now, halfLifeMs }) };
+  });
+  keyed.sort((a, b) => a.key - b.key);
+  const kept = new Set(keyed.slice(0, count).map((k) => k.index));
+  return transcripts.filter((_, index) => kept.has(index));
+}
+
+/**
+ * Apply the configured cap to a discovery result, reporting it on stderr when sampling
+ * actually happened. Under the cap the set passes through untouched and nothing is
+ * printed.
+ */
+export function capTranscripts(result, config, { now = Date.now() } = {}) {
+  const cap = parseMaxTranscripts(config.maxTranscripts);
+  const discovered = result.transcripts.length;
+  if (cap === null || discovered <= cap) return result;
+  const sampled = sampleTranscripts(result.transcripts, cap, {
+    seed: config.seed ?? undefined,
+    now,
+    halfLife: config.sampleHalfLife,
+  });
+  info(
+    `${color.yellow("·")} discovered ${discovered} transcript(s), analyzing a recency-weighted sample of ${sampled.length} (--max-transcripts)`,
+  );
+  return { ...result, transcripts: sampled, sampledFrom: discovered };
+}

--- a/test/sample.test.js
+++ b/test/sample.test.js
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { capTranscripts, recencyWeight, sampleTranscripts, seededRandom } from "../src/sample.js";
+import { CONFIG_FILENAME, loadConfig, parseMaxTranscripts } from "../src/config.js";
+import { UserError, setLoggerSink } from "../src/logger.js";
+
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 7, 22);
+
+/** `count` transcripts spread evenly over `spanDays`, newest first like discovery. */
+function transcripts(count, spanDays) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `t${i}`,
+    startedAt: NOW - (i * spanDays * DAY) / count,
+    mtimeMs: 0,
+  }));
+}
+
+function tempDir(config) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-sample-"));
+  if (config !== undefined) fs.writeFileSync(path.join(dir, CONFIG_FILENAME), JSON.stringify(config));
+  return dir;
+}
+
+function captureInfo(fn) {
+  const lines = [];
+  setLoggerSink((line) => lines.push(line));
+  try {
+    fn();
+  } finally {
+    setLoggerSink(null);
+  }
+  return lines;
+}
+
+test("the seeded RNG is deterministic and uniform on [0, 1)", () => {
+  const a = seededRandom(42);
+  const b = seededRandom(42);
+  const seq = Array.from({ length: 1000 }, () => a());
+  assert.deepEqual(
+    seq,
+    Array.from({ length: 1000 }, () => b()),
+  );
+  assert.ok(seq.every((x) => x >= 0 && x < 1));
+  const mean = seq.reduce((s, x) => s + x, 0) / seq.length;
+  assert.ok(Math.abs(mean - 0.5) < 0.05, `mean ${mean} is not close to 0.5`);
+  assert.notEqual(seededRandom(1)(), seededRandom(2)());
+});
+
+test("weight halves every half-life and never reaches zero", () => {
+  const opts = { now: NOW, halfLifeMs: 14 * DAY };
+  assert.equal(recencyWeight({ startedAt: NOW }, opts), 1);
+  assert.ok(Math.abs(recencyWeight({ startedAt: NOW - 14 * DAY }, opts) - 0.5) < 1e-12);
+  assert.ok(Math.abs(recencyWeight({ startedAt: NOW - 28 * DAY }, opts) - 0.25) < 1e-12);
+  assert.ok(recencyWeight({ startedAt: NOW - 10_000 * DAY }, opts) > 0);
+  assert.ok(recencyWeight({ startedAt: null, mtimeMs: NOW }, opts) === 1, "mtime is the fallback timestamp");
+  assert.ok(recencyWeight({ startedAt: null, mtimeMs: 0 }, opts) > 0, "undated transcripts keep a tiny weight");
+});
+
+test("under the cap every transcript passes through untouched", () => {
+  const set = transcripts(10, 30);
+  assert.equal(sampleTranscripts(set, 10, { seed: 1, now: NOW }), set);
+  assert.equal(sampleTranscripts(set, 100, { seed: 1, now: NOW }), set);
+  assert.equal(sampleTranscripts(set, null, { seed: 1, now: NOW }), set, "null disables the cap");
+});
+
+test("over the cap exactly `cap` are kept, in discovery order, reproducibly per seed", () => {
+  const set = transcripts(300, 90);
+  const a = sampleTranscripts(set, 100, { seed: 7, now: NOW });
+  const b = sampleTranscripts(set, 100, { seed: 7, now: NOW });
+  assert.equal(a.length, 100);
+  assert.deepEqual(a, b, "the same seed yields the same sample");
+  assert.equal(new Set(a).size, 100, "sampling is without replacement");
+  const order = a.map((t) => set.indexOf(t));
+  assert.deepEqual(
+    order,
+    [...order].sort((x, y) => x - y),
+    "original order is preserved",
+  );
+  assert.notDeepEqual(
+    sampleTranscripts(set, 100, { seed: 8, now: NOW }),
+    a,
+    "a different seed yields a different sample",
+  );
+});
+
+test("recent transcripts are favored over old ones", () => {
+  const set = transcripts(300, 90);
+  let newestKept = 0;
+  let oldestKept = 0;
+  for (let seed = 0; seed < 50; seed++) {
+    const kept = sampleTranscripts(set, 100, { seed, now: NOW });
+    newestKept += kept.filter((t) => set.indexOf(t) < 100).length;
+    oldestKept += kept.filter((t) => set.indexOf(t) >= 200).length;
+  }
+  // Newest third is within one 14d half-life (weight >= 0.23); oldest third is 60-90 days
+  // out (weight <= 0.05). Unweighted sampling would keep each third equally (~1667 each).
+  assert.ok(newestKept > 2 * oldestKept, `newest ${newestKept} vs oldest ${oldestKept}`);
+  assert.ok(newestKept > 1667, `newest third is over-represented: ${newestKept}`);
+  assert.ok(oldestKept < 1667, `oldest third is under-represented: ${oldestKept}`);
+});
+
+test("capTranscripts reports a greppable line only when sampling happened", () => {
+  const config = loadConfig(tempDir(), { seed: 3 });
+  const small = { transcripts: transcripts(40, 30), perHarness: {} };
+  let lines = captureInfo(() => {
+    const result = capTranscripts(small, config, { now: NOW });
+    assert.equal(result, small, "under the cap the result object is untouched");
+  });
+  assert.deepEqual(lines, []);
+
+  const big = { transcripts: transcripts(340, 60), perHarness: {} };
+  let result = big;
+  lines = captureInfo(() => {
+    result = capTranscripts(big, config, { now: NOW });
+  });
+  assert.equal(result.transcripts.length, 100);
+  assert.equal(result.sampledFrom, 340);
+  assert.equal(result.perHarness, big.perHarness, "other discovery fields are preserved");
+  assert.equal(lines.length, 1);
+  assert.match(
+    lines[0],
+    /discovered 340 transcript\(s\), analyzing a recency-weighted sample of 100 \(--max-transcripts\)/,
+  );
+});
+
+test("maxTranscripts is configurable and 0 / all disable the cap", () => {
+  assert.equal(loadConfig(tempDir()).maxTranscripts, 100);
+  assert.equal(loadConfig(tempDir({ maxTranscripts: 25 })).maxTranscripts, 25);
+  assert.equal(loadConfig(tempDir({ maxTranscripts: 25 }), { maxTranscripts: 7 }).maxTranscripts, 7, "flag wins");
+  assert.equal(loadConfig(tempDir({ maxTranscripts: 25 }), { maxTranscripts: null }).maxTranscripts, null);
+  assert.equal(loadConfig(tempDir({ maxTranscripts: 0 })).maxTranscripts, null);
+  assert.equal(loadConfig(tempDir({ maxTranscripts: "all" })).maxTranscripts, null);
+  assert.equal(parseMaxTranscripts("0", "--max-transcripts"), null);
+  assert.equal(parseMaxTranscripts("all", "--max-transcripts"), null);
+  assert.equal(parseMaxTranscripts("12", "--max-transcripts"), 12);
+  assert.throws(() => parseMaxTranscripts("-1", "--max-transcripts"), UserError);
+  assert.throws(() => parseMaxTranscripts("lots", "--max-transcripts"), UserError);
+  assert.throws(() => loadConfig(tempDir({ sampleHalfLife: "soon" })), UserError);
+  assert.throws(() => loadConfig(tempDir({ seed: 1.5 })), UserError);
+
+  const big = { transcripts: transcripts(340, 60), perHarness: {} };
+  const all = loadConfig(tempDir(), { maxTranscripts: null });
+  const lines = captureInfo(() => assert.equal(capTranscripts(big, all, { now: NOW }), big));
+  assert.deepEqual(lines, [], "no sampling line when the cap is disabled");
+  const seven = loadConfig(tempDir(), { maxTranscripts: 7, seed: 1 });
+  captureInfo(() => assert.equal(capTranscripts(big, seven, { now: NOW }).transcripts.length, 7));
+});


### PR DESCRIPTION
## Summary

Analysis is one model call per transcript, so a long history (or `--since all`) has no cost bound. This adds a cap with recency-weighted sampling past it.

- New config `maxTranscripts` (default **100**), overridable in `.backpassrc.json` / user config and via `--max-transcripts N`, with the same layered precedence as `maxEditsPerRun` / `--budget`. `0` or `all` disables the cap.
- New `src/sample.js`: when discovery exceeds the cap, a weighted sample without replacement is drawn; weight = `2^(-age / sampleHalfLife)` using the session start time (mtime fallback). `sampleHalfLife` is config-only (default `14d`).
- `--seed N` / `config.seed` makes the sample reproducible.
- Applied in `runAnalysis` (`src/commands/analyze.js`) after discovery and before the analyze loop, so both `backpass` and `backpass analyze` are bounded. The cache path is untouched: sampled transcripts with fresh evidence are still served from cache. `src/commands/run.js` is not modified.
- Greppable stderr line only when sampling occurs: `discovered 340 transcript(s), analyzing a recency-weighted sample of 100 (--max-transcripts)`.
- README and `--help` updated; the existing `--limit` (deterministic newest-N) is unchanged and documented as such.

## Why exponential decay with a 14-day half-life

The default discovery window is 30d, so a 14d half-life puts the oldest in-window session at 1/4 the weight of a fresh one: a clear recency bias, but old sessions are still sampled rather than cut off, which matters because memory instructions are judged on recurring behavior. Exponential decay is memoryless (the relative preference between two sessions depends only on their age gap, not on `now`), so the sample stays stable across runs on consecutive days. The half-life is configurable for repos that use `--since all`.

## Why Efraimidis-Spirakis

Key = `-ln(u) / weight`, keep the N smallest. This is exactly weighted sampling without replacement (an exponential race with rate = weight), one pass, `O(n log n)`, no rejection loop and no renormalization as items are removed. The RNG is splitmix32, seedable for deterministic tests and `--seed`.

## Tests (`test/sample.test.js`)

- under the cap: identical set passes through, no line printed
- over the cap: exactly `cap` kept, without replacement, discovery order preserved, same seed => same sample
- recency bias: over 50 seeds the newest third is kept far more often than the oldest third (and more than an unweighted draw would)
- config default / repo config / flag precedence, `0` and `all` disable, invalid values rejected
- the report line appears exactly once when sampling and never otherwise

`pnpm run check` green (154 tests).
