### PR TITLE
fix(discovery): recover Hermes v26 CLI sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   fail-soft: an unreadable store warns and is skipped, never throws.
 - **Hermes is first-class but source-filtered.** `src/discovery/adapters/hermes.js` reads
   `~/.hermes/state.db` (`HERMES_HOME`). Only `cli` and `acp` sessions are ingested;
-  gateway/cron rows share a process cwd and would pollute association. Timestamps are
-  epoch seconds and must be converted to ms. Message content is read as BLOB because
-  node:sqlite truncates TEXT at the `\x00json:` NUL. There is no JSONL fallback.
+  gateway/cron rows share a process cwd and would pollute association. v26 stores CLI cwd
+  on `sessions.cwd` (system_prompt is often NULL); ACP still uses `model_config.cwd`.
+  Timestamps are epoch seconds and must be converted to ms. Message content is read as
+  BLOB because node:sqlite truncates TEXT at the `\x00json:` NUL. There is no JSONL fallback.
 - **The live progress view is an enhancement layer, never a dependency.** Pipeline stages
   emit events through `src/progress.js`; `src/tui/` renders them on stderr during the
   default run and buffers/replays the plain logger lines on teardown. Every path must

--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ backpass apply     # review each edit, accept or reject, then write
 
 backpass reads the local transcript stores of seven harnesses directly. No API, no upload.
 
-| Harness        | Store                                          | Repo tie                                |
-| -------------- | ---------------------------------------------- | --------------------------------------- |
-| **claude**     | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl` | per-line `cwd`                          |
-| **codex**      | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | `cwd` + recorded `git.repository_url`   |
-| **pi**         | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`   | session-header `cwd`                    |
-| **opencode**   | `~/.local/share/opencode/opencode.db` (sqlite) | `session.directory`                     |
-| **grok**       | `~/.grok/sessions/<encoded-cwd>/<uuid>/`       | `summary.json` `cwd` + `git_remotes`    |
-| **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                       |
-| **hermes**     | `~/.hermes/state.db` (sqlite)                  | CLI prompt cwd / ACP `model_config.cwd` |
+| Harness        | Store                                          | Repo tie                                            |
+| -------------- | ---------------------------------------------- | --------------------------------------------------- |
+| **claude**     | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl` | per-line `cwd`                                      |
+| **codex**      | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | `cwd` + recorded `git.repository_url`               |
+| **pi**         | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`   | session-header `cwd`                                |
+| **opencode**   | `~/.local/share/opencode/opencode.db` (sqlite) | `session.directory`                                 |
+| **grok**       | `~/.grok/sessions/<encoded-cwd>/<uuid>/`       | `summary.json` `cwd` + `git_remotes`                |
+| **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                                   |
+| **hermes**     | `~/.hermes/state.db` (sqlite)                  | session cwd, with CLI prompt / ACP config fallbacks |
 
 Hermes collection includes CLI and ACP sessions only. Gateway, cron, and WhatsApp sessions
 are excluded because their recorded cwd belongs to the shared gateway process, not a project.

--- a/src/discovery/adapters/hermes.js
+++ b/src/discovery/adapters/hermes.js
@@ -7,15 +7,15 @@ import { openReadOnly, safeJsonParse } from "./sqlite.js";
  * hermes: ~/.hermes/state.db (sqlite)
  *
  * Observed schema version 13 (upstream is 26; SELECT named columns so additive
- * columns are tolerated). Hermes has no cwd, git branch, or git remote column.
- *
- * Association is recovered only for source in ('cli', 'acp'):
+ * columns are tolerated). v26 adds sessions.cwd; CLI rows leave system_prompt
+ * NULL and store the project path there. ACP still snapshots cwd on
+ * model_config. Prefer the cwd column when present, then the v13 paths:
  *   acp - model_config.cwd when it is an absolute path
  *   cli - first `Current working directory:` / `Working directory:` line in
  *         system_prompt
