### PR TITLE
fix: exclude backpass's own sessions, recover pi usage from its session file, let synthesis read the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,18 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   second full file is warned about, never silently ignored or double-written.
 - **Never trust model-reported numbers.** Token deltas and budget projections are measured
   in `src/proposal.js` from the actual text; the synthesis model's own figures are ignored.
-  Usage accounting comes only from acpx's `[acpx] tokens:` stderr line, which acpx prints
-  when the ACP adapter returns usage (codex, claude do; pi does not). Records are
+  Usage accounting comes from acpx's `[acpx] tokens:` stderr line, which acpx prints
+  when the ACP adapter returns usage (codex, claude do; pi-acp does not), with one
+  harness-store fallback: pi's per-turn usage is read back from its own session file,
+  located by the prompt text (`recoverUsageFromStore` in `src/acpx.js`). Records are
   `{ agent, usage|null }` (`usageRecord` in `src/acpx.js`) and `src/commands/usage.js` is
   the one place that prints them - never `n/a`: nothing when no call ran, the harness by
   name when it stayed silent.
+- **backpass must never analyze itself.** Its own acpx calls are filed by each harness
+  under the repo's cwd, a tier-1 match. Every prompt starts with `SELF_SESSION_SENTINEL`
+  (`src/prompts.js`) and discovery drops transcripts whose first user message begins with
+  it (`src/discovery/self.js`) before sampling. Keep the sentinel on every model-facing
+  prompt; the triviality filter is not a substitute.
 - **acpx is alpha.** All model invocation is isolated behind `src/acpx.js` so an upstream
   CLI change has one blast radius. v1 uses plain `exec` and named sessions only; acpx flows
   are deferred until they are stable upstream. The one sanctioned exception is the

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Association runs in three tiers:
 Discovery is incremental. Codex alone can hold 10,000+ rollouts, so verdicts are cached in
 `.backpass/scan-cache.json` by path, mtime and size - re-scans cost only the new files.
 A harness whose store is missing or has drifted into an unrecognised shape produces a
