### PR TITLE
feat: rename pipeline steps to training-loop terms in user-facing text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 - The pipeline is one stage per module, in order: `src/discovery/` -> `src/sample.js` (cap) -> `src/distill.js` ->
   `src/analyze.js` -> `src/fold.js` -> `src/synthesize.js` -> `src/proposal.js` -> `src/apply/`.
   Each module's header comment explains its role; read those before changing a stage.
+- **User-facing step names are the training-loop terms**, not the module names: discover =
+  "collect samples", analyze = "calculate loss", fold = "aggregate gradients", synthesize =
+  "gradient descent" (`STAGE_LABELS` in `src/tui/render.js`). Internal keys, event names, and
+  the typed subcommands (`scan`, `analyze`, `propose`) keep their short names; only what the
+  user reads changes. Never introduce a multi-word subcommand.
 - Zero runtime dependencies, ESM, no build step. Node >= 22.5 (for `node:sqlite`).
 - pnpm is the package manager; `pnpm run check` runs lint, format:check, typecheck, and
   tests. All tests are offline and use fixtures under `test/fixtures/`. Supply-chain

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ token budget, gated by you.
 AGENTS.md / CLAUDE.md          (the weights)
   → agent session               (forward pass)
   → transcript on disk          (loss signal)
-  → backpass: discover, distill, analyze, fold
-  → backpass: synthesize        (diffs + skill extractions)
+  → backpass: collect samples, distill, calculate loss, aggregate gradients
+  → backpass: gradient descent  (diffs + skill extractions)
   → you accept or reject        (the human gate)
   → back to the weights
 ```
@@ -65,13 +65,13 @@ you have already authenticated.
 ```sh
 cd your-repo
 backpass init      # write .backpassrc.json, exclude .backpass/ via .git/info/exclude