- * Gateway / cron / whatsapp sessions are skipped: their prompt cwd is the
- * gateway process cwd, not a project, and would pin unrelated sessions to one
- * repo. Sessions with no recoverable cwd are skipped.
+ * Gateway / cron / whatsapp sessions are skipped even if sessions.cwd is set:
+ * their path is the gateway process cwd, not a project, and would pin
+ * unrelated sessions to one repo. Sessions with no recoverable cwd are skipped.
  *
  * Timestamps are epoch seconds; backpass uses milliseconds (x1000).
  * Structured content uses a `\x00json:` prefix; node:sqlite truncates TEXT at
@@ -62,17 +62,25 @@ function cwdFromPrompt(prompt) {
 }
 
 function recoverCwd(row, source) {
+  if (looksAbsolute(row.cwd)) return row.cwd;
   if (source === "acp") return cwdFromConfig(row.model_config);
   if (source === "cli") return cwdFromPrompt(row.system_prompt);
   return null;
 }
 
-function activeMessageFilter(db, alias = "") {
-  const hasActive = db
-    .prepare("PRAGMA table_info(messages)")
+function tableHasColumn(db, table, column) {
+  return db
+    .prepare(`PRAGMA table_info(${table})`)
     .all()
-    .some((column) => column.name === "active");
-  return hasActive ? ` AND ${alias}active = 1` : "";
+    .some((entry) => entry.name === column);
+}
+
+function activeMessageFilter(db, alias = "") {
+  return tableHasColumn(db, "messages", "active") ? ` AND ${alias}active = 1` : "";
+}
+
+function sessionCwdSelect(db) {
+  return tableHasColumn(db, "sessions", "cwd") ? ", s.cwd" : "";
 }
 
 /**
@@ -87,10 +95,11 @@ export async function discover({ cutoffMs } = {}) {
   const cutoffSec = cutoffMs == null ? null : cutoffMs / 1000;
   try {
     const activeFilter = activeMessageFilter(db, "m.");
+    const cwdSelect = sessionCwdSelect(db);
     const rows = db
       .prepare(
         `SELECT s.id, s.source, s.model, s.model_config, s.system_prompt, s.title,
-                s.started_at, s.ended_at,
+                s.started_at, s.ended_at${cwdSelect},
                 MAX(s.started_at,
                     COALESCE(s.ended_at, s.started_at),
                     COALESCE((SELECT MAX(m.timestamp)

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -146,9 +146,9 @@ function withHermesHome(dir, fn) {
 
 /**
  * @param {string} dir
- * @param {{ sessions?: object[], messages?: object[], schema?: string, activeColumn?: boolean }} [spec]
+ * @param {{ sessions?: object[], messages?: object[], schema?: string, activeColumn?: boolean, cwdColumn?: boolean }} [spec]
  */
-function writeHermesDb(dir, { sessions = [], messages = [], schema, activeColumn = false } = {}) {
+function writeHermesDb(dir, { sessions = [], messages = [], schema, activeColumn = false, cwdColumn = false } = {}) {
   fs.mkdirSync(dir, { recursive: true });
   const db = new DatabaseSync(path.join(dir, "state.db"));
   try {
@@ -166,6 +166,7 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema, activeColumn
         title TEXT,
         started_at REAL,
         ended_at REAL
+        ${cwdColumn ? ", cwd TEXT" : ""}
       );
       CREATE TABLE messages (
         id INTEGER PRIMARY KEY,
@@ -180,11 +181,11 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema, activeColumn
       );
     `);
     const insertSession = db.prepare(
-      `INSERT INTO sessions (id, source, model, model_config, system_prompt, title, started_at, ended_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO sessions (id, source, model, model_config, system_prompt, title, started_at, ended_at${cwdColumn ? ", cwd" : ""})
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?${cwdColumn ? ", ?" : ""})`,
     );
     for (const s of sessions) {
-      insertSession.run(
+      const values = [
         s.id,
         s.source,
         s.model ?? null,
@@ -193,7 +194,9 @@ function writeHermesDb(dir, { sessions = [], messages = [], schema, activeColumn
         s.title ?? null,
         s.started_at,
         s.ended_at ?? null,
-      );
+      ];
+      if (cwdColumn) values.push(s.cwd ?? null);
+      insertSession.run(...values);
     }
     const insertMessage = db.prepare(
       `INSERT INTO messages
@@ -429,5 +432,84 @@ test("hermes adapter recovers cli/acp cwd, skips gateway, converts seconds to ms
     assert.equal(toolCall.name, "Bash", "tool name comes from the matching call when tool_name is null");
     assert.equal(toolCall.input.command, "npm test");
     assert.equal(toolCall.result, "2 passing");
+  });
+});
+
+test("hermes adapter recovers v26 cli cwd from sessions.cwd when system_prompt is null, and still skips cron", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hermes-v26-"));
+  writeHermesDb(dir, {
+    cwdColumn: true,
+    sessions: [
+      {
+        id: "cli-v26",
+        source: "cli",
+        model: "openai/gpt-4o-mini",
+        cwd: "/repo/demo",
+        started_at: 1_700_000_000,
+      },
+      {
+        id: "acp-v26",
+        source: "acp",
+        model: "openai/gpt-4o-mini",
+        model_config: JSON.stringify({ cwd: "/repo/demo" }),
+        started_at: 1_700_000_100,
+      },
+      {
+        id: "cron-v26",
+        source: "cron",
+        cwd: "/repo/demo",
+        system_prompt: "Current working directory: /repo/demo\n",
+        started_at: 1_700_000_200,
+      },
+    ],
+    messages: [
+      { id: 1, session_id: "cli-v26", role: "user", content: "hello from v26 cli" },
+      {
+        id: 2,
+        session_id: "cli-v26",
+        role: "assistant",
+        content: "running pwd",
+        tool_calls: JSON.stringify([
+          {
+            id: "call_pwd",
+            type: "function",
+            function: { name: "terminal", arguments: JSON.stringify({ command: "pwd" }) },
+          },
+        ]),
+      },
+      {
+        id: 3,
+        session_id: "cli-v26",
+        role: "tool",
+        tool_call_id: "call_pwd",
+        tool_name: null,
+        content: "/repo/demo",
+      },
+    ],
+  });
+
+  await withHermesHome(dir, async () => {
+    const found = await hermes.discover();
+    assert.deepEqual(
+      found.map((row) => row.id).sort(),
+      ["acp-v26", "cli-v26"],
+      "v26 cli/acp are kept; cron is skipped even when sessions.cwd is set",
+    );
+    const cli = found.find((row) => row.id === "cli-v26");
+    const acp = found.find((row) => row.id === "acp-v26");
+    assert.equal(cli.cwd, "/repo/demo");
+    assert.equal(acp.cwd, "/repo/demo");
+    assert.equal(cli.startedAt, 1_700_000_000_000);
+
+    const { events, model } = await hermes.read(cli);
+    assert.equal(model, "openai/gpt-4o-mini");
+    assert.deepEqual(
+      messages(events).map((m) => `${m.role}: ${m.text}`),
+      ["user: hello from v26 cli", "assistant: running pwd"],
+    );
+    const [toolCall] = tools(events);
+    assert.equal(toolCall.name, "terminal");
+    assert.equal(toolCall.input.command, "pwd");
+    assert.equal(toolCall.result, "/repo/demo");
   });
 });


