### PR TITLE
fix(apply): improve the Lavish review flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,13 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   (`classifyAcpxFailure`). Reasoning effort is a per-adapter session option
   (`EFFORT_OPTION_KEYS`), so effortful calls always go through `sessionPrompt`. Verdicts
   cache in `.backpass/agent-probe-cache.json`.
+- **The Lavish apply surface is chatty and its output is YAML-quoted.** `lavish-axi poll`
+  can return feedback that is not a decision vector (a comment, a queued layout report) any
+  number of times before the real one; `pollDecisions` in `src/apply/lavish.js` announces
+  each wait state once and never per cycle. Session URLs are printed as `url: "http://..."`,
+  so parse them with `extractUrl`, never a bare `\S+`. Browser launch is best effort
+  (`src/apply/browser.js`): the printed URL is the contract. `test/fixtures/fake-lavish/`
+  stands in for the CLI via `BACKPASS_LAVISH_BIN` in tests.
 - Cursor IDE support is deliberately deferred to v1.1 (`--include-cursor-ide`, best effort);
   see the header of `src/discovery/adapters/cursor-ide.js` for why.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
   <a href="https://x.com/kunchenguid"
     ><img alt="X" src="https://img.shields.io/badge/X-@kunchenguid-black?style=flat-square"
   /></a>
+  <a href="https://discord.gg/Wsy2NpnZDu"
+    ><img
+      alt="Discord"
+      src="https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord"
+  /></a>
 </p>
 
 <h3 align="center">Gradient descent for your agent memory.</h3>
@@ -226,12 +231,15 @@ the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT.
 
 The surface is a static template shipped in the package - the CLI injects one JSON payload,
 so it is instant, deterministic, and identical every run. Nothing there is model-generated.
+It opens in your default browser when one is available; the URL is always printed too, so
+a headless box or `--no-open` just hands you the link.
 
 There is no DEFER button, and it isn't missing: **rejections are remembered.** A rejected
 edit is not proposed again unless materially new evidence arrives.
 
 ```sh
 backpass apply --no-ui     # same decision, in the terminal
+backpass apply --no-open   # print the surface URL, don't launch a browser
 backpass apply --dry-run   # show what would be written
 ```
 

