### PR TITLE
fix: synthesis edits a staging copy natively and backpass measures the hunks, ending find-text skew

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 
 - `README.md` documents the user-facing surface; `src/cli.js` is the authoritative flag list.
 - The pipeline is one stage per module, in order: `src/discovery/` -> `src/sample.js` (cap) -> `src/distill.js` ->
-  `src/analyze.js` -> `src/fold.js` -> `src/synthesize.js` -> `src/proposal.js` -> `src/apply/`.
-  Each module's header comment explains its role; read those before changing a stage.
+  `src/analyze.js` -> `src/fold.js` -> `src/synthesize.js` (with `src/workspace.js` + `src/diff.js`) ->
+  `src/proposal.js` -> `src/apply/`. Each module's header comment explains its role; read those
+  before changing a stage.
 - **User-facing step names are the training-loop terms**, not the module names: discover =
   "collect samples", analyze = "calculate loss", fold = "aggregate gradients", synthesize =
   "gradient descent" (`STAGE_LABELS` in `src/tui/render.js`). Internal keys, event names, and
@@ -39,6 +40,14 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
+- **Synthesis edits natively, in a staging copy, never by describing text.** The agent
+  gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
+  only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,
+  `anchoredHunks`) and the agent annotates the measured changes by id in a second turn of
+  the same session. The model never supplies `find` text - every hunk is cut from the raw
+  file, widened until unique, so "find text does not appear" cannot recur. Never pass
+  `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that
+  writes there fails the run loudly.
 - **Skills only count if a harness loads them.** Extractions target `.agents/skills` with
   `.claude/skills -> ../.agents/skills` as a symlink (`ensureSkillsLayout` in
   `src/skills.js`, run at write time); a bare `skills/` dir is never auto-detected and a

--- a/README.md
+++ b/README.md
@@ -152,21 +152,33 @@ a sighting retires once the memory file gains an instruction that covers it, and
 sightings expire after `gapLedgerMaxAge` (default 90d). Until a gap corroborates it stays
 out of the proposal entirely.
 
-### 5. Gradient descent - one big call
+### 5. Gradient descent - one session, native edits
 
-A single high-reasoning call turns the aggregated gradients into concrete edits: ADD, REMOVE,
-REWRITE, or EXTRACT→SKILL. Then mechanical gates run, and they are not negotiable:
+A single high-reasoning session turns the aggregated gradients into concrete edits: ADD,
+REMOVE, REWRITE, or EXTRACT→SKILL. The agent does not describe edits for backpass to
+splice in - it makes them, with its harness's own file tools, in a **staging copy** of the
+memory file under `.backpass/synthesis/` (the repo itself is read-only to it, for
+grounding). backpass then diffs the copy against the original and shows the agent the
+measured changes by id; the agent annotates each one with a title, rationale, and the
+verbatim evidence behind it. Nothing textual is ever taken from the model: every hunk's
+text is copied out of your file by construction, so an edit can never "not appear" in it.
+Then mechanical gates run, and they are not negotiable:
 
 - at most `maxEditsPerRun` edits (the learning rate). By default the cap is adaptive: 5
   when the file is near or under budget, and in a shrink plan (file over budget) one edit
   per ~40 tokens of overage, capped at 20, so badly overgrown files recover in fewer runs.
   An explicit `--max-edits` or config value always pins it.
-- new instructions need evidence from `minGapEvidence` distinct sessions
+- every measured change belongs to exactly one annotated edit - an unexplained change
+  is a violation, so is an edit that names no change
+- new instructions need evidence from `minGapEvidence` distinct sessions (an edit that
+  only adds text is a new instruction, whatever the model calls it)
 - every edit carries a verbatim quote
-- the post-edit file must fit the budget
+- the post-edit file must fit the budget, measured on the staged file
 
-A violation triggers exactly one re-prompt naming the exact breach. If that also fails,
-backpass **fails loudly** and saves the rejected proposal. It never silently truncates.
+A violation triggers a re-prompt naming the exact breach (at most two). If those also
+fail, backpass **fails loudly** and saves the rejected proposal. It never silently
+truncates. A harness that writes past the staging copy into the repo is an error, never
+an apply.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -355,6 +367,8 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence/<id>.json     per-transcript loss
   evidence-summary.json  aggregated gradients
   proposal.json          the latest gradient-descent step
+  synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
+  prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them
   gap-ledger.json        gap sightings by gap and session, accumulated across runs

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -53,6 +53,8 @@ export class AcpxError extends Error {
     this.code = code;
     this.timedOut = timedOut;
     this.spawnError = spawnError;
+    /** Set when the adapter has no session support at all (not an availability verdict). */
+    this.unsupported = false;
   }
 }
 
@@ -92,10 +94,14 @@ export function classifyAcpxFailure(failure) {
   return null;
 }
 
-/** acpx prints a per-run accounting line: `[acpx] tokens: input=10 output=47 ... total=34194`. */
+/**
+ * acpx prints a per-run accounting line: `[acpx] tokens: input=10 output=47 ... total=34194`.
+ * @returns {Record<string, number> | null}
+ */
 export function parseTokenLine(text) {
   const match = /\[acpx\]\s+tokens:\s+(.+)/.exec(text || "");
   if (!match) return null;
+  /** @type {Record<string, number>} */
   const usage = {};
   for (const pair of match[1].trim().split(/\s+/)) {
     const [key, value] = pair.split("=");
@@ -144,10 +150,17 @@ export function extractJson(text) {
   return null;
 }
 
-function baseArgs({ cwd, model, timeoutSeconds, approveReads, suppressReads }) {
+/**
+ * Permission modes. `approveAll` is what native editing needs: the harness's own
+ * `edit`/`write` tools are approved, which is why every call that sets it runs with a
+ * staging workspace as `cwd` (`src/workspace.js`), never the repo. acpx's policy rules
+ * match tool kinds, not paths, so the workspace is the blast-radius boundary.
+ */
+function baseArgs({ cwd, model, timeoutSeconds, approveReads, approveAll = false, suppressReads }) {
   const args = [];
   if (cwd) args.push("--cwd", cwd);
-  if (approveReads) args.push("--approve-reads");
+  if (approveAll) args.push("--approve-all");
+  else if (approveReads) args.push("--approve-reads");
   else args.push("--deny-all");
   if (suppressReads) args.push("--suppress-reads");
   args.push("--non-interactive-permissions", "deny");
@@ -250,26 +263,24 @@ export async function execOneShot({
 }
 
 /**
- * A prompt through a short-lived named session (design section 5).
+ * A named session that stays open across turns (design section 5).
  *
  * Reasoning effort is a session config option on every adapter that has one, and
- * `exec` cannot set it - so any call that wants effort applied goes through here:
- * the synthesis pass always, and the analysis pass whenever an effort is configured.
- * Adapters that do not advertise an effort option skip that step with a report line -
- * never silently.
+ * `exec` cannot set it - so any call that wants effort applied goes through a session.
+ * Synthesis also needs more than one turn in the same context: the agent edits the
+ * staging copy, then annotates the changes backpass measured. Adapters that do not
+ * advertise an effort option skip that step with a report line - never silently.
+ *
+ * Resolves to the handle, or throws an `AcpxError` (`unsupported: true` when the adapter
+ * has no session support at all, which `sessionPrompt` turns into an exec fallback).
+ *
+ * @returns {Promise<{ notes: string[],
+ *   prompt: (options: { promptFile: string, timeoutSeconds?: number, promptRetries?: number,
+ *     approveReads?: boolean, approveAll?: boolean, suppressReads?: boolean }) =>
+ *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
+ *   close: () => Promise<void> }>}
  */
-export async function sessionPrompt({
-  agent,
-  model = null,
-  effort = null,
-  sessionName,
-  promptFile,
-  cwd,
-  timeoutSeconds = 900,
-  promptRetries = 1,
-  approveReads = true,
-  suppressReads = true,
-}) {
+export async function openSession({ agent, model = null, effort = null, sessionName, cwd }) {
   const notes = [];
   const acpxAgent = acpxAgentName(agent);
   const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs: 60_000, cwd });
@@ -279,21 +290,25 @@ export async function sessionPrompt({
     if (classifyAcpxFailure(created)) {
       throw new AcpxError(`acpx ${agent} session create failed: ${firstLine(created.stderr)}`, created);
     }
-    // No session support for this adapter: fall back to a one-shot, and say so.
-    notes.push(`session unsupported for ${agent}; fell back to exec one-shot`);
-    if (effort) notes.push(`${agent} cannot set effort without a session; ran without effort=${effort}`);
-    const fallback = await execOneShot({
-      agent,
-      model,
-      promptFile,
-      cwd,
-      timeoutSeconds,
-      promptRetries,
-      approveReads,
-      suppressReads,
-    });
-    return { ...fallback, notes };
+    const err = new AcpxError(
+      `acpx ${agent} has no session support: ${firstLine(created.stderr) || `exit ${created.code}`}`,
+      created,
+    );
+    err.unsupported = true;
+    throw err;
   }
+
+  const startedAt = Date.now();
+  let closed = false;
+  let firstPromptFile = null;
+  let storeUsageSeen = null;
+
+  const close = async () => {
+    if (closed) return;
+    closed = true;
+    const result = await run([acpxAgent, "sessions", "close", sessionName], { timeoutMs: 30_000, cwd });
+    if (result.code !== 0) warn(`could not close acpx session ${sessionName}`);
+  };
 
   try {
     if (model) {
@@ -314,9 +329,23 @@ export async function sessionPrompt({
         notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${effort}`);
       }
     }
+  } catch (err) {
+    await close();
+    throw err;
+  }
 
+  const prompt = async ({
+    promptFile,
+    timeoutSeconds = 900,
+    promptRetries = 1,
+    approveReads = true,
+    approveAll = false,
+    suppressReads = true,
+  }) => {
+    if (closed) throw new AcpxError(`acpx ${agent} session ${sessionName} is closed`);
+    firstPromptFile = firstPromptFile || promptFile;
     const args = [
-      ...baseArgs({ cwd, model: null, timeoutSeconds, approveReads, suppressReads }),
+      ...baseArgs({ cwd, model: null, timeoutSeconds, approveReads, approveAll, suppressReads }),
       "--prompt-retries",
       String(promptRetries),
       acpxAgent,
@@ -325,17 +354,75 @@ export async function sessionPrompt({
       "--file",
       promptFile,
     ];
-    const startedAt = Date.now();
     const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd });
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
     if (result.code !== 0) throw new AcpxError(`acpx ${agent} session prompt failed (exit ${result.code})`, result);
 
     const combined = `${result.stdout}\n${result.stderr}`;
-    const usage = parseTokenLine(combined) ?? recoverUsageFromStore({ agent, promptFile, cwd, startedAt });
+    /** @type {Record<string, number> | null} */
+    let usage = parseTokenLine(combined);
+    if (!usage) {
+      // The harness store holds the whole session's usage; this turn is the increase.
+      const cumulative = recoverUsageFromStore({ agent, promptFile: firstPromptFile, cwd, startedAt });
+      usage = cumulative ? subtractUsage(cumulative, storeUsageSeen) : null;
+      if (cumulative) storeUsageSeen = cumulative;
+    }
     return { text: stripAcpxNoise(result.stdout), usage, raw: result.stdout, notes };
+  };
+
+  return { notes, prompt, close };
+}
+
+/** @returns {Record<string, number>} */
+function subtractUsage(current, previous) {
+  if (!previous) return current;
+  /** @type {Record<string, number>} */
+  const out = {};
+  for (const [key, value] of Object.entries(current)) out[key] = value - (previous[key] || 0);
+  return out;
+}
+
+/**
+ * One prompt through a short-lived named session: open, prompt, close. The analysis
+ * pass uses this whenever an effort is configured. An adapter without session support
+ * falls back to a one-shot `exec`, and says so.
+ */
+export async function sessionPrompt({
+  agent,
+  model = null,
+  effort = null,
+  sessionName,
+  promptFile,
+  cwd,
+  timeoutSeconds = 900,
+  promptRetries = 1,
+  approveReads = true,
+  suppressReads = true,
+}) {
+  let session;
+  try {
+    session = await openSession({ agent, model, effort, sessionName, cwd });
+  } catch (err) {
+    if (!(err instanceof AcpxError) || !err.unsupported) throw err;
+    const notes = [`session unsupported for ${agent}; fell back to exec one-shot`];
+    if (effort) notes.push(`${agent} cannot set effort without a session; ran without effort=${effort}`);
+    const fallback = await execOneShot({
+      agent,
+      model,
+      promptFile,
+      cwd,
+      timeoutSeconds,
+      promptRetries,
+      approveReads,
+      suppressReads,
+    });
+    return { ...fallback, notes };
+  }
+
+  try {
+    return await session.prompt({ promptFile, timeoutSeconds, promptRetries, approveReads, suppressReads });
   } finally {
-    const closed = await run([acpxAgent, "sessions", "close", sessionName], { timeoutMs: 30_000, cwd });
-    if (closed.code !== 0) warn(`could not close acpx session ${sessionName}`);
+    await session.close();
   }
 }
 
@@ -364,6 +451,7 @@ const STORE_USAGE_RECOVERY = { pi: recoverPiUsage };
 /** Slack for a harness that stamps the session timestamp slightly before we spawned it. */
 const STORE_MTIME_SLACK_MS = 5_000;
 