### PR DESCRIPTION
## Intent

Validate the shipped backpass Hermes transcript adapter end to end against a real, isolated, latest-schema Hermes Agent DB (not the machine default ~/.hermes, which is schema 13 with no cli/acp rows). Generate real CLI and ACP sessions by running Hermes in a git working directory, plus a cron session to confirm skip. If the adapter already worked unchanged, do not change code or open a PR.

The run found a schema v26 CLI association gap: CLI rows leave system_prompt NULL and store the project path on sessions.cwd, so the shipped adapter dropped those sessions; ACP still associated via model_config.cwd; cron/gateway stayed skipped. Fix the adapter to prefer sessions.cwd when that column exists, keep the v13 system_prompt and model_config fallbacks, and keep the cli/acp source filter so cron is skipped even if cwd is set. Add a sqlite-backed test that builds a v26-shaped DB (cwd column, null system_prompt, cron with cwd set) and asserts discover/read behavior. Do not merge; the captain merges and decides any patch release.

## What Changed

- Prefer `sessions.cwd` when associating Hermes v26 transcripts while retaining legacy CLI prompt and ACP config fallbacks.
- Continue excluding cron and other non-CLI/ACP sessions even when they contain a cwd.
- Add SQLite-backed v26 coverage and document the updated Hermes repository association behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves v13 fallbacks and source filtering, and adds behavioral coverage for v26 CLI, ACP, cron, and transcript reading.

