### PR TITLE
feat(discovery): add Hermes transcript support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,16 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 
 ## Sharp edges
 
-- **Transcript formats are undocumented and drift.** Every adapter in
-  `src/discovery/adapters/` is pinned by a golden fixture in `test/fixtures/`. When a
-  harness changes its on-disk shape, fix the adapter and update its fixture together.
-  Adapters must stay fail-soft: an unreadable store warns and is skipped, never throws.
+- **Transcript formats are undocumented and drift.** File adapters in
+  `src/discovery/adapters/` are pinned by golden fixtures in `test/fixtures/`; SQLite
+  adapters (opencode, hermes) build tiny temp databases in tests. When a harness changes
+  its on-disk shape, fix the adapter and its fixture/test together. Adapters must stay
+  fail-soft: an unreadable store warns and is skipped, never throws.
+- **Hermes is first-class but source-filtered.** `src/discovery/adapters/hermes.js` reads
+  `~/.hermes/state.db` (`HERMES_HOME`). Only `cli` and `acp` sessions are ingested;
+  gateway/cron rows share a process cwd and would pollute association. Timestamps are
+  epoch seconds and must be converted to ms. Message content is read as BLOB because
+  node:sqlite truncates TEXT at the `\x00json:` NUL. There is no JSONL fallback.
 - **The live progress view is an enhancement layer, never a dependency.** Pipeline stages
   emit events through `src/progress.js`; `src/tui/` renders them on stderr during the
   default run and buffers/replays the plain logger lines on teardown. Every path must

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The loop only closes when a human happens to remember a failure and edits the fi
 what happened in them, and proposes evidence-backed edits to your memory file - under a
 token budget, gated by you.
 
-- **Local-first** - Reads the transcript stores of six agent harnesses directly from disk.
+- **Local-first** - Reads the transcript stores of seven agent harnesses directly from disk.
   No API, no upload; transcripts never leave your machine except into an agent you already
   authenticated, and obvious secrets are redacted before they do.
 - **Evidence-gated** - Every proposed edit carries verbatim quotes from real sessions, a
@@ -78,16 +78,17 @@ backpass apply     # review each edit, accept or reject, then write
 
 ### 1. Collect samples - which sessions belong to this repo
 
-backpass reads the local transcript stores of six harnesses directly. No API, no upload.
+backpass reads the local transcript stores of seven harnesses directly. No API, no upload.
 
-| Harness        | Store                                          | Repo tie                              |
-| -------------- | ---------------------------------------------- | ------------------------------------- |
-| **claude**     | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl` | per-line `cwd`                        |
-| **codex**      | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | `cwd` + recorded `git.repository_url` |
-| **pi**         | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`   | session-header `cwd`                  |
-| **opencode**   | `~/.local/share/opencode/opencode.db` (sqlite) | `session.directory`                   |
-| **grok**       | `~/.grok/sessions/<encoded-cwd>/<uuid>/`       | `summary.json` `cwd` + `git_remotes`  |
-| **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                     |
+| Harness        | Store                                          | Repo tie                                |
+| -------------- | ---------------------------------------------- | --------------------------------------- |
+| **claude**     | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl` | per-line `cwd`                          |
+| **codex**      | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | `cwd` + recorded `git.repository_url`   |
+| **pi**         | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`   | session-header `cwd`                    |
+| **opencode**   | `~/.local/share/opencode/opencode.db` (sqlite) | `session.directory`                     |
+| **grok**       | `~/.grok/sessions/<encoded-cwd>/<uuid>/`       | `summary.json` `cwd` + `git_remotes`    |
+| **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                       |
+| **hermes**     | `~/.hermes/state.db` (sqlite)                  | CLI prompt cwd / ACP `model_config.cwd` |
 
 Association runs in three tiers:
 