+/** @returns {Record<string, number> | null} */
 export function recoverUsageFromStore({ agent, promptFile, cwd, startedAt }) {
   const recover = STORE_USAGE_RECOVERY[agent];
   if (!recover) return null;

--- a/src/apply/terminal.js
+++ b/src/apply/terminal.js
@@ -9,14 +9,30 @@ import { formatTokens } from "../tokens.js";
  * machines with no browser (or reviewers who would rather stay in the terminal).
  */
 
+/** Measured edits carry display lines per hunk; a legacy edit shows its find/replace. */
+export function diffLinesOf(edit) {
+  if (Array.isArray(edit.hunks)) {
+    return edit.hunks.flatMap((hunk, i) => [...(i > 0 ? [{ type: "gap", text: "" }] : []), ...(hunk.lines || [])]);
+  }
+  return [
+    ...(edit.find || "")
+      .split("\n")
+      .filter(Boolean)
+      .map((text) => ({ type: "del", text })),
+    ...(edit.replace || "")
+      .split("\n")
+      .filter(Boolean)
+      .map((text) => ({ type: "ins", text })),
+  ];
+}
+
 function renderDiff(edit) {
   const lines = [];
-  if (edit.context) lines.push(color.dim(`  ${edit.context}`));
-  for (const line of (edit.find || "").split("\n")) {
-    if (line) lines.push(color.red(`  - ${line}`));
-  }
-  for (const line of (edit.replace || "").split("\n")) {
-    if (line) lines.push(color.green(`  + ${line}`));
+  for (const line of diffLinesOf(edit)) {
+    if (line.type === "del") lines.push(color.red(`  - ${line.text}`));
+    else if (line.type === "ins") lines.push(color.green(`  + ${line.text}`));
+    else if (line.type === "gap") lines.push(color.dim("  ..."));
+    else lines.push(color.dim(`    ${line.text}`));
   }
   return lines.join("\n");
 }

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,0 +1,305 @@
+/**
+ * Line diff between a file as backpass read it and the copy the synthesis agent edited
+ * natively (design section 3, native-edit revision).
+ *
+ * The synthesis model never hands backpass text to locate in a file; it edits a staging
+ * copy with its own file tools and backpass measures what changed. Each measured hunk is
+ * then turned into a find/replace pair whose `find` is copied out of the original file by
+ * construction - so it always matches, and `applyEdit` can apply it later (at apply time,
+ * against whatever the file is by then) with no fuzzing.
+ *
+ * Two guarantees make the hunks independently reviewable:
+ *   - each `find` is widened with context lines until it occurs exactly once in the file
+ *   - hunks whose context windows touch are merged, so accepting one never moves
+ *     another's anchor
+ */
+
+/** Myers refinement is bounded; past this many edit steps the middle is one hunk. */
+const MAX_EDIT_DISTANCE = 4000;
+
+/**
+ * Shortest edit script between two line arrays (Myers, O(ND)), as a list of ops:
+ * `{ type: "equal" | "delete" | "insert", oldIndex, newIndex }`.
+ */
+export function diffOps(oldLines, newLines) {
+  // Common prefix/suffix first: a real edit touches a tiny fraction of the file.
+  let prefix = 0;
+  const maxPrefix = Math.min(oldLines.length, newLines.length);
+  while (prefix < maxPrefix && oldLines[prefix] === newLines[prefix]) prefix += 1;
+  let suffix = 0;
+  while (
+    suffix < maxPrefix - prefix &&
+    oldLines[oldLines.length - 1 - suffix] === newLines[newLines.length - 1 - suffix]
+  ) {
+    suffix += 1;
+  }
+
+  const ops = [];
+  for (let i = 0; i < prefix; i += 1) ops.push({ type: "equal", oldIndex: i, newIndex: i });
+
+  const a = oldLines.slice(prefix, oldLines.length - suffix);
+  const b = newLines.slice(prefix, newLines.length - suffix);
+  for (const op of myers(a, b)) {
+    ops.push({ type: op.type, oldIndex: op.oldIndex + prefix, newIndex: op.newIndex + prefix });
+  }
+
+  for (let i = 0; i < suffix; i += 1) {
+    ops.push({
+      type: "equal",
+      oldIndex: oldLines.length - suffix + i,
+      newIndex: newLines.length - suffix + i,
+    });
+  }
+  return ops;
+}
+
+function myers(a, b) {
+  const n = a.length;
+  const m = b.length;
+  if (!n && !m) return [];
+  if (!n) return b.map((_, j) => ({ type: "insert", oldIndex: 0, newIndex: j }));
+  if (!m) return a.map((_, i) => ({ type: "delete", oldIndex: i, newIndex: 0 }));
+
+  const max = Math.min(n + m, MAX_EDIT_DISTANCE);
+  const offset = max;
+  const trace = [];
+  let v = new Int32Array(2 * max + 2);
+  v[offset + 1] = 0;
+  let found = false;
+
+  for (let d = 0; d <= max && !found; d += 1) {
+    const snapshot = new Int32Array(v);
+    trace.push(snapshot);
+    for (let k = -d; k <= d; k += 2) {
+      let x;
+      if (k === -d || (k !== d && v[offset + k - 1] < v[offset + k + 1])) x = v[offset + k + 1];
+      else x = v[offset + k - 1] + 1;
+      let y = x - k;
+      while (x < n && y < m && a[x] === b[y]) {
+        x += 1;
+        y += 1;
+      }
+      v[offset + k] = x;
+      if (x >= n && y >= m) {
+        found = true;
+        break;
+      }
+    }
+  }
+
+  if (!found) {
+    // Too different to refine within bounds: one hunk replacing the whole middle.
+    return [
+      ...a.map((_, i) => ({ type: "delete", oldIndex: i, newIndex: 0 })),
+      ...b.map((_, j) => ({ type: "insert", oldIndex: n, newIndex: j })),
+    ];
+  }
+
+  // Backtrack through the recorded frontiers.
+  const ops = [];
+  let x = n;
+  let y = m;
+  for (let d = trace.length - 1; d >= 0; d -= 1) {
+    const frontier = trace[d];
+    const k = x - y;
+    let prevK;
+    if (k === -d || (k !== d && frontier[offset + k - 1] < frontier[offset + k + 1])) prevK = k + 1;
+    else prevK = k - 1;
+    const prevX = frontier[offset + prevK];
+    const prevY = prevX - prevK;
+    while (x > prevX && y > prevY) {
+      x -= 1;
+      y -= 1;
+      ops.push({ type: "equal", oldIndex: x, newIndex: y });
+    }
+    if (d > 0) {
+      if (x === prevX) {
+        y -= 1;
+        ops.push({ type: "insert", oldIndex: x, newIndex: y });
+      } else {
+        x -= 1;
+        ops.push({ type: "delete", oldIndex: x, newIndex: y });
+      }
+    }
+  }
+  ops.reverse();
+  return ops;
+}
+
+/**
+ * Raw hunks: maximal runs of non-equal ops, as half-open line ranges into each side.
+ */
+export function rawHunks(ops) {
+  const hunks = [];
+  let current = null;
+  let oldCursor = 0;
+  let newCursor = 0;
+  for (const op of ops) {
+    if (op.type === "equal") {
+      if (current) {
+        hunks.push(current);
+        current = null;
+      }
+      oldCursor = op.oldIndex + 1;
+      newCursor = op.newIndex + 1;
+      continue;
+    }
+    if (!current) current = { oldStart: oldCursor, oldEnd: oldCursor, newStart: newCursor, newEnd: newCursor };
+    if (op.type === "delete") {
+      current.oldEnd = op.oldIndex + 1;
+      oldCursor = op.oldIndex + 1;
+    } else {
+      current.newEnd = op.newIndex + 1;
+      newCursor = op.newIndex + 1;
+    }
+  }
+  if (current) hunks.push(current);
+  return hunks;
+}
+
+/**
+ * Occurrences may overlap (a run of identical lines): counting them non-overlapping
+ * would call a window unique while the first match sits somewhere else entirely.
+ */
+function countOccurrences(haystack, needle) {
+  if (!needle) return 0;
+  let count = 0;
+  let at = haystack.indexOf(needle);
+  while (at !== -1) {
+    count += 1;
+    at = haystack.indexOf(needle, at + 1);
+  }
+  return count;
+}
+
+/**
+ * The text of lines [start, end) together with the separators that make them whole lines
+ * in `lines.join("\n")`: a newline after each line, except that the file's tail carries the
+ * newline *before* it instead. Both sides of a hunk share tail-ness (the suffix after the
+ * change is identical), so `find` and `replace` built this way splice cleanly.
+ */
+function span(lines, start, end) {
+  if (end <= start) return "";
+  const body = lines.slice(start, end).join("\n");
+  if (end === lines.length) return `${start > 0 ? "\n" : ""}${body}`;
+  return `${body}\n`;
+}
+
+/**
+ * Widen a hunk's window symmetrically until its `find` text occurs exactly once in the
+ * original. Terminates because the whole file occurs once.
+ */
+function uniqueWindow(oldLines, oldText, hunk) {
+  let before = 0;
+  let after = 0;
+  for (;;) {
+    const start = hunk.oldStart - before;
+    const end = hunk.oldEnd + after;
+    const find = span(oldLines, start, end);
+    if (find && countOccurrences(oldText, find) === 1) return { before, after };
+    const canBefore = start > 0;
+    const canAfter = end < oldLines.length;
+    if (!canBefore && !canAfter) return { before, after };
+    // Grow the side that still has room, alternating when both do.
+    if (canBefore && (!canAfter || before <= after)) before += 1;
+    else after += 1;
+  }
+}
+
+function mergeTouching(windows) {
+  const merged = [];
+  for (const w of windows) {
+    const last = merged[merged.length - 1];
+    if (last && w.oldStart - w.before <= last.oldEnd + last.after) {
+      last.oldEnd = Math.max(last.oldEnd, w.oldEnd);
+      last.newEnd = Math.max(last.newEnd, w.newEnd);
+      last.touched = true;
+    } else {
+      merged.push({ ...w });
+    }
+  }
+  return merged;
+}
+
+/** Display lines for one window: context, removed, and added lines in file order. */
+function displayLines(oldSlice, newSlice) {
+  const lines = [];
+  for (const op of diffOps(oldSlice, newSlice)) {
+    if (op.type === "equal") lines.push({ type: "ctx", text: oldSlice[op.oldIndex] });
+    else if (op.type === "delete") lines.push({ type: "del", text: oldSlice[op.oldIndex] });
+    else lines.push({ type: "ins", text: newSlice[op.newIndex] });
+  }
+  return lines;
+}
+
+/**
+ * Measure `newText` against `oldText` as anchored hunks:
+ *
+ *   {
+ *     find, replace,        // context-widened; `find` occurs exactly once in oldText
+ *     oldStart, oldEnd,     // 1-based inclusive line range of the changed lines in oldText
+ *                           // (oldEnd === oldStart - 1 for a pure insertion)
+ *     removed, added,       // changed line counts, context excluded
+ *     lines,                // [{ type: "ctx" | "del" | "ins", text }] for display
+ *   }
+ *
+ * Hunks are independent: their context windows never overlap, so any subset applies in
+ * any order via `applyEdit`.
+ */
+export function anchoredHunks(oldText, newText) {
+  if (oldText === newText) return [];
+  if (!oldText) {
+    return [
+      {
+        find: "",
+        replace: newText,
+        oldStart: 1,
+        oldEnd: 0,
+        removed: 0,
+        added: newText.split("\n").length,
+        lines: newText.split("\n").map((text) => ({ type: "ins", text })),
+      },
+    ];
+  }
+
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+  let windows = rawHunks(diffOps(oldLines, newLines)).map((h) => ({ ...h, ...uniqueWindow(oldLines, oldText, h) }));
+
+  // Merging can widen a window past a neighbour; iterate to a fixed point.
+  for (;;) {
+    const merged = mergeTouching(windows);
+    const settled = merged.map((w) =>
+      w.touched ? { ...w, ...uniqueWindow(oldLines, oldText, w), touched: false } : w,
+    );
+    if (settled.length === windows.length) {
+      windows = settled;
+      break;
+    }
+    windows = settled;
+  }
+
+  return windows.map((w) => {
+    const start = w.oldStart - w.before;
+    const end = w.oldEnd + w.after;
+    const newStart = w.newStart - w.before;
+    const newEnd = w.newEnd + w.after;
+    return {
+      find: span(oldLines, start, end),
+      replace: span(newLines, newStart, newEnd),
+      oldStart: w.oldStart + 1,
+      oldEnd: w.oldEnd,
+      removed: w.oldEnd - w.oldStart,
+      added: w.newEnd - w.newStart,
+      lines: displayLines(oldLines.slice(start, end), newLines.slice(newStart, newEnd)),
+    };
+  });
+}
+
+/** Plain-text rendering of a hunk's lines, unified-diff style, for prompts and terminals. */
+export function renderHunkLines(lines, { maxLines = 400 } = {}) {
+  const marks = { ctx: " ", del: "-", ins: "+" };
+  const shown = lines.slice(0, maxLines).map((l) => `${marks[l.type]} ${l.text}`);
+  if (lines.length > maxLines) shown.push(`  ... ${lines.length - maxLines} more line(s)`);
+  return shown.join("\n");
+}

--- a/src/memory.js
+++ b/src/memory.js
@@ -140,10 +140,17 @@ export function memorySetHash(files) {
   return `sha256:${sha256(files.map((f) => `${f.path}:${f.hash}`).join("|")).slice(0, 16)}`;
 }
 
-/** Render the instruction index that both prompt tiers see. */
+/**
+ * Render the instruction index that both prompt tiers see. It is a lookup table keyed
+ * by alias, never a stand-in for the file: units are listed with the lines they occupy
+ * so the synthesis agent can find them in the raw file it edits.
+ */
 export function renderInstructionIndex(file) {
   return file.units
-    .map((u) => `[${u.id}] (${u.tokens} tok)${u.section ? ` <${u.section}>` : ""}\n${u.text}`)
+    .map((u) => {
+      const lines = u.startLine === u.endLine ? `L${u.startLine}` : `L${u.startLine}-${u.endLine}`;
+      return `[${u.id}] (${u.tokens} tok, ${lines})${u.section ? ` <${u.section}>` : ""}\n${u.text}`;
+    })
     .join("\n\n");
 }
 

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -1,0 +1,48 @@
+backpass measured the changes you made in the staging copy. Every change below is
+identified by an id; annotate each one so a human can review it with its evidence.
+
+## Measured changes
+
+{{CHANGES}}
+
+## What to produce
+
+Return ONE JSON object and nothing else. No prose, no markdown fence.
+
+```
+{
+  "edits": [
+    {
+      "changes": ["H1"],
+      "kind": "add" | "remove" | "rewrite" | "extract",
+      "title": "one line a human can decide on",
+      "rationale": "why the evidence supports this",
+      "instructions": ["AG-017"],
+      "evidence": [{"polarity": "negative", "text": "the verbatim quote", "source": "claude · abc123 · turn 12"}],
+      "transcripts": 3
+    }
+  ],
+  "verdicts": [
+    {"instruction": "AG-042", "verdict": "keep" | "strengthen" | "weaken" | "remove", "positive": 6, "negative": 1, "note": "one line"}
+  ],
+  "notes": ["anything a human should know that is not an edit"]
+}
+```
+
+Hard rules - a violation fails the whole proposal:
+
+1. **Every measured change belongs to exactly one edit.** Group the changes that make up
+   one decision (an extraction is the new `SKILL.md` plus the removal it pays for); do
+   not leave a change out. If a change should not ship, revert it in the file first.
+2. **At most {{MAX_EDITS}} edits** - the learning rate. Regroup or revert if you are over.
+3. **Every edit carries at least one verbatim quote in `evidence`**, with its source.
+4. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
+   sessions.** `transcripts` is how many distinct sessions back the edit; an edit that
+   only adds text is a new instruction whatever its `kind` says.
+5. `kind: "extract"` is exactly an edit whose changes include one created `SKILL.md`
+   and at least one change to `{{MEMORY_PATH}}`. Any other edit must not include a
+   created file, and an edit changes one file only.
+6. **Budget:** {{BUDGET_RULE}}
+
+If you still need to change the files, do that first and then answer; backpass
+re-measures after this reply and shows you the new ids if anything moved.

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -1,12 +1,23 @@
 You are performing the synthesis step of a backward pass over a repository's agent
 memory file. Evidence from many past agent sessions has already been gathered and
 folded. Your job is to turn that evidence into a small set of concrete, budget-aware
-edits - one gradient step on the weights, not a rewrite.
+edits - one gradient step on the weights, not a rewrite - by editing the file directly.
 
 ## Repository
 
 {{REPO_NAME}} - {{TRANSCRIPT_COUNT}} sessions analyzed across {{HARNESS_SUMMARY}}.
 {{RUN_NOTE}}
+
+## Where you are
+
+Your working directory is a staging copy, not the repository. It holds exactly two
+things: the memory file at `./{{MEMORY_PATH}}` and the skills directory at
+`./{{SKILLS_DIR}}/`. The repository itself is at `{{REPO_ROOT}}` - open any file there
+to ground or verify an edit against the real code, but NEVER write there. Nothing you
+change in the staging copy reaches the repository until a human reviews each change.
+
+**Make your edits by editing `./{{MEMORY_PATH}}` in place with your file tools.** Do not
+paste the edited text into your reply; backpass measures what you changed in the file.
 
 ## Current memory file: {{MEMORY_PATH}}
 
@@ -15,11 +26,30 @@ Budget: {{CURRENT_TOKENS}} / {{BUDGET_TOKENS}} estimated tokens ({{BUDGET_STATE}
 Every token in this file is paid on every future session, forever, and instruction
 following dilutes as the file grows. The budget is the constraint you optimize under.
 
+The index below is a lookup table, not the file: it names each instruction (`AG-nnn`),
+its always-loaded cost, and the lines it occupies in `./{{MEMORY_PATH}}`. The evidence
+refers to instructions by these ids.
+
 {{INSTRUCTION_INDEX}}
 
 ## Existing skills (load-on-trigger, in {{SKILLS_DIR}})
 
 {{SKILL_INDEX}}
+
+To extract a section into a skill, create `./{{SKILLS_DIR}}/<skill-name>/SKILL.md` with
+this exact shape, then remove the extracted detail from `./{{MEMORY_PATH}}`
+(optionally leaving a one-line pointer):
+
+```
+---
+name: <skill-name>
+description: <one line - this IS the trigger condition>
+---
+
+<the full markdown body of the skill>
+```
+
+To tune an existing skill's trigger, edit its `description:` line under `./{{SKILLS_DIR}}/`.
 
 ## Folded evidence
 
@@ -28,62 +58,24 @@ analyzed sessions in which an instruction drew any evidence at all.
 
 {{EVIDENCE}}
 
-You are running inside the repository with read access, so you can open its files to
-ground or verify an edit against the real code when that would help - your call.
-
 ## Previously rejected edits - do not re-propose these
 
 {{REJECTIONS}}
 
-## What to produce
+## Hard rules - a violation fails the whole proposal
 
-Return ONE JSON object and nothing else. No prose, no markdown fence.
-
-```
-{
-  "edits": [
-    {
-      "kind": "add" | "remove" | "rewrite" | "extract",
-      "file": "{{MEMORY_PATH}}",
-      "title": "one line a human can decide on",
-      "find": "exact existing text to replace, copied character-for-character from the memory file above; empty string for a pure addition",
-      "replace": "the new text; empty string for a pure removal",
-      "anchor": "when find is empty, the exact existing text this should be inserted AFTER (a heading line is ideal)",
-      "rationale": "why the evidence supports this",
-      "instructions": ["AG-017"],
-      "evidence": [{"polarity": "negative", "text": "the verbatim quote", "source": "claude · abc123 · turn 12"}],
-      "transcripts": 3,
-      "skill": {
-        "name": "release-signing",
-        "path": "{{SKILLS_DIR}}/release-signing/SKILL.md",
-        "description": "the frontmatter description - this IS the trigger condition",
-        "body": "the full markdown body of the extracted skill"
-      }
-    }
-  ],
-  "verdicts": [
-    {"instruction": "AG-042", "verdict": "keep" | "strengthen" | "weaken" | "remove", "positive": 6, "negative": 1, "note": "one line"}
-  ],
-  "notes": ["anything a human should know that is not an edit"]
-}
-```
-
-Hard rules - a violation fails the whole proposal:
-
-1. **At most {{MAX_EDITS}} edits.** This is the learning rate. Pick the highest-signal
-   changes; a small correct step beats a large speculative one.
-2. **`find` must be copied exactly from the memory file shown above**, including
-   punctuation and leading list markers. It must appear exactly once in the file. If you
-   cannot reproduce it exactly, use a shorter unique fragment.
-3. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
+1. **At most {{MAX_EDITS}} edits.** This is the learning rate. An edit is one change a
+   human can decide on; pick the highest-signal ones. A small correct step beats a large
+   speculative one.
+2. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
    sessions.** One bad session never rewrites the weights.
-4. **Every edit carries at least one verbatim quote in `evidence`.**
-5. **Budget:** {{BUDGET_RULE}}
-6. `skill` is required for `kind: "extract"` and forbidden otherwise. An extract must
-   also set `find`/`replace` to remove the extracted detail from the memory file,
-   optionally leaving a one-line pointer.
-7. Prefer removing a dead instruction over adding a new one. Instructions with high
+3. **Every edit must be backed by at least one verbatim quote** from the evidence. You
+   will attach the quotes in the next step, so only make changes you can back.
+4. **Budget:** {{BUDGET_RULE}}
+5. Prefer removing a dead instruction over adding a new one. Instructions with high
    token cost and zero positive evidence across many sessions are the best removals.
+6. Change only `./{{MEMORY_PATH}}` and files under `./{{SKILLS_DIR}}/`. Never delete a
+   file. Do not create notes, scripts, or scratch files.
 
 ## Where an instruction belongs
 
@@ -96,5 +88,11 @@ A skill's description is always loaded and its body is free until triggered, so 
 long, narrow, crisply-triggered section into a skill is nearly pure budget profit.
 
 **Skill descriptions are weights too.** If the evidence shows an agent lacked knowledge
-an existing skill already contains, that is a failed trigger: propose a `rewrite` of that
-skill's description line, not duplicate content in the memory file.
+an existing skill already contains, that is a failed trigger: rewrite that skill's
+description line instead of duplicating content in the memory file.
+
+## When you are done
+
+Reply with a short plain-text summary of what you changed and why (a few lines). No
+JSON yet - backpass will measure the changes and ask you to annotate each one next.
+If the evidence does not justify any change, change nothing and say so.

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,19 +1,24 @@
+import { renderHunkLines } from "./diff.js";
 import { budgetStatus, estimateTokens } from "./tokens.js";
 
 /**
  * The proposal model: what a synthesis pass is allowed to produce, and the mechanical
  * gates it must clear before a human ever sees it (design sections 3, 6, 7).
  *
- * An edit is a find/replace against one file, which keeps the contract narrow enough to
- * validate deterministically and to apply without a patch library:
+ * The synthesis agent edits a staging copy of the memory file natively
+ * (`src/workspace.js`); backpass measures the result as anchored hunks (`src/diff.js`)
+ * and the agent annotates them - kind, title, rationale, evidence - by id. An edit is
+ * therefore a group of measured changes against one file:
  *
- *   add      find === ''      insert `replace` after `anchor`
- *   remove   replace === ''   delete `find`
- *   rewrite  both set         replace `find` with `replace`
- *   extract  both set + skill move detail into a new SKILL.md, leave a pointer behind
+ *   add      only inserts text                  (gated like a new instruction)
+ *   remove   only deletes text
+ *   rewrite  replaces text
+ *   extract  memory-file change(s) + one created SKILL.md
  *
- * `find` must match exactly once in the target file. Anything else is rejected rather
- * than guessed at - a memory file is not something to fuzzy-patch.
+ * Each hunk carries a `find`/`replace` pair copied out of the original file by
+ * construction; `find` occurs exactly once there. That is what the writer applies later,
+ * against whatever the file is by then: anything that no longer matches is rejected
+ * rather than guessed at - a memory file is not something to fuzzy-patch.
  */
 
 export const EDIT_KINDS = ["add", "remove", "rewrite", "extract"];
@@ -46,21 +51,18 @@ export class ProposalViolation extends Error {
   }
 }
 
-function normalizeEdit(raw, index, defaults) {
+function normalizeEdit(raw, index) {
   const kind = String(raw?.kind || "").toLowerCase();
+  const refs = Array.isArray(raw?.changes) ? raw.changes : Array.isArray(raw?.hunks) ? raw.hunks : [];
   return {
     id: `e${index + 1}`,
     kind,
-    file: raw?.file || defaults.memoryPath,
+    changeIds: refs.map((c) => String(c).trim().toUpperCase()).filter(Boolean),
     title: String(raw?.title || "").trim() || "(untitled edit)",
-    find: typeof raw?.find === "string" ? raw.find : "",
-    replace: typeof raw?.replace === "string" ? raw.replace : "",
-    anchor: typeof raw?.anchor === "string" && raw.anchor.trim() ? raw.anchor : null,
     rationale: String(raw?.rationale || "").trim(),
     instructions: Array.isArray(raw?.instructions) ? raw.instructions.map(String) : [],
     evidence: normalizeEvidence(raw?.evidence),
     transcripts: Number.isFinite(raw?.transcripts) ? Number(raw.transcripts) : countSources(raw?.evidence),
-    skill: normalizeSkill(raw?.skill),
   };
 }
 
@@ -80,40 +82,48 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-function normalizeSkill(skill) {
-  if (!skill || typeof skill !== "object") return null;
-  if (!skill.name || !skill.description) return null;
-  return {
-    name: String(skill.name).trim(),
-    path: skill.path ? String(skill.path) : null,
-    description: String(skill.description).trim(),
-    body: String(skill.body || "").trim(),
-  };
-}
-
+/** Overlapping count: a run of identical lines must not pass as unique. */
 function occurrences(haystack, needle) {
   if (!needle) return 0;
   let count = 0;
   let index = haystack.indexOf(needle);
   while (index !== -1) {
     count += 1;
-    index = haystack.indexOf(needle, index + needle.length);
+    index = haystack.indexOf(needle, index + 1);
   }
   return count;
 }
 
+function replaceOnce(text, find, replace, label, file) {
+  const found = occurrences(text, find);
+  if (found === 0) throw new Error(`${label}: "find" text does not appear in ${file}`);
+  if (found > 1) throw new Error(`${label}: "find" text appears ${found} times in ${file}; must be unique`);
+  return text.replace(find, () => replace);
+}
+
 /**
- * Apply one edit to file text. Returns the new text, or throws with a precise reason -
- * that reason is what gets fed back to the model in the single re-prompt.
+ * Apply one edit to file text. Returns the new text, or throws with a precise reason.
+ *
+ * A measured edit applies each of its hunks; the hunks' windows never overlap, so they
+ * apply in any order and any subset. The legacy single `find`/`replace`/`anchor` shape
+ * is still honored so a proposal saved by an earlier version stays applicable.
  */
 export function applyEdit(text, edit) {
-  if (edit.find) {
-    const found = occurrences(text, edit.find);
-    if (found === 0) throw new Error(`edit ${edit.id}: "find" text does not appear in ${edit.file}`);
-    if (found > 1)
-      throw new Error(`edit ${edit.id}: "find" text appears ${found} times in ${edit.file}; must be unique`);
-    return text.replace(edit.find, () => edit.replace);
+  if (Array.isArray(edit.hunks)) {
+    let current = text;
+    for (const hunk of edit.hunks) {
+      const label = `edit ${edit.id} (${hunk.id || "hunk"})`;
+      if (!hunk.find) {
+        if (current !== "") throw new Error(`${label}: ${edit.file} is no longer empty`);
+        current = hunk.replace;
+        continue;
+      }
+      current = replaceOnce(current, hunk.find, hunk.replace, label, edit.file);
+    }
+    return current;
   }
+
+  if (edit.find) return replaceOnce(text, edit.find, edit.replace, `edit ${edit.id}`, edit.file);
 
   if (!edit.replace) throw new Error(`edit ${edit.id}: nothing to add and nothing to remove`);
 
@@ -135,9 +145,50 @@ export function applyEdits(text, edits) {
   return edits.reduce((current, edit) => applyEdit(current, edit), text);
 }
 
+/** One-line label for a measured change, used in gate messages and the annotate prompt. */
+export function describeChange(change) {
+  if (change.kind === "created") return `${change.id}: new file ${change.file}`;
+  if (change.kind === "deleted") return `${change.id}: deletes ${change.file}`;
+  const where = change.removed
+    ? change.oldStart === change.oldEnd
+      ? `line ${change.oldStart}`
+      : `lines ${change.oldStart}-${change.oldEnd}`
+    : `after line ${change.oldStart - 1}`;
+  return `${change.id}: ${change.file} ${where} (-${change.removed}/+${change.added})`;
+}
+
+/** The measured changes as the annotate prompt shows them. */
+export function renderChangesForPrompt(measured, memoryFile) {
+  if (!measured.changes.length) return "(no changes - the staging copy is identical to the original)";
+  const unitsAt = (change) => {
+    if (change.file !== memoryFile.path || change.kind !== "hunk") return "";
+    const from = change.oldStart;
+    const to = change.removed ? change.oldEnd : change.oldStart;
+    const ids = memoryFile.units.filter((u) => u.startLine <= to && u.endLine >= from).map((u) => u.id);
+    return ids.length ? ` · ${ids.join(", ")}` : "";
+  };
+  return measured.changes
+    .map((change) => {
+      const head = `[${describeChange(change)}${unitsAt(change)}]`;
+      if (change.kind === "deleted") return head;
+      if (change.kind === "created") {
+        return `${head}\n${renderHunkLines(
+          change.text.split("\n").map((text) => ({ type: "ins", text })),
+          { maxLines: 80 },
+        )}`;
+      }
+      return `${head}\n${renderHunkLines(change.lines)}`;
+    })
+    .join("\n\n");
+}
+
 /**
- * Validate a raw synthesis result against the mechanical gates. Returns
+ * Validate the annotated, measured changes against the mechanical gates. Returns
  * `{ proposal, violations }`; the caller decides whether to re-prompt or fail loudly.
+ *
+ * `context.measured` is the workspace measurement (`measureWorkspace`); `rawResult` is
+ * the model's annotation. Nothing textual is taken from the model: the hunks, their
+ * deltas, the projected budget, and even whether an edit is an addition are measured.
  */
 export function buildProposal(rawResult, context) {
   const {
@@ -145,76 +196,140 @@ export function buildProposal(rawResult, context) {
     config,
     repo,
     summary,
+    measured = { changes: [], stray: [] },
     harnessCounts = {},
     rejections = { entries: {} },
     isSuppressed = () => false,
-    skillFiles = [],
   } = context;
 
   const violations = [];
+  const notes = Array.isArray(rawResult?.notes) ? rawResult.notes.map(String) : [];
   const rawEdits = Array.isArray(rawResult?.edits) ? rawResult.edits : [];
-  const edits = rawEdits.map((raw, i) => normalizeEdit(raw, i, { memoryPath: memoryFile.path }));
+  const edits = rawEdits.map((raw, i) => normalizeEdit(raw, i));
+  const changesById = new Map(measured.changes.map((c) => [c.id, c]));
 
   const maxEdits = effectiveMaxEdits(memoryFile, config);
   if (edits.length > maxEdits) {
     violations.push(`proposed ${edits.length} edits but the per-run cap is ${maxEdits} (the learning rate)`);
   }
 
-  const accepted = [];
-  const knownSkillPaths = new Set(skillFiles.map((s) => s.path));
-
+  // Every measured change must be claimed exactly once.
+  const claimedBy = new Map();
   for (const edit of edits) {
+    for (const id of edit.changeIds) {
+      if (!changesById.has(id)) {
+        violations.push(`edit ${edit.id} refers to ${id}, which is not a measured change`);
+        continue;
+      }
+      if (claimedBy.has(id)) {
+        violations.push(`${id} is claimed by both edit ${claimedBy.get(id)} and edit ${edit.id}`);
+        continue;
+      }
+      claimedBy.set(id, edit.id);
+    }
+  }
+  for (const change of measured.changes) {
+    if (change.kind === "deleted") {
+      violations.push(`${describeChange(change)}; backpass cannot propose deletions - restore the file`);
+      continue;
+    }
+    if (!claimedBy.has(change.id)) {
+      violations.push(
+        `${describeChange(change)} is not part of any edit; every change needs an edit with evidence, or revert it`,
+      );
+    }
+  }
+
+  const accepted = [];
+  for (const edit of edits) {
+    const changes = edit.changeIds.map((id) => changesById.get(id)).filter(Boolean);
+    const created = changes.filter((c) => c.kind === "created");
+    const hunks = changes.filter((c) => c.kind === "hunk");
+    const files = [...new Set(hunks.map((h) => h.file))];
+
     if (!EDIT_KINDS.includes(edit.kind)) {
       violations.push(`edit ${edit.id}: unknown kind "${edit.kind}"`);
+      continue;
+    }
+    if (!changes.length) {
+      violations.push(`edit ${edit.id} ("${edit.title}") names no measured change`);
+      continue;
+    }
+    if (files.length > 1) {
+      violations.push(`edit ${edit.id} ("${edit.title}") changes ${files.join(" and ")}; an edit changes one file`);
       continue;
     }
     if (!edit.evidence.length) {
       violations.push(`edit ${edit.id} ("${edit.title}") carries no verbatim evidence quote`);
       continue;
     }
-    if (edit.kind === "add" && edit.transcripts < config.minGapEvidence) {
+    if (edit.kind === "extract") {
+      if (created.length !== 1 || !hunks.length || files[0] !== memoryFile.path) {
+        violations.push(
+          `edit ${edit.id}: kind "extract" must group exactly one created SKILL.md with change(s) to ${memoryFile.path}`,
+        );
+        continue;
+      }
+      if (!created[0].skill) {
+        violations.push(
+          `edit ${edit.id}: ${created[0].file} needs YAML frontmatter with \`name:\` and \`description:\``,
+        );
+        continue;
+      }
+    } else if (created.length) {
+      violations.push(`edit ${edit.id}: only kind "extract" may include a created file (${created[0].id})`);
+      continue;
+    }
+
+    // An addition is measured, not declared: text that only goes in is a new instruction.
+    const onlyAdds = hunks.every((h) => h.removed === 0);
+    if (edit.kind !== "extract" && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
       );
       continue;
     }
-    if (edit.kind === "extract" && !edit.skill) {
-      violations.push(`edit ${edit.id}: kind "extract" requires a skill draft`);
-      continue;
-    }
-    if (edit.kind !== "extract" && edit.skill) {
-      violations.push(`edit ${edit.id}: only kind "extract" may carry a skill draft`);
-      continue;
-    }
-    if (isSuppressed(edit, rejections)) {
+
+    const file = files[0];
+    const proposed = {
+      id: edit.id,
+      kind: edit.kind,
+      file,
+      title: edit.title,
+      rationale: edit.rationale,
+      instructions: edit.instructions,
+      evidence: edit.evidence,
+      transcripts: edit.transcripts,
+      skill: created[0]?.skill || null,
+      hunks: hunks.map((h) => ({
+        id: h.id,
+        find: h.find,
+        replace: h.replace,
+        oldStart: h.oldStart,
+        oldEnd: h.oldEnd,
+        removed: h.removed,
+        added: h.added,
+        lines: h.lines,
+      })),
+      targetsMemoryFile: file === memoryFile.path,
+    };
+
+    if (isSuppressed(proposed, rejections)) {
       // Rejections are respected until materially new evidence arrives (captain tweak 3).
       continue;
     }
-
-    edit.targetsMemoryFile = edit.file === memoryFile.path;
-    if (!edit.targetsMemoryFile && !knownSkillPaths.has(edit.file) && edit.kind !== "extract") {
-      violations.push(`edit ${edit.id}: targets ${edit.file}, which is neither the memory file nor a known skill`);
-      continue;
-    }
-    if (edit.kind === "extract" && edit.skill && !edit.skill.path) {
-      edit.skill.path = `${config.skillsDir}/${slug(edit.skill.name)}/SKILL.md`;
-    }
-
-    accepted.push(edit);
+    accepted.push(proposed);
   }
 
   // Deltas are measured here, never taken from the model.
-  const memoryEdits = accepted.filter((e) => e.targetsMemoryFile);
-  let running = memoryFile.text;
+  const running = new Map();
   for (const edit of accepted) {
-    if (!edit.targetsMemoryFile) {
-      edit.deltaTokens = estimateTokens(edit.replace) - estimateTokens(edit.find);
-      continue;
-    }
+    const before =
+      running.get(edit.file) ?? (edit.targetsMemoryFile ? memoryFile.text : (measured.originals?.get(edit.file) ?? ""));
     let next;
     try {
-      next = applyEdit(running, edit);
+      next = applyEdit(before, edit);
     } catch (err) {
       violations.push(err.message);
       edit.applicable = false;
@@ -222,18 +337,11 @@ export function buildProposal(rawResult, context) {
       continue;
     }
     edit.applicable = true;
-    edit.deltaTokens = estimateTokens(next) - estimateTokens(running);
-    running = next;
+    edit.deltaTokens = estimateTokens(next) - estimateTokens(before);
+    running.set(edit.file, next);
   }
 
-  const applicableMemoryEdits = memoryEdits.filter((e) => e.applicable);
-  let projectedText;
-  try {
-    projectedText = applyEdits(memoryFile.text, applicableMemoryEdits);
-  } catch {
-    projectedText = running;
-  }
-
+  const projectedText = running.get(memoryFile.path) ?? memoryFile.text;
   const budget = budgetStatus(memoryFile.text, projectedText, config.budgetTokens);
 
   /**
@@ -260,8 +368,11 @@ export function buildProposal(rawResult, context) {
     );
   }
 
+  for (const file of measured.stray || [])
+    notes.push(`ignored ${file}: synthesis wrote it outside the memory file and skills`);
+
   const proposal = {
-    version: 1,
+    version: 2,
     tool: "backpass",
     generatedAt: new Date().toISOString(),
     repo: { name: repo.name, root: repo.root },
@@ -285,7 +396,7 @@ export function buildProposal(rawResult, context) {
     },
     edits: accepted,
     verdicts: Array.isArray(rawResult?.verdicts) ? rawResult.verdicts : [],
-    notes: Array.isArray(rawResult?.notes) ? rawResult.notes.map(String) : [],
+    notes,
   };
 
   return { proposal, violations };

--- a/src/skills.js
+++ b/src/skills.js
@@ -109,7 +109,8 @@ export function renderSkillFile(skill) {
  */
 export function extractionBudgetEffect(edit) {
   if (edit.kind !== "extract" || !edit.skill) return null;
-  const removedFromMemory = estimateTokens(edit.find) - estimateTokens(edit.replace);
+  const pairs = Array.isArray(edit.hunks) ? edit.hunks : [edit];
+  const removedFromMemory = pairs.reduce((sum, p) => sum + estimateTokens(p.find) - estimateTokens(p.replace), 0);
   const descriptionCost = estimateTokens(edit.skill.description);
   return {
     alwaysLoadedDelta: -removedFromMemory,

--- a/src/state.js
+++ b/src/state.js
@@ -22,6 +22,8 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   rejections.json        edits the human rejected, and the evidence weight behind them
  *   gap-ledger.json        gap observations by gap and session, accumulated across runs (src/gap-ledger.js)
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
+ *   prompts/               the exact prompts of the last run, one file per model turn
+ *   synthesis/             the staging copy the synthesis agent edits natively (src/workspace.js)
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -176,7 +178,10 @@ export function isEvidenceFresh(evidence, transcript, memoryHash) {
  * backed by strictly more transcripts than when it was turned down.
  */
 export function rejectionKey(edit) {
-  return sha256([edit.kind, edit.file, edit.find || "", edit.replace || ""].join(" ")).slice(0, 16);
+  const body = Array.isArray(edit.hunks)
+    ? edit.hunks.map((h) => `${h.find}\u0000${h.replace}`).join("\u0001")
+    : `${edit.find || ""}\u0000${edit.replace || ""}`;
+  return sha256([edit.kind, edit.file, body].join(" ")).slice(0, 16);
 }
 
 export function isSuppressedByRejection(edit, rejections) {

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -1,25 +1,38 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { extractJson, sessionPrompt, usageRecord } from "./acpx.js";
+import { extractJson, openSession, usageRecord } from "./acpx.js";
 import { renderEvidenceForPrompt } from "./fold.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt } from "./prompts.js";
-import { buildProposal, effectiveMaxEdits, ProposalViolation } from "./proposal.js";
+import { buildProposal, effectiveMaxEdits, ProposalViolation, renderChangesForPrompt } from "./proposal.js";
 import { loadSkills, renderSkillIndex, resolveOverflowTarget } from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
-import { color, info, warn } from "./logger.js";
+import { measureWorkspace, prepareWorkspace, repoFingerprint } from "./workspace.js";
+import { UserError, color, info, warn } from "./logger.js";
 
 /**
- * Stage 3 of the pipeline (design section 3): one big high-reasoning call that turns
+ * Stage 3 of the pipeline (design section 3): one high-reasoning session that turns
  * folded evidence into concrete edits.
  *
- * This is the expensive half of the two-tier design - cheap analysis, smart synthesis -
- * so it runs exactly once per run, plus at most one re-prompt when the mechanical gates
- * catch a violation. If the second attempt also violates, backpass fails loudly and
- * saves the rejected proposal rather than quietly trimming it (design section 6).
+ * The agent never describes an edit for backpass to locate - it makes the edit, with its
+ * harness's own file tools, in a staging copy of the memory file (`src/workspace.js`).
+ * One session, two kinds of turn:
+ *
+ *   edit      the synthesis prompt; the agent edits `./AGENTS.md` in the staging copy
+ *   annotate  backpass measures the copy against the original (`src/diff.js`) and shows
+ *             the changes by id; the agent attaches kind, title, rationale, and evidence
+ *
+ * The annotation is what the mechanical gates validate (`buildProposal`); on a violation
+ * the agent is re-prompted with the exact breaches, at most ANNOTATE_TURNS times in all,
+ * then backpass fails loudly and saves the rejected proposal rather than quietly trimming
+ * it (design section 6). The repo is fingerprinted before and checked after: a harness
+ * that wrote past the staging copy is an error, never a silent apply.
  */
+
+/** Annotation turns per run: the first answer plus re-prompts with the exact violations. */
+export const ANNOTATE_TURNS = 3;
 
 function budgetRule(memoryFile, config, maxEdits) {
   const remaining = config.budgetTokens - memoryFile.tokens;
@@ -68,6 +81,18 @@ function harnessCountsOf(transcripts) {
   return counts;
 }
 
+/** The repo must be exactly as fingerprinted; the staging copy is the only place to write. */
+function assertRepoUntouched(repo, before, workspaceRoot) {
+  const after = repoFingerprint(repo, Object.keys(before));
+  const moved = Object.keys(before).filter((file) => before[file] !== after[file]);
+  if (!moved.length) return;
+  throw new UserError(
+    `synthesis changed ${moved.join(", ")} in the repository directly instead of the staging copy ` +
+      `(${workspaceRoot}); nothing was proposed`,
+    `inspect the change with \`git diff\`, restore the file, and re-run - a harness that edits outside its cwd cannot be trusted with the synthesis role`,
+  );
+}
+
 export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
   const state = config.state;
   const rejections = state.readRejections();
@@ -77,26 +102,30 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   const harnessCounts = harnessCountsOf(transcripts);
   const maxEdits = effectiveMaxEdits(memoryFile, config);
 
-  const values = {
+  const common = {
+    MEMORY_PATH: memoryFile.path,
+    BUDGET_RULE: budgetRule(memoryFile, config, maxEdits),
+    MAX_EDITS: String(maxEdits),
+    MIN_GAP_EVIDENCE: String(config.minGapEvidence),
+  };
+  const editValues = {
+    ...common,
     REPO_NAME: repo.name,
+    REPO_ROOT: repo.root,
     TRANSCRIPT_COUNT: String(summary.analyzedSessions),
     RUN_NOTE: runNote,
     HARNESS_SUMMARY:
       Object.entries(harnessCounts)
         .map(([h, n]) => `${h} ${n}`)
         .join(" · ") || "none",
-    MEMORY_PATH: memoryFile.path,
     CURRENT_TOKENS: String(memoryFile.tokens),
     BUDGET_TOKENS: String(config.budgetTokens),
     BUDGET_STATE: budgetState(memoryFile, config),
-    BUDGET_RULE: budgetRule(memoryFile, config, maxEdits),
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
     SKILLS_DIR: overflow.dir,
     SKILL_INDEX: renderSkillIndex(skillFiles),
     EVIDENCE: renderEvidenceForPrompt(summary),
     REJECTIONS: renderRejections(rejections),
-    MAX_EDITS: String(maxEdits),
-    MIN_GAP_EVIDENCE: String(config.minGapEvidence),
   };
 
   const context = {
@@ -112,93 +141,147 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
 
   const promptDir = path.join(state.root, "prompts");
   fs.mkdirSync(promptDir, { recursive: true });
+  const editPromptFile = path.join(promptDir, "synthesis-edit.md");
+  fs.writeFileSync(editPromptFile, renderPrompt("synthesis", editValues));
 
-  let prompt = renderPrompt("synthesis", values);
+  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
+  const sessionName = `backpass-synth-${process.pid}`;
+  const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
   const usage = [];
   const notes = [];
-  let lastViolations = [];
+  const noteOnce = (note) => {
+    // The same adapter limitation is reported on every turn; say it once.
+    if (notes.includes(note)) return;
+    notes.push(note);
+    warn(note);
+  };
 
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
-    const promptFile = path.join(promptDir, `synthesis-${attempt}.md`);
-    fs.writeFileSync(promptFile, prompt);
-
-    const pick = await config.agents.resolve("synthesis");
-    info(
-      `${color.cyan("·")} synthesizing with ${pick.agent}` +
-        `${pick.model ? ` (${pick.model})` : ""}` +
-        `${pick.effort ? ` effort=${pick.effort}` : ""}` +
-        `${attempt > 1 ? " [re-prompt]" : ""}`,
-    );
+  const pick = await config.agents.resolve("synthesis");
+  info(
+    `${color.cyan("·")} synthesizing with ${pick.agent}` +
+      `${pick.model ? ` (${pick.model})` : ""}` +
+      `${pick.effort ? ` effort=${pick.effort}` : ""}`,
+  );
+  let ranWith = pick.agent;
+  const progress = (phase, extra = {}) =>
     emitProgress("synth:start", {
-      agent: pick.agent,
+      agent: ranWith,
       model: pick.model,
       effort: pick.effort,
-      attempt,
+      phase,
       maxEdits,
-      sessionName: `backpass-synth-${process.pid}`,
+      sessionName,
       gapClusters: summary.totals.gapClusters,
       instructions: summary.instructions.length,
       suppressed: Object.keys(rejections.entries || {}).length,
+      ...extra,
     });
 
-    // A classifiable failure (not logged in, model rejected, adapter missing) falls
-    // through to the next ladder candidate; the switch is recorded in the notes so the
-    // proposal's provenance is visible.
-    let ranWith = pick.agent;
-    const result = await config.agents.withFallthrough("synthesis", async (current) => {
-      ranWith = current.agent;
-      if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-      return sessionPrompt({
-        agent: current.agent,
-        model: current.model,
-        effort: current.effort,
-        sessionName: `backpass-synth-${process.pid}`,
-        promptFile,
-        cwd: repo.root,
-        timeoutSeconds: Math.max(config.timeoutSeconds, 900),
+  // A classifiable failure (not logged in, model rejected, adapter missing) falls
+  // through to the next ladder candidate; the switch is recorded in the notes so the
+  // proposal's provenance is visible. Once the editing turn has run, later turns stay
+  // on the same candidate - a run never silently switches models after real work.
+  /** @type {Awaited<ReturnType<typeof openSession>> | null} */
+  let session = null;
+  /** @type {ReturnType<typeof prepareWorkspace>} */
+  let workspace = null;
+  const editResult = await config.agents.withFallthrough("synthesis", async (current) => {
+    ranWith = current.agent;
+    if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
+    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir });
+    progress("edit", { attempt: 1 });
+    session = await openSession({
+      agent: current.agent,
+      model: current.model,
+      effort: current.effort,
+      sessionName,
+      cwd: workspace.root,
+    });
+    try {
+      return await session.prompt({
+        promptFile: editPromptFile,
+        approveAll: true,
+        timeoutSeconds,
+        promptRetries: config.promptRetries,
       });
-    });
-
-    usage.push(usageRecord(ranWith, result));
-    // The same adapter limitation is reported on every attempt; say it once.
-    for (const note of result.notes || []) {
-      if (notes.includes(note)) continue;
-      notes.push(note);
-      warn(note);
+    } catch (err) {
+      await session.close();
+      session = null;
+      throw err;
     }
+  });
+  usage.push(usageRecord(ranWith, editResult));
+  for (const note of editResult.notes || []) noteOnce(note);
 
-    const parsed = extractJson(result.text);
-    if (!parsed) {
-      lastViolations = ["synthesis returned no parseable JSON object"];
-    } else {
-      const { proposal, violations } = buildProposal(parsed, context);
-      if (!violations.length) {
-        proposal.notes = [...proposal.notes, ...notes];
-        proposal.usage = usage;
-        proposal.overflowTarget = overflow;
-        emitProgress("synth:done", { edits: proposal.edits.length, attempt });
-        return { proposal, violations: [] };
+  const turn = session;
+  try {
+    let lastViolations = [];
+    for (let attempt = 1; attempt <= ANNOTATE_TURNS; attempt += 1) {
+      assertRepoUntouched(repo, fingerprint, workspace.root);
+      const measured = measureWorkspace(workspace);
+
+      let prompt = renderPrompt("annotate", {
+        ...common,
+        CHANGES: renderChangesForPrompt(measured, memoryFile),
+      });
+      if (lastViolations.length) {
+        prompt +=
+          `\n\n## Your previous answer was rejected\n\nIt violated these hard rules. Fix every one of them ` +
+          `(edit the files first if a change must go or move) and return the corrected JSON object only.\n\n` +
+          `${lastViolations.map((v) => `- ${v}`).join("\n")}\n`;
       }
-      lastViolations = violations;
-      proposal.notes = [...proposal.notes, ...notes];
-      proposal.usage = usage;
-      proposal.overflowTarget = overflow;
-      proposal.violations = violations;
-      // Keep the rejected proposal so a loud failure is still inspectable.
-      state.writeProposal(proposal);
+      const promptFile = path.join(promptDir, `synthesis-annotate-${attempt}.md`);
+      fs.writeFileSync(promptFile, prompt);
+      progress("annotate", { attempt, changes: measured.changes.length });
+
+      const result = await turn.prompt({
+        promptFile,
+        approveAll: true,
+        timeoutSeconds,
+        promptRetries: config.promptRetries,
+      });
+      usage.push(usageRecord(ranWith, result));
+      for (const note of result.notes || []) noteOnce(note);
+
+      // The agent may keep editing during an annotate turn; ids are then stale, so the
+      // answer is discarded and the fresh measurement is shown instead.
+      assertRepoUntouched(repo, fingerprint, workspace.root);
+      const remeasured = measureWorkspace(workspace);
+      if (remeasured.signature !== measured.signature) {
+        lastViolations = [
+          "the files changed after the changes were measured; annotate the re-measured changes shown above",
+        ];
+      } else {
+        const parsed = extractJson(result.text);
+        if (!parsed) {
+          lastViolations = ["synthesis returned no parseable JSON object"];
+        } else {
+          const { proposal, violations } = buildProposal(parsed, { ...context, measured });
+          proposal.notes = [...proposal.notes, ...notes];
+          proposal.usage = usage;
+          proposal.overflowTarget = overflow;
+          if (!violations.length) {
+            emitProgress("synth:done", { edits: proposal.edits.length, attempt });
+            return { proposal, violations: [] };
+          }
+          lastViolations = violations;
+          proposal.violations = violations;
+          // Keep the rejected proposal so a loud failure is still inspectable.
+          state.writeProposal(proposal);
+        }
+      }
+
+      if (attempt < ANNOTATE_TURNS) {
+        warn(`synthesis violated ${lastViolations.length} gate(s); re-prompting with the exact violations`);
+        emitProgress("synth:violations", { attempt, violations: lastViolations });
+      }
     }
 
-    if (attempt === 1) {
-      warn(`synthesis violated ${lastViolations.length} gate(s); re-prompting once with the exact violations`);
-      emitProgress("synth:violations", { attempt, violations: lastViolations });
-      prompt = `${renderPrompt("synthesis", values)}\n\n## Your previous answer was rejected\n\nIt violated these hard rules. Fix every one of them and return the corrected JSON object only.\n\n${lastViolations
-        .map((v) => `- ${v}`)
-        .join("\n")}\n`;
-    }
+    throw new ProposalViolation(
+      `synthesis could not produce a valid proposal after ${ANNOTATE_TURNS - 1} re-prompt(s) (${lastViolations.length} violation(s))`,
+      lastViolations,
+    );
+  } finally {
+    await turn.close();
   }
-
-  throw new ProposalViolation(
-    `synthesis could not produce a valid proposal after one re-prompt (${lastViolations.length} violation(s))`,
-    lastViolations,
-  );
 }

--- a/src/tui/index.js
+++ b/src/tui/index.js
@@ -96,6 +96,8 @@ export function initialState(meta) {
       model: null,
       effort: null,
       attempt: 0,
+      phase: "edit",
+      changes: null,
       sessionName: null,
       gapClusters: 0,
       instructions: 0,
@@ -221,6 +223,8 @@ export function reduceEvent(state, event, data, now = Date.now()) {
       s.model = data.model;
       s.effort = data.effort;
       s.attempt = data.attempt;
+      s.phase = data.phase || "edit";
+      s.changes = data.changes ?? null;
       if (data.maxEdits) state.meta.maxEdits = data.maxEdits;
       s.sessionName = data.sessionName;
       s.gapClusters = data.gapClusters;

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -246,12 +246,15 @@ function synthSummary(theme, s) {
   const model = [s.agent, s.model].filter(Boolean).join(" · ");
   const effort = s.effort ? ` · effort ${s.effort}` : "";
   if (s.status === "done") return theme.paint(`${s.edits} edit(s) · passed validation`, "dim");
-  if (s.attempt > 1) {
+  if (s.phase === "annotate" && s.attempt > 1) {
     return (
-      theme.paint("re-prompt ", "dim") + theme.paint("1 of 1", "yellow") + theme.paint(` · ${model}${effort}`, "dim")
+      theme.paint("re-prompt ", "dim") +
+      theme.paint(`${s.attempt - 1}`, "yellow") +
+      theme.paint(` · ${model}${effort}`, "dim")
     );
   }
-  return theme.paint(`one call · ${model}${effort}`, "dim");
+  const phase = s.phase === "annotate" ? "annotating" : "editing";
+  return theme.paint(`${phase} · ${model}${effort}`, "dim");
 }
 
 function sectionRule(theme, name, description, width) {
@@ -380,18 +383,22 @@ function synthesizeDetail(state, theme, width, spin) {
     sectionRule(theme, STAGE_LABELS.synthesize, `aggregated gradients → at most ${state.meta.maxEdits} edits`, width),
   ];
 
-  if (s.attempt > 1 && s.violations.length) {
+  if (s.phase === "annotate" && s.attempt > 1 && s.violations.length) {
     lines.push(
-      ` ${theme.paint("!", "yellow")} ${theme.paint(`synthesis violated ${s.violations.length} gate(s)`, "text")} ${theme.paint("· re-prompting once with the exact breaches", "dim")}`,
+      ` ${theme.paint("!", "yellow")} ${theme.paint(`synthesis violated ${s.violations.length} gate(s)`, "text")} ${theme.paint("· re-prompting with the exact breaches", "dim")}`,
     );
     for (const violation of s.violations.slice(0, 4)) {
       lines.push(`    ${theme.paint("✗", "red")} ${theme.paint(clipPlain(violation, width - 8), "dim")}`);
     }
   }
 
+  const doing =
+    s.phase === "annotate"
+      ? `annotating ${s.changes ?? 0} measured change(s) with evidence…`
+      : `weighing ${s.gapClusters} gap clusters + ${s.instructions} instruction records against the budget…`;
   lines.push(
     lr(
-      ` ${theme.paint(spin, "mint")} weighing ${s.gapClusters} gap clusters + ${s.instructions} instruction records against the budget…`,
+      ` ${theme.paint(spin, "mint")} ${doing}`,
       state.narrow || !s.sessionName ? null : theme.paint(`session ${s.sessionName}`, "faint"),
       width,
     ),

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { anchoredHunks } from "./diff.js";
+import { parseFrontmatter } from "./skills.js";
+import { sha256 } from "./state.js";
+
+/**
+ * The synthesis staging workspace (design section 3, native-edit revision).
+ *
+ * The synthesis agent edits the memory file with its harness's own file tools - the
+ * same `edit`/`write` it uses on any repo - instead of handing backpass text to splice.
+ * So that a run stays safe to interrupt and `src/apply/writer.js` stays the only module
+ * that writes to the repo, those tools never see the repo: they run in a staging copy
+ * under `.backpass/synthesis/` holding only the memory file and the skills directory.
+ * The agent reads the real repository by absolute path for grounding; what it changes in
+ * the copy is measured here (`measureWorkspace`) and becomes the proposal the human
+ * reviews. The copy is wiped and rebuilt on every synthesis.
+ */
+
+export const WORKSPACE_DIRNAME = "synthesis";
+
+export function workspaceRoot(state) {
+  return path.join(state.root, WORKSPACE_DIRNAME);
+}
+
+/**
+ * Build a fresh staging copy. `originals` records every file placed there, so the
+ * measurement can tell a modified file from a created or deleted one.
+ */
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
+  const root = workspaceRoot(state);
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+
+  const originals = new Map();
+  const memoryTarget = path.join(root, memoryFile.path);
+  fs.mkdirSync(path.dirname(memoryTarget), { recursive: true });
+  fs.writeFileSync(memoryTarget, memoryFile.text);
+  originals.set(memoryFile.path, memoryFile.text);
+
+  const skillsSource = path.join(repo.root, skillsDir);
+  if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
+    for (const relative of walkFiles(skillsSource)) {
+      const from = path.join(skillsSource, relative);
+      const to = path.join(root, skillsDir, relative);
+      fs.mkdirSync(path.dirname(to), { recursive: true });
+      fs.copyFileSync(from, to);
+      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
+    }
+  }
+  fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
+
+  return { root, memoryPath: memoryFile.path, skillsDir, originals };
+}
+
+function walkFiles(dir, prefix = "") {
+  const out = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const relative = prefix ? path.posix.join(prefix, entry.name) : entry.name;
+    if (entry.isDirectory()) out.push(...walkFiles(path.join(dir, entry.name), relative));
+    else if (entry.isFile()) out.push(relative);
+  }
+  return out;
+}
+
+/** A created file counts as a skill only in the layouts `loadSkills` reads. */
+export function isSkillFilePath(relative, skillsDir) {
+  const prefix = `${skillsDir}/`;
+  if (!relative.startsWith(prefix)) return false;
+  const inside = relative.slice(prefix.length);
+  const parts = inside.split("/");
+  if (parts.length === 1) return parts[0].endsWith(".md");
+  return parts.length === 2 && parts[1] === "SKILL.md";
+}
+
+/** Split a SKILL.md into the fields `writeSkill` needs; null when the frontmatter is unusable. */
+export function parseSkillFile(relative, text) {
+  const frontmatter = parseFrontmatter(text);
+  if (!frontmatter.name || !frontmatter.description) return null;
+  const end = /^---\n[\s\S]*?\n---\n?/.exec(text);
+  const body = end ? text.slice(end[0].length) : text;
+  return {
+    name: String(frontmatter.name).trim(),
+    description: String(frontmatter.description).trim(),
+    path: relative,
+    body: body.trim(),
+  };
+}
+
+/**
+ * Everything that differs between the originals and the workspace now, as changes with
+ * stable ids the annotate turn refers to:
+ *
+ *   { id: "H1", kind: "hunk",    file, find, replace, oldStart, oldEnd, removed, added, lines }
+ *   { id: "H4", kind: "created", file, text, skill | null }   a new SKILL.md
+ *   { id: "H5", kind: "deleted", file }                        a staged file removed
+ *
+ * Files outside the memory file and the skill layouts are `stray` - reported, never
+ * carried. Ids are assigned in file order so a re-measurement after an unchanged
+ * workspace yields identical ids.
+ */
+export function measureWorkspace(workspace) {
+  const { root, memoryPath, skillsDir, originals } = workspace;
+  /** @type {any[]} */
+  const changes = [];
+  const stray = [];
+  const texts = new Map();
+
+  const present = new Set(walkFiles(root).map((p) => p.split(path.sep).join("/")));
+
+  const ordered = [memoryPath, ...[...originals.keys()].filter((f) => f !== memoryPath).sort()];
+  for (const relative of ordered) {
+    const original = originals.get(relative);
+    if (!present.has(relative)) {
+      changes.push({ kind: "deleted", file: relative });
+      continue;
+    }
+    const text = fs.readFileSync(path.join(root, relative), "utf8");
+    texts.set(relative, text);
+    for (const hunk of anchoredHunks(original, text)) changes.push({ kind: "hunk", file: relative, ...hunk });
+  }
+
+  for (const relative of [...present].sort()) {
+    if (originals.has(relative)) continue;
+    if (!isSkillFilePath(relative, skillsDir)) {
+      stray.push(relative);
+      continue;
+    }
+    const text = fs.readFileSync(path.join(root, relative), "utf8");
+    texts.set(relative, text);
+    changes.push({ kind: "created", file: relative, text, skill: parseSkillFile(relative, text) });
+  }
+
+  changes.forEach((change, index) => {
+    change.id = `H${index + 1}`;
+  });
+
+  return { changes, stray, texts, originals, signature: signatureOf(changes) };
+}
+
+function signatureOf(changes) {
+  return sha256(
+    JSON.stringify(changes.map((c) => [c.kind, c.file, c.find ?? "", c.replace ?? "", c.text ?? ""])),
+  ).slice(0, 16);
+}
+
+/** The files backpass must find untouched in the repo after synthesis: a moved write is a bug, loudly. */
+export function repoFingerprint(repo, files) {
+  const out = {};
+  for (const relative of files) {
+    const absolute = path.join(repo.root, relative);
+    out[relative] = fs.existsSync(absolute) ? sha256(fs.readFileSync(absolute, "utf8")) : null;
+  }
+  return out;
+}

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -364,6 +364,15 @@
         color: var(--faint);
         padding: 1px 8px;
       }
+      .diff .ctx::before {
+        content: "  ";
+      }
+      .diff .gap {
+        display: block;
+        color: var(--faint);
+        padding: 1px 8px;
+        border-top: 1px dashed var(--line-soft);
+      }
 
       .evidence {
         border-top: 1px dashed var(--line-soft);
@@ -740,19 +749,9 @@
           }
 
           var diff = el("div", "diff");
-          if (edit.context) diff.appendChild(el("span", "ctx", edit.context));
-          (edit.find || "")
-            .split("\n")
-            .filter(nonEmpty)
-            .forEach(function (line) {
-              diff.appendChild(el("span", "del", line));
-            });
-          (edit.replace || "")
-            .split("\n")
-            .filter(nonEmpty)
-            .forEach(function (line) {
-              diff.appendChild(el("span", "ins", line));
-            });
+          diffLines(edit).forEach(function (line) {
+            diff.appendChild(el("span", line.type, line.text));
+          });
           body.appendChild(diff);
 
           if ((edit.evidence || []).length) {
@@ -808,6 +807,35 @@
 
         function nonEmpty(line) {
           return line.length > 0;
+        }
+
+        // Measured edits carry display lines per hunk (ctx/del/ins); a legacy
+        // find/replace edit is shown as removed then added lines.
+        function diffLines(edit) {
+          if (Array.isArray(edit.hunks)) {
+            var out = [];
+            edit.hunks.forEach(function (hunk, i) {
+              if (i > 0) out.push({ type: "gap", text: "\u2026" });
+              (hunk.lines || []).forEach(function (line) {
+                out.push(line);
+              });
+            });
+            return out;
+          }
+          return (edit.find || "")
+            .split("\n")
+            .filter(nonEmpty)
+            .map(function (text) {
+              return { type: "del", text: text };
+            })
+            .concat(
+              (edit.replace || "")
+                .split("\n")
+                .filter(nonEmpty)
+                .map(function (text) {
+                  return { type: "ins", text: text };
+                }),
+            );
         }
 
         // ---- notes ----

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -53,20 +53,34 @@ function fakeAnalyze({ transcripts, memoryFile, config, memoryHash }) {
   return { total: transcripts.length, analyzed: transcripts.length, cached: 0, skipped: 0, failed: 0, usage: [] };
 }
 
+/**
+ * Stands in for the synthesis harness: edits the staging copy the way a harness's own
+ * file tools would, then annotates the measured change.
+ */
 function fakeSynthesize(captured) {
   return async ({ memoryFile, summary, runNote }) => {
     captured.runNote = runNote;
     captured.gapClusters = summary.totals.gapClusters;
     const { buildProposal } = await import("../src/proposal.js");
+    const { stageAndMeasure, writeIn } = await import("./helpers/staging.js");
+    const { measured } = stageAndMeasure({
+      repo: captured.repo,
+      memoryPath: memoryFile.path,
+      edit: (root) =>
+        writeIn(root, memoryFile.path, (t) =>
+          t.replace(
+            "- None recorded yet. backpass adds evidence-backed entries here from real sessions.",
+            "- Run migrations only against a scratch database, never the shared one.",
+          ),
+        ),
+    });
     const { proposal, violations } = buildProposal(
       {
         edits: [
           {
+            changes: ["H1"],
             kind: "rewrite",
-            file: memoryFile.path,
             title: "record the migration trap",
-            find: "- None recorded yet. backpass adds evidence-backed entries here from real sessions.",
-            replace: "- Run migrations only against a scratch database, never the shared one.",
             evidence: [
               { polarity: "negative", text: "applied the migration to prod-db", source: "claude · s1" },
               { polarity: "negative", text: "applied the migration to prod-db", source: "claude · s2" },
@@ -75,7 +89,7 @@ function fakeSynthesize(captured) {
           },
         ],
       },
-      { memoryFile, config: captured.config, repo: captured.repo, summary },
+      { memoryFile, config: captured.config, repo: captured.repo, summary, measured },
     );
     assert.deepEqual(violations, []);
     return { proposal, violations };

--- a/test/diff.test.js
+++ b/test/diff.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { anchoredHunks, diffOps, rawHunks, renderHunkLines } from "../src/diff.js";
+import { applyEdit } from "../src/proposal.js";
+
+function applyAll(text, hunks) {
+  return hunks.reduce((t, h, i) => applyEdit(t, { id: `e${i}`, file: "f", hunks: [{ ...h, id: `H${i}` }] }), text);
+}
+
+test("diffOps is a shortest edit script that replays the new text", () => {
+  const a = ["a", "b", "c", "d"];
+  const b = ["a", "x", "c", "d", "e"];
+  const ops = diffOps(a, b);
+  assert.deepEqual(
+    ops.map((o) => o.type),
+    ["equal", "delete", "insert", "equal", "equal", "insert"],
+  );
+  assert.deepEqual(rawHunks(ops), [
+    { oldStart: 1, oldEnd: 2, newStart: 1, newEnd: 2 },
+    { oldStart: 4, oldEnd: 4, newStart: 4, newEnd: 5 },
+  ]);
+});
+
+test("each hunk's find is copied from the original, occurs once, and the set rebuilds the new text", () => {
+  const old = "# T\n\n- one\n- two\n- three\n\n## S\n\n- four\n";
+  const next = "# T\n\n- one\n- TWO\n- three\n\n## S\n\n- four\n- five\n";
+  const hunks = anchoredHunks(old, next);
+  assert.equal(hunks.length, 2);
+  for (const h of hunks) assert.equal(old.split(h.find).length, 2, `${h.find} occurs once`);
+  assert.deepEqual(
+    hunks.map((h) => [h.oldStart, h.oldEnd, h.removed, h.added]),
+    [
+      [4, 4, 1, 1],
+      [10, 9, 0, 1],
+    ],
+  );
+  assert.equal(applyAll(old, hunks), next);
+  assert.equal(applyAll(old, [...hunks].reverse()), next, "hunks are independent of application order");
+  assert.equal(applyAll(old, [hunks[1]]), "# T\n\n- one\n- two\n- three\n\n## S\n\n- four\n- five\n");
+});
+
+test("a change inside a run of identical lines is widened until it is unique, never matched elsewhere", () => {
+  const old = "- a\n- a\n- a\n- a\n- b\n";
+  const next = "- a\n- a\n- a\n- b\n";
+  const hunks = anchoredHunks(old, next);
+  assert.equal(hunks.length, 1);
+  assert.equal(applyAll(old, hunks), next);
+  // Overlapping occurrences are counted: a find of three "- a" lines would match twice.
+  assert.ok(hunks[0].find.includes("- b"), "context reaches the distinct line");
+});
+
+test("changes at the head and the tail of a file, and whole-line deletions, splice cleanly", () => {
+  assert.equal(applyAll("x\ny\n", anchoredHunks("x\ny\n", "w\nx\ny\n")), "w\nx\ny\n");
+  assert.equal(applyAll("x\ny\n", anchoredHunks("x\ny\n", "x\ny\nz\n")), "x\ny\nz\n");
+  assert.equal(applyAll("x\ny\n", anchoredHunks("x\ny\n", "y\n")), "y\n");
+  assert.equal(applyAll("x\ny", anchoredHunks("x\ny", "x")), "x");
+  assert.equal(applyAll("x\ny\n", anchoredHunks("x\ny\n", "")), "");
+});
+
+test("an empty original becomes one whole-file insertion that only applies while the file is still empty", () => {
+  const hunks = anchoredHunks("", "# New\n");
+  assert.deepEqual(
+    hunks.map((h) => [h.find, h.replace, h.removed, h.added]),
+    [["", "# New\n", 0, 2]],
+  );
+  assert.equal(applyAll("", hunks), "# New\n");
+  assert.throws(() => applyAll("already here\n", hunks), /no longer empty/);
+});
+
+test("hunks whose context windows touch are merged so accepting one never moves another", () => {
+  // Two edits one line apart, where uniqueness needs the shared middle line as context.
+  const old = "- a\n- m\n- a\n- m\n- a\n";
+  const next = "- A\n- m\n- a\n- m\n- B\n";
+  const hunks = anchoredHunks(old, next);
+  assert.equal(applyAll(old, hunks), next);
+  const starts = hunks.map((h) => h.oldStart);
+  assert.deepEqual(
+    starts,
+    [...starts].sort((x, y) => x - y),
+  );
+  for (let i = 1; i < hunks.length; i += 1) {
+    assert.ok(hunks[i].oldStart > hunks[i - 1].oldEnd, "windows never overlap");
+  }
+});
+
+test("display lines carry context, removals, and additions in file order", () => {
+  const hunks = anchoredHunks("- one\n- two\n- two\n", "- one\n- two\n- three\n");
+  // The minimal unique window reaches one "- two" line of context, not further.
+  assert.equal(renderHunkLines(hunks[0].lines), ["  - two", "- - two", "+ - three"].join("\n"));
+  assert.equal(renderHunkLines(hunks[0].lines, { maxLines: 2 }), "  - two\n- - two\n  ... 1 more line(s)");
+});
+
+test("identical texts measure as no change", () => {
+  assert.deepEqual(anchoredHunks("same\n", "same\n"), []);
+});

--- a/test/helpers/staging.js
+++ b/test/helpers/staging.js
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { readMemoryFile } from "../../src/memory.js";
+import { State } from "../../src/state.js";
+import { measureWorkspace, prepareWorkspace } from "../../src/workspace.js";
+
+/**
+ * Test-side stand-in for the synthesis harness: stage the memory file exactly as
+ * `synthesizeProposal` does, change the staging copy with plain file writes (which is
+ * all a harness's own edit/write tools amount to), and measure the result. Tests then
+ * annotate the measured changes the way the model does.
+ */
+
+export function makeRepo(files = {}) {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-stage-")));
+  for (const [name, text] of Object.entries(files)) {
+    const absolute = path.join(dir, name);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, text);
+  }
+  return { root: dir, realRoot: dir, name: path.basename(dir), worktrees: [dir], remotes: [] };
+}
+
+/** Write a file inside a directory tree, creating parents; `fn` maps the current text. */
+export function writeIn(root, relative, textOrFn) {
+  const absolute = path.join(root, relative);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  const current = fs.existsSync(absolute) ? fs.readFileSync(absolute, "utf8") : "";
+  fs.writeFileSync(absolute, typeof textOrFn === "function" ? textOrFn(current) : textOrFn);
+}
+
+/**
+ * @param {{ repo: any, memoryPath?: string, skillsDir?: string, edit: (workspaceRoot: string) => void }} options
+ */
+export function stageAndMeasure({ repo, memoryPath = "AGENTS.md", skillsDir = ".agents/skills", edit }) {
+  const memoryFile = readMemoryFile(repo.root, memoryPath);
+  const state = new State(repo.root).ensure();
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir });
+  edit(workspace.root);
+  return { memoryFile, state, workspace, measured: measureWorkspace(workspace) };
+}

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -10,8 +10,8 @@ import { loadConfig } from "../src/config.js";
 import { setLoggerSink } from "../src/logger.js";
 import { isPointerTo, resolveMemoryFiles } from "../src/memory.js";
 import { buildProposal } from "../src/proposal.js";
-import { State } from "../src/state.js";
 import { renderPointer } from "../src/bootstrap.js";
+import { stageAndMeasure, writeIn } from "./helpers/staging.js";
 
 const AGENTS = "# Memory\n\n## Rules\n\n- Run the tests before pushing.\n- Never edit generated files.\n";
 const SEPARATE_CLAUDE = "# Claude notes\n\n- Prefer bun over npm.\n";
@@ -32,7 +32,7 @@ function captureWarnings(fn) {
   }
 }
 
-/** One evidence-backed edit against AGENTS.md, pushed through the real writer. */
+/** One evidence-backed edit against AGENTS.md, staged like synthesis and pushed through the real writer. */
 function applyOneEdit(repo, config) {
   const { file } = primaryMemoryFile(repo, config);
   const summary = {
@@ -41,24 +41,30 @@ function applyOneEdit(repo, config) {
     gaps: [],
     totals: { positive: 0, negative: 2, gapClusters: 0 },
   };
+  const { measured, state } = stageAndMeasure({
+    repo,
+    memoryPath: file.path,
+    skillsDir: config.skillsDir,
+    edit: (root) =>
+      writeIn(root, file.path, (t) =>
+        t.replace("- Run the tests before pushing.", "- Run the full test suite before pushing."),
+      ),
+  });
   const { proposal, violations } = buildProposal(
     {
       edits: [
         {
+          changes: ["H1"],
           kind: "rewrite",
-          file: file.path,
           title: "tighten",
-          find: "- Run the tests before pushing.",
-          replace: "- Run the full test suite before pushing.",
           evidence: [{ polarity: "negative", text: "skipped tests", source: "claude · s1 · turn 2" }],
           transcripts: 2,
         },
       ],
     },
-    { memoryFile: file, config, repo, summary },
+    { memoryFile: file, config, repo, summary, measured },
   );
   assert.deepEqual(violations, []);
-  const state = new State(repo.root).ensure();
   return applyDecisions({ proposal, decisions: { e1: "accepted" }, repo, state, config });
 }
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1,7 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import {
@@ -13,12 +12,12 @@ import {
   SHRINK_EDIT_TOKENS,
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
-import { parseMemoryUnits } from "../src/memory.js";
 import { estimateTokens } from "../src/tokens.js";
-import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
+import { isSuppressedByRejection, recordRejection } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
 import { injectPayload, parseDecisions } from "../src/apply/lavish.js";
 import { extractJson, parseTokenLine, stripAcpxNoise } from "../src/acpx.js";
+import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
 
 const MEMORY_TEXT = [
   "# Demo agent instructions",
@@ -26,41 +25,57 @@ const MEMORY_TEXT = [
   "## Rules",
   "",
   "- Whenever a PR is mentioned, include its URL.",
+  "- Prefer small commits.",
   "- Use Node 18 via nvm before running any script.",
   "",
 ].join("\n");
 
-function memoryFile(text = MEMORY_TEXT) {
-  return {
-    path: "AGENTS.md",
-    text,
-    hash: "sha256:test",
-    tokens: estimateTokens(text),
-    units: parseMemoryUnits(text),
-  };
-}
+const QUOTE = [{ polarity: "negative", text: "it used a bare #2731 reference", source: "claude · abc · turn 3" }];
 
-function context(overrides = {}) {
+function config(overrides = {}) {
   return {
-    memoryFile: memoryFile(),
-    repo: { name: "demo", root: "/repo/demo" },
-    summary: { analyzedSessions: 4, totals: { positive: 3, negative: 2, gapClusters: 1 } },
-    config: {
-      budgetTokens: 5000,
-      maxEditsPerRun: 5,
-      minGapEvidence: 2,
-      skillsDir: ".claude/skills",
-      analysis: { agent: "codex" },
-      synthesis: { agent: "claude" },
-    },
-    skillFiles: [],
+    budgetTokens: 5000,
+    maxEditsPerRun: 5,
+    minGapEvidence: 2,
+    skillsDir: ".agents/skills",
+    analysis: { agent: "codex" },
+    synthesis: { agent: "claude" },
     ...overrides,
   };
 }
 
-const QUOTE = [{ polarity: "negative", text: "it used a bare #2731 reference", source: "claude · abc · turn 3" }];
+/**
+ * Stage `text`, let `edit` change the staging copy, and run the gate over `annotation`
+ * (the model's answer to the annotate turn). Returns everything a test may inspect.
+ */
+function gate({ text = MEMORY_TEXT, files = {}, edit, annotation, config: cfg = config(), context = {} }) {
+  const repo = makeRepo({ "AGENTS.md": text, ...files });
+  const staged = stageAndMeasure({ repo, skillsDir: cfg.skillsDir, edit });
+  const summary = { analyzedSessions: 4, totals: { positive: 3, negative: 2, gapClusters: 1 } };
+  const result = buildProposal(annotation, {
+    memoryFile: staged.memoryFile,
+    config: cfg,
+    repo,
+    summary,
+    measured: staged.measured,
+    ...context,
+  });
+  return { ...result, ...staged, repo };
+}
 
-test("a rewrite edit replaces exactly the text it names", () => {
+const memoryEdit = (fn) => (root) => writeIn(root, "AGENTS.md", fn);
+const claim = (changes, extra = {}) => ({
+  changes,
+  kind: "rewrite",
+  title: "t",
+  evidence: QUOTE,
+  transcripts: 3,
+  ...extra,
+});
+
+// ---------- the mechanical applier ----------
+
+test("a legacy rewrite edit replaces exactly the text it names", () => {
   const next = applyEdit(MEMORY_TEXT, {
     id: "e1",
     file: "AGENTS.md",
@@ -71,7 +86,7 @@ test("a rewrite edit replaces exactly the text it names", () => {
   assert.ok(!next.includes("include its URL."));
 });
 
-test("an add edit inserts after its anchor, and appends when there is none", () => {
+test("a legacy add edit inserts after its anchor, and appends when there is none", () => {
   const anchored = applyEdit(MEMORY_TEXT, {
     id: "e1",
     file: "AGENTS.md",
@@ -86,16 +101,6 @@ test("an add edit inserts after its anchor, and appends when there is none", () 
 
   const appended = applyEdit(MEMORY_TEXT, { id: "e2", file: "AGENTS.md", find: "", replace: "- Appended rule." });
   assert.ok(appended.trimEnd().endsWith("- Appended rule."));
-});
-
-test("a remove edit deletes its text", () => {
-  const next = applyEdit(MEMORY_TEXT, {
-    id: "e1",
-    file: "AGENTS.md",
-    find: "- Use Node 18 via nvm before running any script.\n",
-    replace: "",
-  });
-  assert.ok(!next.includes("Node 18"));
 });
 
 test("an edit whose find text is missing or ambiguous is refused, never guessed at", () => {
@@ -115,227 +120,267 @@ test("an edit whose find text is missing or ambiguous is refused, never guessed 
       }),
     /appears 2 times/,
   );
+
+  // Overlapping occurrences count too: a run of identical lines is not unique.
+  assert.throws(
+    () => applyEdit("- a\n- a\n- a\n", { id: "e1", file: "AGENTS.md", find: "- a\n- a\n", replace: "" }),
+    /appears 2 times/,
+  );
 });
 
-test("the per-run edit cap is enforced - it is the learning rate", () => {
-  const edits = Array.from({ length: 6 }, (_, i) => ({
-    kind: "rewrite",
-    file: "AGENTS.md",
-    title: `edit ${i}`,
-    find: "- Use Node 18 via nvm before running any script.",
-    replace: `- Rule ${i}.`,
-    evidence: QUOTE,
-    transcripts: 3,
-  }));
+test("a measured edit applies each of its hunks, and refuses once the file has drifted", () => {
+  const { proposal, violations } = gate({
+    edit: memoryEdit((t) => t.replace("include its URL.", "include its full URL.").replace("Node 18", "Node 22")),
+    annotation: { edits: [claim(["H1", "H2"], { title: "both" })] },
+  });
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits[0].hunks.length, 2);
+  const applied = applyEdit(MEMORY_TEXT, proposal.edits[0]);
+  assert.ok(applied.includes("full URL") && applied.includes("Node 22"));
 
-  const { violations } = buildProposal({ edits }, context());
+  const drifted = MEMORY_TEXT.replace("Node 18", "Node 20");
+  assert.throws(() => applyEdit(drifted, proposal.edits[0]), /\(H2\): "find" text does not appear/);
+});
+
+// ---------- the skew that motivated native editing ----------
+
+test("an edit spanning several single-newline list items lands: find is measured from the raw file", () => {
+  // The report's failing shape: adjacent list items the instruction index shows with a
+  // blank line between them. The agent edits the raw copy; nothing is copied by hand.
+  const text = [
+    "# Memory",
+    "",
+    "## Sharp edges",
+    "",
+    "- Transcript formats drift; adapters are pinned by golden fixtures.",
+    "- The live progress view is an enhancement layer, never a dependency.",
+    "- Only src/apply/writer.js writes to the repo.",
+    "- Skills only count if a harness loads them.",
+    "",
+    "## Other",
+    "",
+    "- Keep this file short.",
+    "",
+  ].join("\n");
+  const { proposal, violations, measured, memoryFile, repo } = gate({
+    text,
+    edit: memoryEdit((t) =>
+      t
+        .replace(
+          "- Transcript formats drift; adapters are pinned by golden fixtures.\n- The live progress view is an enhancement layer, never a dependency.\n",
+          "",
+        )
+        .replace("- Keep this file short.", "- Keep this file short; point at files instead of copying them."),
+    ),
+    annotation: {
+      edits: [
+        { ...claim(["H1"]), kind: "remove", title: "drop two dead sharp edges" },
+        { ...claim(["H2"]), kind: "rewrite", title: "sharpen the brevity rule" },
+      ],
+    },
+  });
+
+  assert.deepEqual(violations, []);
+  assert.equal(measured.changes.length, 2);
+  for (const edit of proposal.edits) {
+    for (const hunk of edit.hunks) {
+      assert.equal(text.split(hunk.find).length, 2, `${hunk.id} find text occurs exactly once in the raw file`);
+      assert.ok(!hunk.find.includes("[AG-"), "no index headers leak into the find text");
+    }
+  }
+  const applied = applyEdit(memoryFile.text, proposal.edits[0]);
+  const both = applyEdit(applied, proposal.edits[1]);
+  assert.equal(both, fs.readFileSync(path.join(repo.root, ".backpass", "synthesis", "AGENTS.md"), "utf8"));
+  assert.ok(proposal.edits[0].deltaTokens < 0);
+});
+
+// ---------- evidence gates ----------
+
+test("the per-run edit cap is enforced - it is the learning rate", () => {
+  const lines = Array.from({ length: 6 }, (_, i) => `- Rule number ${i}.`);
+  const text = `# T\n\n${lines.join("\n")}\n`;
+  const { violations } = gate({
+    text,
+    edit: memoryEdit((t) => lines.reduce((acc, line, i) => acc.replace(line, `- Rule ${i} rewritten.`), t)),
+    annotation: { edits: Array.from({ length: 6 }, (_, i) => claim([`H${i + 1}`], { title: `edit ${i}` })) },
+  });
   assert.ok(violations.some((v) => /per-run cap is 5/.test(v)));
 });
 
-test("a new instruction backed by too few sessions is rejected", () => {
-  const { proposal, violations } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "add",
-          file: "AGENTS.md",
-          title: "new rule from one session",
-          find: "",
-          anchor: "## Rules",
-          replace: "- Speculative rule.",
-          evidence: QUOTE,
-          transcripts: 1,
-        },
-      ],
-    },
-    context(),
-  );
-
-  assert.equal(proposal.edits.length, 0);
-  assert.ok(violations.some((v) => /backed by 1 session/.test(v)));
+test("a new instruction backed by too few sessions is rejected, whatever kind the model declares", () => {
+  const insert = memoryEdit((t) => t.replace("## Rules\n\n", "## Rules\n\n- Speculative rule.\n"));
+  for (const kind of ["add", "rewrite"]) {
+    const { proposal, violations } = gate({
+      edit: insert,
+      annotation: { edits: [claim(["H1"], { kind, title: "new rule from one session", transcripts: 1 })] },
+    });
+    assert.equal(proposal.edits.length, 0, `${kind}: measured as an addition`);
+    assert.ok(violations.some((v) => /backed by 1 session/.test(v)));
+  }
 });
 
 test("an edit with no verbatim quote is rejected", () => {
-  const { proposal, violations } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "remove",
-          file: "AGENTS.md",
-          title: "unsupported",
-          find: "- Use Node 18 via nvm before running any script.\n",
-          replace: "",
-          evidence: [],
-        },
-      ],
-    },
-    context(),
-  );
-
+  const { proposal, violations } = gate({
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "unsupported", evidence: [] })] },
+  });
   assert.equal(proposal.edits.length, 0);
   assert.ok(violations.some((v) => /no verbatim evidence quote/.test(v)));
 });
 
-test("token deltas are measured by backpass, not taken from the model", () => {
-  const { proposal, violations } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "remove",
-          file: "AGENTS.md",
-          title: "drop the stale Node pin",
-          find: "- Use Node 18 via nvm before running any script.\n",
-          replace: "",
-          evidence: QUOTE,
-          transcripts: 3,
-          deltaTokens: 9999,
-        },
-      ],
-    },
-    context(),
+test("every measured change must be claimed by exactly one edit", () => {
+  const twoChanges = memoryEdit((t) =>
+    t.replace("include its URL.", "include its full URL.").replace("Node 18", "Node 22"),
   );
+
+  const unclaimed = gate({ edit: twoChanges, annotation: { edits: [claim(["H1"])] } });
+  assert.ok(unclaimed.violations.some((v) => /H2: AGENTS\.md line 7 \(-1\/\+1\) is not part of any edit/.test(v)));
+
+  const doubled = gate({ edit: twoChanges, annotation: { edits: [claim(["H1", "H2"]), claim(["H2"])] } });
+  assert.ok(doubled.violations.some((v) => /H2 is claimed by both edit e1 and edit e2/.test(v)));
+
+  const phantom = gate({ edit: twoChanges, annotation: { edits: [claim(["H1", "H2", "H9"])] } });
+  assert.ok(phantom.violations.some((v) => /H9, which is not a measured change/.test(v)));
+
+  const nothing = gate({ edit: () => {}, annotation: { edits: [] } });
+  assert.deepEqual(nothing.violations, []);
+  assert.equal(nothing.proposal.edits.length, 0);
+});
+
+test("token deltas and the projected budget are measured by backpass, not taken from the model", () => {
+  const { proposal, violations } = gate({
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin", deltaTokens: 9999 })] },
+  });
 
   assert.deepEqual(violations, []);
   assert.equal(proposal.edits.length, 1);
   assert.ok(proposal.edits[0].deltaTokens < 0, "a removal must reduce the always-loaded cost");
   assert.notEqual(proposal.edits[0].deltaTokens, 9999);
   assert.equal(proposal.budget.projected, proposal.budget.current + proposal.edits[0].deltaTokens);
+  assert.equal(
+    proposal.budget.projected,
+    estimateTokens(MEMORY_TEXT.replace("- Use Node 18 via nvm before running any script.\n", "")),
+  );
 });
 
 test("a proposal that would exceed the budget fails the gate", () => {
   const big = "x".repeat(4800); // ~1,200 tok, over a tiny cap
-  const { violations } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "add",
-          file: "AGENTS.md",
-          title: "bloat",
-          find: "",
-          anchor: "## Rules",
-          replace: big,
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-      ],
-    },
-    context({ config: { ...context().config, budgetTokens: 100 } }),
-  );
-
+  const { violations } = gate({
+    edit: memoryEdit((t) => t.replace("## Rules\n\n", `## Rules\n\n${big}\n`)),
+    annotation: { edits: [claim(["H1"], { kind: "add", title: "bloat" })] },
+    config: config({ budgetTokens: 100 }),
+  });
   assert.ok(violations.some((v) => /over the 100-token budget/.test(v)));
 });
 
-test("an extract edit requires a skill draft, and a non-extract must not carry one", () => {
-  const skill = { name: "release-signing", description: "Load before tagging a release.", body: "steps" };
+test("an extract is one created SKILL.md grouped with the memory change that pays for it", () => {
+  const skillText =
+    "---\nname: release-signing\ndescription: Load before tagging a release.\n---\n\n## Steps\n\n1. sign\n";
+  const extractEdit = (root) => {
+    writeIn(root, "AGENTS.md", (t) =>
+      t.replace("- Use Node 18 via nvm before running any script.", "- See the release-signing skill."),
+    );
+    writeIn(root, ".agents/skills/release-signing/SKILL.md", skillText);
+  };
 
-  const missing = buildProposal(
-    {
-      edits: [
-        {
-          kind: "extract",
-          file: "AGENTS.md",
-          title: "x",
-          find: "- Use Node 18 via nvm before running any script.",
-          replace: "see skill",
-          evidence: QUOTE,
-          transcripts: 2,
-        },
-      ],
-    },
-    context(),
-  );
-  assert.ok(missing.violations.some((v) => /requires a skill draft/.test(v)));
-
-  const stray = buildProposal(
-    {
-      edits: [
-        {
-          kind: "rewrite",
-          file: "AGENTS.md",
-          title: "x",
-          find: "- Use Node 18 via nvm before running any script.",
-          replace: "y",
-          evidence: QUOTE,
-          transcripts: 2,
-          skill,
-        },
-      ],
-    },
-    context(),
-  );
-  assert.ok(stray.violations.some((v) => /only kind "extract"/.test(v)));
-
-  const good = buildProposal(
-    {
-      edits: [
-        {
-          kind: "extract",
-          file: "AGENTS.md",
-          title: "x",
-          find: "- Use Node 18 via nvm before running any script.",
-          replace: "- See the release-signing skill.",
-          evidence: QUOTE,
-          transcripts: 2,
-          skill,
-        },
-      ],
-    },
-    context(),
-  );
+  const good = gate({
+    edit: extractEdit,
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "x" })] },
+  });
   assert.deepEqual(good.violations, []);
-  assert.equal(good.proposal.edits[0].skill.path, ".claude/skills/release-signing/SKILL.md");
+  assert.equal(good.proposal.edits[0].skill.path, ".agents/skills/release-signing/SKILL.md");
+  assert.equal(good.proposal.edits[0].skill.name, "release-signing");
+  assert.equal(good.proposal.edits[0].skill.body, "## Steps\n\n1. sign");
   assert.equal(good.proposal.stats.skillExtractions, 1);
+
+  const split = gate({
+    edit: extractEdit,
+    annotation: { edits: [claim(["H1"], { kind: "extract", title: "x" }), claim(["H2"], { kind: "add", title: "y" })] },
+  });
+  assert.ok(split.violations.some((v) => /kind "extract" must group exactly one created SKILL\.md/.test(v)));
+  assert.ok(split.violations.some((v) => /only kind "extract" may include a created file \(H2\)/.test(v)));
+
+  const headless = gate({
+    edit: (root) => {
+      extractEdit(root);
+      writeIn(root, ".agents/skills/release-signing/SKILL.md", "no frontmatter here\n");
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "x" })] },
+  });
+  assert.ok(headless.violations.some((v) => /needs YAML frontmatter/.test(v)));
+});
+
+test("a skill's description can be rewritten in place; deletions and stray files are refused or ignored", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const rewritten = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) =>
+      writeIn(root, ".agents/skills/db/SKILL.md", (t) =>
+        t.replace("old trigger", "Load before touching the database."),
+      ),
+    annotation: { edits: [claim(["H1"], { title: "fix the trigger" })] },
+  });
+  assert.deepEqual(rewritten.violations, []);
+  assert.equal(rewritten.proposal.edits[0].file, ".agents/skills/db/SKILL.md");
+  assert.equal(rewritten.proposal.edits[0].targetsMemoryFile, false);
+  assert.equal(rewritten.proposal.budget.delta, 0, "skill files are not always-loaded");
+
+  const deleted = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) => fs.rmSync(path.join(root, ".agents/skills/db"), { recursive: true }),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the skill" })] },
+  });
+  assert.ok(
+    deleted.violations.some((v) =>
+      /H1: deletes \.agents\/skills\/db\/SKILL\.md; backpass cannot propose deletions/.test(v),
+    ),
+  );
+
+  const stray = gate({
+    edit: (root) => {
+      writeIn(root, "notes.md", "scratch");
+      writeIn(root, "AGENTS.md", (t) => t.replace("Node 18", "Node 22"));
+    },
+    annotation: { edits: [claim(["H1"])] },
+  });
+  assert.deepEqual(stray.violations, []);
+  assert.ok(stray.proposal.notes.some((n) => /ignored notes\.md/.test(n)));
 });
 
 test("a previously rejected edit is suppressed until new evidence arrives", () => {
-  const edit = {
-    kind: "remove",
-    file: "AGENTS.md",
-    title: "drop the stale Node pin",
-    find: "- Use Node 18 via nvm before running any script.\n",
-    replace: "",
-    evidence: QUOTE,
-    transcripts: 3,
-  };
+  const edit = memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", ""));
+  const first = gate({
+    edit,
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] },
+  });
+  const rejections = recordRejection(first.proposal.edits[0], { version: 1, entries: {} });
 
-  const rejections = recordRejection({ ...edit, id: "e1" }, { version: 1, entries: {} });
-
-  const suppressed = buildProposal({ edits: [edit] }, context({ rejections, isSuppressed: isSuppressedByRejection }));
+  const suppressed = gate({
+    edit,
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] },
+    context: { rejections, isSuppressed: isSuppressedByRejection },
+  });
   assert.equal(suppressed.proposal.edits.length, 0, "same evidence weight stays rejected");
+  assert.deepEqual(suppressed.violations, [], "a suppressed edit is dropped, not a violation");
 
-  const revived = buildProposal(
-    { edits: [{ ...edit, transcripts: 9 }] },
-    context({ rejections, isSuppressed: isSuppressedByRejection }),
-  );
+  const revived = gate({
+    edit,
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin", transcripts: 9 })] },
+    context: { rejections, isSuppressed: isSuppressedByRejection },
+  });
   assert.equal(revived.proposal.edits.length, 1, "materially new evidence revives the edit");
 });
 
 test("projectWithDecisions tracks the budget for the subset the human accepted", () => {
-  const { proposal } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "remove",
-          file: "AGENTS.md",
-          title: "a",
-          find: "- Use Node 18 via nvm before running any script.\n",
-          replace: "",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-        {
-          kind: "rewrite",
-          file: "AGENTS.md",
-          title: "b",
-          find: "- Whenever a PR is mentioned, include its URL.",
-          replace: "- Whenever a PR is mentioned, include its full https:// URL before any shorthand.",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-      ],
-    },
-    context(),
-  );
+  const { proposal } = gate({
+    edit: memoryEdit((t) =>
+      t
+        .replace("- Use Node 18 via nvm before running any script.\n", "")
+        .replace("include its URL.", "include its full https:// URL before any shorthand."),
+    ),
+    annotation: { edits: [claim(["H2"], { kind: "remove", title: "a" }), claim(["H1"], { title: "b" })] },
+  });
 
   const none = projectWithDecisions(MEMORY_TEXT, proposal.edits, [], 5000);
   assert.equal(none.budget.delta, 0);
@@ -349,46 +394,34 @@ test("projectWithDecisions tracks the budget for the subset the human accepted",
   assert.ok(onlyFirst.text.includes("include its URL."), "the unaccepted edit is not applied");
 });
 
-test("applying decisions writes accepted edits, skips rejected ones, and remembers rejections", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-apply-"));
-  fs.writeFileSync(path.join(dir, "AGENTS.md"), MEMORY_TEXT);
-  const state = new State(dir).ensure();
+// ---------- the human gate ----------
 
-  const { proposal } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "remove",
-          file: "AGENTS.md",
-          title: "drop node pin",
-          find: "- Use Node 18 via nvm before running any script.\n",
-          replace: "",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-        {
-          kind: "rewrite",
-          file: "AGENTS.md",
-          title: "pr url",
-          find: "- Whenever a PR is mentioned, include its URL.",
-          replace: "- Always include the full PR URL.",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-      ],
+test("applying decisions writes accepted edits, skips rejected ones, and remembers rejections", () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) =>
+      t
+        .replace("- Use Node 18 via nvm before running any script.\n", "")
+        .replace("- Whenever a PR is mentioned, include its URL.", "- Always include the full PR URL."),
+    ),
+    annotation: {
+      edits: [claim(["H2"], { kind: "remove", title: "drop node pin" }), claim(["H1"], { title: "pr url" })],
     },
-    context({ repo: { name: "demo", root: dir } }),
+  });
+  assert.equal(
+    fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"),
+    MEMORY_TEXT,
+    "synthesis never writes the repo",
   );
 
   const results = applyDecisions({
     proposal,
     decisions: { e1: "accepted", e2: "rejected" },
-    repo: { root: dir },
+    repo,
     state,
     config: { budgetTokens: 5000 },
   });
 
-  const written = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8");
+  const written = fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8");
   assert.ok(!written.includes("Node 18"), "the accepted removal is applied");
   assert.ok(written.includes("include its URL."), "the rejected rewrite is not applied");
   assert.equal(results.accepted, 1);
@@ -400,39 +433,52 @@ test("applying decisions writes accepted edits, skips rejected ones, and remembe
   assert.equal(Object.keys(remembered.entries).length, 1);
 });
 
-test("a dry run reports what it would write without touching the file", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-dry-"));
-  fs.writeFileSync(path.join(dir, "AGENTS.md"), MEMORY_TEXT);
-  const state = new State(dir).ensure();
-
-  const { proposal } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "remove",
-          file: "AGENTS.md",
-          title: "drop node pin",
-          find: "- Use Node 18 via nvm before running any script.\n",
-          replace: "",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-      ],
+test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {
+  const skillText =
+    "---\nname: release-signing\ndescription: Load before tagging a release.\n---\n\n## Steps\n\n1. sign\n";
+  const { proposal, repo, state } = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) =>
+        t.replace("- Use Node 18 via nvm before running any script.", "- See the release-signing skill."),
+      );
+      writeIn(root, ".agents/skills/release-signing/SKILL.md", skillText);
     },
-    context({ repo: { name: "demo", root: dir } }),
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "x" })] },
+  });
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.equal(results.failed.length, 0);
+  const written = fs.readFileSync(path.join(repo.root, ".agents/skills/release-signing/SKILL.md"), "utf8");
+  assert.match(
+    written,
+    /^---\nname: release-signing\ndescription: Load before tagging a release\.\nuser-invocable: false/,
   );
