### PR TITLE
ci: migrate no-mistakes gate to shared action

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -3,13 +3,12 @@ run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ git
 
 on:
   pull_request:
-    # The verdict is a pure function of pull_request.body, so a push carries no
-    # new body to judge but does move the head SHA. The pipeline pushes before
-    # it writes the deterministic Pipeline section, so a synchronize trigger
-    # pinned a FAILURE check run to the new head for a body the same run was
-    # about to fix. GitHub keeps that failure next to the later edited SUCCESS,
-    # and gh pr checks collapses same-named check runs by startedAt alone, so the
-    # CI monitor could park the run red forever (no-mistakes PR #773).
+    # The gate validates the head SHA recorded in pull_request.body. The
+    # pipeline pushes first, then rewrites that attestation, so the edited event
+    # checks the final body against the new head. A synchronize run would judge
+    # the old body in between and leave a same-named failure beside the later
+    # success. This check is not required by a ruleset or branch protection, so
+    # omitting synchronize cannot leave an expected check pending.
     types: [opened, edited, reopened]
     branches:
       - main

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -3,7 +3,14 @@ run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ git
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    # The verdict is a pure function of pull_request.body, so a push carries no
+    # new body to judge but does move the head SHA. The pipeline pushes before
+    # it writes the deterministic Pipeline section, so a synchronize trigger
+    # pinned a FAILURE check run to the new head for a body the same run was
+    # about to fix. GitHub keeps that failure next to the later edited SUCCESS,
+    # and gh pr checks collapses same-named check runs by startedAt alone, so the
+    # CI monitor could park the run red forever (no-mistakes PR #773).
+    types: [opened, edited, reopened]
     branches:
       - main
 
@@ -13,7 +20,7 @@ permissions:
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
 # an immutable per-event group so first-time-fork approvals can never collapse
-# opened/edited checks. Keep synchronize/reopened coalescing as before.
+# opened/edited checks. Keep reopened coalescing as before.
 concurrency:
   group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
@@ -22,102 +29,26 @@ jobs:
   check:
     name: PR must be raised via no-mistakes
     runs-on: ubuntu-latest
+    # Known automation accounts are exempt so automation keeps working:
+    # - github-actions[bot] opens PRs via GITHUB_TOKEN (release-please)
+    # - dependabot[bot] opens dependency update PRs
+    # Other authors (human or bot) must raise PRs through `git push no-mistakes`.
+    #
+    # These stay job-level rather than moving to the action's `exempt-authors`
+    # input on purpose: an in-job exemption still requires the run to start, and
+    # a GITHUB_TOKEN PR's run is created in action_required and never starts.
+    # Keeping the condition here preserves the exact verdict shape this
+    # repository's gate already produces for those authors.
     if: >-
       github.event.pull_request.user.login != 'github-actions[bot]' &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