-warning and is skipped; the run continues.
+warning and is skipped; the run continues. backpass's own analysis and synthesis calls land
+in these same stores under the repo's cwd; every prompt it sends is tagged, and tagged
+sessions are excluded from the corpus (the `SELF` column in `backpass scan`).
 
 ```sh
 backpass scan --since 7d --strict

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -1,5 +1,9 @@
+import fs from "node:fs";
+
 import { warn } from "./logger.js";
 import { runCapture } from "./subprocess.js";
+import * as piStore from "./discovery/adapters/pi.js";
+import { readJsonl } from "./discovery/adapters/shared.js";
 
 /**
  * The acpx execution layer (design section 4).
@@ -230,6 +234,7 @@ export async function execOneShot({
     promptFile,
   ];
 
+  const startedAt = Date.now();
   const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd });
   if (result.spawnError && result.spawnError.code === "ENOENT") throw notFoundError(result);
   if (result.timedOut) {
@@ -240,7 +245,8 @@ export async function execOneShot({
   }
 
   const combined = `${result.stdout}\n${result.stderr}`;
-  return { text: stripAcpxNoise(result.stdout), usage: parseTokenLine(combined), raw: result.stdout };
+  const usage = parseTokenLine(combined) ?? recoverUsageFromStore({ agent, promptFile, cwd, startedAt });
+  return { text: stripAcpxNoise(result.stdout), usage, raw: result.stdout };
 }
 
 /**
@@ -319,12 +325,14 @@ export async function sessionPrompt({
       "--file",
       promptFile,
     ];
+    const startedAt = Date.now();
     const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd });
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
     if (result.code !== 0) throw new AcpxError(`acpx ${agent} session prompt failed (exit ${result.code})`, result);
 
     const combined = `${result.stdout}\n${result.stderr}`;
-    return { text: stripAcpxNoise(result.stdout), usage: parseTokenLine(combined), raw: result.stdout, notes };
+    const usage = parseTokenLine(combined) ?? recoverUsageFromStore({ agent, promptFile, cwd, startedAt });
+    return { text: stripAcpxNoise(result.stdout), usage, raw: result.stdout, notes };
   } finally {
     const closed = await run([acpxAgent, "sessions", "close", sessionName], { timeoutMs: 30_000, cwd });
     if (closed.code !== 0) warn(`could not close acpx session ${sessionName}`);
@@ -336,13 +344,100 @@ function firstLine(text) {
 }
 
 /**
- * Per-call usage accounting (design section 9).
+ * Harness-store usage fallback.
  *
  * acpx prints its `[acpx] tokens:` line only when the ACP adapter returns `usage` in
- * the `session/prompt` result. codex and claude do; pi does not (its result is a bare
- * `{ stopReason }`), so a pi-backed pass legitimately has nothing to report. A record
- * therefore keeps the harness next to the (possibly null) usage, so the report can say
- * *who* stayed silent instead of printing a meaningless "n/a".
+ * the `session/prompt` result. codex and claude do; pi-acp (0.0.31) answers with a bare
+ * `{ stopReason }` - but pi itself records per-turn usage in its own session file
+ * (`~/.pi/agent/sessions/<escaped-cwd>/<ts>_<id>.jsonl`), the same store discovery
+ * reads. A plain `exec` leaves no session id to look the file up by, so the handle is
+ * the prompt text itself: pi stores it verbatim as the session's first user message.
+ * The newest file under this cwd, modified during the call, whose first user message
+ * equals the prompt we sent, is ours; its assistant turns' `usage` sum is the answer,
+ * mapped onto acpx's key names so the two sources add up in one table.
+ *
+ * Strictly fail-soft: any miss (no store, no match, no usage fields) is null, which the
+ * report prints as "not reported by pi" exactly as before.
+ */
+const STORE_USAGE_RECOVERY = { pi: recoverPiUsage };
+
+/** Slack for a harness that stamps the session timestamp slightly before we spawned it. */
+const STORE_MTIME_SLACK_MS = 5_000;
+
+export function recoverUsageFromStore({ agent, promptFile, cwd, startedAt }) {
+  const recover = STORE_USAGE_RECOVERY[agent];
+  if (!recover) return null;
+  try {
+    return recover({ promptFile, cwd, startedAt }) || null;
+  } catch {
+    return null;
+  }
+}
+
+const PI_USAGE_KEYS = {
+  input: "input",
+  output: "output",
+  cacheRead: "cache_read",
+  cacheWrite: "cache_write",
+  reasoning: "reasoning",
+  totalTokens: "total",
+};
+
+function recoverPiUsage({ promptFile, cwd, startedAt }) {
+  const prompt = fs.readFileSync(promptFile, "utf8").trim();
+  if (!prompt) return null;
+  const wanted = new Set([cwd, realpathOrNull(cwd)].filter(Boolean));
+  const since = (startedAt || 0) - STORE_MTIME_SLACK_MS;
+
+  const candidates = piStore
+    .enumerate()
+    .filter((c) => c.mtimeMs >= since)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const candidate of candidates) {
+    const descriptor = piStore.classify(candidate);
+    if (!descriptor || !wanted.has(descriptor.cwd)) continue;
+    const entries = readJsonl(candidate.path);
+    const firstUser = entries.find((e) => e.type === "message" && e.message?.role === "user");
+    if (!firstUser || piMessageText(firstUser.message.content).trim() !== prompt) continue;
+
+    const usage = {};
+    for (const entry of entries) {
+      if (entry.type !== "message" || entry.message?.role !== "assistant") continue;
+      const turn = entry.message.usage;
+      if (!turn || typeof turn !== "object") continue;
+      for (const [piKey, key] of Object.entries(PI_USAGE_KEYS)) {
+        if (Number.isFinite(turn[piKey])) usage[key] = (usage[key] || 0) + turn[piKey];
+      }
+    }
+    return Object.keys(usage).length ? usage : null;
+  }
+  return null;
+}
+
+function piMessageText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((b) => (typeof b === "string" ? b : b?.type === "text" ? (b.text ?? "") : ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+function realpathOrNull(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-call usage accounting (design section 9).
+ *
+ * A record keeps the harness next to the (possibly null) usage, so when neither acpx
+ * nor the harness store yielded numbers the report can say *who* stayed silent instead
+ * of printing a meaningless "n/a".
  *
  * @typedef {{ agent: string, usage: Record<string, number> | null }} UsageRecord
  */

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -31,17 +31,20 @@ export async function cmdScan(ctx) {
   out(`${ctx.repo.name} · ${ctx.repo.worktrees.length} worktree(s) · since ${ctx.config.discovery.since}`);
   out("");
 
-  const rows = [["HARNESS", "SCANNED", "MATCHED", "CACHED", "NOTE"]];
+  const rows = [["HARNESS", "SCANNED", "MATCHED", "SELF", "CACHED", "NOTE"]];
   for (const [harness, stats] of Object.entries(perHarness)) {
     rows.push([
       harness,
       String(stats.scanned),
       String(stats.matched),
+      String(stats.self || 0),
       String(stats.cached),
       stats.error ? `unreadable: ${stats.error}` : "",
     ]);
   }
   out(table(rows));
+  const selfTotal = Object.values(perHarness).reduce((n, s) => n + (s.self || 0), 0);
+  if (selfTotal) out(color.dim(`  SELF = backpass's own analysis/synthesis sessions, excluded from the corpus`));
   out("");
 
   const byTier = { 1: 0, 2: 0, 3: 0 };

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -7,6 +7,7 @@ import * as cursorCli from "./adapters/cursor-cli.js";
 import * as cursorIde from "./adapters/cursor-ide.js";
 
 import { associate, passesStrict } from "./association.js";