+  assert.ok(written.endsWith("## Steps\n\n1. sign\n"));
+  assert.ok(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8").includes("See the release-signing skill."));
+});
+
+test("a dry run reports what it would write without touching the file", () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
+  });
 
   const results = applyDecisions({
     proposal,
     decisions: { e1: "accepted" },
-    repo: { root: dir },
+    repo,
     state,
     config: { budgetTokens: 5000 },
     dryRun: true,
   });
 
   assert.equal(results.written.length, 1);
-  assert.equal(fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8"), MEMORY_TEXT, "dry run must not write");
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT, "dry run must not write");
 });
 
 test("the apply surface receives one payload, with markup in the data neutralised", () => {
@@ -474,27 +520,16 @@ test("JSON is recovered from a fenced or prose-wrapped model reply", () => {
   assert.equal(extractJson("no json at all"), null);
 });
 
-test('an over-budget file switches the gate from "fit the cap" to "make progress"', () => {
-  // 30,000 bytes ~= 7,500 tok against a 5,000 cap: unreachable in one capped run.
-  const overBudget = `${MEMORY_TEXT}\n${"padding text. ".repeat(2000)}`;
-  const ctx = context({ memoryFile: memoryFile(overBudget) });
+// ---------- the budget gate's two modes ----------
 
-  const shrinking = buildProposal(
-    {
-      edits: [
-        {
-          kind: "remove",
-          file: "AGENTS.md",
-          title: "drop the stale Node pin",
-          find: "- Use Node 18 via nvm before running any script.\n",
-          replace: "",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-      ],
-    },
-    ctx,
-  );
+const OVER_BUDGET = `${MEMORY_TEXT}\n${"padding text. ".repeat(2000)}`; // ~7,500 tok against a 5,000 cap
+
+test('an over-budget file switches the gate from "fit the cap" to "make progress"', () => {
+  const shrinking = gate({
+    text: OVER_BUDGET,
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] },
+  });
 
   assert.deepEqual(shrinking.violations, [], "a net-negative step passes even though the cap is not reached");
   assert.equal(shrinking.proposal.budget.mode, "shrink");
@@ -504,109 +539,70 @@ test('an over-budget file switches the gate from "fit the cap" to "make progress
 });
 
 test("an over-budget file still refuses an edit set that grows it", () => {
-  const overBudget = `${MEMORY_TEXT}\n${"padding text. ".repeat(2000)}`;
-  const ctx = context({ memoryFile: memoryFile(overBudget) });
-
-  const { violations } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "add",
-          file: "AGENTS.md",
-          title: "more rules on an already bloated file",
-          find: "",
-          anchor: "## Rules",
-          replace: "- Yet another rule.",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-      ],
-    },
-    ctx,
-  );
-
-  assert.ok(violations.some((v) => /must shrink it/.test(v)));
+  const { violations } = gate({
+    text: OVER_BUDGET,
+    edit: memoryEdit((t) => t.replace("## Rules\n\n", "## Rules\n\n- Yet another rule.\n")),
+    annotation: { edits: [claim(["H1"], { kind: "add", title: "more rules on an already bloated file" })] },
+  });
+  assert.ok(violations.some((v) => /must shrink it, but the proposed edits change it by \+/.test(v)));
 });
 
-test("a file within budget keeps the strict cap gate", () => {
-  const { proposal } = buildProposal(
-    {
-      edits: [
-        {
-          kind: "remove",
-          file: "AGENTS.md",
-          title: "x",
-          find: "- Use Node 18 via nvm before running any script.\n",
-          replace: "",
-          evidence: QUOTE,
-          transcripts: 3,
-        },
-      ],
-    },
-    context(),
-  );
+test("a file within budget keeps the fit-the-cap gate", () => {
+  const { proposal, violations } = gate({
+    edit: memoryEdit((t) => t.replace("## Rules\n\n", "## Rules\n\n- A small new rule.\n")),
+    annotation: { edits: [claim(["H1"], { kind: "add", title: "small" })] },
+  });
+  assert.deepEqual(violations, []);
   assert.equal(proposal.budget.mode, "cap");
   assert.equal(proposal.budget.startedOverBudget, false);
 });
 
-function rawEdits(count) {
-  return Array.from({ length: count }, (_, i) => ({
-    kind: "remove",
-    title: `remove rule ${i + 1}`,
-    find: `- rule ${i + 1}`,
-    replace: "",
-    rationale: "no positive evidence",
-    evidence: QUOTE,
-    transcripts: 3,
-  }));
-}
-
-function overBudgetFile(overage, budgetTokens = 200) {
-  const rules = [];
-  let text = "";
-  let i = 0;
-  while (estimateTokens(text) < budgetTokens + overage) {
-    i += 1;
-    rules.push(`- rule ${i} keeps the file long enough to sit over the budget line`);
-    text = `# Long memory\n\n${rules.join("\n")}\n`;
-  }
-  return memoryFile(text);
-}
-
-test("cap mode keeps the gentle default edit cap", () => {
-  const ctx = context({ config: { ...context().config, maxEditsPerRun: null } });
-  assert.equal(effectiveMaxEdits(ctx.memoryFile, ctx.config), DEFAULT_MAX_EDITS);
-});
-
-test("shrink mode scales the edit cap to the overage, up to the ceiling", () => {
-  const config = { ...context().config, budgetTokens: 200, maxEditsPerRun: null };
-  const modest = overBudgetFile(400, 200);
-  const modestCap = effectiveMaxEdits(modest, config);
-  assert.ok(modestCap > DEFAULT_MAX_EDITS, `a 400-token overage should allow more than ${DEFAULT_MAX_EDITS} edits`);
-  assert.ok(modestCap < SHRINK_MAX_EDITS, "a modest overage should not hit the ceiling");
-  assert.equal(modestCap, Math.ceil((modest.tokens - 200) / SHRINK_EDIT_TOKENS));
-
-  const large = overBudgetFile(5000, 200);
-  assert.equal(effectiveMaxEdits(large, config), SHRINK_MAX_EDITS);
-});
-
-test("an explicit maxEditsPerRun wins over the adaptive cap in both modes", () => {
-  const config = { ...context().config, budgetTokens: 200, maxEditsPerRun: 3 };
-  assert.equal(effectiveMaxEdits(overBudgetFile(5000, 200), config), 3);
-  assert.equal(effectiveMaxEdits(memoryFile(), config), 3);
+test("the edit cap scales with the overage in shrink mode and stays at the default otherwise", () => {
+  const base = { budgetTokens: 5000, maxEditsPerRun: null };
+  const tokens = (t) => ({ tokens: t });
+  assert.equal(effectiveMaxEdits(tokens(4000), base), DEFAULT_MAX_EDITS);
+  assert.equal(effectiveMaxEdits(tokens(5000), base), DEFAULT_MAX_EDITS);
+  assert.equal(
+    effectiveMaxEdits(tokens(5000 + SHRINK_EDIT_TOKENS * 2), base),
+    DEFAULT_MAX_EDITS,
+    "tiny overage keeps the floor",
+  );
+  assert.equal(effectiveMaxEdits(tokens(5000 + SHRINK_EDIT_TOKENS * 12), base), 12);
+  assert.equal(effectiveMaxEdits(tokens(5000 + SHRINK_EDIT_TOKENS * 12 - 1), base), 12, "partial steps round up");
+  assert.equal(effectiveMaxEdits(tokens(19259), base), SHRINK_MAX_EDITS, "a 4x-over file hits the ceiling");
+  assert.equal(effectiveMaxEdits(tokens(19259), { ...base, maxEditsPerRun: 3 }), 3, "an explicit cap always wins");
 });
 
 test("the cap-exceeded violation fires above the effective adaptive cap, not the flat default", () => {
-  const file = overBudgetFile(400, 200);
-  const config = { ...context().config, budgetTokens: 200, maxEditsPerRun: null };
-  const cap = effectiveMaxEdits(file, config);
+  const cfg = config({ budgetTokens: 200, maxEditsPerRun: null });
+  const rules = [];
+  let text = "";
+  while (estimateTokens(text) < 200 + 400) {
+    rules.push(`- rule ${rules.length + 1} keeps the file long enough to sit over the budget line`);
+    text = `# Long memory\n\n${rules.join("\n")}\n`;
+  }
+  const cap = effectiveMaxEdits({ tokens: estimateTokens(text) }, cfg);
   assert.ok(cap > DEFAULT_MAX_EDITS);
 
-  const within = buildProposal({ edits: rawEdits(cap) }, context({ memoryFile: file, config }));
+  // Every other rule goes, so each removal is its own measured change.
+  const removeEveryOther = (count) =>
+    memoryEdit((t) => {
+      let out = t;
+      for (let i = 0; i < count; i += 1) out = out.replace(`${rules[i * 2]}\n`, "");
+      return out;
+    });
+  const annotate = (count) => ({
+    edits: Array.from({ length: count }, (_, i) =>
+      claim([`H${i + 1}`], { kind: "remove", title: `remove rule ${i * 2 + 1}` }),
+    ),
+  });
+
+  const within = gate({ text, edit: removeEveryOther(cap), annotation: annotate(cap), config: cfg });
+  assert.equal(within.measured.changes.length, cap);
   assert.ok(!within.violations.some((v) => v.includes("per-run cap")), within.violations.join("\n"));
   assert.equal(within.proposal.config.maxEditsPerRun, cap, "the proposal records the effective cap");
 
-  const above = buildProposal({ edits: rawEdits(cap + 1) }, context({ memoryFile: file, config }));
+  const above = gate({ text, edit: removeEveryOther(cap + 1), annotation: annotate(cap + 1), config: cfg });
   assert.ok(
     above.violations.some((v) => v.includes(`per-run cap is ${cap}`)),
     above.violations.join("\n"),

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -1,0 +1,352 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * End-to-end synthesis against a stand-in acpx that behaves like a harness with native
+ * file tools: on the editing turn it changes `<cwd>/AGENTS.md` (and only when writes
+ * are approved), on each annotate turn it answers with scripted JSON - optionally
+ * editing again first, as a real agent may. Every invocation is logged so the tests can
+ * assert the session lifecycle and the permission flags backpass passed.
+ */
+const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fake-synth-"));
+const fakeAcpx = path.join(fakeDir, "acpx");
+fs.writeFileSync(
+  fakeAcpx,
+  `#!${process.execPath}
+const fs = require("node:fs");
+const path = require("node:path");
+const argv = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify({ argv, cwd: process.cwd() }) + "\\n");
+const script = JSON.parse(fs.readFileSync(process.env.FAKE_ACPX_SCRIPT, "utf8"));
+const cwdAt = argv.indexOf("--cwd");
+const cwd = cwdAt >= 0 ? argv[cwdAt + 1] : process.cwd();
+if (argv.includes("sessions")) {
+  if (argv.includes("new")) process.stdout.write("fake-session-id\\n");
+  process.exit(0);
+}
+if (argv.includes("set")) process.exit(0);
+const fileAt = argv.indexOf("--file");
+if (fileAt < 0) process.exit(2);
+const prompt = fs.readFileSync(argv[fileAt + 1], "utf8");
+const statePath = process.env.FAKE_ACPX_STATE;
+const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : { annotate: 0 };
+function applyEdits(edits) {
+  for (const [file, change] of Object.entries(edits || {})) {
+    const target = path.isAbsolute(file) ? file : path.join(cwd, file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    if (typeof change === "string") { fs.writeFileSync(target, change); continue; }
+    if (change === null) { fs.rmSync(target, { recursive: true, force: true }); continue; }
+    let text = fs.readFileSync(target, "utf8");
+    for (const [from, to] of change.replace) {
+      if (!text.includes(from)) throw new Error("fake harness: cannot find " + JSON.stringify(from));
+      text = text.replace(from, to);
+    }
+    fs.writeFileSync(target, text);
+  }
+}
+if (!prompt.includes("## Measured changes")) {
+  if (!argv.includes("--approve-all")) {
+    process.stdout.write("I could not edit the file: write permission was denied.\\n");
+    process.exit(0);
+  }
+  applyEdits(script.edit);
+  process.stdout.write("Edited the staging copy.\\n");
+  process.stderr.write("[acpx] tokens: input=1000 output=20 total=1020\\n");
+} else {
+  const step = script.annotations[Math.min(state.annotate, script.annotations.length - 1)];
+  state.annotate += 1;
+  if (step.editFirst) applyEdits(step.editFirst);
+  process.stdout.write(typeof step.reply === "string" ? step.reply : JSON.stringify(step.reply) + "\\n");
+  process.stderr.write("[acpx] tokens: input=500 output=30 total=530\\n");
+}
+fs.writeFileSync(statePath, JSON.stringify(state));
+`,
+);
+fs.chmodSync(fakeAcpx, 0o755);
+process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+
+const { synthesizeProposal, ANNOTATE_TURNS } = await import("../src/synthesize.js");
+const { applyDecisions } = await import("../src/apply/writer.js");
+const { loadConfig } = await import("../src/config.js");
+const { readMemoryFile } = await import("../src/memory.js");
+const { ProposalViolation } = await import("../src/proposal.js");
+const { State } = await import("../src/state.js");
+const { UserError, setLoggerSink } = await import("../src/logger.js");
+const { makeRepo } = await import("./helpers/staging.js");
+
+setLoggerSink(() => {});
+
+const AGENTS = [
+  "# Memory",
+  "",
+  "## Sharp edges",
+  "",
+  "- Transcript formats drift; adapters are pinned by golden fixtures.",
+  "- The live progress view is an enhancement layer, never a dependency.",
+  "- Only src/apply/writer.js writes to the repo.",
+  "- Skills only count if a harness loads them.",
+  "",
+  "## Style",
+  "",
+  "- Keep this file short.",
+  "",
+].join("\n");
+
+const TWO_ITEMS =
+  "- Transcript formats drift; adapters are pinned by golden fixtures.\n- The live progress view is an enhancement layer, never a dependency.\n";
+const QUOTE = {
+  polarity: "negative",
+  text: "the agent re-read the adapter fixture instead",
+  source: "claude · s1 · turn 4",
+};
+const removal = (changes) => ({
+  changes,
+  kind: "remove",
+  title: "drop two sharp edges nobody hits",
+  evidence: [QUOTE],
+  transcripts: 3,
+});
+const tighten = (changes) => ({
+  changes,
+  kind: "rewrite",
+  title: "sharpen the brevity rule",
+  evidence: [QUOTE],
+  transcripts: 2,
+});
+
+function summaryFor(sessions = 3) {
+  return {
+    analyzedSessions: sessions,
+    instructions: [],
+    gaps: [],
+    totals: { positive: 1, negative: 2, gapClusters: 0, droppedGapSingletons: 0 },
+  };
+}
+
+/** A pinned synthesis candidate; the ladder walk is covered in agents.test.js. */
+const pick = { agent: "claude", model: "claude-opus-5", effort: "high", pinned: true };
+const agents = { resolve: async () => pick, withFallthrough: async (_role, fn) => fn(pick) };
+
+function setup(script, { text = AGENTS, overrides = {} } = {}) {
+  const repo = makeRepo({ "AGENTS.md": text });
+  const config = loadConfig(repo.root, overrides);
+  config.state = new State(repo.root).ensure();
+  config.agents = agents;
+  const log = path.join(fakeDir, `log-${Date.now()}-${Math.random().toString(16).slice(2)}.jsonl`);
+  fs.writeFileSync(log, "");
+  process.env.FAKE_ACPX_LOG = log;
+  process.env.FAKE_ACPX_SCRIPT = path.join(repo.root, "fake-script.json");
+  process.env.FAKE_ACPX_STATE = path.join(repo.root, "fake-state.json");
+  fs.writeFileSync(process.env.FAKE_ACPX_SCRIPT, JSON.stringify(script));
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const run = () =>
+    synthesizeProposal({ memoryFile, summary: summaryFor(), config, repo, transcripts: [{ harness: "claude" }] });
+  const calls = () =>
+    fs
+      .readFileSync(log, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  return { repo, config, memoryFile, run, calls };
+}
+
+test("synthesis edits the staging copy natively; measured hunks anchor to the raw file and nothing touches the repo until apply", async () => {
+  const { repo, config, run, calls } = setup({
+    edit: {
+      "AGENTS.md": {
+        replace: [
+          [TWO_ITEMS, ""],
+          ["- Keep this file short.", "- Keep this file short; point at files instead of copying them."],
+        ],
+      },
+    },
+    annotations: [{ reply: { edits: [removal(["H1"]), tighten(["H2"])], verdicts: [], notes: ["one note"] } }],
+  });
+
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits.length, 2);
+  assert.deepEqual(
+    proposal.edits.map((e) => [e.id, e.kind, e.hunks.map((h) => h.id)]),
+    [
+      ["e1", "remove", ["H1"]],
+      ["e2", "rewrite", ["H2"]],
+    ],
+  );
+  for (const edit of proposal.edits) {
+    for (const hunk of edit.hunks) {
+      assert.equal(AGENTS.split(hunk.find).length, 2, `${hunk.id}: find occurs exactly once in the raw file`);
+    }
+  }
+  assert.ok(proposal.edits[0].deltaTokens < 0);
+  assert.ok(proposal.budget.delta < 0);
+  assert.deepEqual(proposal.notes, ["one note"]);
+  assert.equal(proposal.usage.length, 2, "one usage record per turn");
+
+  // The repo is untouched: the staging copy under .backpass/ is where the agent wrote.
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), AGENTS);
+  const staged = fs.readFileSync(path.join(repo.root, ".backpass", "synthesis", "AGENTS.md"), "utf8");
+  assert.ok(!staged.includes("Transcript formats drift"));
+
+  // Session lifecycle: new -> set model -> set effort -> edit turn -> annotate turn -> close,
+  // every turn in the staging workspace with writes approved, never --deny-all.
+  const invocations = calls();
+  const workspace = path.join(repo.root, ".backpass", "synthesis");
+  assert.deepEqual(
+    invocations.map((c) =>
+      c.argv
+        .filter((a) =>
+          [
+            "sessions",
+            "new",
+            "close",
+            "set",
+            "model",
+            "effort",
+            "--file",
+            "--approve-all",
+            "--deny-all",
+            "--approve-reads",
+          ].includes(a),
+        )
+        .join(" "),
+    ),
+    ["sessions new", "set model", "set effort", "--approve-all --file", "--approve-all --file", "sessions close"],
+  );
+  for (const turn of invocations.filter((c) => c.argv.includes("--file"))) {
+    assert.equal(turn.argv[turn.argv.indexOf("--cwd") + 1], workspace);
+    assert.equal(turn.cwd, workspace);
+  }
+  const editPrompt = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-edit.md"), "utf8");
+  assert.match(editPrompt, /^<!-- backpass:self-session -->/);
+  assert.ok(editPrompt.includes(`The repository itself is at \`${repo.root}\``));
+  assert.ok(editPrompt.includes("[AG-001] ("), "the index stays as the lookup table");
+  const annotatePrompt = fs.readFileSync(
+    path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-1.md"),
+    "utf8",
+  );
+  assert.match(annotatePrompt, /^<!-- backpass:self-session -->/);
+  assert.ok(annotatePrompt.includes("[H1: AGENTS.md lines 5-6 (-2/+0) · AG-001, AG-002]"));
+  assert.ok(annotatePrompt.includes("- - The live progress view is an enhancement layer, never a dependency."));
+  assert.ok(annotatePrompt.includes("[H2: AGENTS.md line 12 (-1/+1) · AG-005]"));
+
+  // The human gate is unchanged: accept one, reject one, the writer applies the raw-file hunks.
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted", e2: "rejected" },
+    repo,
+    state: config.state,
+    config,
+  });
+  assert.equal(results.failed.length, 0);
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), AGENTS.replace(TWO_ITEMS, ""));
+});
+
+test("a violated annotation is re-prompted with the exact breach, and the corrected answer passes", async () => {
+  const { repo, run } = setup({
+    edit: {
+      "AGENTS.md": {
+        replace: [
+          [TWO_ITEMS, ""],
+          ["- Keep this file short.", "- Keep it short."],
+        ],
+      },
+    },
+    annotations: [{ reply: { edits: [removal(["H1"])] } }, { reply: { edits: [removal(["H1"]), tighten(["H2"])] } }],
+  });
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits.length, 2);
+  const second = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-2.md"), "utf8");
+  assert.ok(second.includes("## Your previous answer was rejected"));
+  assert.ok(second.includes("- H2: AGENTS.md line 12 (-1/+1) is not part of any edit"));
+});
+
+test("an agent that keeps editing during an annotate turn is shown the re-measured changes", async () => {
+  const { repo, run } = setup({
+    edit: { "AGENTS.md": { replace: [[TWO_ITEMS, ""]] } },
+    annotations: [
+      {
+        editFirst: { "AGENTS.md": { replace: [["- Keep this file short.", "- Keep it short."]] } },
+        reply: { edits: [removal(["H1"])] },
+      },
+      { reply: { edits: [removal(["H1"]), tighten(["H2"])] } },
+    ],
+  });
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits.length, 2);
+  const second = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-2.md"), "utf8");
+  assert.ok(second.includes("the files changed after the changes were measured"));
+  assert.ok(second.includes("[H2: AGENTS.md line 12 (-1/+1)"));
+});
+
+test("the budget gate is measured on the staged file: growth on an over-budget file is refused until the agent trims", async () => {
+  const padded = `${AGENTS}\n${"padding text that keeps the file over budget. ".repeat(120)}\n`;
+  const { run } = setup(
+    {
+      edit: {
+        "AGENTS.md": { replace: [["## Style\n\n", "## Style\n\n- A brand new rule with three sessions behind it.\n"]] },
+      },
+      annotations: [
+        // Attempt 1: the addition alone grows an over-budget file - refused.
+        { reply: { edits: [{ ...tighten(["H1"]), kind: "add", transcripts: 3 }] } },
+        // Attempt 2: the agent trims first; its answer is stale and discarded.
+        { editFirst: { "AGENTS.md": { replace: [[TWO_ITEMS, ""]] } }, reply: { edits: [] } },
+        // Attempt 3: annotates the re-measured changes - the removal pays for the addition.
+        { reply: { edits: [removal(["H1"]), { ...tighten(["H2"]), kind: "add", transcripts: 3 }] } },
+      ],
+    },
+    { text: padded, overrides: { budgetTokens: 200 } },
+  );
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.budget.mode, "shrink");
+  assert.ok(proposal.budget.delta < 0, "the accepted set is net-negative");
+  assert.ok(proposal.usage.length >= 3, "the re-prompt turn is accounted");
+});
+
+test("when every re-prompt fails the gates, synthesis fails loudly and keeps the rejected proposal", async () => {
+  const { config, run } = setup({
+    edit: { "AGENTS.md": { replace: [[TWO_ITEMS, ""]] } },
+    annotations: [{ reply: { edits: [{ ...removal(["H1"]), evidence: [] }] } }],
+  });
+  await assert.rejects(run(), (err) => {
+    assert.ok(err instanceof ProposalViolation);
+    assert.match(err.message, new RegExp(`after ${ANNOTATE_TURNS - 1} re-prompt`));
+    assert.ok(err.violations.some((v) => /carries no verbatim evidence quote/.test(v)));
+    return true;
+  });
+  const saved = config.state.readProposal();
+  assert.ok(saved.violations.length, "the rejected proposal is inspectable");
+  assert.equal(saved.edits.length, 0);
+});
+
+test("a harness that writes to the repository instead of the staging copy is refused, loudly", async () => {
+  const { repo, run } = setup({ edit: {} });
+  // The fake writes by absolute path when told to - the misbehaving case.
+  fs.writeFileSync(
+    process.env.FAKE_ACPX_SCRIPT,
+    JSON.stringify({
+      edit: { [path.join(repo.root, "AGENTS.md")]: { replace: [[TWO_ITEMS, ""]] } },
+      annotations: [{ reply: { edits: [] } }],
+    }),
+  );
+  await assert.rejects(run(), (err) => {
+    assert.ok(err instanceof UserError);
+    assert.match(err.message, /synthesis changed AGENTS\.md in the repository directly/);
+    return true;
+  });
+});
+
+test("an agent that changes nothing yields an empty proposal, never an invented edit", async () => {
+  const { run } = setup({ edit: {}, annotations: [{ reply: { edits: [], notes: ["the evidence is too thin"] } }] });
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits.length, 0);
+  assert.equal(proposal.budget.delta, 0);
+});

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -331,7 +331,7 @@ test("synthesis frame: fold rail line, sparse panel, suppression note - no gates
 
   assert.ok(text.includes("23 ok · 1 skipped · 1 failed · 33 reused"));
   assert.ok(text.includes("24 instructions scored · 9 gaps → 4 clusters kept (seen in ≥2 sessions)"));
-  assert.ok(text.includes("one call · claude · claude-opus-5 · effort high"));
+  assert.ok(text.includes("editing · claude · claude-opus-5 · effort high"));
   assert.ok(text.includes("── gradient descent · aggregated gradients → at most 5 edits"));
   assert.ok(text.includes("weighing 4 gap clusters + 24 instruction records against the budget…"));
   assert.ok(text.includes("session backpass-synth-84121"));
@@ -347,16 +347,25 @@ test("a gate violation renders the exact breaches and the re-prompt marker", () 
       ["synth:violations", { attempt: 1, violations: ["E2 adds an instruction with evidence from 1 session"] }],
       [
         "synth:start",
-        { agent: "claude", model: "claude-opus-5", effort: "high", attempt: 2, sessionName: "backpass-synth-84121" },
+        {
+          agent: "claude",
+          model: "claude-opus-5",
+          effort: "high",
+          phase: "annotate",
+          attempt: 2,
+          changes: 3,
+          sessionName: "backpass-synth-84121",
+        },
       ],
     ]),
   );
   const text = lines.join("\n");
 
   assert.ok(text.includes("synthesis violated 1 gate(s)"));