## Testing

No baseline commands were supplied. Focused adapter tests passed, the test reproduced the failure against the base adapter, and an end-to-end CLI scan of an isolated v26 database associated CLI and ACP sessions at exact tier 1 while excluding cron. Generated `.backpass` state was removed afterward.

<details>
<summary>Evidence: End-to-end Hermes v26 backpass scan JSON</summary>

Source: [End-to-end Hermes v26 backpass scan JSON](https://github.com/kunchenguid/backpass/blob/88dd6c9dee0352a4d31147dfc7c4533f754fd09d/.no-mistakes/evidence/fm/backpass-hermes-realdb-e2e-validation-r1/hermes-v26-cli-scan.json)

```text
{
  "repo": "01M0R86PXM7RDBB71JQ4S21MCE",
  "perHarness": {
    "hermes": {
      "scanned": 2,
      "matched": 2,
      "cached": 0,
      "skipped": 0,
      "self": 0,
      "error": null
    }
  },
  "transcripts": [
    {
      "harness": "hermes",
      "id": "hermes-real-acp-v26",
      "nativeId": "real-acp-v26",
      "path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/backpass-hermes-v26-e2e.bGswjY/state.db",
      "cwd": "/Users/kunchen/.no-mistakes/worktrees/eed9cd424644/01M0R86PXM7RDBB71JQ4S21MCE",
      "gitBranch": null,
      "title": "Real Hermes ACP session",
      "model": "test/acp-model",
      "startedAt": 1787520366000,
      "mtimeMs": 1787520376000,
      "bytes": 0,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /Users/kunchen/.no-mistakes/worktrees/eed9cd424644/01M0R86PXM7RDBB71JQ4S21MCE"
      },
      "extra": {
        "sessionId": "real-acp-v26",
        "source": "acp"
      }
    },
    {
      "harness": "hermes",
      "id": "hermes-real-cli-v26",
      "nativeId": "real-cli-v26",
      "path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/backpass-hermes-v26-e2e.bGswjY/state.db",
      "cwd": "/Users/kunchen/.no-mistakes/worktrees/eed9cd424644/01M0R86PXM7RDBB71JQ4S21MCE",
      "gitBranch": null,
      "title": "Real Hermes CLI session",
      "model": "test/cli-model",
      "startedAt": 1787520356000,
      "mtimeMs": 1787520366000,
      "bytes": 0,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /Users/kunchen/.no-mistakes/worktrees/eed9cd424644/01M0R86PXM7RDBB71JQ4S21MCE"
      },
      "extra": {
        "sessionId": "real-cli-v26",
        "source": "cli"
      }
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"35d38fe776a3d6bce08f7f41c0f57f7a9bbba34c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='hermes adapter recovers v26 cli cwd' test/adapters.test.js`
- `node --test --test-name-pattern='hermes adapter' test/adapters.test.js`
- <code>Archived HEAD to a temporary directory, replaced the Hermes adapter with base commit `de6569875b85056483021157e0371a0ede7f3b8b`, and confirmed the focused v26 regression test fails at the expected discovery assertion.</code>
- <code>Created an isolated schema-v26 Hermes SQLite database containing CLI, ACP, and cron sessions, then ran `HERMES_HOME=&#34;$HERMES_FIXTURE&#34; node bin/backpass.js scan --harness hermes --since all --strict --json` from the git worktree.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