@@ -355,7 +356,7 @@ CLI flags on top:
     ]
   },
   "discovery": {
-    "harnesses": ["claude", "codex", "pi", "opencode", "grok", "cursor"],
+    "harnesses": ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes"],
     "since": "30d",
     "worktreeGlobs": [],
     "minUserTurns": 2

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ backpass reads the local transcript stores of seven harnesses directly. No API, 
 | **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                       |
 | **hermes**     | `~/.hermes/state.db` (sqlite)                  | CLI prompt cwd / ACP `model_config.cwd` |
 
+Hermes collection includes CLI and ACP sessions only. Gateway, cron, and WhatsApp sessions
+are excluded because their recorded cwd belongs to the shared gateway process, not a project.
+
 Association runs in three tiers:
 
 1. **Tier 1 - deterministic.** The session's cwd is (or sits inside) one of this repo's

--- a/src/cli.js
+++ b/src/cli.js
@@ -83,7 +83,7 @@ COMMANDS
 COLLECT SAMPLES
   --since <dur>            only sessions newer than this (30d, 12h, 2w, all)  [30d]
   --harness <a,b>          limit to these harnesses
-                           (claude, codex, pi, opencode, grok, cursor)
+                           (claude, codex, pi, opencode, grok, cursor, hermes)
   --strict                 deterministic associations only (tiers 1 and 2)
   --include-cursor-ide     also scan the Cursor IDE store (best-effort, v1.1 preview)
   --limit <n>              analyze at most N transcripts this run (newest first)

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ import { UserError, warn } from "./logger.js";
 export const CONFIG_FILENAME = ".backpassrc.json";
 export const STATE_DIRNAME = ".backpass";
 
-export const ALL_HARNESSES = ["claude", "codex", "pi", "opencode", "grok", "cursor"];
+export const ALL_HARNESSES = ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes"];
 /** Cursor IDE is deferred to v1.1 and only ever runs behind --include-cursor-ide. */
 export const OPT_IN_HARNESSES = ["cursor-ide"];
 

--- a/src/discovery/adapters/hermes.js
+++ b/src/discovery/adapters/hermes.js
@@ -61,8 +61,10 @@ function cwdFromPrompt(prompt) {
   return looksAbsolute(cwd) ? cwd : null;
 }
 
-function recoverCwd(row) {
-  return cwdFromConfig(row.model_config) || cwdFromPrompt(row.system_prompt);
+function recoverCwd(row, source) {
+  if (source === "acp") return cwdFromConfig(row.model_config);
+  if (source === "cli") return cwdFromPrompt(row.system_prompt);
+  return null;
 }
 
 /**
@@ -78,11 +80,22 @@ export async function discover({ cutoffMs } = {}) {
   try {
     const rows = db
       .prepare(
-        `SELECT id, source, model, model_config, system_prompt, title,
-                started_at, ended_at
-           FROM sessions
-          WHERE (? IS NULL OR COALESCE(ended_at, started_at) >= ?)
-            AND lower(source) IN ('cli', 'acp')`,
+        `SELECT s.id, s.source, s.model, s.model_config, s.system_prompt, s.title,
+                s.started_at, s.ended_at,
+                MAX(s.started_at,
+                    COALESCE(s.ended_at, s.started_at),
+                    COALESCE(activity.last_message_at, s.started_at)) AS activity_at
+           FROM sessions s
+           LEFT JOIN (
+             SELECT session_id, MAX(timestamp) AS last_message_at
+               FROM messages
+              GROUP BY session_id
+           ) activity ON activity.session_id = s.id
+          WHERE (? IS NULL OR
+                 MAX(s.started_at,
+                     COALESCE(s.ended_at, s.started_at),
+                     COALESCE(activity.last_message_at, s.started_at)) >= ?)
+            AND lower(s.source) IN ('cli', 'acp')`,
       )
       .all(cutoffSec, cutoffSec ?? 0);
 
@@ -90,10 +103,10 @@ export async function discover({ cutoffMs } = {}) {
     for (const row of rows) {
       const source = String(row.source || "").toLowerCase();
       if (!CLI_ACP.has(source)) continue;
-      const cwd = recoverCwd(row);
+      const cwd = recoverCwd(row, source);
       if (!cwd) continue;
       const startedAt = toMs(row.started_at);
-      const endedAt = toMs(row.ended_at);
+      const activityAt = toMs(row.activity_at);
       out.push({
         key: `hermes:${row.id}`,
         id: row.id,
@@ -104,7 +117,7 @@ export async function discover({ cutoffMs } = {}) {
         remotes: [],
         title: row.title || null,
         startedAt,
-        mtimeMs: endedAt || startedAt || 0,
+        mtimeMs: activityAt || startedAt || 0,
         bytes: 0,
         model: row.model || null,
         extra: { sessionId: row.id, source },

--- a/src/discovery/adapters/hermes.js
+++ b/src/discovery/adapters/hermes.js
@@ -1,0 +1,200 @@
+import path from "node:path";
+
+import { home, contentToEvents, attachToolResults } from "./shared.js";
+import { openReadOnly, safeJsonParse } from "./sqlite.js";
+
+/**
+ * hermes: ~/.hermes/state.db (sqlite)
+ *
+ * Observed schema version 13 (upstream is 26; SELECT named columns so additive
+ * columns are tolerated). Hermes has no cwd, git branch, or git remote column.
+ *
+ * Association is recovered only for source in ('cli', 'acp'):
+ *   acp - model_config.cwd when it is an absolute path
+ *   cli - first `Current working directory:` / `Working directory:` line in
+ *         system_prompt
+ * Gateway / cron / whatsapp sessions are skipped: their prompt cwd is the
+ * gateway process cwd, not a project, and would pin unrelated sessions to one
+ * repo. Sessions with no recoverable cwd are skipped.
+ *
+ * Timestamps are epoch seconds; backpass uses milliseconds (x1000).
+ * Structured content uses a `\x00json:` prefix; node:sqlite truncates TEXT at
+ * NUL, so message content is read as BLOB and decoded.
+ * JSONL leftovers under ~/.hermes/sessions/ are abandoned and not read.
+ * Honor HERMES_HOME; do not walk profile directories.
+ */
+
+export const name = "hermes";
+export const sqliteBacked = true;
+
+const CLI_ACP = new Set(["cli", "acp"]);
+const JSON_PREFIX = "\x00json:";
+const CWD_LINE = /^(?:Current working directory|Working directory):\s*(.+)$/m;
+
+export function storeRoot() {
+  return process.env.HERMES_HOME || home(".hermes");
+}
+
+export function dbPath() {
+  return path.join(storeRoot(), "state.db");
+}
+
+function toMs(epochSeconds) {
+  const n = Number(epochSeconds);
+  return Number.isFinite(n) ? Math.round(n * 1000) : null;
+}
+
+function looksAbsolute(value) {
+  return typeof value === "string" && value.length > 0 && path.isAbsolute(value);
+}
+
+function cwdFromConfig(raw) {
+  const parsed = typeof raw === "string" ? safeJsonParse(raw) : raw;
+  return looksAbsolute(parsed?.cwd) ? parsed.cwd : null;
+}
+
+function cwdFromPrompt(prompt) {
+  if (typeof prompt !== "string" || !prompt) return null;
+  const match = prompt.match(CWD_LINE);
+  if (!match) return null;
+  const cwd = match[1].trim();
+  return looksAbsolute(cwd) ? cwd : null;
+}
+
+function recoverCwd(row) {
+  return cwdFromConfig(row.model_config) || cwdFromPrompt(row.system_prompt);
+}
+
+/**
+ * Discovery is one indexed query. The caller applies the shared association
+ * tiers. Missing DB or schema surprises yield an empty list, never a throw.
+ * @param {{ cutoffMs?: number }} [options]
+ */
+export async function discover({ cutoffMs } = {}) {
+  const db = await openReadOnly(dbPath());
+  if (!db) return [];
+
+  const cutoffSec = cutoffMs == null ? null : cutoffMs / 1000;
+  try {
+    const rows = db
+      .prepare(
+        `SELECT id, source, model, model_config, system_prompt, title,
+                started_at, ended_at
+           FROM sessions
+          WHERE (? IS NULL OR COALESCE(ended_at, started_at) >= ?)
+            AND lower(source) IN ('cli', 'acp')`,
+      )
+      .all(cutoffSec, cutoffSec ?? 0);
+
+    const out = [];
+    for (const row of rows) {
+      const source = String(row.source || "").toLowerCase();
+      if (!CLI_ACP.has(source)) continue;
+      const cwd = recoverCwd(row);
+      if (!cwd) continue;
+      const startedAt = toMs(row.started_at);
+      const endedAt = toMs(row.ended_at);
+      out.push({
+        key: `hermes:${row.id}`,
+        id: row.id,
+        path: dbPath(),
+        cwd,
+        gitRoot: null,
+        gitBranch: null,
+        remotes: [],
+        title: row.title || null,
+        startedAt,
+        mtimeMs: endedAt || startedAt || 0,
+        bytes: 0,
+        model: row.model || null,
+        extra: { sessionId: row.id, source },
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  } finally {
+    db.close();
+  }
+}
+
+/** node:sqlite truncates TEXT at a NUL, so `\x00json:` payloads must be read as BLOB. */
+function sqliteText(value) {
+  if (value == null) return value;
+  if (typeof value === "string") return value;
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    return new TextDecoder("utf8").decode(value);
+  }
+  return String(value);
+}
+
+function decodeContent(content) {
+  const text = sqliteText(content);
+  if (typeof text !== "string") return content;
+  if (!text.startsWith(JSON_PREFIX)) return text;
+  const parsed = safeJsonParse(text.slice(JSON_PREFIX.length));
+  return parsed == null ? text : parsed;
+}
+
+function emitTools(raw, events, idAlias) {
+  const text = sqliteText(raw);
+  const parsed = typeof text === "string" ? safeJsonParse(text) : text;
+  if (!Array.isArray(parsed)) return;
+  for (const call of parsed) {
+    if (!call || typeof call !== "object") continue;
+    const fn = call.function && typeof call.function === "object" ? call.function : {};
+    const name = fn.name || call.name;
+    let input = fn.arguments ?? call.arguments;
+    if (typeof input === "string") {
+      const parsedInput = safeJsonParse(input);
+      if (parsedInput !== null) input = parsedInput;
+    }
+    const pendingId = call.id || call.call_id;
+    if (call.id) idAlias.set(call.id, pendingId);
+    if (call.call_id) idAlias.set(call.call_id, pendingId);
+    events.push({ kind: "tool", name, input, pendingId });
+  }
+}
+
+export async function read(ref) {
+  const db = await openReadOnly(dbPath());
+  if (!db) return { events: [], model: ref.model || null };
+
+  try {
+    const sessionId = ref.extra?.sessionId || ref.id;
+    const rows = db
+      .prepare(
+        `SELECT role, CAST(content AS BLOB) AS content, tool_call_id, tool_calls, tool_name
+           FROM messages
+          WHERE session_id = ?
+          ORDER BY id`,
+      )
+      .all(sessionId);
+
+    const events = [];
+    const idAlias = new Map();
+    for (const row of rows) {
+      const role = row.role;
+      if (role === "session_meta") continue;
+      const content = decodeContent(row.content);
+      if (role === "user" || role === "assistant") {
+        contentToEvents(role, content, events);
+        if (role === "assistant") emitTools(row.tool_calls, events, idAlias);
+        continue;
+      }
+      if (role === "tool") {
+        events.push({
+          kind: "tool-result",
+          id: idAlias.get(row.tool_call_id) || row.tool_call_id,
+          result: content,
+          status: "completed",
+        });
+      }
+    }
+    return { events: attachToolResults(events), model: ref.model || null };
+  } catch {
+    return { events: [], model: ref.model || null };
+  } finally {
+    db.close();
+  }
+}

--- a/src/discovery/adapters/hermes.js
+++ b/src/discovery/adapters/hermes.js
@@ -84,18 +84,19 @@ export async function discover({ cutoffMs } = {}) {
                 s.started_at, s.ended_at,
                 MAX(s.started_at,
                     COALESCE(s.ended_at, s.started_at),
-                    COALESCE(activity.last_message_at, s.started_at)) AS activity_at
+                    COALESCE((SELECT MAX(m.timestamp)
+                                FROM messages m
+                               WHERE m.session_id = s.id),
+                             s.started_at)) AS activity_at
            FROM sessions s
-           LEFT JOIN (
-             SELECT session_id, MAX(timestamp) AS last_message_at
-               FROM messages
-              GROUP BY session_id
-           ) activity ON activity.session_id = s.id
-          WHERE (? IS NULL OR
+          WHERE lower(s.source) IN ('cli', 'acp')
+            AND (? IS NULL OR
                  MAX(s.started_at,
                      COALESCE(s.ended_at, s.started_at),
-                     COALESCE(activity.last_message_at, s.started_at)) >= ?)
-            AND lower(s.source) IN ('cli', 'acp')`,
+                     COALESCE((SELECT MAX(m.timestamp)
+                                 FROM messages m
+                                WHERE m.session_id = s.id),
+                              s.started_at)) >= ?)`,
       )
       .all(cutoffSec, cutoffSec ?? 0);
 

--- a/src/discovery/adapters/hermes.js
+++ b/src/discovery/adapters/hermes.js
@@ -67,9 +67,17 @@ function recoverCwd(row, source) {
   return null;
 }
 
+function activeMessageFilter(db, alias = "") {
+  const hasActive = db
+    .prepare("PRAGMA table_info(messages)")
+    .all()
+    .some((column) => column.name === "active");
+  return hasActive ? ` AND ${alias}active = 1` : "";
+}
+
 /**
  * Discovery is one indexed query. The caller applies the shared association
- * tiers. Missing DB or schema surprises yield an empty list, never a throw.
+ * tiers and handles schema errors per harness. A missing DB yields an empty list.
  * @param {{ cutoffMs?: number }} [options]
  */
 export async function discover({ cutoffMs } = {}) {
@@ -78,6 +86,7 @@ export async function discover({ cutoffMs } = {}) {
 
   const cutoffSec = cutoffMs == null ? null : cutoffMs / 1000;
   try {
+    const activeFilter = activeMessageFilter(db, "m.");
     const rows = db
       .prepare(
         `SELECT s.id, s.source, s.model, s.model_config, s.system_prompt, s.title,
@@ -86,7 +95,7 @@ export async function discover({ cutoffMs } = {}) {
                     COALESCE(s.ended_at, s.started_at),
                     COALESCE((SELECT MAX(m.timestamp)
                                 FROM messages m
-                               WHERE m.session_id = s.id),
+                               WHERE m.session_id = s.id${activeFilter}),
                              s.started_at)) AS activity_at
            FROM sessions s
           WHERE lower(s.source) IN ('cli', 'acp')
@@ -95,7 +104,7 @@ export async function discover({ cutoffMs } = {}) {
                      COALESCE(s.ended_at, s.started_at),
                      COALESCE((SELECT MAX(m.timestamp)
                                  FROM messages m
-                                WHERE m.session_id = s.id),
+                                WHERE m.session_id = s.id${activeFilter}),
                               s.started_at)) >= ?)`,
       )
       .all(cutoffSec, cutoffSec ?? 0);
@@ -125,8 +134,6 @@ export async function discover({ cutoffMs } = {}) {
       });
     }
     return out;
-  } catch {
-    return [];
   } finally {
     db.close();
   }
@@ -176,11 +183,12 @@ export async function read(ref) {
 
   try {
     const sessionId = ref.extra?.sessionId || ref.id;
+    const activeFilter = activeMessageFilter(db);
     const rows = db
       .prepare(
         `SELECT role, CAST(content AS BLOB) AS content, tool_call_id, tool_calls, tool_name
            FROM messages
-          WHERE session_id = ?
+          WHERE session_id = ?${activeFilter}
           ORDER BY timestamp, id`,
       )
       .all(sessionId);

--- a/src/discovery/adapters/hermes.js
+++ b/src/discovery/adapters/hermes.js
@@ -181,7 +181,7 @@ export async function read(ref) {
         `SELECT role, CAST(content AS BLOB) AS content, tool_call_id, tool_calls, tool_name
            FROM messages
           WHERE session_id = ?
-          ORDER BY id`,
+          ORDER BY timestamp, id`,
       )
       .all(sessionId);
 

--- a/src/discovery/adapters/opencode.js
+++ b/src/discovery/adapters/opencode.js
@@ -11,7 +11,7 @@ import { openReadOnly, safeJsonParse } from "./sqlite.js";
  *   message(id, session_id, data)     - data is JSON: {role, model, time, ...}
  *   part(id, message_id, session_id, data) - data is JSON: {type: text|tool|reasoning|...}
  *
- * This is the best-behaved store of the six: association is a SQL predicate on
+ * This is the best-behaved store: association is a SQL predicate on
  * `session.directory`, deleted worktrees included, and both listing and reading are
  * indexed. Older opencode versions used file storage under `storage/`; that layout is
  * handled as a fallback so long-lived machines still yield transcripts.

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -3,6 +3,7 @@ import * as codex from "./adapters/codex.js";
 import * as pi from "./adapters/pi.js";
 import * as grok from "./adapters/grok.js";
 import * as opencode from "./adapters/opencode.js";
+import * as hermes from "./adapters/hermes.js";
 import * as cursorCli from "./adapters/cursor-cli.js";
 import * as cursorIde from "./adapters/cursor-ide.js";
 
@@ -18,6 +19,7 @@ export const ADAPTERS = {
   pi,
   grok,
   opencode,
+  hermes,
   cursor: cursorCli,
   "cursor-ide": cursorIde,
 };
@@ -34,8 +36,8 @@ export function getAdapter(harness) {
  * Re-scans are then O(new files) - which matters: codex alone had 10,317 rollouts on
  * the machine this was designed against.
  *
- * SQLite-backed stores (opencode, cursor IDE) answer the same question with one indexed
- * query, so they skip the cache entirely.
+ * SQLite-backed stores (opencode, hermes, cursor IDE) answer the same question with one
+ * indexed query, so they skip the cache entirely.
  *
  * Every harness is fail-soft: a store that is missing, unreadable, or has drifted into
  * an unrecognised format produces a named warning and is skipped, never a failed run.

--- a/src/discovery/self.js
+++ b/src/discovery/self.js
@@ -16,7 +16,7 @@ import { SELF_SESSION_SENTINEL } from "../prompts.js";
  *
  * The check reads only the head of the file and keys on the JSON-encoded user text as
  * every file-backed harness records it (`"text":"..."` / `"content":"..."` /
- * `"message":"..."`). SQLite-backed stores (opencode, cursor IDE) have no file to
+ * `"message":"..."`). SQLite-backed stores (opencode, hermes, cursor IDE) have no file to
  * inspect and acpx does not drive them, so they are passed through.
  */
 

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -33,6 +33,7 @@ const HARNESS_HUES = {
   grok: "magenta",
   cursor: "blue",
   "cursor-ide": "blue",
+  hermes: "yellow",
 };
 
 /**
@@ -302,7 +303,7 @@ function discoverDetail(state, theme, width, spin) {
       const scanned = `${formatCount(h.scanned)} sessions`;
       const fresh = h.newCount > 0 || h.scanned > 0 ? ` · ${formatCount(h.newCount)} new` : "";
       const self = h.self > 0 ? ` · ${formatCount(h.self)} self` : "";
-      const query = harness === "opencode" ? "1 sqlite query" : `${scanned}${fresh}${self}`;
+      const query = harness === "opencode" || harness === "hermes" ? "1 sqlite query" : `${scanned}${fresh}${self}`;
       activity = theme.paint(fitPlain(query, activityWidth), "dim");
       count = padVis(
         `${theme.paint(formatCount(h.matched), "text", { bold: true })} ${theme.paint("this repo", "faint")}`,

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -1,13 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
 
 import * as claude from "../src/discovery/adapters/claude.js";
 import * as codex from "../src/discovery/adapters/codex.js";
 import * as pi from "../src/discovery/adapters/pi.js";
 import * as grok from "../src/discovery/adapters/grok.js";
 import * as cursorCli from "../src/discovery/adapters/cursor-cli.js";
+import * as hermes from "../src/discovery/adapters/hermes.js";
 import { statOrNull } from "../src/discovery/adapters/shared.js";
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
@@ -120,4 +124,223 @@ test("cursor CLI chat directories are addressed by md5 of the cwd", () => {
     cursorCli.cwdHash("/Users/kunchen/.treehouse/sshhip-b697bb/9/sshhip"),
     "43ed8ea0825f9a5321fbe6d772769411",
   );
+});
+
+function withHermesHome(dir, fn) {
+  const prev = process.env.HERMES_HOME;
+  process.env.HERMES_HOME = dir;
+  const restore = () => {
+    if (prev === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = prev;
+  };
+  try {
+    const result = fn();
+    if (result && typeof result.then === "function") return result.finally(restore);
+    restore();
+    return result;
+  } catch (err) {
+    restore();
+    throw err;
+  }
+}
+
+/**
+ * @param {string} dir
+ * @param {{ sessions?: object[], messages?: object[], schema?: string }} [spec]
+ */
+function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  const db = new DatabaseSync(path.join(dir, "state.db"));
+  try {
+    if (schema) {
+      db.exec(schema);
+      return;
+    }
+    db.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        source TEXT,
+        model TEXT,
+        model_config TEXT,
+        system_prompt TEXT,
+        title TEXT,
+        started_at REAL,
+        ended_at REAL
+      );
+      CREATE TABLE messages (
+        id INTEGER PRIMARY KEY,
+        session_id TEXT,
+        role TEXT,
+        content TEXT,
+        tool_call_id TEXT,
+        tool_calls TEXT,
+        tool_name TEXT
+      );
+    `);
+    const insertSession = db.prepare(
+      `INSERT INTO sessions (id, source, model, model_config, system_prompt, title, started_at, ended_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const s of sessions) {
+      insertSession.run(
+        s.id,
+        s.source,
+        s.model ?? null,
+        s.model_config ?? null,
+        s.system_prompt ?? null,
+        s.title ?? null,
+        s.started_at,
+        s.ended_at ?? null,
+      );
+    }
+    const insertMessage = db.prepare(
+      `INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, tool_name)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const m of messages) {
+      insertMessage.run(
+        m.id,
+        m.session_id,
+        m.role,
+        m.content ?? null,
+        m.tool_call_id ?? null,
+        m.tool_calls ?? null,
+        m.tool_name ?? null,
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
+
+test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms, and folds tools", async () => {
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hermes-empty-"));
+  await withHermesHome(empty, async () => {
+    assert.deepEqual(await hermes.discover(), []);
+    const emptyRead = await hermes.read({ id: "missing", extra: { sessionId: "missing" } });
+    assert.deepEqual(emptyRead.events, []);
+  });
+
+  const junk = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hermes-junk-"));
+  writeHermesDb(junk, { schema: "CREATE TABLE dummy (id INTEGER)" });
+  await withHermesHome(junk, async () => {
+    assert.deepEqual(await hermes.discover(), [], "a db without sessions fails soft");
+  });
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hermes-"));
+  const prompt = "You are Hermes.\nCurrent working directory: /repo/demo\n";
+  const toolCalls = JSON.stringify([
+    {
+      id: "call_1",
+      type: "function",
+      function: { name: "Bash", arguments: JSON.stringify({ command: "npm test" }) },
+    },
+  ]);
+  writeHermesDb(dir, {
+    sessions: [
+      {
+        id: "cli-1",
+        source: "cli",
+        model: "claude-sonnet-4",
+        system_prompt: prompt,
+        title: "CLI session",
+        started_at: 1_700_000_000,
+        ended_at: 1_700_000_060,
+      },
+      {
+        id: "acp-1",
+        source: "acp",
+        model: "claude-sonnet-4",
+        model_config: JSON.stringify({ cwd: "/repo/demo" }),
+        title: "ACP session",
+        started_at: 1_700_000_100,
+      },
+      {
+        id: "wa-1",
+        source: "whatsapp",
+        system_prompt: prompt,
+        started_at: 1_700_000_200,
+      },
+      {
+        id: "cron-1",
+        source: "cron",
+        system_prompt: prompt,
+        started_at: 1_700_000_300,
+      },
+      {
+        id: "cli-nocwd",
+        source: "cli",
+        system_prompt: "no directory line here",
+        started_at: 1_700_000_400,
+      },
+    ],
+    messages: [
+      { id: 1, session_id: "cli-1", role: "user", content: "Please open a PR for the parser fix." },
+      {
+        id: 2,
+        session_id: "cli-1",
+        role: "assistant",
+        content: "I'll run the tests first.",
+        tool_calls: toolCalls,
+      },
+      {
+        id: 3,
+        session_id: "cli-1",
+        role: "tool",
+        tool_call_id: "call_1",
+        tool_name: null,
+        content: "2 passing",
+      },
+      {
+        id: 4,
+        session_id: "cli-1",
+        role: "assistant",
+        content: `\x00json:${JSON.stringify([{ type: "text", text: "Opened PR #2731." }])}`,
+      },
+      {
+        id: 5,
+        session_id: "cli-1",
+        role: "session_meta",
+        content: "session-meta-must-not-surface",
+      },
+    ],
+  });
+
+  await withHermesHome(dir, async () => {
+    const found = await hermes.discover();
+    assert.deepEqual(
+      found.map((row) => row.id).sort(),
+      ["acp-1", "cli-1"],
+      "cli and acp are kept; gateway, cron, and cwd-less cli are skipped",
+    );
+
+    const cli = found.find((row) => row.id === "cli-1");
+    const acp = found.find((row) => row.id === "acp-1");
+    assert.equal(cli.cwd, "/repo/demo");
+    assert.equal(acp.cwd, "/repo/demo");
+    assert.equal(cli.startedAt, 1_700_000_000_000, "epoch seconds become milliseconds");
+    assert.equal(cli.mtimeMs, 1_700_000_060_000);
+    assert.equal(acp.mtimeMs, 1_700_000_100_000, "ended_at falls back to started_at");
+    assert.equal(cli.extra.source, "cli");
+    assert.equal(acp.extra.source, "acp");
+    assert.deepEqual(cli.remotes, []);
+    assert.equal(cli.gitBranch, null);
+
+    const { events, model } = await hermes.read(cli);
+    assert.equal(model, "claude-sonnet-4");
+    assert.deepEqual(
+      messages(events).map((m) => `${m.role}: ${m.text}`),
+      [
+        "user: Please open a PR for the parser fix.",
+        "assistant: I'll run the tests first.",
+        "assistant: Opened PR #2731.",
+      ],
+    );
+    assert.ok(!JSON.stringify(events).includes("session-meta-must-not-surface"), "session_meta rows are dropped");
+
+    const [toolCall] = tools(events);
+    assert.equal(toolCall.name, "Bash", "tool name comes from the matching call when tool_name is null");
+    assert.equal(toolCall.input.command, "npm test");
+    assert.equal(toolCall.result, "2 passing");
+  });
 });

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -174,7 +174,8 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
         content TEXT,
         tool_call_id TEXT,
         tool_calls TEXT,
-        tool_name TEXT
+        tool_name TEXT,
+        timestamp REAL NOT NULL
       );
     `);
     const insertSession = db.prepare(
@@ -194,8 +195,9 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
       );
     }
     const insertMessage = db.prepare(
-      `INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, tool_name)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO messages
+         (id, session_id, role, content, tool_call_id, tool_calls, tool_name, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const m of messages) {
       insertMessage.run(
@@ -206,6 +208,7 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
         m.tool_call_id ?? null,
         m.tool_calls ?? null,
         m.tool_name ?? null,
+        m.timestamp ?? 1_700_000_000 + m.id,
       );
     }
   } finally {
@@ -270,8 +273,21 @@ test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms
       {
         id: "cli-nocwd",
         source: "cli",
+        model_config: JSON.stringify({ cwd: "/repo/wrong-source" }),
         system_prompt: "no directory line here",
         started_at: 1_700_000_400,
+      },
+      {
+        id: "acp-nocwd",
+        source: "acp",
+        system_prompt: prompt,
+        started_at: 1_700_000_450,
+      },
+      {
+        id: "cli-resumed",
+        source: "cli",
+        system_prompt: prompt,
+        started_at: 1_600_000_000,
       },
     ],
     messages: [
@@ -303,6 +319,13 @@ test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms
         role: "session_meta",
         content: "session-meta-must-not-surface",
       },
+      {
+        id: 6,
+        session_id: "cli-resumed",
+        role: "user",
+        content: "Continue this old session.",
+        timestamp: 1_700_000_600,
+      },
     ],
   });
 