+import { isSelfSession } from "./self.js";
 import { sinceCutoff } from "../config.js";
 import { emitProgress } from "../progress.js";
 import { warn } from "../logger.js";
@@ -38,6 +39,10 @@ export function getAdapter(harness) {
  *
  * Every harness is fail-soft: a store that is missing, unreadable, or has drifted into
  * an unrecognised format produces a named warning and is skipped, never a failed run.
+ *
+ * Sessions backpass itself created (its analysis and synthesis calls, which the harness
+ * files under this repo's cwd) are excluded after association and counted in
+ * `perHarness[h].self` - see `./self.js`.
  */
 export async function discoverTranscripts({ repo, config, strict = false, harnesses = null, now = Date.now() }) {
   const cutoffMs = sinceCutoff(config.discovery.since, now);
@@ -57,7 +62,7 @@ export async function discoverTranscripts({ repo, config, strict = false, harnes
       continue;
     }
 
-    const stats = { scanned: 0, matched: 0, cached: 0, skipped: 0, error: null };
+    const stats = { scanned: 0, matched: 0, cached: 0, skipped: 0, self: 0, error: null };
     perHarness[harness] = stats;
     emitProgress("discover:harness:start", { harness });
 
@@ -82,6 +87,7 @@ export async function discoverTranscripts({ repo, config, strict = false, harnes
         scanned: stats.scanned,
         cached: stats.cached,
         matched: stats.matched,
+        self: stats.self,
         tiers: tierCounts(found),
       });
     } catch (err) {
@@ -119,7 +125,12 @@ async function discoverDirect(adapter, { repo, config, cutoffMs, strict, stats }
       stats.skipped += 1;
       continue;
     }
-    out.push(toTranscript(adapter, row, association, row.id));
+    const transcript = toTranscript(adapter, row, association, row.id);
+    if (isSelfSession(transcript)) {
+      stats.self += 1;
+      continue;
+    }
+    out.push(transcript);
   }
   return out;
 }
@@ -170,7 +181,14 @@ function discoverFiles(adapter, { repo, config, cutoffMs, strict, stats, cache, 
       continue;
     }
 
-    out.push(toTranscript(adapter, { ...candidate, ...descriptor }, association, descriptor.id));
+    const transcript = toTranscript(adapter, { ...candidate, ...descriptor }, association, descriptor.id);
+    // backpass's own acpx runs land in this store under this cwd; drop them here so
+    // they never reach sampling or analysis (see ./self.js).
+    if (isSelfSession(transcript)) {
+      stats.self += 1;
+      continue;
+    }
+    out.push(transcript);
   }
 
   return out;

--- a/src/discovery/self.js
+++ b/src/discovery/self.js
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+
+import { SELF_SESSION_SENTINEL } from "../prompts.js";
+
+/**
+ * Self-session exclusion.
+ *
+ * backpass's own model calls run through acpx with `--cwd <repo root>`, so the harness
+ * files each one in its normal store under this repo's cwd - a tier-1 exact match for
+ * discovery. Left alone, the next run would analyze backpass talking to itself (and a
+ * synthesis session quotes the memory file verbatim, so the "evidence" would be
+ * backpass's own text). Every prompt backpass writes begins with
+ * `SELF_SESSION_SENTINEL`; a transcript whose first user message starts with it is
+ * backpass's and is dropped here, before sampling, so it never takes a slot or a
+ * model call.
+ *
+ * The check reads only the head of the file and keys on the JSON-encoded user text as
+ * every file-backed harness records it (`"text":"..."` / `"content":"..."` /
+ * `"message":"..."`). SQLite-backed stores (opencode, cursor IDE) have no file to
+ * inspect and acpx does not drive them, so they are passed through.
+ */
+
+const HEAD_BYTES = 256 * 1024;
+
+const SENTINEL_PATTERN = new RegExp(`"(?:text|content|message)":"${escapeRegExp(jsonInner(SELF_SESSION_SENTINEL))}`);
+
+function jsonInner(text) {
+  return JSON.stringify(text).slice(1, -1);
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** True when `text` (the head of a transcript file) opens a user message with the sentinel. */
+export function headHasSelfSentinel(text) {
+  return SENTINEL_PATTERN.test(text || "");
+}
+
+/**
+ * @param {{ path?: string | null }} transcript
+ * @returns {boolean}
+ */
+export function isSelfSession(transcript) {
+  const file = transcript?.path;
+  if (!file) return false;
+  let fd;
+  try {
+    fd = fs.openSync(file, "r");
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) return false;
+    const length = Math.min(stat.size, HEAD_BYTES);
+    const buffer = Buffer.alloc(length);
+    fs.readSync(fd, buffer, 0, length, 0);
+    return headHasSelfSentinel(buffer.toString("utf8"));
+  } catch {
+    // Unreadable here means unreadable for the adapter too; let the adapter report it.
+    return false;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -20,6 +20,17 @@ export function render(template, values) {
   );
 }
 
+/**
+ * Every prompt backpass sends to a harness starts with this line. The harness records
+ * the prompt as the session's first user message in its own store - the very store
+ * discovery reads - so without a marker backpass's analysis and synthesis runs would
+ * be discovered as ordinary sessions on the next pass and the loop would analyze
+ * itself. Discovery (`src/discovery/self.js`) drops any transcript whose first user
+ * message begins with it. It keys on content backpass owns, so it survives harness
+ * format drift and needs nothing from acpx.
+ */
+export const SELF_SESSION_SENTINEL = "<!-- backpass:self-session -->";
+
 export function renderPrompt(name, values) {
-  return render(loadPrompt(name), values);
+  return `${SELF_SESSION_SENTINEL}\n${render(loadPrompt(name), values)}`;
 }

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -28,6 +28,9 @@ analyzed sessions in which an instruction drew any evidence at all.
 
 {{EVIDENCE}}
 
+You are running inside the repository with read access, so you can open its files to
+ground or verify an edit against the real code when that would help - your call.
+
 ## Previously rejected edits - do not re-propose these
 
 {{REJECTIONS}}

--- a/src/tui/index.js
+++ b/src/tui/index.js
@@ -153,6 +153,7 @@ export function reduceEvent(state, event, data, now = Date.now()) {
         h.scanned = data.scanned;
         h.matched = data.matched;
         h.newCount = Math.max(data.scanned - (data.cached || 0), 0);
+        h.self = data.self || 0;
         h.tiers = data.tiers || {};
         d.storesOk += 1;
         d.files += data.scanned;

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -287,7 +287,8 @@ function discoverDetail(state, theme, width, spin) {
     } else {
       const scanned = `${formatCount(h.scanned)} sessions`;
       const fresh = h.newCount > 0 || h.scanned > 0 ? ` · ${formatCount(h.newCount)} new` : "";
-      const query = harness === "opencode" ? "1 sqlite query" : `${scanned}${fresh}`;
+      const self = h.self > 0 ? ` · ${formatCount(h.self)} self` : "";
+      const query = harness === "opencode" ? "1 sqlite query" : `${scanned}${fresh}${self}`;
       activity = theme.paint(fitPlain(query, activityWidth), "dim");
       count = padVis(
         `${theme.paint(formatCount(h.matched), "text", { bold: true })} ${theme.paint("this repo", "faint")}`,

--- a/test/self-session.test.js
+++ b/test/self-session.test.js
@@ -1,0 +1,188 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * backpass's own analysis/synthesis calls are filed by each harness under this repo's
+ * cwd, so discovery would pick them up as tier-1 sessions. These tests drive real
+ * discovery over a fake HOME holding the three acpx-backed stores (pi, codex, claude),
+ * each with one genuine session and one session whose first user message is an actual
+ * prompt backpass rendered, and assert only the genuine ones come back.
+ */
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-self-home-"));
+process.env.HOME = fakeHome;
+
+const { discoverTranscripts } = await import("../src/discovery/index.js");
+const { renderPrompt, SELF_SESSION_SENTINEL } = await import("../src/prompts.js");
+const { isSelfSession } = await import("../src/discovery/self.js");
+const { loadConfig } = await import("../src/config.js");
+
+const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-self-repo-"));
+const realRoot = fs.realpathSync(repoRoot);
+const repo = { name: "demo", root: realRoot, worktrees: [realRoot], remotes: [] };
+
+const analysisPrompt = renderPrompt("analysis", {
+  MEMORY_PATH: "AGENTS.md",
+  INSTRUCTION_INDEX: "1. Run pnpm check before pushing.",
+  TRACE: "user: fix the flaky test\nagent: ran the suite",
+});
+const synthesisPrompt = renderPrompt("synthesis", { REPO_NAME: "demo", MEMORY_PATH: "AGENTS.md" });
+
+function jsonl(lines) {
+  return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+}
+
+function writePiSession(dir, id, firstUserText) {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `2026-08-20T10-00-00-000Z_${id}.jsonl`);
+  fs.writeFileSync(
+    file,
+    jsonl([
+      { type: "session", version: 3, id, timestamp: "2026-08-20T10:00:00.000Z", cwd: realRoot },
+      { type: "model_change", id: "m1", parentId: null, provider: "openai-codex", modelId: "gpt-5.6-sol" },
+      {
+        type: "message",
+        id: "e1",
+        parentId: "m1",
+        message: { role: "user", content: [{ type: "text", text: firstUserText }] },
+      },
+      {
+        type: "message",
+        id: "e2",
+        parentId: "e1",
+        message: { role: "assistant", content: [{ type: "text", text: "{}" }] },
+      },
+    ]),
+  );
+  return file;
+}
+
+function writeCodexSession(dir, id, firstUserText) {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `rollout-2026-08-20T10-00-00-${id}.jsonl`);
+  fs.writeFileSync(
+    file,
+    jsonl([
+      {
+        timestamp: "2026-08-20T10:00:00.000Z",
+        type: "session_meta",
+        payload: { session_id: id, cwd: realRoot, source: "exec", git: { branch: "main" } },
+      },
+      { timestamp: "2026-08-20T10:00:01.000Z", type: "turn_context", payload: { cwd: realRoot, model: "gpt-5.2" } },
+      {
+        timestamp: "2026-08-20T10:00:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "<permissions instructions>ignore me" }],
+        },
+      },
+      {
+        timestamp: "2026-08-20T10:00:03.000Z",
+        type: "response_item",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: firstUserText }] },
+      },
+      {
+        timestamp: "2026-08-20T10:00:04.000Z",
+        type: "response_item",
+        payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "{}" }] },
+      },
+    ]),
+  );
+  return file;
+}
+
+function writeClaudeSession(dir, id, firstUserText) {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${id}.jsonl`);
+  fs.writeFileSync(
+    file,
+    jsonl([
+      { type: "mode", mode: "normal", sessionId: id },
+      {
+        parentUuid: null,
+        isSidechain: false,
+        type: "user",
+        message: { role: "user", content: firstUserText },
+        uuid: "u1",
+        timestamp: "2026-08-20T10:00:00.000Z",
+        cwd: realRoot,
+        gitBranch: "main",
+        sessionId: id,
+      },
+      {
+        parentUuid: "u1",
+        isSidechain: false,
+        type: "assistant",
+        message: { model: "claude-opus-5", role: "assistant", content: [{ type: "text", text: "{}" }] },
+        uuid: "a1",
+        timestamp: "2026-08-20T10:00:05.000Z",
+        cwd: realRoot,
+        sessionId: id,
+      },
+    ]),
+  );
+  return file;
+}
+
+const piDir = path.join(fakeHome, ".pi", "agent", "sessions", `-${realRoot.replace(/\//g, "-")}--`);
+const codexDir = path.join(fakeHome, ".codex", "sessions", "2026", "08", "20");
+const claudeDir = path.join(fakeHome, ".claude", "projects", realRoot.replace(/[/.]/g, "-"));
+
+writePiSession(piDir, "pi-real", "Add the changelog entry.");
+writePiSession(piDir, "pi-self", analysisPrompt);
+writeCodexSession(codexDir, "codex-real", "Fix the flaky test.");
+writeCodexSession(codexDir, "codex-self", synthesisPrompt);
+writeClaudeSession(claudeDir, "claude-real", "Open a PR for the parser fix.");
+writeClaudeSession(claudeDir, "claude-self", analysisPrompt);
+// A genuine session that merely *talks about* the sentinel is not a self-session.
+writePiSession(piDir, "pi-mentions", `Why does backpass prepend ${SELF_SESSION_SENTINEL} to its prompts?`);
+
+function configFor() {
+  const config = loadConfig(realRoot, { discovery: { harnesses: ["pi", "codex", "claude"], since: "all" } });
+  const cache = { version: 1, entries: {} };
+  config.state = { readScanCache: () => cache, writeScanCache: () => {} };
+  return config;
+}
+
+test("every prompt backpass sends begins with the self-session sentinel", () => {
+  assert.ok(analysisPrompt.startsWith(`${SELF_SESSION_SENTINEL}\n`));
+  assert.ok(synthesisPrompt.startsWith(`${SELF_SESSION_SENTINEL}\n`));
+});
+
+test("discovery excludes backpass-originated sessions from every acpx-backed harness", async () => {
+  const { transcripts, perHarness } = await discoverTranscripts({ repo, config: configFor() });
+
+  const ids = transcripts.map((t) => t.nativeId).sort();
+  assert.deepEqual(ids, ["claude-real", "codex-real", "pi-mentions", "pi-real"]);
+  assert.equal(perHarness.pi.self, 1);
+  assert.equal(perHarness.codex.self, 1);
+  assert.equal(perHarness.claude.self, 1);
+  assert.equal(perHarness.pi.matched, 2);
+  assert.equal(perHarness.codex.matched, 1);
+  assert.equal(perHarness.claude.matched, 1);
+  for (const t of transcripts) assert.equal(t.association.tier, 1);
+});
+
+test("the exclusion survives the scan cache (a cached descriptor is still checked)", async () => {
+  const config = configFor();
+  await discoverTranscripts({ repo, config });
+  const second = await discoverTranscripts({ repo, config });
+  assert.deepEqual(second.transcripts.map((t) => t.nativeId).sort(), [
+    "claude-real",
+    "codex-real",
+    "pi-mentions",
+    "pi-real",
+  ]);
+  assert.equal(second.perHarness.pi.cached, 3);
+  assert.equal(second.perHarness.pi.self, 1);
+});
+
+test("isSelfSession is fail-soft on a missing or directory path", () => {
+  assert.equal(isSelfSession({ path: path.join(fakeHome, "nope.jsonl") }), false);
+  assert.equal(isSelfSession({ path: fakeHome }), false);
+  assert.equal(isSelfSession({ path: null }), false);
+});

--- a/test/usage-output.test.js
+++ b/test/usage-output.test.js
@@ -5,24 +5,66 @@ import os from "node:os";
 import path from "node:path";
 
 /**
- * A stand-in acpx: answers on stdout and prints the per-run accounting line on stderr
- * exactly as the real `--format quiet` does for a harness that reports usage (codex,
- * claude). With FAKE_ACPX_SILENT set it behaves like pi, whose ACP result carries no
- * usage, so acpx prints no line at all.
+ * A stand-in acpx that reproduces what each harness really leaves behind for backpass
+ * to account from. codex answers and prints the per-run `[acpx] tokens:` line on
+ * stderr, exactly as the real `--format quiet` does when the ACP adapter returns
+ * usage. pi answers and prints no line at all (pi-acp returns a bare `{ stopReason }`),
+ * but - like the real pi - files the session under `~/.pi/agent/sessions/<escaped-cwd>/`
+ * with the prompt as its first user message and per-turn `usage` on every assistant
+ * turn. The usage numbers live only in that file; backpass has to go and read them.
  */
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-usage-home-"));
+process.env.HOME = fakeHome;
+
 const fakeAcpxDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fake-acpx-"));
 const fakeAcpx = path.join(fakeAcpxDir, "acpx");
+const workDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-usage-cwd-")));
+const piSessionDir = path.join(fakeHome, ".pi", "agent", "sessions", `-${workDir.replace(/\//g, "-")}--`);
+
+/** The per-turn usage the fake pi writes; shape copied from a real pi 0.82 session. */
+const PI_TURNS = [
+  { input: 9608, output: 158, cacheRead: 0, cacheWrite: 0, reasoning: 106, totalTokens: 9766 },
+  { input: 1170, output: 50, cacheRead: 8704, cacheWrite: 0, reasoning: 13, totalTokens: 9924 },
+];
+
 fs.writeFileSync(
   fakeAcpx,
-  [
-    "#!/bin/sh",
-    "printf '{\"ok\":true}\\n'",
-    'if [ -z "$FAKE_ACPX_SILENT" ]; then',
-    '  echo "[acpx] tokens: input=14585 output=5 cache_read=11008 total=25598" >&2',
-    "fi",
-    "exit 0",
-    "",
-  ].join("\n"),
+  `#!${process.execPath}
+const fs = require("node:fs");
+const path = require("node:path");
+const argv = process.argv.slice(2);
+const agent = argv.find((a) => a === "codex" || a === "pi");
+const cwd = argv[argv.indexOf("--cwd") + 1];
+const promptFile = argv[argv.indexOf("--file") + 1];
+process.stdout.write('{"ok":true}\\n');
+if (agent === "codex") {
+  process.stderr.write("[acpx] tokens: input=14585 output=5 cache_read=11008 total=25598\\n");
+} else if (agent === "pi" && !process.env.FAKE_PI_NO_STORE) {
+  const prompt = fs.readFileSync(promptFile, "utf8");
+  const dir = ${JSON.stringify(piSessionDir)};
+  fs.mkdirSync(dir, { recursive: true });
+  const id = "01a02b65-" + Date.now().toString(16) + "-" + process.pid;
+  const turns = ${JSON.stringify(PI_TURNS)};
+  const lines = [
+    { type: "session", version: 3, id, timestamp: new Date().toISOString(), cwd },
+    { type: "model_change", id: "b7e9dc92", parentId: null, provider: "openai-codex", modelId: "gpt-5.6-sol" },
+    { type: "thinking_level_change", id: "72a6aaad", parentId: "b7e9dc92", thinkingLevel: "high" },
+    { type: "message", id: "9a9e48f3", parentId: "72a6aaad", message: { role: "user", content: [{ type: "text", text: prompt }] } },
+  ];
+  let parent = "9a9e48f3";
+  turns.forEach((usage, i) => {
+    const mid = "turn" + i;
+    lines.push({
+      type: "message", id: mid, parentId: parent,
+      message: { role: "assistant", content: [{ type: "thinking", thinking: "..." }, { type: "text", text: i === 0 ? "Working." : '{"ok":true}' }],
+        api: "openai-codex-responses", provider: "openai-codex", model: "gpt-5.6-sol", usage: { ...usage, cost: { total: 0.002 } }, stopReason: "stop" },
+    });
+    parent = mid;
+  });
+  fs.writeFileSync(path.join(dir, new Date().toISOString().replace(/[:.]/g, "-") + "_" + id + ".jsonl"),
+    lines.map((l) => JSON.stringify(l)).join("\\n") + "\\n");
+}
+`,
 );
 fs.chmodSync(fakeAcpx, 0o755);
 process.env.BACKPASS_ACPX_BIN = fakeAcpx;
@@ -56,25 +98,68 @@ function proposalWith(usage) {
 }
 
 const promptFile = path.join(fakeAcpxDir, "prompt.md");
-fs.writeFileSync(promptFile, "hello");
+fs.writeFileSync(promptFile, "<!-- backpass:self-session -->\nAudit this session.\n\n- a list item\n");
 
 test("a harness that reports usage through acpx yields a numeric record", async () => {
-  delete process.env.FAKE_ACPX_SILENT;
-  const result = await execOneShot({ agent: "codex", promptFile, cwd: fakeAcpxDir, timeoutSeconds: 5 });
+  const result = await execOneShot({ agent: "codex", promptFile, cwd: workDir, timeoutSeconds: 5 });
   const record = usageRecord("codex", result);
   assert.deepEqual(record, { agent: "codex", usage: { input: 14585, output: 5, cache_read: 11008, total: 25598 } });
   assert.equal(describeUsage([record, record]), "input=29,170 output=10 cache_read=22,016 total=51,196");
 });
 
-test("a harness that reports nothing (pi) is named instead of printing n/a", async () => {
-  process.env.FAKE_ACPX_SILENT = "1";
+test("pi usage is recovered from pi's own session file when acpx prints no tokens line", async () => {
+  // An older pi session in the same cwd with a different prompt must not be mistaken for ours.
+  fs.mkdirSync(piSessionDir, { recursive: true });
+  const decoy = path.join(piSessionDir, "2026-08-01T00-00-00-000Z_decoy.jsonl");
+  fs.writeFileSync(
+    decoy,
+    [
+      JSON.stringify({ type: "session", version: 3, id: "decoy", timestamp: "2026-08-01T00:00:00.000Z", cwd: workDir }),
+      JSON.stringify({
+        type: "message",
+        id: "u",
+        parentId: null,
+        message: { role: "user", content: [{ type: "text", text: "something else" }] },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "a",
+        parentId: "u",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "no" }],
+          usage: { input: 1, output: 1, totalTokens: 2 },
+        },
+      }),
+      "",
+    ].join("\n"),
+  );
+  const old = new Date(Date.now() - 3_600_000);
+  fs.utimesSync(decoy, old, old);
+
+  const result = await execOneShot({ agent: "pi", promptFile, cwd: workDir, timeoutSeconds: 5 });
+  const record = usageRecord("pi", result);
+  assert.deepEqual(record, {
+    agent: "pi",
+    usage: { input: 10778, output: 208, cache_read: 8704, cache_write: 0, reasoning: 119, total: 19690 },
+  });
+  assert.equal(
+    describeUsage([record]),
+    "input=10,778 output=208 cache_read=8,704 cache_write=0 reasoning=119 total=19,690",
+  );
+});
+
+test("a pi call that leaves no session file stays honest: named, never n/a", async () => {
+  process.env.FAKE_PI_NO_STORE = "1";
+  const silentPrompt = path.join(fakeAcpxDir, "prompt-silent.md");
+  fs.writeFileSync(silentPrompt, "<!-- backpass:self-session -->\nA prompt no session file answers.\n");
   try {
-    const result = await execOneShot({ agent: "pi", promptFile, cwd: fakeAcpxDir, timeoutSeconds: 5 });
+    const result = await execOneShot({ agent: "pi", promptFile: silentPrompt, cwd: workDir, timeoutSeconds: 5 });
     const record = usageRecord("pi", result);
     assert.deepEqual(record, { agent: "pi", usage: null });
     assert.equal(describeUsage([record]), "not reported by pi");
   } finally {
-    delete process.env.FAKE_ACPX_SILENT;
+    delete process.env.FAKE_PI_NO_STORE;
   }
 });
 


### PR DESCRIPTION
Three fixes grounded in the behavior-scout report (`fm-homes/mini-default/data/backpass-behavior-design-qs-s1/report.md`, Q1, Q5, Q2). Defect #4 (gap-singleton discard) is deliberately untouched.

## 1. Self-pollution: backpass no longer ingests its own sessions (report Q1)

backpass's analysis/synthesis calls run through acpx with `--cwd <repo root>`, so each harness files them in its normal store under the repo's cwd - a tier-1 exact match for discovery. The report measured 14 of 46 transcripts (30%) in a 2-day window as backpass talking to itself, held back only incidentally by the triviality filter.

- `src/prompts.js`: `renderPrompt` now prepends `SELF_SESSION_SENTINEL` (`<!-- backpass:self-session -->`) to every model-facing prompt (the report's "tag at the source" recommendation - keys on content backpass owns, so it survives harness format drift).
- `src/discovery/self.js` (new): `isSelfSession` reads the head of a transcript and matches a user message that *begins with* the sentinel (JSON-encoded `"text"/"content"/"message"` field, covering claude, codex, pi). A session that merely mentions the sentinel is not excluded.
- `src/discovery/index.js`: excluded after association and before sampling, so self-sessions never take a `--max-transcripts` slot or a model call; counted in `perHarness[h].self`, shown as a `SELF` column in `backpass scan` and as `· N self` in the TUI discover row.
- `test/self-session.test.js`: drives real `discoverTranscripts` over a fake HOME holding pi, codex and claude stores, each with a genuine session plus one whose first user message is an actual `renderPrompt("analysis"|"synthesis")` output; asserts only the genuine ones come back, per-harness `self` counts, that the exclusion survives the scan cache, and fail-soft on bad paths. Mutation-checked: disabling the exclusion fails the test.

Note: sessions created by backpass *before* this change carry no sentinel and stay in the corpus until they age past `--since`.

## 2. pi token usage recovered from pi's own session file; fake test replaced (report Q5)

pi-acp 0.0.31 returns a bare `{ stopReason }` from `session/prompt`, so acpx prints no `[acpx] tokens:` line and backpass printed "not reported by pi". pi itself writes per-turn `usage` into `~/.pi/agent/sessions/<escaped-cwd>/<ts>_<id>.jsonl`.

- `src/acpx.js`: when `parseTokenLine` yields nothing, `recoverUsageFromStore` runs the harness-specific fallback. For pi it locates the session file under the call's cwd, modified during the call, whose first user message equals the prompt text we sent (a plain `exec` leaves no session id, so the prompt is the handle), and sums assistant-turn usage mapped onto acpx key names (`cacheRead -> cache_read`, `totalTokens -> total`, ...). Strictly fail-soft: any miss is `null` and the report still names pi. Confined to `src/acpx.js` per the "acpx is the one model boundary" rule; reuses the pi discovery adapter's store reader.
- Live-verified on this machine against real acpx + pi: `execOneShot({agent:"pi"})` now returns `input=3,719 output=5 cache_read=1,536 total=5,260`, matching the session file exactly, where before it returned `null`.
- `test/usage-output.test.js`: the old pi test set `FAKE_ACPX_SILENT` and asserted `usage: null` - it hardcoded the answer and proved nothing. The stand-in acpx now does what each harness really does: codex prints the tokens line; pi prints none and writes a pi-format session file (shape copied from a real pi 0.82 session, two assistant turns with usage) into the fake HOME. The test asserts the summed numbers are recovered through the real enumerate/classify/match path, that an older same-cwd session with a different prompt is not mistaken for ours, and that a pi call leaving no file still yields "not reported by pi". Mutation-checked: removing the recovery call fails the test.

Filing the upstream fix against pi-acp (forward `usage` in the prompt result) remains worthwhile; when it lands, acpx prints the line and this fallback simply never runs.

## 3. Synthesis repo-grounding, light touch (report Q2)

One sentence added to `src/prompts/synthesis.md`: the agent is told it runs inside the repository with read access and *can* open files to ground or verify an edit when that would help - explicitly its call. No required step, no enforcement, no permission changes (`--approve-reads` was already granted).

## Docs
`AGENTS.md` sharp edges updated (self-session sentinel; pi usage fallback), one README note in the discovery section.

## Verification
`pnpm install` + `pnpm run check`: lint, format, typecheck, 178/178 tests green. `node bin/backpass.js scan --since 2d` on this repo shows the new `SELF` column (0 today, since pre-change self-sessions carry no sentinel).
