### PR TITLE
harden: missing or incorrect trustpolicy in pnpm-workspace.yaml...

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
 
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
+trustPolicy: no-downgrade
+blockExoticSubdeps: true
 # Zero runtime dependencies; no dev dependency needs a build script either,
 # so nothing is allowlisted and pnpm's default-deny stays fully closed.
 onlyBuiltDependencies: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,6 @@ packages:
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 trustPolicy: no-downgrade
-blockExoticSubdeps: true
 # Zero runtime dependencies; no dev dependency needs a build script either,
 # so nothing is allowlisted and pnpm's default-deny stays fully closed.
 onlyBuiltDependencies: []


### PR DESCRIPTION
## Summary
Harden input handling in `pnpm-workspace.yaml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | package_managers.pnpm.pnpm-trust-policy.pnpm-trust-policy |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `package_managers.pnpm.pnpm-trust-policy.pnpm-trust-policy` |
| **File** | `pnpm-workspace.yaml:1` |
| **Assessment** | Defensive hardening |

**Description**: Missing or incorrect trustPolicy. Set `trustPolicy: no-downgrade` to prevent malicious package updates from downgrading security settings. Added in: v10.21.0 Reference: https://pnpm.io/settings#trustpolicy

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `pnpm-workspace.yaml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