@@ -310,17 +333,24 @@ test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms
     const found = await hermes.discover();
     assert.deepEqual(
       found.map((row) => row.id).sort(),
-      ["acp-1", "cli-1"],
-      "cli and acp are kept; gateway, cron, and cwd-less cli are skipped",
+      ["acp-1", "cli-1", "cli-resumed"],
+      "cli and acp are kept; disallowed sources and source-invalid cwd fields are skipped",
     );
 
     const cli = found.find((row) => row.id === "cli-1");
     const acp = found.find((row) => row.id === "acp-1");
+    const resumed = found.find((row) => row.id === "cli-resumed");
     assert.equal(cli.cwd, "/repo/demo");
     assert.equal(acp.cwd, "/repo/demo");
     assert.equal(cli.startedAt, 1_700_000_000_000, "epoch seconds become milliseconds");
     assert.equal(cli.mtimeMs, 1_700_000_060_000);
-    assert.equal(acp.mtimeMs, 1_700_000_100_000, "ended_at falls back to started_at");
+    assert.equal(acp.mtimeMs, 1_700_000_100_000, "activity falls back to started_at");
+    assert.equal(resumed.mtimeMs, 1_700_000_600_000, "latest message determines resumed-session activity");
+    assert.deepEqual(
+      (await hermes.discover({ cutoffMs: 1_700_000_500_000 })).map((row) => row.id),
+      ["cli-resumed"],
+      "a recently resumed old session passes the activity cutoff",
+    );
     assert.equal(cli.extra.source, "cli");
     assert.equal(acp.extra.source, "acp");
     assert.deepEqual(cli.remotes, []);

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -326,6 +326,20 @@ test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms
         content: "Continue this old session.",
         timestamp: 1_700_000_600,
       },