-      - name: Verify no-mistakes signature in PR body
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -eu
-          marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
-            echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
-            if ! command -v jq >/dev/null 2>&1; then
-              echo "::error::This check requires jq to parse no-mistakes pipeline step attestation, but jq was not found on the runner." >&2
-              exit 1
-            fi
-            prefix='<!-- no-mistakes-pipeline-attestation:v1 '
-            suffix=' -->'
-            body="${PR_BODY:-}"
-            json=''
-            parse_ok=0
-            case "$body" in
-              *"$prefix"*)
-                rest="${body#*"$prefix"}"
-                case "$rest" in
-                  *"$suffix"*)
-                    json="${rest%%"$suffix"*}"
-                    if printf '%s' "$json" | jq -e . >/dev/null 2>&1; then
-                      parse_ok=1
-                    fi
-                    ;;
-                esac
-                ;;
-            esac
-            if [ "$parse_ok" -ne 1 ]; then
-              {
-                echo "::error::This repository requires no-mistakes >= 1.46.0; structured pipeline step attestation is missing or unparseable."
-                echo
-                echo "The no-mistakes signature was found, but this check also requires one"
-                echo "HTML comment in the PR body:"
-                echo
-                echo '    <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->'
-                echo
-                echo "That comment is emitted by no-mistakes >= 1.46.0 (the release that started"
-                echo "emitting structured step attestation; see https://github.com/kunchenguid/no-mistakes/pull/670)."
-                echo "An older no-mistakes that writes only the signature line is not enough."
-                echo
-                echo "Re-run the pipeline with 'git push no-mistakes' using no-mistakes >= 1.46.0."
-                echo "See CONTRIBUTING.md for setup and the full workflow."
-                echo
-                echo "PR author: ${PR_AUTHOR}"
-              } >&2
-              exit 1
-            fi
-            incomplete=''
-            for required in review test document; do
-              status=$(printf '%s' "$json" | jq -r --arg step "$required" \
-                '([(.steps | arrays | .[]) | select(.step == $step) | .status] | first // empty | select(. != "")) // "missing"')
-              if [ "$status" != "completed" ]; then
-                if [ -n "$incomplete" ]; then
-                  incomplete="${incomplete}, "
-                fi
-                incomplete="${incomplete}${required}=${status}"
-              fi
-            done
-            if [ -n "$incomplete" ]; then
-              {
-                echo "::error::Required no-mistakes pipeline steps are not completed: ${incomplete}."
-                echo
-                echo "This repository requires review, test, and document to each have status"
-                echo "exactly 'completed'. Quota skips and agent skips are not compliant."
-                echo
-                echo "Re-run the pipeline with 'git push no-mistakes' using no-mistakes >= 1.46.0"
-                echo "so those required steps complete rather than skip."
-                echo "See CONTRIBUTING.md for setup and the full workflow."
-                echo
-                echo "PR author: ${PR_AUTHOR}"
-              } >&2
-              exit 1
-            fi
-            echo "Pipeline step attestation is valid: review, test, and document are completed."
-            exit 0
-          fi
-          {
-            echo "::error::This PR was not raised through no-mistakes."
-            echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review/test/lint/CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
-            echo
-            echo "    $marker"
-            echo
-            echo "See CONTRIBUTING.md for setup and the full workflow."
-            echo
-            echo "PR author: ${PR_AUTHOR}"
-          } >&2
-          exit 1
+      # The enforcement itself lives in the shared composite action in the
+      # no-mistakes repository, so this repository no longer carries its own
+      # copy of the script to drift.
+      #
+      # Pinned to an immutable commit, never @main: main is editable by the very
+      # pull request this gate is judging. Bumping the pin is a separate,
+      # deliberate pull request.
+      - name: Verify no-mistakes signature and pipeline attestation in PR body
+        uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,14 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 - Releases are automated by release-please (`.github/workflows/release-please.yml`,
   npm trusted publishing). Never hand-edit `CHANGELOG.md` or
   `.release-please-manifest.json`; CI guards reject PRs that touch them.
+- `.github/workflows/no-mistakes-required.yml` is a thin caller of the shared
+  `kunchenguid/no-mistakes/.github/actions/require-no-mistakes` composite action, pinned
+  to an immutable commit SHA and never `@main`. Enforcement logic and tests live upstream
+  in the no-mistakes repository; change enforcement there, never by copying it locally,
+  and bump the pin in a deliberate separate PR. This repo still owns the `on:`,
+  `concurrency`, `permissions`, job name, and author-exemption `if:`. The action binds the
+  attestation to the head SHA, so a PR whose body no-mistakes did not rewrite for the
+  current head goes red by contract: push through `git push no-mistakes`.
 
 ## Sharp edges
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,11 @@ Thanks for wanting to contribute.
 
 1. Fork the repo and create a branch.
 2. Make your changes and run `pnpm run check` until it is green.