-  assert.ok(text.includes("re-prompting once with the exact breaches"));
+  assert.ok(text.includes("re-prompting with the exact breaches"));
   assert.ok(text.includes("✗ E2 adds an instruction with evidence from 1 session"));
-  assert.ok(text.includes("re-prompt 1 of 1"));
+  assert.ok(text.includes("re-prompt 1"));
+  assert.ok(text.includes("annotating 3 measured change(s) with evidence…"));
 });
 
 test("an over-budget file flips the header gauge into shrink-plan mode", () => {

--- a/test/usage-output.test.js
+++ b/test/usage-output.test.js
@@ -34,11 +34,21 @@ const fs = require("node:fs");
 const path = require("node:path");
 const argv = process.argv.slice(2);
 const agent = argv.find((a) => a === "codex" || a === "pi");
+// Session management calls (new / set / close) succeed silently, as acpx's do.
+if (argv.includes("sessions") || argv.includes("set")) process.exit(0);
 const cwd = argv[argv.indexOf("--cwd") + 1];
 const promptFile = argv[argv.indexOf("--file") + 1];
 process.stdout.write('{"ok":true}\\n');
 if (agent === "codex") {
   process.stderr.write("[acpx] tokens: input=14585 output=5 cache_read=11008 total=25598\\n");
+} else if (agent === "pi" && process.env.FAKE_PI_SESSION_FILE) {
+  // A follow-up turn in a named session: pi appends to the session's own file.
+  const file = process.env.FAKE_PI_SESSION_FILE;
+  const usage = { input: 300, output: 40, cacheRead: 9000, cacheWrite: 0, reasoning: 20, totalTokens: 9360 };
+  fs.appendFileSync(file, JSON.stringify({
+    type: "message", id: "turn-followup-" + Date.now(), parentId: "turn1",
+    message: { role: "assistant", content: [{ type: "text", text: '{"ok":true}' }], usage, stopReason: "stop" },
+  }) + "\\n");
 } else if (agent === "pi" && !process.env.FAKE_PI_NO_STORE) {
   const prompt = fs.readFileSync(promptFile, "utf8");
   const dir = ${JSON.stringify(piSessionDir)};
@@ -61,15 +71,16 @@ if (agent === "codex") {
     });
     parent = mid;
   });