--- a/src/apply/browser.js
+++ b/src/apply/browser.js
@@ -1,0 +1,49 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Open a URL in the user's default browser, best effort.
+ *
+ * The review surface URL is always printed as the fallback, so this must never throw or
+ * block: a missing opener, a headless box, or a crashing helper all degrade to "print the
+ * URL only". Returns true when an opener was launched, false when the environment opted
+ * out or had no display.
+ *
+ * Dependencies are injectable so the decision logic is testable without a real browser.
+ *
+ * @typedef {(bin: string, args: string[], options: object) => { on?: Function, unref?: Function }} Spawner
+ * @param {string | null} url
+ * @param {{ platform?: string, env?: Record<string, string | undefined>, spawnFn?: Spawner }} [deps]
+ */
+export function openInBrowser(url, { platform = process.platform, env = process.env, spawnFn = spawn } = {}) {
+  if (!url || !/^https?:\/\//.test(url)) return false;
+  if (!canOpenBrowser({ platform, env })) return false;
+
+  const { bin, args } = openerCommand(url, platform);
+  try {
+    const child = spawnFn(bin, args, { stdio: "ignore", detached: true, windowsHide: true });
+    // A missing or failing opener must not surface as an unhandled error.
+    child.on?.("error", () => {});
+    child.unref?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Headless detection: honor explicit opt-outs, CI, and display-less Linux.
+ * @param {{ platform?: string, env?: Record<string, string | undefined> }} [deps]
+ */
+export function canOpenBrowser({ platform = process.platform, env = process.env } = {}) {
+  if (env.BACKPASS_NO_BROWSER || env.CI) return false;
+  if (platform === "darwin" || platform === "win32") return true;
+  return Boolean(env.DISPLAY || env.WAYLAND_DISPLAY);
+}
+
+/** @returns {{ bin: string, args: string[] }} */
+function openerCommand(url, platform) {
+  if (platform === "darwin") return { bin: "open", args: [url] };
+  // `start` treats its first quoted argument as the window title; pass an empty one.
+  if (platform === "win32") return { bin: "cmd", args: ["/c", "start", "", url] };
+  return { bin: "xdg-open", args: [url] };
+}

--- a/src/apply/lavish.js
+++ b/src/apply/lavish.js
@@ -88,18 +88,37 @@ export async function openApplySurface(file) {
   if (result.code !== 0) {
     throw new UserError(`${LAVISH_BIN} failed to open the apply surface`, result.stderr.trim().slice(0, 400));
   }
-  const url = /(https?:\/\/\S+)/.exec(`${result.stdout}\n${result.stderr}`);
-  return url ? url[1] : null;
+  return extractUrl(`${result.stdout}\n${result.stderr}`);
 }
+
+/**
+ * Pull the session URL out of lavish-axi's output. The CLI prints it YAML-style as
+ * `url: "http://..."`, so a bare `\S+` would swallow the closing quote; stop at any
+ * quote or bracket and drop trailing punctuation.
+ */
+export function extractUrl(text) {
+  const match = /https?:\/\/[^\s"'<>()[\]]+/.exec(text || "");
+  if (!match) return null;
+  return match[0].replace(/[.,;:!?]+$/, "");
+}
+
+/** Breathing room between polls that came back without a decision vector. */
+export const POLL_RETRY_DELAY_MS = 1000;
 
 /**
  * Long-poll for the human's decision vector. `lavish-axi poll` blocks until the reviewer
  * sends feedback, so this is intentionally a foreground wait.
+ *
+ * Feedback that is not a decision vector (a comment, a queued layout report) keeps the
+ * wait going. Each state is announced once: the wait line on entry, and a single note the
+ * first time non-decision feedback arrives - never one line per poll cycle, which on a
+ * chatty surface floods the terminal.
  */
-export async function pollDecisions(file, editIds) {
+export async function pollDecisions(file, editIds, { delayMs = POLL_RETRY_DELAY_MS } = {}) {
   info(
     `${color.dim("waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)")}`,
   );
+  let notedOtherFeedback = false;
 
   for (;;) {
     const result = await runLavish(["poll", file]);
@@ -118,8 +137,14 @@ export async function pollDecisions(file, editIds) {
       warn("review session ended without a decision vector - nothing applied");
       return null;
     }
-    // Feedback that was not a decision vector (a comment, a layout report): keep waiting.
-    info(`${color.dim("received feedback without a decision vector; still waiting")}`);
+
+    if (!notedOtherFeedback) {
+      notedOtherFeedback = true;
+      info(
+        `${color.dim("feedback arrived without a decision vector - click APPLY in the browser and send from the panel; still waiting")}`,
+      );
+    }
+    if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,6 +53,7 @@ const OPTIONS = {
 
   "dry-run": { type: "boolean" },
   "no-ui": { type: "boolean" },
+  "no-open": { type: "boolean" },
   "no-auto-agent": { type: "boolean" },
   force: { type: "boolean" },
   limit: { type: "string" },
@@ -114,6 +115,7 @@ BUDGET AND SHAPE
 
 APPLY
   --no-ui                  terminal accept/reject instead of the Lavish surface
+  --no-open                print the review surface URL without opening a browser
   --dry-run                show what would be written, write nothing
   --force                  re-analyze transcripts that already have fresh evidence,
                            and re-probe agents instead of trusting the probe cache

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -2,6 +2,7 @@ import { UserError, color, info, json, out, warn } from "../logger.js";
 import { applyDecisions } from "../apply/writer.js";
 import { closeApplySurface, openApplySurface, pollDecisions, renderApplySurface } from "../apply/lavish.js";
 import { reviewInTerminal } from "../apply/terminal.js";
+import { openInBrowser } from "../apply/browser.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 
 /**
@@ -45,6 +46,8 @@ export async function cmdApply(ctx) {
     surfaceFile = renderApplySurface(proposal, config.state, ctx.version);
     const url = await openApplySurface(surfaceFile);
     info(`${color.cyan("·")} review surface: ${url || surfaceFile}`);
+    // Best effort: the printed URL above is the fallback when nothing opens.
+    if (!ctx.flags["no-open"]) openInBrowser(url);
     decisions = await pollDecisions(surfaceFile, editIds);
   }
 

--- a/test/apply-surface.test.js
+++ b/test/apply-surface.test.js
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { setLoggerSink } from "../src/logger.js";
+import { canOpenBrowser, openInBrowser } from "../src/apply/browser.js";
+
+// `LAVISH_BIN` is read when the module loads, so point it at the fake before importing.
+process.env.BACKPASS_LAVISH_BIN = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "fake-lavish",
+  "lavish-axi",
+);
+const { extractUrl, openApplySurface, pollDecisions } = await import("../src/apply/lavish.js");
+
+const LAYOUT_REPORT = [
+  "prompts[1]{uid,prompt,selector,tag,text}:",
+  '  "","Fix the overlapping text","div#edits > article","layout-warnings","1 issue"',
+].join("\n");
+const DECISIONS = [
+  "prompts[1]{uid,prompt,selector,tag,text}:",
+  '  "1","BACKPASS_DECISIONS e1=accepted e2=rejected",button#btn-apply,choice,e1=accepted e2=rejected',
+].join("\n");
+
+function scenario(polls, extra = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-lavish-"));
+  const file = path.join(dir, "scenario.json");
+  fs.writeFileSync(file, JSON.stringify({ polls, ...extra }));
+  process.env.FAKE_LAVISH_SCENARIO = file;
+  return path.join(dir, "apply.html");
+}
+
+function captureLog(t) {
+  const lines = [];
+  setLoggerSink((line) => lines.push(line));
+  t.after(() => setLoggerSink(null));
+  return lines;
+}
+
+test("the review surface URL comes back without lavish's closing quote", async () => {
+  const surface = scenario([], { url: "http://127.0.0.1:4387/session/51233fdaf6389690" });
+  const url = await openApplySurface(surface);
+  assert.equal(url, "http://127.0.0.1:4387/session/51233fdaf6389690");
+});
+
+test("extractUrl stops at quotes and trailing punctuation", () => {
+  assert.equal(extractUrl('  url: "http://host:4387/session/abc"\n'), "http://host:4387/session/abc");
+  assert.equal(extractUrl("open http://host/s/abc."), "http://host/s/abc");
+  assert.equal(extractUrl("(http://host/s/abc)"), "http://host/s/abc");
+  assert.equal(extractUrl("no link here"), null);
+});
+
+test("the wait line prints once, not once per poll cycle", async (t) => {
+  const lines = captureLog(t);
+  const surface = scenario([LAYOUT_REPORT, LAYOUT_REPORT, LAYOUT_REPORT, LAYOUT_REPORT, DECISIONS]);
+
+  const decisions = await pollDecisions(surface, ["e1", "e2"], { delayMs: 0 });
+
+  assert.deepEqual(decisions, { e1: "accepted", e2: "rejected" });
+  const waiting = lines.filter((l) => l.includes("waiting for your decisions"));
+  const noted = lines.filter((l) => l.includes("without a decision vector"));
+  assert.equal(waiting.length, 1, `wait line repeated:\n${lines.join("\n")}`);
+  assert.equal(noted.length, 1, `non-decision note repeated:\n${lines.join("\n")}`);
+  assert.equal(lines.length, 2);
+});
+
+test("a decision vector on the first poll returns with only the wait line", async (t) => {
+  const lines = captureLog(t);
+  const surface = scenario([DECISIONS]);
+  const decisions = await pollDecisions(surface, ["e1", "e2"], { delayMs: 0 });
+  assert.deepEqual(decisions, { e1: "accepted", e2: "rejected" });
+  assert.equal(lines.length, 1);
+});
+
+test("a session that ends without decisions returns null", async (t) => {
+  captureLog(t);
+  const surface = scenario(["status: session ended"]);
+  assert.equal(await pollDecisions(surface, ["e1"], { delayMs: 0 }), null);
+});
+
+test("openInBrowser launches a detached opener and never throws", () => {
+  const calls = [];
+  const spawnFn = (bin, args, opts) => {
+    calls.push({ bin, args, opts });
+    return { on() {}, unref() {} };
+  };
+  const env = { DISPLAY: ":0" };
+  assert.equal(openInBrowser("http://h/s/1", { platform: "darwin", env, spawnFn }), true);
+  assert.equal(openInBrowser("http://h/s/1", { platform: "linux", env, spawnFn }), true);
+  assert.equal(openInBrowser("http://h/s/1", { platform: "win32", env, spawnFn }), true);
+  assert.deepEqual(
+    calls.map((c) => [c.bin, ...c.args]),
+    [
+      ["open", "http://h/s/1"],
+      ["xdg-open", "http://h/s/1"],
+      ["cmd", "/c", "start", "", "http://h/s/1"],
+    ],
+  );
+  for (const call of calls) assert.equal(call.opts.detached, true);
+
+  const throwing = () => {
+    throw new Error("ENOENT");
+  };
+  assert.equal(openInBrowser("http://h/s/1", { platform: "darwin", env, spawnFn: throwing }), false);
+  assert.equal(openInBrowser(null, { platform: "darwin", env, spawnFn }), false);
+  assert.equal(openInBrowser("/tmp/apply.html", { platform: "darwin", env, spawnFn }), false);
+});
+
+test("headless and opted-out environments print the URL only", () => {
+  const spawnFn = () => assert.fail("must not spawn an opener");
+  assert.equal(canOpenBrowser({ platform: "linux", env: {} }), false);
+  assert.equal(canOpenBrowser({ platform: "linux", env: { WAYLAND_DISPLAY: "wayland-0" } }), true);
+  assert.equal(canOpenBrowser({ platform: "darwin", env: { CI: "true" } }), false);
+  assert.equal(canOpenBrowser({ platform: "darwin", env: { BACKPASS_NO_BROWSER: "1" } }), false);
+  assert.equal(openInBrowser("http://h/s/1", { platform: "linux", env: {}, spawnFn }), false);
+});

--- a/test/fixtures/fake-lavish/lavish-axi
+++ b/test/fixtures/fake-lavish/lavish-axi
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Stand-in for `lavish-axi`, shaped like the real CLI's output: the open command prints
+// the session URL YAML-quoted, and `poll` returns whatever the scenario file queues,
+// one entry per call, so tests can script a chatty review surface.
+import fs from "node:fs";
+
+const [cmd, file] = process.argv.slice(2);
+const scenarioPath = process.env.FAKE_LAVISH_SCENARIO;
+const scenario = scenarioPath && fs.existsSync(scenarioPath) ? JSON.parse(fs.readFileSync(scenarioPath, "utf8")) : {};
+
+if (cmd === "poll") {
+  const next = scenario.polls?.shift();
+  if (scenarioPath) fs.writeFileSync(scenarioPath, JSON.stringify(scenario));
+  if (!next) {
+    console.error("fake lavish-axi: poll queue exhausted");
+    process.exit(2);
+  }
+  process.stdout.write(`session:\n  file: ${file}\n  status: feedback\n${next}\n`);
+} else if (cmd === "end") {
+  process.stdout.write(`session:\n  file: ${file}\n  status: ended\n`);
+} else {
+  process.stdout.write(
+    `session:\n  file: ${cmd}\n  url: "${scenario.url || "http://127.0.0.1:4387/session/51233fdaf6389690"}"\n  status: opened\n`,
+  );
+}


### PR DESCRIPTION
## Intent

Fix three UX defects in `backpass apply`'s interactive Lavish review-surface flow, and add the fleet Discord badge to the README. Each defect was root-caused from the actual apply/poll source, not symptom-patched. (1) Auto-open the review surface in the default browser when apply starts; keep the printed URL as the fallback and degrade gracefully in headless/no-display environments (print URL only, never error). Implemented as src/apply/browser.js: open/xdg-open/cmd start, spawned detached, errors swallowed; skipped under CI, BACKPASS_NO_BROWSER, display-less Linux, or the new --no-open flag (documented in cli.js help and README). (2) Stop spamming the wait line: 'received feedback without a decision vector; still waiting' printed on every poll cycle. Root cause: lavish-axi poll returns for any non-decision feedback (a comment, or on the captain's lavish version the overlapping-text layout warnings the apply surface triggers), and the loop logged each iteration. pollDecisions now prints the waiting line once, prints one single note the first time non-decision feedback arrives (reworded to tell the reviewer to click APPLY and send from the panel), never repeats, and sleeps POLL_RETRY_DELAY_MS (1s, injectable for tests) before re-polling so a chatty surface cannot spin. A plain once-only line was chosen over an in-place spinner because the logger/TUI contract requires identical plain-line output in non-TTY/CI/--quiet. (3) Stray trailing double-quote after the review-surface URL: lavish-axi prints the session URL YAML-quoted (url: "http://...") and the old regex https?://\S+ captured the closing quote. New extractUrl stops at quotes/brackets and trims trailing punctuation. (4) README: canonical fleet Discord badge copied byte-for-byte from the no-mistakes README (link https://discord.gg/Wsy2NpnZDu, image https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord), placed last in the centered badge row after the X badge, matching sibling repo order. Tests: test/apply-surface.test.js exercises openApplySurface and pollDecisions through the real interface via a fake lavish-axi executable (test/fixtures/fake-lavish/lavish-axi, selected with BACKPASS_LAVISH_BIN, which lavish.js reads at import time hence the dynamic import in the test) asserting the URL carries no quote, that four non-decision polls yield exactly one wait line and one note, session-ended returns null, and the browser opener's platform commands, detached spawn, never-throw and headless opt-outs. AGENTS.md gained a short sharp-edge entry pointing at these modules. Conventions: pnpm, ESM, zero runtime deps, no em dashes, no co-author trailer. Verified with pnpm run check (lint, prettier, tsc, 216 tests) and a real end-to-end backpass apply run against a temp repo with real lavish-axi and the default browser.

## What Changed

- Open the Lavish review surface in the default browser when available, with `--no-open` and headless environment opt-outs.
- Clean quoted session URLs and throttle non-decision polling while reporting each waiting state only once.
- Add the fleet Discord badge to the README.

## Risk Assessment

✅ Low: The changes are well-bounded, satisfy the stated UX requirements, and introduce no material source-verifiable defects.

## Testing

Targeted apply-surface and proposal tests passed, and end-to-end CLI evidence confirmed clean URL extraction, automatic browser launch, once-only feedback messaging with poll throttling, successful persistence, and `--no-open` suppression. Temporary worktree artifacts were removed.

<details>
<summary>Evidence: End-to-end apply flow with automatic browser launch and persisted edit</summary>

Source: [End-to-end apply flow with automatic browser launch and persisted edit](https://github.com/kunchenguid/backpass/blob/241a966bd21057938c417cce9efe4b6c2b435b60/.no-mistakes/evidence/fm/backpass-apply-ux-r1/apply-e2e-transcript.txt)

```text
· review surface: http://127.0.0.1:4387/session/e2e-review
waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)
feedback arrived without a decision vector - click APPLY in the browser and send from the panel; still waiting

1 accepted · 0 rejected
  wrote AGENTS.md (e1)
    budget [................................] 11 -> 12 / 5,000 tok

Elapsed wall time: 2s (two non-decision retries at 1s each)

Browser launch evidence:
default-browser opener received: http://127.0.0.1:4387/session/e2e-review

Persisted memory after apply:
# Demo memory

- Use the improved review flow.
```
</details>
<details>
<summary>Evidence: Default browser opener invocation</summary>

Source: [Default browser opener invocation](https://github.com/kunchenguid/backpass/blob/241a966bd21057938c417cce9efe4b6c2b435b60/.no-mistakes/evidence/fm/backpass-apply-ux-r1/browser-open.log)

```text
default-browser opener received: http://127.0.0.1:4387/session/e2e-review
```
</details>
<details>
<summary>Evidence: End-to-end --no-open fallback flow</summary>

Source: [End-to-end --no-open fallback flow](https://github.com/kunchenguid/backpass/blob/241a966bd21057938c417cce9efe4b6c2b435b60/.no-mistakes/evidence/fm/backpass-apply-ux-r1/apply-no-open-transcript.txt)

```text
· review surface: http://127.0.0.1:4387/session/no-open-review
waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)

1 accepted · 0 rejected
  wrote AGENTS.md (e1)
    budget [................................] 11 -> 12 / 5,000 tok

Verified: --no-open printed the clean URL and did not invoke the browser opener.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2ed8f5f329ccf9724a809fa0ebcb6c6e306764d4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec node --test test/apply-surface.test.js test/proposal.test.js`
- <code>End-to-end `node bin/backpass.js apply` using the fake Lavish executable and fake default-browser opener, including two non-decision polls and an accepted persisted edit</code>
- <code>End-to-end `node bin/backpass.js apply --no-open`, verifying the clean URL was printed and the browser opener was not invoked</code>
- `Compared the README Discord badge with the canonical no-mistakes README from GitHub`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