-3. Push your branch and open a pull request against `main`.
+3. Configure the [no-mistakes](https://github.com/kunchenguid/no-mistakes) push target.
+4. Submit the branch with `git push no-mistakes`; the pipeline creates or updates the pull request against `main`.
+
+Do not open the pull request manually. The repository gate requires the signature and
+head-SHA-bound pipeline attestation that no-mistakes writes to the pull request body.
 
 CI runs lint, format:check, typecheck, and the test suite on every PR; a guard also
 rejects hand-edits to release-please-generated files.


### PR DESCRIPTION
## Intent

Migrate backpass's inline PR-enforcement gate (.github/workflows/no-mistakes-required.yml, previously inline jq) to a thin caller of the shared composite action kunchenguid/no-mistakes/.github/actions/require-no-mistakes, pinned to commit 32d396ac0f29135daf7fcb9964aba9d5f4e796d6 (post-v1.57.1, untagged, action added in no-mistakes #819), replicating the exact pattern already merged and validated in kunchenguid/rough-cut-axi PR #4. Requirements: preserve backpass's job-level if: exemptions for github-actions[bot] and dependabot[bot] (deliberately kept job-level, not moved to the action's exempt-authors input, because a GITHUB_TOKEN PR's run never starts); keep the job name EXACTLY 'PR must be raised via no-mistakes' so the check name is unchanged; set on.pull_request.types to [opened, edited, reopened], dropping synchronize - this was verified safe because backpass has no rulesets and no branch protection (GitHub API /rulesets and /rules/branches/main empty, /branches/main/protection 404), so the check is not required and nothing wedges on 'Expected - waiting for status'. Semantics: last-wins verdict semantics are intended (captain decision). Relaxing the stricter inline jq (exact 'completed' status for review/test/document, jq presence check) to whatever the shared action enforces is CORRECT and deliberate, not a regression; do not try to preserve extra strictness beyond the shared action. No local tests were added for the workflow: backpass had none, and the reference PR removed the workflow test because enforcement and its tests now live upstream; a test that greps workflow YAML would violate the test-quality rule. AGENTS.md gained a pointer entry documenting the thin-caller/pinned-SHA contract and the head-SHA attestation binding, mirroring the reference PR.

## What Changed

- Replace inline PR attestation enforcement with the shared no-mistakes composite action pinned to an immutable commit.
- Limit gate triggers to opened, edited, and reopened events while preserving the existing check name and bot exemptions.
- Document the shared-action contract and require contributors to submit PRs through `git push no-mistakes`.

## Risk Assessment

✅ Low: The change is narrowly scoped, matches the authoritative migration pattern and pinned action, and preserves all required repository-owned workflow semantics.

## Testing

Inspected the targeted diff, confirmed the pinned upstream action exists, validated the workflow as a normalized machine-consumed configuration, and executed the exact pinned verifier through pass, stale-head failure, and last-wins scenarios. All checks succeeded and the worktree remained clean. This workflow-only change has no rendered UI, so reviewer-visible JSON and CLI behavior logs were captured instead of screenshots.

<details>
<summary>Evidence: Pinned shared action behavior across compliant, stale-head, and last-wins PR events</summary>

Source: [Pinned shared action behavior across compliant, stale-head, and last-wins PR events](https://github.com/kunchenguid/backpass/blob/568d89eede0291047d37fd4298a32cbc1dd4ea4c/.no-mistakes/evidence/fm/nm-migrate-backpass-gate-r1/shared-action-behavior.txt)

```text
Pinned shared action behavior at 32d396ac0f29135daf7fcb9964aba9d5f4e796d6

=== matching head and completed steps passes ===
Found no-mistakes signature in PR #42 body.
Found structurally compliant pipeline step attestation.
::warning::PR-body attestation is author-editable and is not cryptographic proof that no-mistakes produced it.
exit=0 expected=0
outputs:
exempt=false
compliant=true

=== stale head attestation fails ===
::error::Pipeline attestation head_sha does not match the current PR head.

attestation.head_sha: old456
PR head: abc123

A later push must not pass on an older attestation. Re-run 'git push no-mistakes' so the PR body attestation binds to the current head.

See CONTRIBUTING.md for setup and the full workflow.

PR author: contributor
Found no-mistakes signature in PR #42 body.
exit=1 expected=1
outputs:
exempt=false
compliant=false
exempt=false

=== duplicate step uses last verdict ===
Found no-mistakes signature in PR #42 body.
Found structurally compliant pipeline step attestation.
::warning::PR-body attestation is author-editable and is not cryptographic proof that no-mistakes produced it.
exit=0 expected=0
outputs:
exempt=false
compliant=true
```
</details>
<details>
<summary>Evidence: Normalized workflow semantics showing triggers, check name, exemptions, permissions, and pinned action</summary>

Source: [Normalized workflow semantics showing triggers, check name, exemptions, permissions, and pinned action](https://github.com/kunchenguid/backpass/blob/568d89eede0291047d37fd4298a32cbc1dd4ea4c/.no-mistakes/evidence/fm/nm-migrate-backpass-gate-r1/workflow-semantics.json)

```text
{
  "workflow_name": "Require no-mistakes",
  "pull_request": {
    "types": [
      "opened",
      "edited",
      "reopened"
    ],
    "branches": [
      "main"
    ]
  },
  "permissions": {
    "contents": "read"
  },
  "concurrency": {
    "group": "no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}",
    "cancel-in-progress": true
  },
  "job": {
    "id": "check",
    "check_name": "PR must be raised via no-mistakes",
    "runner": "ubuntu-latest",
    "condition": "github.event.pull_request.user.login != 'github-actions[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'",
    "action_steps": [
      {
        "name": "Verify no-mistakes signature and pipeline attestation in PR body",
        "uses": "kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6"
      }
    ]
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"66c6be03f38489f0bebd1de5a07762cb73fba2d5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=80 ff78b7fdd7cfaa487fb09e234f7153ea16764845..ee040b35366950300f818ee6a91764845b75dba4 -- .github/workflows/no-mistakes-required.yml AGENTS.md`
- <code>`gh api repos/kunchenguid/no-mistakes/commits/32d396ac0f29135daf7fcb9964aba9d5f4e796d6` and fetched the pinned composite action metadata</code>
- `Parsed the workflow with Ruby YAML into a normalized semantic model and asserted its triggers, branch, permissions, exact check name, bot exemptions, single composite-action step, and immutable SHA pin`
- <code>Executed the pinned shared action&#39;s `verify.py` against realistic pull-request event payloads, verifying a matching head passes, a stale head fails, and duplicate step verdicts use last-wins semantics</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
