### PR TITLE
fix: accumulate gap corroboration across runs in a persisted ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `{ agent, usage|null }` (`usageRecord` in `src/acpx.js`) and `src/commands/usage.js` is
   the one place that prints them - never `n/a`: nothing when no call ran, the harness by
   name when it stayed silent.
+- **Gap corroboration is counted across runs through `.backpass/gap-ledger.json`**
+  (`src/gap-ledger.js`, wired in `foldForRun`): one sighting per (gap, transcript id), so a
+  session never counts twice and a gap seen once per run still graduates at `minGapEvidence`.
+  Record this run's evidence _before_ pruning - old evidence files stay on disk and would
+  re-add an expired or covered sighting otherwise. Uncorroborated gaps stay hidden; never
+  surface singletons to the prompt or report.
 - **backpass must never analyze itself.** Its own acpx calls are filed by each harness
   under the repo's cwd, a tier-1 match. Every prompt starts with `SELF_SESSION_SENTINEL`
   (`src/prompts.js`) and discovery drops transcripts whose first user message begins with

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ Evidence is grouped by instruction, giving each one a positive/negative count an
 gaps across sessions are clustered, and clusters seen in fewer than `minGapEvidence`
 sessions (default 2) are dropped. One bad session never rewrites the weights.
 
+Those sessions are counted across runs, not per run: every gap sighting is kept in
+`.backpass/gap-ledger.json` by gap and session, so a gap seen in one session today and in
+another session next week graduates on the later run. The same session never counts twice,
+a sighting retires once the memory file gains an instruction that covers it, and a session's
+sightings expire after `gapLedgerMaxAge` (default 90d). Until a gap corroborates it stays
+out of the proposal entirely.
+
 ### 5. Synthesis - one big call
 
 A single high-reasoning call turns the folded evidence into concrete edits: ADD, REMOVE,
@@ -309,6 +316,7 @@ CLI flags on top:
   "skillsDir": ".agents/skills",
   "maxEditsPerRun": null,
   "minGapEvidence": 2,
+  "gapLedgerMaxAge": "90d",
   "maxTranscripts": 100,
   "sampleHalfLife": "14d",
   "analysis": { "agent": null, "model": null, "effort": null },