-  fs.writeFileSync(path.join(dir, new Date().toISOString().replace(/[:.]/g, "-") + "_" + id + ".jsonl"),
-    lines.map((l) => JSON.stringify(l)).join("\\n") + "\\n");
+  const file = path.join(dir, new Date().toISOString().replace(/[:.]/g, "-") + "_" + id + ".jsonl");
+  fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\\n") + "\\n");
+  if (process.env.FAKE_PI_SESSION_FILE_OUT) fs.writeFileSync(process.env.FAKE_PI_SESSION_FILE_OUT, file);
 }
 `,
 );
 fs.chmodSync(fakeAcpx, 0o755);
 process.env.BACKPASS_ACPX_BIN = fakeAcpx;
 
-const { execOneShot, describeUsage, usageRecord, sumUsage } = await import("../src/acpx.js");
+const { execOneShot, openSession, describeUsage, usageRecord, sumUsage } = await import("../src/acpx.js");
 const { printProposal } = await import("../src/commands/propose.js");
 const { printUsage } = await import("../src/commands/usage.js");
 
@@ -147,6 +158,46 @@ test("pi usage is recovered from pi's own session file when acpx prints no token
     describeUsage([record]),
     "input=10,778 output=208 cache_read=8,704 cache_write=0 reasoning=119 total=19,690",
   );
+});
+
+test("across the turns of one pi session, each turn is accounted as its own increase", async () => {
+  const sessionPrompt = path.join(fakeAcpxDir, "prompt-session.md");
+  fs.writeFileSync(sessionPrompt, "<!-- backpass:self-session -->\nEdit the staging copy.\n");
+  const followUp = path.join(fakeAcpxDir, "prompt-annotate.md");
+  fs.writeFileSync(followUp, "<!-- backpass:self-session -->\nAnnotate the measured changes.\n");
+  const fileOut = path.join(fakeAcpxDir, "pi-session-file.txt");
+  process.env.FAKE_PI_SESSION_FILE_OUT = fileOut;
+  try {
+    const session = await openSession({ agent: "pi", effort: "high", sessionName: "bp-test", cwd: workDir });
+    const first = await session.prompt({ promptFile: sessionPrompt, approveAll: true, timeoutSeconds: 5 });
+    assert.deepEqual(first.usage, {
+      input: 10778,
+      output: 208,
+      cache_read: 8704,
+      cache_write: 0,
+      reasoning: 119,
+      total: 19690,
+    });
+
+    // The second turn appends to the same session file; only the increase is this turn's.
+    process.env.FAKE_PI_SESSION_FILE = fs.readFileSync(fileOut, "utf8");
+    const second = await session.prompt({ promptFile: followUp, approveAll: true, timeoutSeconds: 5 });
+    assert.deepEqual(second.usage, {
+      input: 300,
+      output: 40,
+      cache_read: 9000,
+      cache_write: 0,
+      reasoning: 20,
+      total: 9360,
+    });
+    await session.close();
+
+    const total = sumUsage([usageRecord("pi", first), usageRecord("pi", second)]);
+    assert.equal(total.total, 19690 + 9360);
+  } finally {
+    delete process.env.FAKE_PI_SESSION_FILE;
+    delete process.env.FAKE_PI_SESSION_FILE_OUT;
+  }
 });
 
 test("a pi call that leaves no session file stays honest: named, never n/a", async () => {

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { readMemoryFile } from "../src/memory.js";
+import { State } from "../src/state.js";
+import {
+  isSkillFilePath,
+  measureWorkspace,
+  parseSkillFile,
+  prepareWorkspace,
+  repoFingerprint,
+} from "../src/workspace.js";
+import { makeRepo, writeIn } from "./helpers/staging.js";
+
+const AGENTS = "# M\n\n- one\n- two\n";
+const SKILL = "---\nname: db\ndescription: Load before touching the database.\n---\n\n## Body\n";
+
+function stage(files = {}) {
+  const repo = makeRepo({ "AGENTS.md": AGENTS, ...files });
+  const state = new State(repo.root).ensure();
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills" });
+  return { repo, state, memoryFile, workspace };
+}
+
+test("the staging copy holds exactly the memory file and the skills directory, under .backpass/", () => {
+  const { repo, workspace } = stage({
+    ".agents/skills/db/SKILL.md": SKILL,
+    ".agents/skills/db/notes.txt": "n",
+    "src/index.js": "code",
+  });
+  assert.equal(workspace.root, path.join(repo.root, ".backpass", "synthesis"));
+  assert.equal(fs.readFileSync(path.join(workspace.root, "AGENTS.md"), "utf8"), AGENTS);
+  assert.equal(fs.readFileSync(path.join(workspace.root, ".agents/skills/db/SKILL.md"), "utf8"), SKILL);
+  assert.ok(
+    fs.existsSync(path.join(workspace.root, ".agents/skills/db/notes.txt")),
+    "skill directories are copied whole",
+  );
+  assert.ok(!fs.existsSync(path.join(workspace.root, "src")), "the code is read from the repo, never copied");
+  assert.deepEqual(
+    [...workspace.originals.keys()].sort(),
+    ["AGENTS.md", ".agents/skills/db/SKILL.md", ".agents/skills/db/notes.txt"].sort(),
+  );
+
+  // A fresh staging copy replaces any leftover from an earlier run.
+  writeIn(workspace.root, "AGENTS.md", "stale edit\n");
+  const again = prepareWorkspace({
+    state: new State(repo.root),
+    repo,
+    memoryFile: readMemoryFile(repo.root, "AGENTS.md"),
+    skillsDir: ".agents/skills",
+  });
+  assert.equal(fs.readFileSync(path.join(again.root, "AGENTS.md"), "utf8"), AGENTS);
+});
+
+test("an untouched workspace measures as no change, and ids are stable across re-measurement", () => {
+  const { workspace } = stage();
+  const first = measureWorkspace(workspace);
+  assert.deepEqual(first.changes, []);
+
+  writeIn(workspace.root, "AGENTS.md", (t) => t.replace("- two", "- 2"));
+  writeIn(workspace.root, ".agents/skills/new/SKILL.md", SKILL.replace("db", "new"));
+  const a = measureWorkspace(workspace);
+  const b = measureWorkspace(workspace);
+  assert.deepEqual(
+    a.changes.map((c) => [c.id, c.kind, c.file]),
+    [
+      ["H1", "hunk", "AGENTS.md"],
+      ["H2", "created", ".agents/skills/new/SKILL.md"],
+    ],
+  );
+  assert.equal(a.signature, b.signature);
+  assert.equal(a.changes[1].skill.name, "new");
+  assert.notEqual(first.signature, a.signature);
+});
+
+test("only the skill layouts a harness loads count as created skills; anything else is stray", () => {
+  assert.equal(isSkillFilePath(".agents/skills/db/SKILL.md", ".agents/skills"), true);
+  assert.equal(isSkillFilePath(".agents/skills/db.md", ".agents/skills"), true);
+  assert.equal(isSkillFilePath(".agents/skills/db/reference.md", ".agents/skills"), false);
+  assert.equal(isSkillFilePath(".agents/skills/a/b/SKILL.md", ".agents/skills"), false);
+  assert.equal(isSkillFilePath("skills/db/SKILL.md", ".agents/skills"), false);
+
+  assert.deepEqual(parseSkillFile("x/SKILL.md", SKILL), {
+    name: "db",
+    description: "Load before touching the database.",
+    path: "x/SKILL.md",
+    body: "## Body",
+  });
+  assert.equal(parseSkillFile("x/SKILL.md", "no frontmatter\n"), null);
+  assert.equal(
+    parseSkillFile("x/SKILL.md", "---\nname: only\n---\nbody\n"),
+    null,
+    "a description is the trigger; required",
+  );
+});
+
+test("the repo fingerprint notices a changed or removed guarded file", () => {
+  const { repo } = stage({ ".agents/skills/db/SKILL.md": SKILL });
+  const files = ["AGENTS.md", ".agents/skills/db/SKILL.md", "missing.md"];
+  const before = repoFingerprint(repo, files);
+  assert.equal(before["missing.md"], null);
+  assert.deepEqual(repoFingerprint(repo, files), before);
+  fs.appendFileSync(path.join(repo.root, "AGENTS.md"), "- three\n");
+  const after = repoFingerprint(repo, files);
+  assert.notEqual(after["AGENTS.md"], before["AGENTS.md"]);
+  assert.equal(after[".agents/skills/db/SKILL.md"], before[".agents/skills/db/SKILL.md"]);
+});


### PR DESCRIPTION
Fixes defect 2 of the analyze/synthesis diagnosis (`"find" text does not appear in AGENTS.md`, e1..e4+ on an over-budget shrink plan) the way the captain chose: **rely on the harness's native file editing of the raw file rather than inventing a new addressing system.**

## Root cause (from the diagnosis)

Synthesis was shown the instruction *index* - units joined by blank lines, headings dropped, `[AG-nnn] (N tok)` prefixes - while rule 2 demanded `find` be copied "character-for-character from the memory file above", and the gate then ran exact `indexOf` against the *raw* file. Any `find` spanning two adjacent list items (which the file joins with one newline, the index with two) could never match. A 4x-over-budget shrink plan makes multi-unit removals and extractions the expected edit shape, so that is where it bit.

## Design

The model no longer hands backpass any text to locate.

1. **Staging copy.** `src/workspace.js` builds `.backpass/synthesis/` holding only the memory file and the skills dir (git-excluded, wiped per run). The synthesis session runs through acpx with `--approve-all` and the workspace as `cwd`, so the harness's own `edit`/`write` tools do the editing. The prompt tells it the repo's absolute path for read-only grounding. acpx policy rules match tool kinds, not paths, so the workspace cwd is the blast-radius boundary; the repo's memory file and known skill files are fingerprinted and a harness that writes there fails the run loudly (`UserError`), never an apply.
2. **Measure.** `src/diff.js` diffs the copy against the original (Myers line diff, zero deps). Each hunk becomes a `find`/`replace` pair cut from the raw file, widened with context lines until `find` occurs exactly once (overlapping occurrences counted - a repeated-line run is not unique), with touching windows merged so hunks are independent: any subset applies in any order. Created `SKILL.md` files are parsed into the skill the writer already knows how to write.
3. **Annotate.** A second turn of the *same* session (`openSession` in `src/acpx.js`, multi-turn with per-turn usage) shows the measured changes by id (`[H1: AGENTS.md lines 17-18 (-2/+0) · AG-009, AG-010]` + unified diff) and asks for the JSON annotation: `changes`, `kind`, `title`, `rationale`, `instructions`, `evidence`, `transcripts`. Same schema as before minus `find`/`replace`/`anchor`.

## How the contract is preserved

- **Human review / apply gate - unchanged.** Synthesis still never writes the repo; `src/apply/writer.js` stays the only writer. The proposal's edits carry their hunks' raw-file `find`/`replace`, `backpass apply` reviews them per edit exactly as before (surface and terminal now render context lines), rejections are still remembered. Verified end to end through the real lavish surface.
- **Budget bound.** Measured on the staged file: cap mode must fit, shrink mode must be net-negative; token deltas per edit are measured by applying hunks. Suppressed (previously rejected) edits are excluded from the projection.
- **Evidence gates.** Every measured change must be claimed by exactly one annotated edit (unclaimed change, double claim, phantom id are violations); every edit needs a verbatim quote; an edit whose hunks only add text is gated as a new instruction (`minGapEvidence`) *whatever kind the model declares*; extract = one created `SKILL.md` grouped with memory-file change(s), frontmatter required; deletions are refused; stray files are ignored with a note. Up to two re-prompts name the exact breach; if the agent edits during an annotate turn, its ids are stale and the fresh measurement is shown instead; then it fails loudly and saves the rejected proposal as before.
- **Option A rejected as directed:** no unit-addressed edit scheme. The `AG-nnn` index stays what it was - a lookup table for evidence (now with line ranges) - never an edit address.

## Verified with real harnesses

- claude and pi both edit the staging copy natively through acpx `--approve-all` (codex on this machine cannot: local `~/.codex/config.toml` has `features.code_mode_host = false`, so its tools fail closed and it replies DONE without editing - which is why the design measures the workspace and never trusts the reply; an agent that changes nothing yields an empty proposal, not invented edits).
- Scratch repo, claude: propose (1 edit, -52 tok) → `backpass apply` via lavish → writer applied exactly the two removed lines; repo untouched until apply.
- Same repo, pi, `--budget 150` (shrink plan): passes, per-turn usage recovered from pi's store.
- **The report's exact failing shape:** the 77,035-byte no-mistakes `AGENTS.md` at `4a5cec6` (19,259 / 5,000 tok, 195 units), claude, shrink plan: 9 edits, -2,490 tok, including 8-line→2-line and 8-line→1-line rewrites, every `find` occurring exactly once in the raw file, gates passed on the first annotate turn, applying all hunks reproduces the staging copy byte for byte.

## Tests (209, all offline)

- `test/diff.test.js`: shortest-edit ops, unique widening with repeated lines, head/tail/whole-line splices, empty original, merged windows, display lines; plus a 6,000-case fuzz against brute-force LCS and round-trip/subset application run locally.
- `test/workspace.test.js`: staging contents, stable ids, skill layouts, fingerprint.
- `test/synthesize.test.js`: end-to-end through a fake acpx with native file tools - session lifecycle and `--approve-all`/`--cwd` flags, raw-file anchoring, repo untouched until apply, re-prompt with the exact breach, stale-id re-measure, budget gate on the staged file with the agent trimming, loud failure with the saved rejected proposal, a harness writing to the repo refused, an agent that changes nothing.
- `test/proposal.test.js` rewritten against the measured interface (staging helper in `test/helpers/staging.js`); bootstrap and memory-resolution fakes ported; multi-turn pi usage in `test/usage-output.test.js`.

`pnpm run check` green.