-backpass           # scan → analyze → propose (never writes)
+backpass           # collect samples → calculate loss → aggregate gradients → gradient descent (never writes)
 backpass apply     # review each edit, accept or reject, then write
 ```
 
 ## How It Works
 
-### 1. Discovery - which sessions belong to this repo
+### 1. Collect samples - which sessions belong to this repo
 
 backpass reads the local transcript stores of six harnesses directly. No API, no upload.
 
@@ -94,10 +94,10 @@ Association runs in three tiers:
 3. **Tier 3 - best-effort.** A dead path whose last segment is the repo's directory name,
    or one matching a glob you configured. Labelled as such, and excluded by `--strict`.
 
-Discovery is incremental. Codex alone can hold 10,000+ rollouts, so verdicts are cached in
+Collection is incremental. Codex alone can hold 10,000+ rollouts, so verdicts are cached in
 `.backpass/scan-cache.json` by path, mtime and size - re-scans cost only the new files.
 A harness whose store is missing or has drifted into an unrecognised shape produces a
-warning and is skipped; the run continues. backpass's own analysis and synthesis calls land
+warning and is skipped; the run continues. backpass's own loss and gradient-descent calls land
 in these same stores under the repo's cwd; every prompt it sends is tagged, and tagged
 sessions are excluded from the corpus (the `SELF` column in `backpass scan`).
 
@@ -116,9 +116,9 @@ dropped, secrets redacted. Typical reduction is **96-99%**.
 The distilled trace ends with the path to the raw transcript, so the analysis agent can
 open the original when - and only when - a specific claim needs it.
 
-### 3. Analysis - one cheap call per transcript
+### 3. Calculate loss - one cheap call per transcript
 
-Analysis costs one call per transcript, so the set is capped first: past `maxTranscripts`
+Calculating loss costs one call per transcript, so the set is capped first: past `maxTranscripts`
 (default 100, `--max-transcripts`) a **recency-weighted sample** is analyzed instead of
 everything. Each transcript's weight halves every `sampleHalfLife` (default 14d), and the
 sample is drawn without replacement, so recent sessions are almost always kept and old
@@ -138,7 +138,7 @@ Results are cached per transcript, keyed to both the transcript's content _and_ 
 file's hash: edit the weights and the evidence correctly re-computes; change nothing and
 the next run is free.
 
-### 4. Folding - deterministic, no model
+### 4. Aggregate gradients - deterministic, no model
 
 Evidence is grouped by instruction, giving each one a positive/negative count and a
 **relevance** figure: the share of analyzed sessions in which it mattered at all. Duplicate
@@ -152,9 +152,9 @@ a sighting retires once the memory file gains an instruction that covers it, and
 sightings expire after `gapLedgerMaxAge` (default 90d). Until a gap corroborates it stays
 out of the proposal entirely.
 
-### 5. Synthesis - one big call
+### 5. Gradient descent - one big call
 
-A single high-reasoning call turns the folded evidence into concrete edits: ADD, REMOVE,
+A single high-reasoning call turns the aggregated gradients into concrete edits: ADD, REMOVE,
 REWRITE, or EXTRACT→SKILL. Then mechanical gates run, and they are not negotiable:
 
 - at most `maxEditsPerRun` edits (the learning rate). By default the cap is adaptive: 5
@@ -198,8 +198,8 @@ valve for the budget.
 | **Broad** (≥20% of sessions, or safety-critical) | memory file                       | memory file            |
 | **Conditional / narrow**                         | **skill**                         | deletion candidate     |
 
-"Matters in N% of sessions" is measured, not guessed - it falls straight out of the fold
-stage. A 640-token procedure relevant to 4% of sessions becomes a 35-token description
+"Matters in N% of sessions" is measured, not guessed - it falls straight out of the
+aggregate-gradients stage. A 640-token procedure relevant to 4% of sessions becomes a 35-token description
 line, and backpass reports the arithmetic: `−611 tok always-loaded, +35 tok description`.
 
 Skill descriptions are weights too. If the evidence shows an agent lacked knowledge a
@@ -243,22 +243,23 @@ pointer-aware:
 
 ## CLI Reference
 
-| Command            | What it does                                                  |
-| ------------------ | ------------------------------------------------------------- |
-| `backpass`         | scan → analyze what is new → propose. Never writes.           |
-| `backpass scan`    | discovery only: the transcript table with a confidence column |
-| `backpass analyze` | tier-1 pass over pending transcripts                          |
-| `backpass propose` | tier-2 synthesis from cached evidence                         |
-| `backpass apply`   | review and write the accepted edits                           |
-| `backpass status`  | cache state, failed transcripts, budget bars                  |
-| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally        |
+| Command            | What it does                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| `backpass`         | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
+| `backpass scan`    | collect samples only: the transcript table with a confidence column                      |
+| `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
+| `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
+| `backpass apply`   | review and write the accepted edits                                                      |
+| `backpass status`  | cache state, failed transcripts, budget bars                                             |
+| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
 
 Run `backpass --help` for the full flag list.
 
 ### Live progress
 
 On an interactive terminal the default run renders a live progress view: the budget gauge,
-a stage rail (discover → analyze → fold → synthesize), per-store discovery counts, one lane
+a stage rail (collect samples → calculate loss → aggregate gradients → gradient descent),
+per-store collection counts, one lane
 per analysis job with its distillation receipt, and a running evidence tally. It draws to
 stderr only and collapses into the plain line summary when the run ends, so scrollback and
 piped output are identical to a run without it.
@@ -350,10 +351,10 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
 
 ```
 .backpass/
-  scan-cache.json        discovery verdicts by path + mtime + size
-  evidence/<id>.json     per-transcript analysis
-  evidence-summary.json  folded evidence
-  proposal.json          the latest synthesis
+  scan-cache.json        collect-samples verdicts by path + mtime + size
+  evidence/<id>.json     per-transcript loss
+  evidence-summary.json  aggregated gradients
+  proposal.json          the latest gradient-descent step
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them
   gap-ledger.json        gap sightings by gap and session, accumulated across runs

--- a/src/cli.js
+++ b/src/cli.js
@@ -69,15 +69,17 @@ USAGE
   backpass [command] [options]
 
 COMMANDS
-  (none)     scan, analyze what is new, and propose. Never writes.
-  scan       discovery only: which transcripts belong to this repo, and how we know
-  analyze    tier-1 pass: one cheap model call per new transcript
-  propose    tier-2 pass: one high-reasoning call turning folded evidence into edits
+  (none)     the full pass: collect samples → calculate loss → aggregate gradients →
+             gradient descent. Never writes.
+  scan       collect samples only: which transcripts belong to this repo, and how we know
+  analyze    calculate loss: one cheap model call per new transcript (tier 1)
+  propose    aggregate gradients, then gradient descent: one high-reasoning call
+             turning the aggregated evidence into edits (tier 2)
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar
   init       write .backpassrc.json and exclude .backpass/ via .git/info/exclude
 