+      {
+        id: 7,
+        session_id: "cli-1",
+        role: "assistant",
+        content: "Imported later message.",
+        timestamp: 1_700_000_050,
+      },
+      {
+        id: 8,
+        session_id: "cli-1",
+        role: "user",
+        content: "Imported earlier message.",
+        timestamp: 1_700_000_040,
+      },
     ],
   });
 
@@ -364,6 +378,8 @@ test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms
         "user: Please open a PR for the parser fix.",
         "assistant: I'll run the tests first.",
         "assistant: Opened PR #2731.",
+        "user: Imported earlier message.",
+        "assistant: Imported later message.",
       ],
     );
     assert.ok(!JSON.stringify(events).includes("session-meta-must-not-surface"), "session_meta rows are dropped");

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -146,9 +146,9 @@ function withHermesHome(dir, fn) {
 
 /**
  * @param {string} dir
- * @param {{ sessions?: object[], messages?: object[], schema?: string }} [spec]
+ * @param {{ sessions?: object[], messages?: object[], schema?: string, activeColumn?: boolean }} [spec]
  */
-function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
+function writeHermesDb(dir, { sessions = [], messages = [], schema, activeColumn = false } = {}) {
   fs.mkdirSync(dir, { recursive: true });
   const db = new DatabaseSync(path.join(dir, "state.db"));
   try {
@@ -176,6 +176,7 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
         tool_calls TEXT,
         tool_name TEXT,
         timestamp REAL NOT NULL
+        ${activeColumn ? ", active INTEGER NOT NULL DEFAULT 1" : ""}
       );
     `);
     const insertSession = db.prepare(
@@ -196,11 +197,11 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
     }
     const insertMessage = db.prepare(
       `INSERT INTO messages
-         (id, session_id, role, content, tool_call_id, tool_calls, tool_name, timestamp)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+         (id, session_id, role, content, tool_call_id, tool_calls, tool_name, timestamp${activeColumn ? ", active" : ""})
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?${activeColumn ? ", ?" : ""})`,
     );
     for (const m of messages) {
-      insertMessage.run(
+      const values = [
         m.id,
         m.session_id,
         m.role,
@@ -209,7 +210,9 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema } = {}) {
         m.tool_calls ?? null,
         m.tool_name ?? null,
         m.timestamp ?? 1_700_000_000 + m.id,
-      );
+      ];
+      if (activeColumn) values.push(m.active ?? 1);
+      insertMessage.run(...values);
     }
   } finally {
     db.close();
@@ -227,7 +230,45 @@ test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms
   const junk = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hermes-junk-"));
   writeHermesDb(junk, { schema: "CREATE TABLE dummy (id INTEGER)" });
   await withHermesHome(junk, async () => {
-    assert.deepEqual(await hermes.discover(), [], "a db without sessions fails soft");
+    await assert.rejects(hermes.discover(), /no such table: sessions/);
+  });
+
+  const current = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hermes-current-"));
+  writeHermesDb(current, {
+    activeColumn: true,
+    sessions: [
+      {
+        id: "cli-rewound",
+        source: "cli",
+        system_prompt: "Working directory: /repo/demo",
+        started_at: 1_600_000_000,
+      },
+    ],
+    messages: [
+      {
+        id: 1,
+        session_id: "cli-rewound",
+        role: "user",
+        content: "Active turn",
+        timestamp: 1_600_000_100,
+      },
+      {
+        id: 2,
+        session_id: "cli-rewound",
+        role: "user",
+        content: "Rewound turn",
+        timestamp: 1_700_000_000,
+        active: 0,
+      },
+    ],
+  });
+  await withHermesHome(current, async () => {
+    assert.deepEqual(await hermes.discover({ cutoffMs: 1_700_000_000_000 }), []);
+    const [rewound] = await hermes.discover();
+    assert.deepEqual(
+      messages((await hermes.read(rewound)).events).map((message) => message.text),
+      ["Active turn"],
+    );
   });
 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hermes-"));

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -23,7 +23,7 @@ test("the defaults match the approved design", () => {
   assert.equal(config.minGapEvidence, 2);
   assert.equal(config.jobs, 4);
   assert.equal(config.discovery.since, "30d");
-  assert.deepEqual(config.discovery.harnesses, ["claude", "codex", "pi", "opencode", "grok", "cursor"]);
+  assert.deepEqual(config.discovery.harnesses, ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes"]);
   assert.ok(!config.discovery.harnesses.includes("cursor-ide"), "Cursor IDE is deferred to v1.1");
   assert.deepEqual(config.analysis, { agent: null, model: null, effort: null }, "agents are auto-picked by default");
   assert.deepEqual(config.synthesis, { agent: null, model: null, effort: null });


### PR DESCRIPTION
## Intent

Build and ship first-class Hermes transcript support in backpass (the published npm tool that ingests AI-agent transcripts). Add a SQLite source adapter src/discovery/adapters/hermes.js modeled on the opencode adapter, reading ~/.hermes/state.db and honoring HERMES_HOME. Register hermes as a first-class harness on ALL_HARNESSES (not an --include-* opt-in), in ADAPTERS, CLI help, and the README harness count/list.

Association: recover cli and acp sessions only (acp: model_config.cwd; cli: parse Current working directory / Working directory from system_prompt). Skip gateway/cron/whatsapp sources so they are not wrongly pinned to one workdir. Skip any session with no recoverable cwd.

Timestamps are epoch seconds and must be converted to milliseconds. Parse assistant tool_calls JSON into tool events (name from function.name, input from function.arguments); fold role=tool rows as results, joining on tool_call_id/id for the name when tool_name is null. Decode the \x00json: structured-content prefix. Drop session_meta rows and reasoning/thinking. SELECT named columns and fail-soft on a missing DB or schema surprises. SQLite only - no JSONL fallback, no parent-chain stitching, no prompt-cwd for gateway sources, no git-remote mining, no profile walking.

Tests must exercise the real adapter interface against a tiny temp SQLite (v13 subset): a cli session (cwd in the system prompt), an acp session (model_config.cwd), and a whatsapp/gateway session with the same prompt cwd that must be skipped; messages covering user, assistant+tool_calls, a tool result, a \x00json: content part, and a session_meta row. Assert cli/acp cwd recovery, gateway/cron skip, timestamp seconds-to-ms conversion, tool-name join, and fail-soft on a missing DB.

Ship through the no-mistakes pipeline to a PR. Do not merge; yolo is off.

## What Changed

- Add first-class Hermes SQLite discovery for CLI and ACP sessions, including cwd recovery, activity timestamps, structured content, and tool-call results.
- Exclude gateway, cron, WhatsApp, inactive, metadata, and cwd-less sessions while keeping missing or incompatible stores fail-soft.
- Register Hermes in default harness configuration, CLI help, progress rendering, documentation, and adapter coverage.

## Risk Assessment

✅ Low: The change is well-bounded, follows existing adapter contracts, and covers the required Hermes discovery and transcript normalization behavior.

## Testing

Targeted adapter and default-configuration tests passed; CLI help exposed Hermes, an end-to-end scan associated only CLI and ACP sessions while excluding gateway data, transcript reading produced normalized messages and folded tool output, and schema drift failed softly with a named warning. Reviewer-visible JSON and log evidence was captured.

<details>
<summary>Evidence: End-to-end Hermes CLI scan showing two exact CLI/ACP associations and no gateway session</summary>

Source: [End-to-end Hermes CLI scan showing two exact CLI/ACP associations and no gateway session](https://github.com/kunchenguid/backpass/blob/da3079b0b72c1fab818a3d97709a1f5ce8ea7b4a/.no-mistakes/evidence/fm/backpass-hermes-transcripts-support-r1/hermes-cli-scan.json)

```text
{
  "repo": "hermes-e2e-repo",
  "perHarness": {
    "hermes": {
      "scanned": 2,
      "matched": 2,
      "cached": 0,
      "skipped": 0,
      "self": 0,
      "error": null
    }
  },
  "transcripts": [
    {
      "harness": "hermes",
      "id": "hermes-acp-e2e",
      "nativeId": "acp-e2e",
      "path": "/Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-home/state.db",
      "cwd": "/Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-e2e-repo",
      "gitBranch": null,
      "title": "ACP E2E",
      "model": "claude-sonnet-4",
      "startedAt": 1787517380000,
      "mtimeMs": 1787517381000,
      "bytes": 0,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-e2e-repo"
      },
      "extra": {
        "sessionId": "acp-e2e",
        "source": "acp"
      }
    },
    {
      "harness": "hermes",
      "id": "hermes-cli-e2e",
      "nativeId": "cli-e2e",
      "path": "/Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-home/state.db",
      "cwd": "/Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-e2e-repo",
      "gitBranch": null,
      "title": "CLI E2E",
      "model": "claude-sonnet-4",
      "startedAt": 1787517370000,
      "mtimeMs": 1787517375000,
      "bytes": 0,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-e2e-repo"
      },
      "extra": {
        "sessionId": "cli-e2e",
        "source": "cli"
      }
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Normalized Hermes transcript events showing structured content, folded tool result, and excluded inactive/session metadata</summary>

Source: [Normalized Hermes transcript events showing structured content, folded tool result, and excluded inactive/session metadata](https://github.com/kunchenguid/backpass/blob/da3079b0b72c1fab818a3d97709a1f5ce8ea7b4a/.no-mistakes/evidence/fm/backpass-hermes-transcripts-support-r1/hermes-adapter-events.json)

```text
{
  "discovered": [
    {
      "id": "cli-e2e",
      "cwd": "/Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-e2e-repo",
      "startedAt": 1787517370000,
      "mtimeMs": 1787517375000
    },
    {
      "id": "acp-e2e",
      "cwd": "/Users/kunchen/.no-mistakes/evidence/01M0R4P06BWXXK7WFCN9RN3D69/hermes-e2e-repo",
      "startedAt": 1787517380000,
      "mtimeMs": 1787517381000
    }
  ],
  "cliEvents": [
    {
      "kind": "message",
      "role": "user",
      "text": "Fix the parser"
    },
    {
      "kind": "message",
      "role": "assistant",
      "text": "Running tests"
    },
    {
      "kind": "tool",
      "name": "Bash",
      "input": {
        "command": "pnpm test"
      },
      "result": "all targeted tests passed",
      "status": "completed"
    },
    {
      "kind": "message",
      "role": "assistant",
      "text": "Parser fixed."
    }
  ],
  "excludedGateway": true,
  "excludedInactiveMessage": true,
  "excludedSessionMeta": true
}
```
</details>
<details>
<summary>Evidence: Named fail-soft warning for Hermes schema drift</summary>

Source: [Named fail-soft warning for Hermes schema drift](https://github.com/kunchenguid/backpass/blob/da3079b0b72c1fab818a3d97709a1f5ce8ea7b4a/.no-mistakes/evidence/fm/backpass-hermes-transcripts-support-r1/hermes-schema-drift-stderr.log)

```text
warn hermes: transcript store unreadable (no such table: sessions) - harness skipped
```
</details>
<details>
<summary>Evidence: Successful CLI JSON response after skipping an unreadable Hermes schema</summary>

Source: [Successful CLI JSON response after skipping an unreadable Hermes schema](https://github.com/kunchenguid/backpass/blob/da3079b0b72c1fab818a3d97709a1f5ce8ea7b4a/.no-mistakes/evidence/fm/backpass-hermes-transcripts-support-r1/hermes-schema-drift-stdout.json)

```text
{
  "repo": "hermes-e2e-repo",
  "perHarness": {
    "hermes": {
      "scanned": 0,
      "matched": 0,
      "cached": 0,
      "skipped": 0,
      "self": 0,
      "error": "no such table: sessions"
    }
  },
  "transcripts": []
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"024c1c4a742e8fc9362cc6a1beec4fd44049b67d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (4) ✅</summary>

- 🚨 `src/discovery/adapters/hermes.js:65` - Intent requires &#34;acp: model_config.cwd; cli: parse Current working directory / Working directory from system_prompt&#34;, but `recoverCwd` applies both strategies to both sources. A CLI row with only `model_config.cwd`, or an ACP row with only a prompt cwd, is therefore associated instead of skipped. Branch on `row.source` so each source uses only its authorized cwd field.
- ⚠️ `src/discovery/adapters/hermes.js:84` - Recency is based only on `ended_at` or `started_at`. Hermes can reopen an old session by clearing `ended_at` and append new messages without changing `started_at`, so a session resumed today but created over 30 days ago is silently excluded by the default cutoff and receives a stale `mtimeMs`. Derive last activity from the latest message timestamp at this discovery boundary.

🔧 Fix: Fix Hermes association and resumed session activity
1 warning still open:

- ⚠️ `src/discovery/adapters/hermes.js:89` - The activity subquery aggregates every message in the database before filtering sessions to `cli`/`acp` or applying the cutoff. A database dominated by old gateway/WhatsApp history therefore incurs a full message-index scan on every default backpass run. Restrict sessions first and obtain each candidate&#39;s latest timestamp through the existing `(session_id, timestamp)` index, such as with a correlated MAX query.

🔧 Fix: Optimize Hermes session activity lookup
1 warning still open:

- ⚠️ `src/discovery/adapters/hermes.js:184` - Messages are ordered only by insertion ID, while Hermes&#39; canonical reader orders by `timestamp, id`. A restored or imported session with id 1 at timestamp 20 and id 2 at timestamp 10 is therefore distilled in reverse conversation order and may misassociate tool results. Order by `timestamp, id`.

🔧 Fix: Order Hermes messages by canonical chronology
2 warnings still open:

- ⚠️ `src/discovery/adapters/hermes.js:181` - Current Hermes schemas soft-delete rewound and compacted messages with `active=0`, but this query reads every row. After `/undo` or in-place compaction, backpass silently analyzes obsolete turns alongside the active conversation, and the discovery activity query can also treat an inactive message as recent. Apply an `active=1` predicate when that column exists while retaining compatibility with the required v13 subset.
- ⚠️ `src/discovery/adapters/hermes.js:128` - Schema/query failures are converted to an empty store, bypassing the shared discovery boundary that emits the required named unreadable-store warning. A drifted Hermes schema therefore looks identical to having no transcripts. Let discovery query errors reach `discoverTranscripts`, which already warns and skips the harness, while continuing to return `[]` for a missing database.

🔧 Fix: Filter inactive Hermes messages and surface schema errors
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='hermes adapter' test/adapters.test.js`
- `node --test --test-name-pattern='the defaults match the approved design' test/config.test.js`
- <code>`node bin/backpass.js --help` to verify Hermes appears as a first-class harness</code>
- <code>Created a tiny Hermes v13-subset SQLite store and ran `backpass scan --harness hermes --since all --json` from a real Git repository</code>
- `Read the discovered CLI session through the Hermes adapter to verify structured content, tool folding, inactive-message filtering, and metadata exclusion`
- `Ran the CLI against an unexpected SQLite schema and verified it warned, skipped Hermes, reported the error in JSON, and exited successfully`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