@@ -348,6 +356,7 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   proposal.json          the latest synthesis
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them
+  gap-ledger.json        gap sightings by gap and session, accumulated across runs
   apply/apply.html       the rendered review surface
 ```
 

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,4 +1,5 @@
 import { foldEvidence } from "../fold.js";
+import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
 import { synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
 import { UserError, color, info, json, out } from "../logger.js";
@@ -8,12 +9,27 @@ import { primaryMemoryFile } from "./analyze.js";
 import { printUsage } from "./usage.js";
 import { discoverForRun } from "./scan.js";
 
+/**
+ * Fold on-disk evidence for the memory file. Gap corroboration is counted through the
+ * persisted ledger so sessions accumulate across runs: record this run's observations,
+ * prune what the current file now covers or what aged out (after recording, because the
+ * evidence files that fed an expired sighting are still on disk and would re-add it),
+ * then cluster from the ledger.
+ */
 export async function foldForRun(ctx, memoryFile) {
-  const evidence = ctx.config.state.listEvidence();
+  const { state, minGapEvidence, gapLedgerMaxAge } = ctx.config;
+  const evidence = state.listEvidence();
   const relevant = evidence.filter((e) => e.memoryPath === memoryFile.path);
+
+  const ledger = state.readGapLedger();
+  recordGapObservations(ledger, relevant);
+  pruneGapLedger(ledger, { memoryFile, memoryPath: memoryFile.path, maxAge: gapLedgerMaxAge });
+  state.writeGapLedger(ledger);
+
   return foldEvidence(relevant, {
-    minGapEvidence: ctx.config.minGapEvidence,
+    minGapEvidence,
     memoryFile,
+    gapObservations: ledgerGapObservations(ledger, memoryFile.path),
   });
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -47,6 +47,12 @@ export const DEFAULT_CONFIG = {
   maxEditsPerRun: null,
   minGapEvidence: 2,
   /**
+   * Gap observations accumulate across runs in `.backpass/gap-ledger.json` so the
+   * `minGapEvidence` bar counts distinct sessions over time, not per run. A session's
+   * observations retire past this age (a duration like 90d, `all` to never expire).
+   */
+  gapLedgerMaxAge: "90d",
+  /**
    * Cap on transcripts analyzed per run; past it a recency-weighted sample is drawn
    * (`src/sample.js`). `0` or "all" disables the cap. `sampleHalfLife` is the age at
    * which a transcript's sampling weight halves; `seed` makes the sample reproducible.
@@ -159,6 +165,11 @@ function validate(config) {
     throw new UserError("config.minGapEvidence must be an integer >= 1");
   }
   config.maxTranscripts = parseMaxTranscripts(config.maxTranscripts, "config.maxTranscripts");
+  try {
+    parseSince(config.gapLedgerMaxAge);
+  } catch {
+    throw new UserError(`config.gapLedgerMaxAge must be a duration like 90d or all (got "${config.gapLedgerMaxAge}")`);
+  }
   if (parseSince(config.sampleHalfLife) === null) {
     throw new UserError(`config.sampleHalfLife must be a duration like 14d (got "${config.sampleHalfLife}")`);
   }

--- a/src/fold.js
+++ b/src/fold.js
@@ -1,4 +1,5 @@
 import { similarity } from "./memory.js";
+import { GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
 
 /**
  * Stage 2 of the pipeline (design section 3): fold per-transcript evidence into one
@@ -13,25 +14,21 @@ import { similarity } from "./memory.js";
  *  2. Near-duplicate gaps from different sessions are clustered, so "three sessions
  *     re-derived the db schema" arrives as one item with three quotes.
  *  3. Gap clusters below `minGapEvidence` are dropped. Batch size > 1: one bad session
- *     never rewrites the weights.
+ *     never rewrites the weights. Sessions are counted across runs, not per run: when the
+ *     caller passes `gapObservations` (the pruned gap ledger, `src/gap-ledger.js`) the
+ *     clusters are built from those instead of this run's records, so a gap seen once now
+ *     and once on a later run graduates. Without a ledger the records alone are used.
  */
 
-const GAP_SIMILARITY_THRESHOLD = 0.45;
-
-function sourceLabel(evidence) {
-  const t = evidence.transcript || {};
-  const date = t.startedAt ? new Date(t.startedAt).toISOString().slice(0, 10) : "unknown date";
-  return `${t.harness} · ${String(t.id || "")
-    .replace(/^[a-z-]+-/, "")
-    .slice(0, 8)} · ${date}`;
-}
-
-export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile = null } = {}) {
+/**
+ * @param {object[]} evidenceRecords
+ * @param {{ minGapEvidence?: number, memoryFile?: object|null, gapObservations?: object[]|null }} [options]
+ */
+export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile = null, gapObservations = null } = {}) {
   const usable = evidenceRecords.filter((e) => e && e.status === "ok");
   const analyzedSessions = usable.length;
 
   const instructions = new Map();
-  const gapClusters = [];
   let positiveCount = 0;
   let negativeCount = 0;
   let usedRawCount = 0;
@@ -49,9 +46,10 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
     return instructions.get(id);
   };
 
+  const recordObservations = [];
   for (const record of usable) {
     if (record.usedRawTranscript) usedRawCount += 1;
-    const source = sourceLabel(record);
+    const source = gapSource(record.transcript);
 
     for (const polarity of ["positive", "negative"]) {
       for (const item of record[polarity] || []) {
@@ -65,32 +63,18 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
     }
 
     for (const gap of record.gaps || []) {
-      const cluster = gapClusters.find(
-        (c) => similarity(c.proposedInstruction, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD,
-      );
-      const item = {
+      recordObservations.push({
+        proposedInstruction: gap.proposedInstruction,
         mistake: gap.mistake,
         quote: gap.quote,
         recurrenceRisk: gap.recurrenceRisk,
         source,
         sessionId: record.transcript.id,
-      };
-      if (cluster) {
-        cluster.items.push(item);
-        cluster.sessions.add(record.transcript.id);
-        // Keep the shortest phrasing: it generalizes best.
-        if (gap.proposedInstruction.length < cluster.proposedInstruction.length) {
-          cluster.proposedInstruction = gap.proposedInstruction;
-        }
-      } else {
-        gapClusters.push({
-          proposedInstruction: gap.proposedInstruction,
-          sessions: new Set([record.transcript.id]),
-          items: [item],
-        });
-      }
+      });
     }
   }
+
+  const gapClusters = clusterGapObservations(gapObservations ?? recordObservations);
 
   // Instructions that exist in the file but drew no evidence at all are the strongest
   // removal / extraction candidates, so they must appear in the summary too.
@@ -141,6 +125,42 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
     instructions: instructionRows,
     gaps,
   };
+}
+
+/**
+ * Greedy similarity clustering over gap observations. A cluster counts each session once
+ * no matter how many observations it contributed (re-analysis, duplicate reports).
+ */
+export function clusterGapObservations(observations) {
+  const clusters = [];
+  for (const obs of observations) {
+    if (!obs || !obs.proposedInstruction) continue;
+    const cluster = clusters.find(
+      (c) => similarity(c.proposedInstruction, obs.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD,
+    );
+    const item = {
+      mistake: obs.mistake,
+      quote: obs.quote,
+      recurrenceRisk: obs.recurrenceRisk,
+      source: obs.source,
+      sessionId: obs.sessionId,
+    };
+    if (cluster) {
+      if (!cluster.sessions.has(obs.sessionId)) cluster.items.push(item);
+      cluster.sessions.add(obs.sessionId);
+      // Keep the shortest phrasing: it generalizes best.
+      if (obs.proposedInstruction.length < cluster.proposedInstruction.length) {
+        cluster.proposedInstruction = obs.proposedInstruction;
+      }
+    } else {
+      clusters.push({
+        proposedInstruction: obs.proposedInstruction,
+        sessions: new Set([obs.sessionId]),
+        items: [item],
+      });
+    }
+  }
+  return clusters;
 }
 
 function highestRisk(items) {

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -1,0 +1,174 @@
+import { similarity } from "./memory.js";
+import { parseSince } from "./config.js";
+import { sha256 } from "./state.js";
+
+/**
+ * Durable gap corroboration across runs (`.backpass/gap-ledger.json`).
+ *
+ * The fold stage only promotes a gap once `minGapEvidence` distinct sessions report it.
+ * Counting those sessions from the evidence that happens to be on disk is lossy: a
+ * transcript's evidence file is rewritten every time it is re-analyzed against a changed
+ * memory file (every apply changes the hash), and the analysis model rephrases gaps
+ * between runs, so two observations of one gap rarely line up in a single fold. This
+ * ledger keeps every gap observation, keyed by gap identity and session, so a gap seen in
+ * one session now and in another session on a later run still reaches the bar.
+ *
+ * Identity and freshness rules:
+ *
+ *  - A gap's identity is its proposed instruction, matched by the same bigram similarity
+ *    the in-run clustering uses (`GAP_SIMILARITY_THRESHOLD`), against the ledger's
+ *    canonical phrasing (the shortest seen). The entry id is a hash of the first phrasing
+ *    and never changes, so rephrasing does not split an entry.
+ *  - Sessions are keyed by transcript id (harness + native session id), so re-analyzing
+ *    or re-sampling the same session overwrites its observation and never adds a count.
+ *  - A gap is a fact about its session: re-analysis that no longer mentions it is model
+ *    noise, not the session changing, so observations are only ever replaced, not removed
+ *    by absence. They retire in exactly two ways: the memory file gains an instruction
+ *    that covers the gap (`GAP_COVERED_THRESHOLD`, the `reanchor` bar), or the sighting
+ *    has waited longer than `gapLedgerMaxAge` for a partner, counted from when backpass
+ *    first saw it (re-analysis never refreshes that clock; session age itself is already
+ *    bounded by discovery's `since` at entry). Keying to the memory hash instead would
+ *    reset the count on every unrelated edit, which is the failure this ledger fixes.
+ *  - The file is fail-soft: a missing or corrupt ledger is rebuilt from this run's
+ *    evidence, which is exactly what the pre-ledger fold saw.
+ */
+
+/** Two gap phrasings at or above this Sorensen-Dice bigram score are one gap. */
+export const GAP_SIMILARITY_THRESHOLD = 0.45;
+/** A memory-file instruction this similar to a gap's proposal covers it. */
+export const GAP_COVERED_THRESHOLD = 0.6;
+
+export function emptyGapLedger() {
+  return { version: 1, entries: {} };
+}
+
+export function gapSource(transcript = {}) {
+  const date = transcript.startedAt ? new Date(transcript.startedAt).toISOString().slice(0, 10) : "unknown date";
+  return `${transcript.harness} · ${String(transcript.id || "")
+    .replace(/^[a-z-]+-/, "")
+    .slice(0, 8)} · ${date}`;
+}
+
+function normalize(text) {
+  return String(text || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function gapEntryId(memoryPath, proposedInstruction) {
+  return sha256(`${memoryPath}\n${normalize(proposedInstruction)}`).slice(0, 16);
+}
+
+/** The ledger entry a proposed instruction belongs to, or null. */
+export function findGapEntry(ledger, memoryPath, proposedInstruction) {
+  let best = null;
+  let bestScore = 0;
+  for (const entry of Object.values(ledger.entries)) {
+    if (entry.memoryPath !== memoryPath) continue;
+    const score = similarity(entry.proposedInstruction, proposedInstruction);
+    if (score >= GAP_SIMILARITY_THRESHOLD && score > bestScore) {
+      best = entry;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+/**
+ * Fold this run's evidence into the ledger. One observation per (gap, session); a
+ * session seen again replaces its own observation and keeps its first-seen timestamp.
+ */
+export function recordGapObservations(ledger, evidenceRecords, { now = new Date() } = {}) {
+  const observedAt = new Date(now).toISOString();
+  let recorded = 0;
+  for (const record of evidenceRecords) {
+    if (!record || record.status !== "ok" || !record.memoryPath) continue;
+    const transcript = record.transcript || {};
+    if (!transcript.id) continue;
+    for (const gap of record.gaps || []) {
+      if (!gap || !gap.proposedInstruction) continue;
+      let entry = findGapEntry(ledger, record.memoryPath, gap.proposedInstruction);
+      if (!entry) {
+        const id = gapEntryId(record.memoryPath, gap.proposedInstruction);
+        entry = ledger.entries[id] = {
+          id,
+          memoryPath: record.memoryPath,
+          proposedInstruction: gap.proposedInstruction,
+          sessions: {},
+        };
+      } else if (gap.proposedInstruction.length < entry.proposedInstruction.length) {
+        // Keep the shortest phrasing: it generalizes best (same rule as the in-run fold).
+        entry.proposedInstruction = gap.proposedInstruction;
+      }
+      const prior = entry.sessions[transcript.id];
+      entry.sessions[transcript.id] = {
+        firstObservedAt: prior?.firstObservedAt || observedAt,
+        observedAt,
+        sessionStartedAt: transcript.startedAt ?? prior?.sessionStartedAt ?? null,
+        memoryHash: record.memoryHash || null,
+        source: gapSource(transcript),
+        mistake: gap.mistake,
+        quote: gap.quote,
+        recurrenceRisk: gap.recurrenceRisk,
+      };
+      recorded += 1;
+    }
+  }
+  return recorded;
+}
+
+/**
+ * Retire observations that no longer count: sightings first seen more than `maxAge` ago
+ * (a duration like `90d`, `all` to disable) and gaps the current memory file now covers.
+ */
+export function pruneGapLedger(
+  ledger,
+  { memoryFile = null, memoryPath = null, maxAge = "90d", now = new Date() } = {},
+) {
+  const maxAgeMs = parseSince(maxAge);
+  const cutoff = maxAgeMs === null ? -Infinity : new Date(now).getTime() - maxAgeMs;
+  const stats = { expired: 0, covered: 0 };
+
+  for (const [id, entry] of Object.entries(ledger.entries)) {
+    const applies = memoryPath === null || entry.memoryPath === memoryPath;
+    if (applies && memoryFile && isCovered(memoryFile, entry.proposedInstruction)) {
+      stats.covered += Object.keys(entry.sessions).length;
+      delete ledger.entries[id];
+      continue;
+    }
+    for (const [sessionId, obs] of Object.entries(entry.sessions)) {
+      const when = Date.parse(obs.firstObservedAt || obs.observedAt);
+      if (!Number.isFinite(when) || when < cutoff) {
+        stats.expired += 1;
+        delete entry.sessions[sessionId];
+      }
+    }
+    if (!Object.keys(entry.sessions).length) delete ledger.entries[id];
+  }
+  return stats;
+}
+
+function isCovered(memoryFile, proposedInstruction) {
+  return (memoryFile.units || []).some((unit) => similarity(unit.text, proposedInstruction) >= GAP_COVERED_THRESHOLD);
+}
+
+/** Flatten the ledger into the observation list `foldEvidence` clusters over. */
+export function ledgerGapObservations(ledger, memoryPath) {
+  const observations = [];
+  for (const entry of Object.values(ledger.entries)) {
+    if (entry.memoryPath !== memoryPath) continue;
+    for (const [sessionId, obs] of Object.entries(entry.sessions)) {
+      observations.push({
+        proposedInstruction: entry.proposedInstruction,
+        sessionId,
+        source: obs.source,
+        mistake: obs.mistake,
+        quote: obs.quote,
+        recurrenceRisk: obs.recurrenceRisk,
+      });
+    }
+  }
+  return observations;
+}

--- a/src/state.js
+++ b/src/state.js
@@ -20,6 +20,7 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   evidence-summary.json  folded evidence (stage 2)
  *   proposal.json          latest tier-2 synthesis (stage 3)
  *   rejections.json        edits the human rejected, and the evidence weight behind them
+ *   gap-ledger.json        gap observations by gap and session, accumulated across runs (src/gap-ledger.js)
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   apply/                 the rendered Lavish apply surface
  */
@@ -32,6 +33,7 @@ export class State {
     this.summaryPath = path.join(this.root, "evidence-summary.json");
     this.proposalPath = path.join(this.root, "proposal.json");
     this.rejectionsPath = path.join(this.root, "rejections.json");
+    this.gapLedgerPath = path.join(this.root, "gap-ledger.json");
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
   }
 
@@ -116,6 +118,18 @@ export class State {
 
   writeRejections(rejections) {
     this.writeJsonFile(this.rejectionsPath, rejections);
+  }
+
+  /** Fail-soft: a missing or corrupt ledger starts empty and is rebuilt from this run's evidence. */
+  readGapLedger() {
+    const value = this.readJsonFile(this.gapLedgerPath, null);
+    return value && value.version === 1 && value.entries && typeof value.entries === "object"
+      ? value
+      : { version: 1, entries: {} };
+  }
+
+  writeGapLedger(ledger) {
+    this.writeJsonFile(this.gapLedgerPath, ledger);
   }
 
   readProbeCache() {

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { State } from "../src/state.js";
+import { parseMemoryUnits } from "../src/memory.js";
+import { foldForRun } from "../src/commands/propose.js";
+import { foldEvidence } from "../src/fold.js";
+
+const MEMORY_PATH = "AGENTS.md";
+const DAY = 86_400_000;
+
+function memoryFile(text = "# T\n\n- Run pnpm test before pushing.\n- Keep the README current.\n") {
+  return { path: MEMORY_PATH, units: parseMemoryUnits(text) };
+}
+
+function record(id, gaps, { startedAt = Date.parse("2026-08-01T00:00:00Z"), memoryHash = "h1" } = {}) {
+  return {
+    status: "ok",
+    transcript: { id, harness: "claude", startedAt },
+    memoryPath: MEMORY_PATH,
+    memoryHash,
+    positive: [],
+    negative: [],
+    gaps: gaps.map((proposedInstruction) => ({
+      proposedInstruction,
+      mistake: "re-derived it",
+      quote: `quote from ${id}`,
+      recurrenceRisk: "high",
+    })),
+  };
+}
+
+/** A throwaway `.backpass/` and a ctx shaped like the one `foldForRun` reads. */
+function harness(overrides = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-ledger-"));
+  const state = new State(root).ensure();
+  const ctx = { config: { state, minGapEvidence: 2, gapLedgerMaxAge: "90d", ...overrides } };
+  return { root, state, ctx };
+}
+
+/** One backpass run: the evidence files on disk at the time, then the fold. */
+async function run(h, records, file = memoryFile()) {
+  for (const r of records) h.state.writeEvidence(r.transcript.id, r);
+  return foldForRun(h.ctx, file);
+}
+
+const GAP = "Read docs/db.md before writing queries.";
+const GAP_REPHRASED = "Read docs/db.md before writing any queries";
+
+test("a gap seen once now and once on a later run accumulates to two sessions and graduates", async () => {
+  const h = harness();
+  const first = await run(h, [record("claude-s1", [GAP])]);
+  assert.equal(first.gaps.length, 0, "one session is not enough on the first run");
+  assert.equal(first.totals.droppedGapSingletons, 1);
+
+  // Later run: s1's evidence was rewritten against a changed memory file and the model
+  // no longer mentions the gap; a new session s2 reports it in different words.
+  const second = await run(h, [record("claude-s1", [], { memoryHash: "h2" }), record("claude-s2", [GAP_REPHRASED])]);
+  assert.equal(second.gaps.length, 1, "the gap graduates once two distinct sessions have reported it");
+  assert.equal(second.gaps[0].sessions, 2);
+  assert.equal(second.gaps[0].proposedInstruction, GAP, "the shortest phrasing is canonical");
+  assert.deepEqual(second.gaps[0].quotes.map((q) => q.text).sort(), ["quote from claude-s1", "quote from claude-s2"]);
+});
+
+test("the same session is never double-counted across runs", async () => {
+  const h = harness();
+  await run(h, [record("claude-s1", [GAP])]);
+  const again = await run(h, [record("claude-s1", [GAP_REPHRASED])]);
+  assert.equal(again.gaps.length, 0, "re-observing s1 must not graduate a one-off");
+  const third = await run(h, [record("claude-s1", [GAP])]);
+  assert.equal(third.gaps.length, 0);
+
+  const ledger = h.state.readGapLedger();
+  const entries = Object.values(ledger.entries);
+  assert.equal(entries.length, 1, "rephrasings of one gap share one ledger entry");
+  assert.deepEqual(Object.keys(entries[0].sessions), ["claude-s1"]);
+});
+
+test("a genuine one-off never graduates, however many runs see it", async () => {
+  const h = harness();
+  for (let i = 0; i < 5; i += 1) {
+    const summary = await run(h, [record("claude-s1", [GAP]), record("claude-s2", ["Never force-push to main."])]);
+    assert.equal(summary.gaps.length, 0);
+    assert.equal(summary.totals.droppedGapSingletons, 2);
+  }
+});
+
+test("two distinct sessions in a single run still clear the gate as before", async () => {
+  const h = harness();
+  const summary = await run(h, [record("claude-s1", [GAP]), record("codex-s2", [GAP_REPHRASED])]);
+  assert.equal(summary.gaps.length, 1);
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(summary.totals.gapClusters, 1);
+  assert.equal(summary.totals.droppedGapSingletons, 0);
+});
+
+/** Backdate every sighting in the ledger, as if the runs had happened `days` ago. */
+function age(h, days) {
+  const ledger = h.state.readGapLedger();
+  const then = new Date(Date.now() - days * DAY).toISOString();
+  for (const entry of Object.values(ledger.entries)) {
+    for (const obs of Object.values(entry.sessions)) obs.firstObservedAt = then;
+  }
+  h.state.writeGapLedger(ledger);
+}
+
+test("a sighting older than gapLedgerMaxAge expires instead of resurfacing indefinitely", async () => {
+  const h = harness({ gapLedgerMaxAge: "90d" });
+  await run(h, [record("claude-s1", [GAP])]);
+  age(h, 120);
+  const summary = await run(h, [record("claude-s2", [GAP])]);
+  assert.equal(summary.gaps.length, 0, "an expired sighting must not corroborate a fresh one");
+  assert.deepEqual(
+    Object.values(h.state.readGapLedger().entries).flatMap((e) => Object.keys(e.sessions)),
+    ["claude-s2"],
+  );
+
+  const forever = harness({ gapLedgerMaxAge: "all" });
+  await run(forever, [record("claude-s1", [GAP])]);
+  age(forever, 120);
+  const kept = await run(forever, [record("claude-s2", [GAP])]);
+  assert.equal(kept.gaps.length, 1, "`all` disables expiry");
+});
+
+test("re-analysis of a session does not restart its expiry clock", async () => {
+  const h = harness({ gapLedgerMaxAge: "90d" });
+  await run(h, [record("claude-s1", [GAP])]);
+  age(h, 120);
+  const summary = await run(h, [record("claude-s1", [GAP], { memoryHash: "h2" }), record("claude-s2", [GAP])]);
+  assert.equal(summary.gaps.length, 0, "the re-seen old sighting keeps its original first-seen time");
+});
+
+test("a gap the memory file now covers is retired from the ledger", async () => {
+  const h = harness();
+  await run(h, [record("claude-s1", [GAP])]);
+  const addressed = memoryFile("# T\n\n- Read docs/db.md before writing queries.\n");
+  const summary = await run(h, [record("claude-s2", [GAP])], addressed);
+  assert.equal(summary.gaps.length, 0, "a covered gap must not graduate");
+  const sessions = Object.values(h.state.readGapLedger().entries).flatMap((e) => Object.keys(e.sessions));
+  assert.deepEqual(sessions, [], "the covered entry is dropped, including this run's sighting");
+});
+
+test("a missing or corrupt ledger is rebuilt from the run's evidence, never a crash", async () => {
+  const h = harness();
+  fs.writeFileSync(h.state.gapLedgerPath, "{not json");
+  const summary = await run(h, [record("claude-s1", [GAP]), record("claude-s2", [GAP])]);
+  assert.equal(summary.gaps.length, 1);
+  assert.equal(h.state.readGapLedger().version, 1);
+
+  fs.writeFileSync(h.state.gapLedgerPath, JSON.stringify({ version: 99, entries: "nope" }));
+  const again = await run(h, []);
+  assert.equal(again.gaps.length, 1, "the evidence on disk is enough to rebuild the count");
+});
+
+test("foldEvidence without a ledger keeps the per-run behavior", () => {
+  const summary = foldEvidence([record("claude-s1", [GAP]), record("claude-s1", [GAP_REPHRASED])], {
+    memoryFile: memoryFile(),
+  });
+  assert.equal(summary.gaps.length, 0, "one session reporting twice is still one session");
+});


### PR DESCRIPTION
Fixes defect #4 (35 gaps -> 0 clusters) the option-B way: gap corroboration is accumulated across runs in a persisted ledger. The `>= 2` distinct-session gate (`minGapEvidence`) is unchanged; what changes is how sessions are counted. Uncorroborated gaps stay hidden until they actually corroborate - nothing is surfaced, watchlisted, or rendered for singletons.

Grounded in the behavior-scout report Q4 (`backpass-behavior-design-qs-s1/report.md`).

## What was actually happening

`foldForRun` already folds every `.backpass/evidence/<id>.json` on disk, so accumulation across runs *partially* existed. It failed in practice for two reasons:

1. A transcript's evidence file is rewritten whenever it is re-analyzed against a changed memory hash - and every apply changes the hash. A gap the model reported last run and did not repeat this run (model noise, not a change in the session) vanished with it.
2. Clustering is by bigram similarity of `proposedInstruction`; the model rephrases between runs, and two observations of one gap rarely lined up in a single fold.

## The fix

New `src/gap-ledger.js` + `.backpass/gap-ledger.json`. `foldForRun` records this run's evidence into the ledger, prunes, writes it, and `foldEvidence` clusters from the ledger's observations (the record-only path is kept for callers without a ledger, so `foldEvidence` tests and bootstrap behave as before).

### (a) Stable gap identity across runs
A gap is matched to an existing ledger entry by the same Sorensen-Dice bigram similarity (`>= 0.45`) the in-run clustering already uses, against the entry's canonical phrasing (shortest seen, same rule as the fold). The entry id is a hash of `memoryPath + normalized first phrasing` and never changes, so later rephrasings join the entry instead of splitting it. A volatile per-run id or an exact-text key would defeat the purpose; semantic-ish matching with the bar the project already trusts keeps one threshold to reason about.

### (b) Distinct sessions, never double-counted
Observations are keyed `entries[gapId].sessions[transcript.id]` - the harness-prefixed native session id that is also the evidence filename. Re-analysis or re-sampling of the same session *replaces* its observation (keeping `firstObservedAt`) and never adds a count. `clusterGapObservations` additionally dedups items per session, so even duplicate records cannot inflate it.

### (c) Freshness / expiry
A gap is a fact about its session - the transcript does not change - so re-analysis that stops mentioning it is model noise, and observations are only replaced, never removed by absence. They retire in exactly two ways:
- **Covered:** the current memory file has a unit `>= 0.6` similar to the proposal (the `reanchor` bar). Once a gap is addressed its entry is dropped, including this run's sighting.
- **Expired:** the sighting has waited longer than `gapLedgerMaxAge` (new config, default `90d`, `all` disables) for a partner, counted from when backpass first saw it. Re-analysis does not restart that clock. Session age itself is already bounded by discovery `since` at entry; expiring on `startedAt` proved fragile (harness fixtures with epoch-1 times, adapters that omit it).

Keying the store to the memory *hash* was rejected: it would reset the count on every unrelated edit, which is precisely the failure being fixed. The store is keyed to the memory *path*, with the covered check doing the semantic invalidation.

Order matters: record, then prune. Old evidence files stay on disk and are re-recorded every run, so pruning first never sticks. Documented in `AGENTS.md`.

Fail-soft: a missing or corrupt ledger starts empty and is rebuilt from the evidence on disk (what the pre-ledger fold saw).

## Tests (`test/gap-ledger.test.js`, through the real `foldForRun` + `State` path)
- gap seen once now + once on a later run (rephrased, with the first session's evidence rewritten under a new hash) -> 2 sessions, graduates
- same session re-observed across runs never graduates a one-off; rephrasings share one entry
- a genuine one-off never graduates over 5 runs
- 2 distinct sessions in a single run still clear the gate
- expiry: a 120-day-old sighting does not corroborate a fresh one; `all` disables; re-analysis does not restart the clock
- a gap the memory file now covers is retired
- corrupt / wrong-version ledger rebuilds, never crashes

`pnpm run check` green (lint, format, typecheck, 187 tests).