-DISCOVERY
+COLLECT SAMPLES
   --since <dur>            only sessions newer than this (30d, 12h, 2w, all)  [30d]
   --harness <a,b>          limit to these harnesses
                            (claude, codex, pi, opencode, grok, cursor)
@@ -129,7 +131,7 @@ or below 60 columns - stdout and --json output are identical either way.
 
 EXAMPLES
   backpass                                  a full run, ending with a proposal
-  backpass scan --since 7d --strict         what would be analyzed, deterministic only
+  backpass scan --since 7d --strict         what would be collected, deterministic only
   backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
 `;

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -121,7 +121,7 @@ export async function bootstrapRun(ctx, deps = {}) {
     if (!(err instanceof ProposalViolation)) throw err;
     // The seed is already on disk, so a bad synthesis degrades to defaults-only.
     for (const violation of err.violations) warn(violation);
-    warn("synthesis failed its gates; the memory file stays defaults-only this run");
+    warn("gradient descent failed its gates; the memory file stays defaults-only this run");
   }
   return result;
 }

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -51,7 +51,7 @@ export async function runProposal(ctx, precomputed = null) {
 
   if (!summary.analyzedSessions) {
     throw new UserError(
-      "no analyzed transcripts to synthesize from",
+      "no loss calculated yet: nothing to run gradient descent on",
       "run `backpass analyze` first, or `backpass` for the full pass",
     );
   }

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -44,7 +44,7 @@ export async function cmdScan(ctx) {
   }
   out(table(rows));
   const selfTotal = Object.values(perHarness).reduce((n, s) => n + (s.self || 0), 0);
-  if (selfTotal) out(color.dim(`  SELF = backpass's own analysis/synthesis sessions, excluded from the corpus`));
+  if (selfTotal) out(color.dim(`  SELF = backpass's own loss / gradient-descent sessions, excluded from the corpus`));
   out("");
 
   const byTier = { 1: 0, 2: 0, 3: 0 };

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -85,7 +85,7 @@ export async function cmdStatus(ctx) {
   );
   if (summary) {
     out(
-      `  folded          ${summary.analyzedSessions} session(s) · ${summary.totals.positive}+ ` +
+      `  gradients       ${summary.analyzedSessions} session(s) · ${summary.totals.positive}+ ` +
         `${summary.totals.negative}- · ${summary.totals.gapClusters} gap cluster(s)`,
     );
   }

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -35,6 +35,18 @@ const HARNESS_HUES = {
   "cursor-ide": "blue",
 };
 
+/**
+ * Display names for the four pipeline stages, in the tool's training-loop vocabulary.
+ * Internal stage keys and event names stay as they are; only what the user reads changes.
+ */
+export const STAGE_LABELS = {
+  discover: "collect samples",
+  analyze: "calculate loss",
+  fold: "aggregate gradients",
+  synthesize: "gradient descent",
+};
+const STAGE_LABEL_WIDTH = Math.max(...Object.values(STAGE_LABELS).map((label) => label.length)) + 1;
+
 const TIER_LABELS = { 1: "ran in this repo", 2: "git remote match", 3: "path match (best-effort)" };
 
 // eslint-disable-next-line no-control-regex -- matching ANSI SGR escapes is the point
@@ -106,7 +118,7 @@ export function formatBytes(n) {
   return `${bytes} B`;
 }
 
