### PR TITLE
docs: add VISION.md, an evidence-grounded acceptance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 
 ## Orientation
 
+- `VISION.md` is the acceptance policy: what a change must be true to, and its closing
+  accept/resist tests. `VISION-ANSWERS.md` records the hypotheticals the author ruled on and
+  why, so a change that argues one of those calls should go the other way starts there.
 - `README.md` documents the user-facing surface; `src/cli.js` is the authoritative flag list.
 - The pipeline is one stage per module, in order: `src/discovery/` -> `src/sample.js` (cap) -> `src/distill.js` ->
   `src/analyze.js` -> `src/fold.js` -> `src/synthesize.js` (with `src/workspace.js` + `src/diff.js`) ->

--- a/VISION-ANSWERS.md
+++ b/VISION-ANSWERS.md
@@ -1,0 +1,128 @@
+# Vision review: recorded answers
+
+Durable calibration material for `VISION.md`.
+Each hypothetical was put to the author on a `/vision` review board; the verdict and reasoning below are his, recorded verbatim.
+Keep this file next to the vision: it is the record of why the vision says what it says, and the first place to look when a future change argues one of these calls should go the other way.
+
+Board: `/vision` review, 12 hypotheticals, from-scratch draft r1 (2026-08-23).
+Evidence base: the 20 merged pull requests authored by the repo owner in `kunchenguid/backpass` (#1 through #26), the open issues #23, #24 and #25, community pull request #21, and the module header comments those changes left behind.
+
+## H-1 - Pool the gap ledger across a team
+
+**Proposal.** Issue #24 proposes sharding the gap ledger into git (`gap-ledger.d/<dev>.json`) so corroboration pools across a team. The union is provably safe; the requester declines to decide the privacy fork: commit colleagues' verbatim quotes into repo history, or a counting-only mode that drops `quote`.
+
+**Principle tested.** "It reads the machine it is on and owns nothing else."
+
+**Why it was not obvious.** For: two people hitting one gap independently is the strongest evidence there is, and the per-machine ledger makes exactly that case invisible. Against: `redact.js` calls itself a coarse net, so this commits a colleague's raw session text with no per-quote review, and the safe variant leaves an unreviewable count.
+
+**Verdict.** _pending_
+
+## H-2 - Close the bootstrap exception
+
+**Proposal.** A repo with no memory file gets the starter files created, and that run's first model-authored proposal is written directly, stamped `appliedBy: bootstrap`. Proposal: create the files, then stop, leaving the proposal for `backpass apply`. PR #6 raised this as an open call for you and it was never settled.
+
+**Principle tested.** "The single write that skips the gate is creating a memory file where none existed."
+
+**Why it was not obvious.** For: the ungated write is not the file creation, it is a model-authored instruction landing unreviewed, the exact class of write everything else refuses. Against: a file that did not exist a second ago has nothing to protect, `git diff` reviews it completely, and a review panel on an empty repo makes the first run a chore.
+
+**Verdict.** _pending_
+
+## H-3 - An unattended apply for trusted repos
+
+**Proposal.** A user runs backpass nightly in their own CI on their own repo and asks for `backpass apply --yes`, off by default, accepting every edit that clears the mechanical gates and was not previously rejected. The gates already encode the policy, they argue.
+
+**Principle tested.** "Automation may prepare a change and argue for it, but it does not land the change on the human's behalf."
+
+**Why it was not obvious.** For: the gates are mechanical and already run, and someone approving their fiftieth identical edit is rubber-stamping; refusing fails the people running the most sessions. Against: the gates check form, not truth, and the human gate is the only step asking whether an instruction is right for this repo.
+
+**Verdict.** _pending_
+
+## H-4 - A whole-file rewrite mode
+
+**Proposal.** For a file several times over budget, offer one whole-file rewrite reviewed as a single diff instead of many runs of up-to-20 edits. The adaptive shrink cap in PR #11 already concedes a fixed learning rate cannot recover the worst files.
+
+**Principle tested.** "It does not rewrite a memory file and will not offer to."
+
+**Why it was not obvious.** For: reviewing twenty edits across five sittings is a worse experience and a worse outcome than one careful pass over a document you wrote yourself. Against: a rewrite collapses review to all-or-nothing, rejection memory is keyed to a hunk and evaporates, and nothing then stops a confident model from dropping a load-bearing instruction.
+
+**Verdict.** _pending_
+
+## H-5 - A Copilot adapter over summaries
+
+**Proposal.** Issue #25 asks for a `copilot.js` adapter. Copilot CLI keeps checkpoint markdown summaries under `~/.copilot/session-state/`, with no confirmed cwd index and no turn-level log, so the adapter would associate at tier 3 and distill model-written summaries as the trace.
+
+**Principle tested.** "Every claim a model makes carries a verbatim quote copied from the trace."
+
+**Why it was not obvious.** For: those users are told there are no transcripts today, and tier 3 exists precisely for weak association and is already labelled. Against: a checkpoint summary is a model's account of a session, so quoting it verbatim yields a verbatim quote of a paraphrase, passing the gate while defeating it.
+
+**Verdict.** _pending_
+
+## H-6 - Deterministic evidence, no quote
+
+**Proposal.** Allow one class of quoteless evidence: facts backpass extracts itself with no model involved, such as the same failing command appearing in six sessions. They are stronger than a model-chosen quote precisely because no model produced them, yet they carry no `quote` field and are discarded today.
+
+**Principle tested.** "A claim without one is discarded rather than softened."
+
+**Why it was not obvious.** For: the quote rule exists to stop a model confabulating influence, so applying it to a measured fact enforces the letter against its own purpose and throws away the pipeline's most trustworthy evidence. Against: the rule's power is that it is absolute and needs no adjudication; every future exception arrives argued as deterministic too.
+
+**Verdict.** _pending_
+
+## H-7 - Model-described edits as a fallback
+
+**Proposal.** Some harnesses cannot write through acpx: PR #17 hit this with codex when `features.code_mode_host` is false, and it replied DONE having changed nothing. Proposal: when synthesis produces no measured change, ask the model for `find`/`replace` text and locate it in the raw file.
+
+**Principle tested.** "backpass measures what changed instead of accepting text the model describes."
+
+**Why it was not obvious.** For: those users get an empty run with no explanation of why their harness is second-class, and a fallback that fails closed when the text is not found beats nothing. Against: PR #17 exists because model-supplied find text was structurally broken; re-adding it as a fallback re-opens that failure on the harnesses least likely to be exercised.
+
+**Verdict.** _pending_
+
+## H-8 - Edit global memory across repos
+
+**Proposal.** backpass already sees sessions across every repo on the machine. A gap corroborating in five different repos is by definition not repo-specific, and `~/.claude/CLAUDE.md` is loaded in every session everywhere. Proposal: propose edits there when a gap clears the bar across N repos.
+
+**Principle tested.** "It does not edit global memory, which is context to read and never a target to write."
+
+**Why it was not obvious.** For: the always-loaded-token argument applies harder there than to any repo file, so refusing means watching the most expensive file on the machine degrade. Against: a global file has no repo to scope evidence to and no owner in the sense the design assumes, and one wrong instruction pollutes every project at once.
+
+**Verdict.** _pending_
+
+## H-9 - Make --strict the default
+
+**Proposal.** Tier 3 matches a dead path whose last segment is the repo's directory name, or a user glob, and it is on by default. Proposal: default to deterministic tier-1 and tier-2 matches only, and move best-effort association behind an opt-in flag.
+
+**Principle tested.** "An association that cannot be made deterministically is labelled best-effort, never presented as a match."
+
+**Why it was not obvious.** For: a directory-name match can attribute another repo's sessions to yours, and against a two-session bar one wrong attribution is half the evidence needed to write a permanent instruction. Against: worktrees here are deleted constantly, so tier 3 is often the only thing that finds anything at all.
+
+**Verdict.** _pending_
+
+## H-10 - Refuse traces we cannot fully redact
+
+**Proposal.** Harden the boundary: before a distilled trace goes to a model, refuse the transcript if it holds a high-entropy string redaction could not classify. `redact.js` describes itself as a coarse net and not a guarantee, and the failure mode is a real secret reaching a third-party model.
+
+**Principle tested.** "They leave the machine only into an agent the user already authenticated."
+
+**Why it was not obvious.** For: the module admits the net is coarse, a miss is irreversible, and a tool reading raw shell transcripts should fail closed on what it cannot afford to get wrong. Against: hashes, UUIDs and minified output would refuse most real sessions, and the predictable response is to disable redaction entirely.
+
+**Verdict.** _pending_
+
+## H-11 - Explain an empty run
+
+**Proposal.** Issue #23 is a user who got nothing back and could not tell whether the tool was broken. The diagnosis behind PR #15 was 35 gaps folding to 0 clusters. Proposal: report uncorroborated singletons as counts in `backpass status`, never as proposals, so an empty run becomes legible.
+
+**Principle tested.** "An uncorroborated gap is not surfaced as a hint, a watchlist, or a maybe."
+
+**Why it was not obvious.** For: a count is not a proposal, and a user staring at zero edits cannot distinguish a healthy file from a broken adapter or an auth failure. Against: shown versus proposed does not survive contact with a person reading it, and the list becomes a to-do list that reintroduces one-session rewrites by hand.
+
+**Verdict.** _pending_
+
+## H-12 - Merge the community omp adapter
+
+**Proposal.** PR #21 adds an `omp.js` adapter for oh-my-pi, a pi fork sharing pi's format. It is a near-copy of `pi.js` differing in store root and one field name, verified against roughly 800 real sessions, and it ships with no golden fixture. The alternative is a store-root parameter on the pi adapter.
+
+**Principle tested.** "Supporting a harness means a pinned fixture and a fail-soft adapter."
+
+**Why it was not obvious.** For: real verified demand from outside the fleet, and turning away a working adapter over its shape discourages the contributions an open harness-neutral tool depends on. Against: drifting formats are the project's sharpest edge, so a fixture-less near-duplicate doubles maintenance while parameterizing pi's store root covers the next fork free.
+
+**Verdict.** _pending_

--- a/VISION-ANSWERS.md
+++ b/VISION-ANSWERS.md
@@ -15,7 +15,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: two people hitting one gap independently is the strongest evidence there is, and the per-machine ledger makes exactly that case invisible. Against: `redact.js` calls itself a coarse net, so this commits a colleague's raw session text with no per-quote review, and the safe variant leaves an unreviewable count.
 
-**Verdict.** _pending_
+**Verdict.** In vision
+
+**Author's reasoning.** (recorded with no reasoning note; clarified by the annotation on the locality heading: "i may actually relax this in the future. it's possible that a person works across a number of machines, or a team wants to use this to aggregate the whole team's memory. that does NOT conflict with my vision")
+
+**Folded in as.** Section renamed from "It reads the machine it is on and owns nothing else" to "It reads what you already have and owns nothing", and two lines added: "One machine is the default, not the limit: pooling corroboration across a person's machines, or across a team, is a change of scale and not a change of kind" and "What may be shared is the derived evidence, carried by infrastructure the user already owns, never a transcript and never through anything backpass runs." The resist test still refuses holding a copy of someone else's transcripts. OPEN: the privacy fork in issue #24 (share quotes vs counting-only) was not ruled on and is deliberately left undecided.
 
 ## H-2 - Close the bootstrap exception
 
@@ -25,7 +29,9 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: the ungated write is not the file creation, it is a model-authored instruction landing unreviewed, the exact class of write everything else refuses. Against: a file that did not exist a second ago has nothing to protect, `git diff` reviews it completely, and a review panel on an empty repo makes the first run a chore.
 
-**Verdict.** _pending_
+**Verdict.** In vision
+
+**Folded in as.** "The human owns the weights" now reads "Nothing reaches the memory file except through that gate, including the first proposal in a repo that had no memory file", and the old asterisk becomes "Creating a starter file where none existed is the one write that is not an edit, and it only ever creates, never overwrites." This makes today's bootstrap behaviour, which applies its first proposal directly, a deviation to fix.
 
 ## H-3 - An unattended apply for trusted repos
 
@@ -35,7 +41,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: the gates are mechanical and already run, and someone approving their fiftieth identical edit is rubber-stamping; refusing fails the people running the most sessions. Against: the gates check form, not truth, and the human gate is the only step asking whether an instruction is right for this repo.
 
-**Verdict.** _pending_
+**Verdict.** In vision
+
+**Author's reasoning.** if it's opt-in only, that's fine, because that's basically still the human in control of how they would like this to operate
+
+**Folded in as.** Replaced "Automation may prepare a change and argue for it, but it does not land the change on the human's behalf" with a default-plus-opt-in pair: "By default every edit is reviewed on its own..." and "A user may opt in to something looser for their own repo, because choosing how their own weights get updated is the human in control, but that is an explicit choice and never a default." The resist test changed from "without a per-edit human decision" to "makes anything but per-edit review the default."
 
 ## H-4 - A whole-file rewrite mode
 
@@ -45,7 +55,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: reviewing twenty edits across five sittings is a worse experience and a worse outcome than one careful pass over a document you wrote yourself. Against: a rewrite collapses review to all-or-nothing, rejection memory is keyed to a hunk and evaporates, and nothing then stops a confident model from dropping a load-bearing instruction.
 
-**Verdict.** _pending_
+**Verdict.** Off mission
+
+**Author's reasoning.** rewrite is not gradient descent
+
+**Folded in as.** Your reasoning became the budget section's line: "A rewrite is not a gradient step, so the cap grows with a bad file and never turns into starting over." The Scope non-goal is unchanged.
 
 ## H-5 - A Copilot adapter over summaries
 
@@ -55,7 +69,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: those users are told there are no transcripts today, and tier 3 exists precisely for weak association and is already labelled. Against: a checkpoint summary is a model's account of a session, so quoting it verbatim yields a verbatim quote of a paraphrase, passing the gate while defeating it.
 
-**Verdict.** _pending_
+**Verdict.** Off mission
+
+**Author's reasoning.** for this to work reliably and consistently, transcripts are must-have
+
+**Folded in as.** New harness-qualification line: "A harness qualifies when it records real session transcripts, because a store holding only a model's summary of a session is not evidence."
 
 ## H-6 - Deterministic evidence, no quote
 
@@ -65,7 +83,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: the quote rule exists to stop a model confabulating influence, so applying it to a measured fact enforces the letter against its own purpose and throws away the pipeline's most trustworthy evidence. Against: the rule's power is that it is absolute and needs no adjudication; every future exception arrives argued as deterministic too.
 
-**Verdict.** _pending_
+**Verdict.** Off mission
+
+**Author's reasoning.** these errors can be noisy without some judgment applied
+
+**Folded in as.** New line under "Evidence is the only currency": "A signal extracted mechanically, with no judgment applied to it, is noise until a quote anchors it to a real moment, so there is no quoteless path into the file."
 
 ## H-7 - Model-described edits as a fallback
 
@@ -75,7 +97,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: those users get an empty run with no explanation of why their harness is second-class, and a fallback that fails closed when the text is not found beats nothing. Against: PR #17 exists because model-supplied find text was structurally broken; re-adding it as a fallback re-opens that failure on the harnesses least likely to be exercised.
 
-**Verdict.** _pending_
+**Verdict.** Off mission
+
+**Author's reasoning.** these fallback behaviors can be a degradation. instead, we should try to get to a real solution
+
+**Folded in as.** New line under "Failure is loud and named": "A gap in capability is fixed or reported, never papered over with a weaker path that quietly produces worse results", and a matching resist test: "...or trades a real fix for a quieter degraded path."
 
 ## H-8 - Edit global memory across repos
 
@@ -85,7 +111,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: the always-loaded-token argument applies harder there than to any repo file, so refusing means watching the most expensive file on the machine degrade. Against: a global file has no repo to scope evidence to and no owner in the sense the design assumes, and one wrong instruction pollutes every project at once.
 
-**Verdict.** _pending_
+**Verdict.** Off mission
+
+**Author's reasoning.** for now, my philosophy is that global memory should be handwritten by the user and only contains their preferences. all the learned knowledge is better put into project-level memory
+
+**Folded in as.** The opener now carries the positive half of your reasoning: "a person's own ~/.claude/CLAUDE.md is handwritten preference, and anything learned belongs in project memory instead." The Scope non-goal was tightened to match.
 
 ## H-9 - Make --strict the default
 
@@ -95,7 +125,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: a directory-name match can attribute another repo's sessions to yours, and against a two-session bar one wrong attribution is half the evidence needed to write a permanent instruction. Against: worktrees here are deleted constantly, so tier 3 is often the only thing that finds anything at all.
 
-**Verdict.** _pending_
+**Verdict.** In vision
+
+**Author's reasoning.** accuracy of the result is a priority, so this is aligned
+
+**Folded in as.** Best-effort association is now stated as opt-in, not merely labelled: "...is labelled best-effort and stays opt-in, because a wrong attribution is worse evidence than none." Your priority became its own line, "When coverage and accuracy are in tension, accuracy wins", and a resist test, "...when it buys coverage with accuracy."
 
 ## H-10 - Refuse traces we cannot fully redact
 
@@ -105,7 +139,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: the module admits the net is coarse, a miss is irreversible, and a tool reading raw shell transcripts should fail closed on what it cannot afford to get wrong. Against: hashes, UUIDs and minified output would refuse most real sessions, and the predictable response is to disable redaction entirely.
 
-**Verdict.** _pending_
+**Verdict.** Conditional
+
+**Author's reasoning.** if we enable this by default it may be too flaky and noisy. i think we would either warn the user and let them decide, or default off
+
+**Folded in as.** Folded as the condition you set: "Redaction is a coarse net and says so, so a stricter check may warn or be offered but never blocks a run by default on a guess."
 
 ## H-11 - Explain an empty run
 
@@ -115,7 +153,11 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: a count is not a proposal, and a user staring at zero edits cannot distinguish a healthy file from a broken adapter or an auth failure. Against: shown versus proposed does not survive contact with a person reading it, and the list becomes a to-do list that reintroduces one-session rewrites by hand.
 
-**Verdict.** _pending_
+**Verdict.** In vision
+
+**Author's reasoning.** better clarity to human users is definitely good
+
+**Folded in as.** Reversed the draft's absolute. "An uncorroborated gap stays out of the proposal entirely, and is not surfaced as a hint, a watchlist, or a maybe" became "An uncorroborated gap never becomes a proposal, though counting one is fair where that helps a person understand a run", plus a new line under failure: "A run that proposes nothing explains why."
 
 ## H-12 - Merge the community omp adapter
 
@@ -125,4 +167,8 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Why it was not obvious.** For: real verified demand from outside the fleet, and turning away a working adapter over its shape discourages the contributions an open harness-neutral tool depends on. Against: drifting formats are the project's sharpest edge, so a fixture-less near-duplicate doubles maintenance while parameterizing pi's store root covers the next fork free.
 
-**Verdict.** _pending_
+**Verdict.** In vision
+
+**Author's reasoning.** covering more harnesses is in vision, as long as it doesn't risk existing ones
+
+**Folded in as.** New line with your constraint attached: "More harnesses is always welcome, provided a new one cannot destabilise the ones already working", kept next to the pinned-fixture and fail-soft requirement.

--- a/VISION.md
+++ b/VISION.md
@@ -1,7 +1,8 @@
 # Vision
 
 `backpass` exists so that a repository's agent memory file improves from what actually happened in its agent sessions, instead of from whatever a human happened to remember.
-It serves the developer who owns an `AGENTS.md` and runs coding agents against their own repo, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
+It serves the developer who owns that file, whether it is `AGENTS.md` or the `CLAUDE.md` Claude Code reads in its place, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
+The project file is the one it trains; a person's own `~/.claude/CLAUDE.md` is handwritten preference and stays that way.
 It owns exactly one thing: the backward pass from session transcripts to a proposed change in the memory file.
 
 ## Evidence is the only currency
@@ -11,7 +12,7 @@ A visible violation outranks any number of "it went fine" observations, because 
 A new instruction needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
 Corroboration accumulates across runs in a ledger rather than resetting each run, so a gap seen today and again next week still graduates.
 An uncorroborated gap stays out of the proposal entirely, and is not surfaced as a hint, a watchlist, or a maybe.
-One bad session never rewrites the weights.
+One bad session never rewrites the weights, because a single session can go wrong for reasons that have nothing to do with the file.
 
 ## The human owns the weights
 
@@ -29,14 +30,18 @@ Every hunk is cut from the real file, so "that text does not appear in the file"
 Token deltas, budget projections, and usage figures are measured from the artifacts themselves, never quoted from the model's own arithmetic.
 An agent that changed nothing yields an empty proposal, never an invented one.
 A number shown to a person must describe the thing it claims to describe, so a display that quietly compares two different measurements is a defect, not a cosmetic issue.
+Every rule here is enforced in code and never merely asked for in a prompt, because a rule the model can decline is not a rule.
 
 ## The budget is the constraint, not a setting
 
 Every always-loaded token is paid on every future session forever, and instruction following dilutes as the file grows.
+A memory file decays by accretion into one of four states, empty, bloated, stale or drifted, because appending a line is always easier than consolidating or pruning one.
 So a run is one gradient step under a fixed budget: few enough edits that a person actually reviews each one in a single sitting.
-When a file is over budget the step scales with the overage, because a tool that cannot help the worst files is useless on exactly the repos that need it most.
+When a file is over budget the step scales with the overage, because a tool that cannot help the worst files is useless on the repos that need it most.
+A step large enough to replace the file is indistinguishable from starting over, so the cap grows and never becomes a rewrite.
 When a file is at budget the step is zero-sum, and every addition names the removal or extraction that pays for it.
-A skill's description is its trigger, which makes extraction the release valve, and the relevance deciding memory-file versus skill placement is measured from evidence rather than guessed.
+An instruction earns its always-loaded place by mattering in a large share of sessions, measured rather than guessed, or by being safety-critical.
+Anything narrow with a detectable trigger becomes a skill, whose description is that trigger, and anything narrow without one is a deletion candidate.
 Growth of the memory file is never reported as progress.
 
 ## It reads the machine it is on and owns nothing else
@@ -60,7 +65,7 @@ A test earns its place by failing when the behavior it names is removed, so a te
 ## Scope
 
 `backpass` is not a code reviewer, not a CI system, not a linter, not a harness, and not a model provider.
-It does not edit global memory such as `~/.claude/CLAUDE.md`, which is context to read and never a target to write.
+It does not train a person's own `~/.claude/CLAUDE.md`, which is handwritten preference, context to read and never a target to write.
 It does not rewrite a memory file and will not offer to, because a rewrite cannot be accepted edit by edit and leaves nothing for a rejection to remember.
 Vocabulary is deliberate: the user reads the training loop, while subcommands and internals keep their short names.
 The repo holds itself to its own standard, including excluding its own sessions from the corpus it analyzes.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,74 @@
+# Vision
+
+`backpass` exists so that a repository's agent memory file improves from what actually happened in its agent sessions, instead of from whatever a human happened to remember.
+It serves the developer who owns an `AGENTS.md` and runs coding agents against their own repo, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
+It owns exactly one thing: the backward pass from session transcripts to a proposed change in the memory file.
+
+## Evidence is the only currency
+
+Every claim a model makes carries a verbatim quote copied from the trace, and a claim without one is discarded rather than softened.
+A visible violation outranks any number of "it went fine" observations, because negative evidence is what proves the file was steering anything at all.
+A new instruction needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
+Corroboration accumulates across runs in a ledger rather than resetting each run, so a gap seen today and again next week still graduates.
+An uncorroborated gap stays out of the proposal entirely, and is not surfaced as a hint, a watchlist, or a maybe.
+One bad session never rewrites the weights.
+
+## The human owns the weights
+
+Every stage is read-only analysis and one module does all the writing, which is what makes a run safe to interrupt at any point.
+Each proposed edit is reviewed on its own, with its diff and the quotes behind it, and accepted or rejected one at a time.
+A rejection is remembered and never re-proposed until materially new evidence arrives, so review effort is not spent twice on the same answer.
+The single write that skips the gate is creating a memory file where none existed, and it can only create, never overwrite.
+Automation may prepare a change and argue for it, but it does not land the change on the human's behalf.
+Convenience is not a reason to widen what writes.
+
+## Nothing the model says is taken on faith
+
+The synthesis agent edits a staging copy with its own file tools, and `backpass` measures what changed instead of accepting text the model describes.
+Every hunk is cut from the real file, so "that text does not appear in the file" is impossible by construction rather than by prompt discipline.
+Token deltas, budget projections, and usage figures are measured from the artifacts themselves, never quoted from the model's own arithmetic.
+An agent that changed nothing yields an empty proposal, never an invented one.
+A number shown to a person must describe the thing it claims to describe, so a display that quietly compares two different measurements is a defect, not a cosmetic issue.
+
+## The budget is the constraint, not a setting
+
+Every always-loaded token is paid on every future session forever, and instruction following dilutes as the file grows.
+So a run is one gradient step under a fixed budget: few enough edits that a person actually reviews each one in a single sitting.
+When a file is over budget the step scales with the overage, because a tool that cannot help the worst files is useless on exactly the repos that need it most.
+When a file is at budget the step is zero-sum, and every addition names the removal or extraction that pays for it.
+A skill's description is its trigger, which makes extraction the release valve, and the relevance deciding memory-file versus skill placement is measured from evidence rather than guessed.
+Growth of the memory file is never reported as progress.
+
+## It reads the machine it is on and owns nothing else
+
+Transcripts are read from local harness stores, never uploaded, and they leave the machine only into an agent the user already authenticated.
+`backpass` holds no API key of its own, so it can never become a bill or a service the user did not ask for.
+All model invocation stays behind one module, so an upstream change has exactly one blast radius.
+State lives under `.backpass/` and is excluded through the repository's local git exclude, because a user's tracked files are theirs and not a place to leave state.
+Every harness is read on equal terms, and a store that is missing or has drifted warns and is skipped while the run continues.
+Supporting a harness means a pinned fixture and a fail-soft adapter, not a row in the README.
+An association that cannot be made deterministically is labelled best-effort, never presented as a match.
+
+## Failure is loud and named
+
+A gate violation re-prompts with the exact breach, then fails the run and saves the rejected proposal, and never silently truncates to fit.
+A missing capability is named along with the command that would fix it, and `n/a` is not an acceptable thing to print at a person.
+A drifted store must never look identical to a repo with no history.
+A bug is fixed at its root and verified against the real shape that produced it, not patched where it happened to be noticed.
+A test earns its place by failing when the behavior it names is removed, so a test that only restates the implementation is deleted.
+
+## Scope
+
+`backpass` is not a code reviewer, not a CI system, not a linter, not a harness, and not a model provider.
+It does not edit global memory such as `~/.claude/CLAUDE.md`, which is context to read and never a target to write.
+It does not rewrite a memory file and will not offer to, because a rewrite cannot be accepted edit by edit and leaves nothing for a rejection to remember.
+Vocabulary is deliberate: the user reads the training loop, while subcommands and internals keep their short names.
+The repo holds itself to its own standard, including excluding its own sessions from the corpus it analyzes.
+
+A change aligns when it makes the evidence behind a proposal stronger, cheaper to verify, or harder to fabricate.
+A change aligns when it lets a person say no faster, or say no once and have it remembered.
+A change aligns when it replaces a reported number with a measured one.
+A change should be resisted when it widens what writes, lowers the two-session bar, or lets a proposal reach the file without a per-edit human decision.
+A change should be resisted when it makes the memory file easier to grow than to shrink.
+A change should be resisted when it requires `backpass` to hold a key, a server, or a copy of someone else's transcripts.
+A change should be resisted when it adds a surface the maintainer cannot pin with a fixture and cannot keep honest when it drifts.

--- a/VISION.md
+++ b/VISION.md
@@ -2,26 +2,27 @@
 
 `backpass` exists so that a repository's agent memory file improves from what actually happened in its agent sessions, instead of from whatever a human happened to remember.
 It serves the developer who owns that file, whether it is `AGENTS.md` or the `CLAUDE.md` Claude Code reads in its place, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
-The project file is the one it trains; a person's own `~/.claude/CLAUDE.md` is handwritten preference and stays that way.
+The project file is the one it trains; a person's own `~/.claude/CLAUDE.md` is handwritten preference, and anything learned belongs in project memory instead.
 It owns exactly one thing: the backward pass from session transcripts to a proposed change in the memory file.
 
 ## Evidence is the only currency
 
 Every claim a model makes carries a verbatim quote copied from the trace, and a claim without one is discarded rather than softened.
+A signal extracted mechanically, with no judgment applied to it, is noise until a quote anchors it to a real moment, so there is no quoteless path into the file.
 A visible violation outranks any number of "it went fine" observations, because negative evidence is what proves the file was steering anything at all.
 A new instruction needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
 Corroboration accumulates across runs in a ledger rather than resetting each run, so a gap seen today and again next week still graduates.
-An uncorroborated gap stays out of the proposal entirely, and is not surfaced as a hint, a watchlist, or a maybe.
+An uncorroborated gap never becomes a proposal, though counting one is fair where that helps a person understand a run.
 One bad session never rewrites the weights, because a single session can go wrong for reasons that have nothing to do with the file.
 
 ## The human owns the weights
 
 Every stage is read-only analysis and one module does all the writing, which is what makes a run safe to interrupt at any point.
-Each proposed edit is reviewed on its own, with its diff and the quotes behind it, and accepted or rejected one at a time.
+By default every edit is reviewed on its own, with its diff and the quotes behind it, and accepted or rejected one at a time.
 A rejection is remembered and never re-proposed until materially new evidence arrives, so review effort is not spent twice on the same answer.
-The single write that skips the gate is creating a memory file where none existed, and it can only create, never overwrite.
-Automation may prepare a change and argue for it, but it does not land the change on the human's behalf.
-Convenience is not a reason to widen what writes.
+Nothing reaches the memory file except through that gate, including the first proposal in a repo that had no memory file.
+Creating a starter file where none existed is the one write that is not an edit, and it only ever creates, never overwrites.
+A user may opt in to something looser for their own repo, because choosing how their own weights get updated is the human in control, but that is an explicit choice and never a default.
 
 ## Nothing the model says is taken on faith
 
@@ -38,42 +39,47 @@ Every always-loaded token is paid on every future session forever, and instructi
 A memory file decays by accretion into one of four states, empty, bloated, stale or drifted, because appending a line is always easier than consolidating or pruning one.
 So a run is one gradient step under a fixed budget: few enough edits that a person actually reviews each one in a single sitting.
 When a file is over budget the step scales with the overage, because a tool that cannot help the worst files is useless on the repos that need it most.
-A step large enough to replace the file is indistinguishable from starting over, so the cap grows and never becomes a rewrite.
+A rewrite is not a gradient step, so the cap grows with a bad file and never turns into starting over.
 When a file is at budget the step is zero-sum, and every addition names the removal or extraction that pays for it.
 An instruction earns its always-loaded place by mattering in a large share of sessions, measured rather than guessed, or by being safety-critical.
 Anything narrow with a detectable trigger becomes a skill, whose description is that trigger, and anything narrow without one is a deletion candidate.
 Growth of the memory file is never reported as progress.
 
-## It reads the machine it is on and owns nothing else
+## It reads what you already have and owns nothing
 
 Transcripts are read from local harness stores, never uploaded, and they leave the machine only into an agent the user already authenticated.
 `backpass` holds no API key of its own, so it can never become a bill or a service the user did not ask for.
+One machine is the default, not the limit: pooling corroboration across a person's machines, or across a team, is a change of scale and not a change of kind.
+What may be shared is the derived evidence, carried by infrastructure the user already owns, never a transcript and never through anything `backpass` runs.
+Redaction is a coarse net and says so, so a stricter check may warn or be offered but never blocks a run by default on a guess.
 All model invocation stays behind one module, so an upstream change has exactly one blast radius.
-State lives under `.backpass/` and is excluded through the repository's local git exclude, because a user's tracked files are theirs and not a place to leave state.
-Every harness is read on equal terms, and a store that is missing or has drifted warns and is skipped while the run continues.
-Supporting a harness means a pinned fixture and a fail-soft adapter, not a row in the README.
-An association that cannot be made deterministically is labelled best-effort, never presented as a match.
+A harness qualifies when it records real session transcripts, because a store holding only a model's summary of a session is not evidence.
+Supporting one means a pinned fixture and a fail-soft adapter, not a row in the README, and a missing or drifted store warns and is skipped while the run continues.
+More harnesses is always welcome, provided a new one cannot destabilise the ones already working.
+An association that cannot be made deterministically is labelled best-effort and stays opt-in, because a wrong attribution is worse evidence than none.
+When coverage and accuracy are in tension, accuracy wins.
 
 ## Failure is loud and named
 
 A gate violation re-prompts with the exact breach, then fails the run and saves the rejected proposal, and never silently truncates to fit.
 A missing capability is named along with the command that would fix it, and `n/a` is not an acceptable thing to print at a person.
+A gap in capability is fixed or reported, never papered over with a weaker path that quietly produces worse results.
 A drifted store must never look identical to a repo with no history.
+A run that proposes nothing explains why.
 A bug is fixed at its root and verified against the real shape that produced it, not patched where it happened to be noticed.
 A test earns its place by failing when the behavior it names is removed, so a test that only restates the implementation is deleted.
 
 ## Scope
 
 `backpass` is not a code reviewer, not a CI system, not a linter, not a harness, and not a model provider.
-It does not train a person's own `~/.claude/CLAUDE.md`, which is handwritten preference, context to read and never a target to write.
+It does not train a person's own `~/.claude/CLAUDE.md`, which is handwritten preference and not a target to write.
 It does not rewrite a memory file and will not offer to, because a rewrite cannot be accepted edit by edit and leaves nothing for a rejection to remember.
 Vocabulary is deliberate: the user reads the training loop, while subcommands and internals keep their short names.
 The repo holds itself to its own standard, including excluding its own sessions from the corpus it analyzes.
 
 A change aligns when it makes the evidence behind a proposal stronger, cheaper to verify, or harder to fabricate.
 A change aligns when it lets a person say no faster, or say no once and have it remembered.
-A change aligns when it replaces a reported number with a measured one.
-A change should be resisted when it widens what writes, lowers the two-session bar, or lets a proposal reach the file without a per-edit human decision.
+A change should be resisted when it widens what writes, lowers the two-session bar, or makes anything but per-edit review the default.
 A change should be resisted when it makes the memory file easier to grow than to shrink.
 A change should be resisted when it requires `backpass` to hold a key, a server, or a copy of someone else's transcripts.
-A change should be resisted when it adds a surface the maintainer cannot pin with a fixture and cannot keep honest when it drifts.
+A change should be resisted when it buys coverage with accuracy, or trades a real fix for a quieter degraded path.


### PR DESCRIPTION
## Intent

Add `VISION.md`, an acceptance policy for backpass: what a change must be true to, stated as
testable present-tense commitments with explicit non-goals and a closing pair of accept/resist
tests. Drafted through the `/vision` skill and approved by the author on a review board.

Not a roadmap and not a feature list. Docs only; no source, config, or workflow changes.

## How it was built

Evidence base, mined rather than assumed: the 20 merged pull requests authored in this repo
(#1 through #26, bodies read across the whole range), open issues #23, #24 and #25, community
pull request #21, and the module header comments those changes left behind. Every line traces
to that evidence or to a recorded verdict. The rationale in
[Your AGENTS.md is a Neural Net](https://blog.kunchenguid.com/p/your-agentsmd-is-a-neural-net)
was folded in at the author's direction.

The draft was then stress-tested with 12 hypotheticals aimed at its real fault lines, both
sides steelmanned, and answered by the author: **6 in vision, 5 off mission, 1 conditional**.
Three reversed the draft, which is the point of the exercise:

- **H-1** team and multi-machine pooling of the gap ledger (issue #24) is *in vision*, so the
  section that had been "It reads the machine it is on and owns nothing else" is now
  "It reads what you already have and owns nothing". The surviving invariant is narrower: what
  may be shared is derived evidence, over infrastructure the user already owns, never a
  transcript and never through anything backpass runs.
- **H-3** an opt-in unattended apply is still the human in control, so per-edit review became
  the *default* rather than an absolute.
- **H-11** counting uncorroborated gaps to explain an empty run (issue #23) is allowed;
  proposing them still is not.

`VISION-ANSWERS.md` ships beside the vision with each hypothetical, the verdict, the author's
reasoning verbatim, and the exact edit it produced. It is durable calibration material: a future
change that argues one of these calls should go the other way starts there.

`AGENTS.md` gains a two-line Orientation pointer to both files.

## Two consequences worth flagging

1. **H-2 makes current behavior a deviation.** The vision states that nothing reaches the memory
   file except through the apply gate, *including* the first proposal in a repo that had no
   memory file. `src/commands/bootstrap.js` applies that first proposal directly today. This PR
   does not change code; the gap is now written down and is a follow-up.
2. **H-1's privacy fork is deliberately unresolved.** Issue #24 asks whether a shared ledger
   carries verbatim quotes or drops them for counts only. The author marked H-1 in vision
   without ruling on it, so the vision stays silent and `VISION-ANSWERS.md` records it as open.

## Testing

Docs-only change. `pnpm run format:check` passes. `VISION.md` is 69 non-blank lines, six
principle sections plus Scope, one sentence per line, no em dashes.

## Note on the gate

Raised as a direct PR under an explicit captain directive, so it did **not** go through
`git push no-mistakes`. The `PR must be raised via no-mistakes` check exempts only
`github-actions[bot]` and `dependabot[bot]`, so it is expected to fail here by contract. That
check is not required by a ruleset or branch protection, so it does not block merge.