-/** m:ss for anything from a second up; bare milliseconds below that (fold is instant). */
+/** m:ss for anything from a second up; bare milliseconds below that (aggregating gradients is instant). */
 export function formatElapsed(ms) {
   const value = Math.max(0, Math.round(Number(ms) || 0));
   if (value < 1000) return `${value}ms`;
@@ -185,12 +197,11 @@ function mark(theme, status, spin) {
   return theme.paint("○", "faint");
 }
 
-function railLine(theme, state, name, summary, stage, width, spin) {
+function railLine(theme, state, key, summary, stage, width, spin) {
   const status = stage?.status || "pending";
+  const name = fitPlain(STAGE_LABELS[key], STAGE_LABEL_WIDTH);
   const label =
-    status === "pending"
-      ? theme.paint(fitPlain(name, 11), "faint")
-      : theme.paint(fitPlain(name, 11), "text", { bold: status === "active" });
+    status === "pending" ? theme.paint(name, "faint") : theme.paint(name, "text", { bold: status === "active" });
   const left = ` ${mark(theme, status, spin)} ${label}${summary || ""}`;
   const elapsed = state.narrow ? null : stageElapsed(stage, state.now);
   return lr(left, elapsed ? theme.paint(elapsed, "faint") : null, width);
@@ -255,7 +266,7 @@ function harnessDot(theme, harness) {
 
 function discoverDetail(state, theme, width, spin) {
   const d = state.discover;
-  const lines = [sectionRule(theme, "discover", "local stores only · nothing leaves this machine", width)];
+  const lines = [sectionRule(theme, STAGE_LABELS.discover, "local stores only · nothing leaves this machine", width)];
   const countWidth = 15;
   const howWidth = 25;
   const activityWidth = width - 2 - 2 - 11 - countWidth - (state.narrow ? 0 : howWidth) - 4;
@@ -327,7 +338,7 @@ function countersLine(a, theme, width) {
 function analyzeDetail(state, theme, width, spin) {
   const a = state.analyze;
   const model = [a.agent, a.model].filter(Boolean).join(" · ");
-  const lines = [sectionRule(theme, "analyze", `one cheap call per transcript · ${model}`, width)];
+  const lines = [sectionRule(theme, STAGE_LABELS.analyze, `one cheap call per transcript · ${model}`, width)];
 
   const receiptWidth = 27;
   const timeWidth = 6;
@@ -365,7 +376,9 @@ function analyzeDetail(state, theme, width, spin) {
 
 function synthesizeDetail(state, theme, width, spin) {
   const s = state.synthesize;
-  const lines = [sectionRule(theme, "synthesize", `folded evidence → at most ${state.meta.maxEdits} edits`, width)];
+  const lines = [
+    sectionRule(theme, STAGE_LABELS.synthesize, `aggregated gradients → at most ${state.meta.maxEdits} edits`, width),
+  ];
 
   if (s.attempt > 1 && s.violations.length) {
     lines.push(

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -198,6 +198,17 @@ test("discovery frame: header gauge, rail, per-harness rows, plain-language labe
   assert.ok(text.includes("2,412 / 5,000 tok"));
   assert.ok(text.includes("63 instructions · budget 48%"));
   assert.ok(text.includes("sessions from this repo so far"));
+  assert.ok(
+    text.includes("── collect samples · local stores only"),
+    "the detail panel carries the training-loop label",
+  );
+  for (const label of ["collect samples", "calculate loss", "aggregate gradients", "gradient descent"]) {
+    assert.ok(
+      lines.some((line) => new RegExp(`^ \\S ${label}( |$)`, "u").test(line)),
+      `the rail shows the stage as "${label}"`,
+    );
+  }
+  assert.ok(!/\b(discover|analyze|fold|synthesize)\b/.test(text), "internal stage keys never reach the screen");
   assert.ok(text.includes("214 sessions · 83 new"));
   assert.ok(text.includes("38 this repo"));
   assert.ok(text.includes("ran in this repo"));
@@ -321,7 +332,7 @@ test("synthesis frame: fold rail line, sparse panel, suppression note - no gates
   assert.ok(text.includes("23 ok · 1 skipped · 1 failed · 33 reused"));
   assert.ok(text.includes("24 instructions scored · 9 gaps → 4 clusters kept (seen in ≥2 sessions)"));
   assert.ok(text.includes("one call · claude · claude-opus-5 · effort high"));
-  assert.ok(text.includes("folded evidence → at most 5 edits"));
+  assert.ok(text.includes("── gradient descent · aggregated gradients → at most 5 edits"));
   assert.ok(text.includes("weighing 4 gap clusters + 24 instruction records against the budget…"));
   assert.ok(text.includes("session backpass-synth-84121"));
   assert.ok(text.includes("1 previously rejected edit(s) suppressed"));


### PR DESCRIPTION
## Summary
- Display the four pipeline stages as **collect samples** / **calculate loss** / **aggregate gradients** / **gradient descent** everywhere the user reads them: TUI rail + section rules (`STAGE_LABELS` in `src/tui/render.js`, label column widened to fit), CLI help, `status`/`scan`/`propose`/bootstrap output, README, AGENTS.md.
- Typed subcommands stay short and unchanged (`scan`, `analyze`, `propose`); internal stage keys and progress event names are untouched.
- Render tests assert the new labels on the rail and panels, and that no internal key reaches the screen.

## Test plan
- [x] `pnpm run check` (lint, format, typecheck, 187 tests) green
- [x] `backpass --help` reviewed by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)