### PR TITLE
fix(agents): name a hung probe instead of stalling the ladder on it

### DIFF
--- a/src/acpx.js
+++ b/src/acpx.js
@@ -184,17 +184,34 @@ export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
  * real auth gate (ACP -32000); for claude it is not, which is why `src/agents.js`
  * checks `claude auth status` before ever calling this.
  *
+ * `run` is injectable so both branches of the kill path can be exercised without racing
+ * a real subprocess: whether a killed child's buffered output reaches us at all is
+ * timing-dependent, which is exactly why the classification below is an opportunistic
+ * upgrade over `timeout` and never something a caller may rely on.
+ *
  * @returns {Promise<{ verdict: "ok" | "unauthenticated" | "model-unavailable" | "unreachable" | "timeout",
  *   detail: string, availableModels: string[] }>}
  */
-export async function probeSession({ agent, sessionName, cwd = undefined, timeoutMs = 20_000 }) {
+export async function probeSession({ agent, sessionName, cwd = undefined, timeoutMs = 10_000, run: exec = run }) {
   const acpxAgent = acpxAgentName(agent);
-  const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs, cwd });
+  const created = await exec([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs, cwd });
   if (created.spawnError?.code === "ENOENT") throw notFoundError(created);
   if (created.timedOut) {
+    // acpx writes its diagnostics as it goes, so a handshake that later wedged has often
+    // already named why on stderr. Reading that back is what turns a bare stall into
+    // "not logged in" with a command that fixes it; only a silent hang stays a timeout.
+    const seconds = Math.round(timeoutMs / 1000);
+    const classified = classifyAcpxFailure(created);
+    if (classified) {
+      return {
+        verdict: classified,
+        detail: firstLine(created.stderr) || `reported before the probe was killed at ${seconds}s`,
+        availableModels: [],
+      };
+    }
     return {
       verdict: "timeout",
-      detail: `probe timed out after ${Math.round(timeoutMs / 1000)}s`,
+      detail: `no answer in ${seconds}s`,
       availableModels: [],
     };
   }
@@ -204,7 +221,7 @@ export async function probeSession({ agent, sessionName, cwd = undefined, timeou
   }
 
   try {
-    const status = await run(["--format", "json", acpxAgent, "status", "-s", sessionName], { timeoutMs, cwd });
+    const status = await exec(["--format", "json", acpxAgent, "status", "-s", sessionName], { timeoutMs, cwd });
     let availableModels = [];
     if (status.code === 0) {
       try {
@@ -216,7 +233,7 @@ export async function probeSession({ agent, sessionName, cwd = undefined, timeou
     }
     return { verdict: "ok", detail: "", availableModels };
   } finally {
-    const closed = await run([acpxAgent, "sessions", "close", sessionName], { timeoutMs, cwd });
+    const closed = await exec([acpxAgent, "sessions", "close", sessionName], { timeoutMs, cwd });
     if (closed.code !== 0) warn(`could not close acpx probe session ${sessionName}`);
   }
 }

--- a/src/agents.js
+++ b/src/agents.js
@@ -1,6 +1,6 @@
 import { UserError, color, info, warn } from "./logger.js";
 import { DEFAULT_EFFORT, LEGACY_DEFAULT_AGENTS } from "./config.js";
-import { AcpxError, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
+import { AcpxError, acpxAgentName, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
 import { runCapture } from "./subprocess.js";
 
 /**
@@ -17,7 +17,15 @@ import { runCapture } from "./subprocess.js";
  * is `NATIVE_PROBES` below: the claude adapter creates sessions happily while logged
  * out and only fails at prompt time, so its login state has to come from the harness's
  * own `claude auth status`. opencode's ACP session has been seen to wedge for minutes
- * on a large profile, so `opencode models` answers first and the ACP probe is capped.
+ * on a large profile, so `opencode models` answers first.
+ *
+ * A probe that never answers is the expensive failure, because it is paid per candidate
+ * before the ladder can be declared empty. Three rules keep it bounded and named:
+ * `sessions new` does no model work, so it is capped at `PROBE_TIMEOUT_MS` for every
+ * adapter; a killed probe is classified from what it already printed before it is called
+ * a timeout (`probeSession`); and an adapter that never answered is model-independent,
+ * so the first `unreachable` or `timeout` retires that agent for the whole run instead
+ * of being re-probed once per rung it appears in.
  *
  * Verdicts are cached in `.backpass/agent-probe-cache.json` (12h for ok, 30min for
  * negatives, invalidated on an acpx version change) and memoized for the run.
@@ -26,8 +34,9 @@ import { runCapture } from "./subprocess.js";
 const OK_TTL_MS = 12 * 60 * 60 * 1000;
 const NEGATIVE_TTL_MS = 30 * 60 * 1000;
 const NATIVE_TIMEOUT_MS = 5_000;
-const PROBE_TIMEOUT_MS = 20_000;
-const PROBE_TIMEOUT_BY_AGENT = { opencode: 10_000 };
+const PROBE_TIMEOUT_MS = 10_000;
+/** Verdicts that describe the adapter itself, not the model asked for. */
+const AGENT_LEVEL_VERDICTS = new Set(["unreachable", "timeout"]);
 
 /** Adapters whose model list is open-ended: any id is forwarded, none can be verified. */
 const TRUSTING_MODEL_AGENTS = new Set(["claude"]);
@@ -53,10 +62,16 @@ const LOGIN_HINTS = {
  * the acpx probe decides). See the module header for why this table exists at all.
  */
 const NATIVE_PROBES = {
-  async claude({ model }) {
-    const result = await runCapture("claude", ["auth", "status"], { timeoutMs: NATIVE_TIMEOUT_MS });
+  async claude({ model }, { timeoutMs = NATIVE_TIMEOUT_MS } = {}) {
+    const result = await runCapture("claude", ["auth", "status"], { timeoutMs });
     if (result.spawnError?.code === "ENOENT") {
       return { verdict: "unreachable", detail: "claude CLI not found on PATH", resolvedModel: model };
+    }
+    if (result.timedOut) {
+      // A killed status call exits non-zero with unparseable output, which would otherwise
+      // read as "not installed / not spawnable" and tell a logged-in user to install the
+      // CLI they already have. An installed claude that did not answer is a timeout.
+      return { verdict: "timeout", detail: `claude auth status did not answer in ${timeoutMs / 1000}s` };
     }
     let parsed = null;
     try {
@@ -73,8 +88,8 @@ const NATIVE_PROBES = {
     }
     return null;
   },
-  async opencode({ model }) {
-    const result = await runCapture("opencode", ["models"], { timeoutMs: NATIVE_TIMEOUT_MS });
+  async opencode({ model }, { timeoutMs = NATIVE_TIMEOUT_MS } = {}) {
+    const result = await runCapture("opencode", ["models"], { timeoutMs });
     if (result.spawnError?.code === "ENOENT") {
       return { verdict: "unreachable", detail: "opencode CLI not found on PATH" };
     }
@@ -133,17 +148,17 @@ export function candidateKey({ agent, model }) {
  * then the zero-token acpx session probe, then model-id resolution.
  *
  * @param {{ agent: string, model: string }} candidate
- * @param {{ cwd?: string, sessionName?: string,
+ * @param {{ cwd?: string, sessionName?: string, nativeTimeoutMs?: number,
  *   probeSession?: (args: { agent: string, sessionName: string, cwd?: string, timeoutMs?: number }) =>
  *     Promise<{ verdict: string, detail: string, availableModels?: string[] }> }} [options]
  * @returns {Promise<{ verdict: string, detail: string, resolvedModel: string | null }>}
  */
 export async function probeCandidate(candidate, options = {}) {
-  const { cwd, sessionName, probeSession: probe = probeSession } = options;
+  const { cwd, sessionName, probeSession: probe = probeSession, nativeTimeoutMs } = options;
   const { agent, model } = candidate;
   const native = NATIVE_PROBES[agent];
   if (native) {
-    const early = await native(candidate);
+    const early = await native(candidate, { timeoutMs: nativeTimeoutMs ?? NATIVE_TIMEOUT_MS });
     if (early) return { resolvedModel: null, ...early };
   }
 
@@ -151,7 +166,7 @@ export async function probeCandidate(candidate, options = {}) {
     agent,
     sessionName,
     cwd,
-    timeoutMs: PROBE_TIMEOUT_BY_AGENT[agent] || PROBE_TIMEOUT_MS,
+    timeoutMs: PROBE_TIMEOUT_MS,
   });
   if (result.verdict !== "ok") return { verdict: result.verdict, detail: result.detail, resolvedModel: null };
 
@@ -184,6 +199,9 @@ export function isProbeEntryFresh(entry, { now = Date.now() } = {}) {
 function hintFor(agent, verdict) {
   if (verdict === "unauthenticated" && LOGIN_HINTS[agent]) return `-> run: ${LOGIN_HINTS[agent]}`;
   if (verdict === "unreachable") return `-> install the ${agent} CLI`;
+  // backpass cannot repair a wedged adapter, so the actionable thing is the command that
+  // reproduces the hang with acpx's own output visible.
+  if (verdict === "timeout") return `-> run: acpx ${acpxAgentName(agent)} sessions new --name probe`;
   return "";
 }
 
@@ -213,6 +231,10 @@ export class AgentResolver {
     this.memo = new Map();
     /** Probes in flight, so parallel analysis workers never double-probe a candidate. */
     this.inflight = new Map();
+    /** Agents that never answered this run: agent -> entry. Not cached to disk - the
+     * on-disk cache is keyed by candidate, and one adapter's silence is not a measurement
+     * of a model it was never asked for. */
+    this.deadAgents = new Map();
     this.picks = {};
     this.cache = null;
     this.version = undefined;
@@ -236,6 +258,8 @@ export class AgentResolver {
   async verdictFor(candidate) {
     const key = candidateKey(candidate);
     if (this.memo.has(key)) return this.memo.get(key);
+    const dead = this.deadAgents.get(candidate.agent);
+    if (dead) return dead;
     if (this.inflight.has(key)) return this.inflight.get(key);
     const pending = this.probeAndRecord(candidate, key).finally(() => this.inflight.delete(key));
     this.inflight.set(key, pending);
@@ -247,6 +271,7 @@ export class AgentResolver {
     const cached = cache.entries[key];
     if (!this.bypassCache && isProbeEntryFresh(cached, { now: this.now() })) {
       this.memo.set(key, { ...cached, cached: true });
+      this.noteAgentVerdict(candidate.agent, this.memo.get(key));
       return this.memo.get(key);
     }
 
@@ -261,8 +286,19 @@ export class AgentResolver {
     };
     cache.entries[key] = entry;
     this.memo.set(key, entry);
+    this.noteAgentVerdict(candidate.agent, entry);
     this.saveCache();
     return entry;
+  }
+
+  /**
+   * Retire an agent for the rest of the run when the adapter itself never answered.
+   * A ladder lists the same harness under several models, so without this a harness that
+   * is not spawnable is waited on once per rung before the ladder can be called empty.
+   */
+  noteAgentVerdict(agent, entry) {
+    if (!AGENT_LEVEL_VERDICTS.has(entry.verdict) || this.deadAgents.has(agent)) return;
+    this.deadAgents.set(agent, { ...entry, agentLevel: true });
   }
 
   /** The candidates for a role, in order, as `{ agent, model }`. */
@@ -343,6 +379,7 @@ export class AgentResolver {
       // First worker to see the failure records it; the rest just re-resolve.
       const entry = { verdict, detail, resolvedModel: null, checkedAt: new Date(this.now()).toISOString() };
       this.memo.set(key, entry);
+      this.noteAgentVerdict(pick.agent, entry);
       const cache = await this.loadCache();
       cache.entries[key] = entry;
       this.saveCache();

--- a/test/acpx-probe.test.js
+++ b/test/acpx-probe.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { probeSession } from "../src/acpx.js";
+
+/**
+ * The kill path of the availability probe.
+ *
+ * These drive `probeSession` through an injected runner rather than a real hanging
+ * subprocess on purpose. Whether a killed child's buffered output reaches the parent at
+ * all is a race - the same fixture captured stderr on one run and lost it on the next -
+ * so a test built on a real kill would assert a coin flip. Injecting the two shapes
+ * pins the decision `probeSession` makes about each, which is the part backpass owns.
+ */
+
+/** A runner whose `sessions new` returns `result`; later calls are never reached. */
+function runnerReturning(result) {
+  const calls = [];
+  return {
+    calls,
+    run: async (args) => {
+      calls.push(args.join(" "));
+      return { code: null, stdout: "", stderr: "", ...result };
+    },
+  };
+}
+
+test("a killed probe is classified from whatever the adapter had already printed", async () => {
+  const { run, calls } = runnerReturning({
+    timedOut: true,
+    stderr: "[acpx] error: RUNTIME AUTH_REQUIRED codex is not logged in\n",
+  });
+  const verdict = await probeSession({ agent: "codex", sessionName: "probe", timeoutMs: 10_000, run });
+
+  assert.equal(verdict.verdict, "unauthenticated", "a diagnosis already on stderr is a verdict, not a stall");
+  assert.match(verdict.detail, /AUTH_REQUIRED/);
+  assert.deepEqual(verdict.availableModels, []);
+  assert.equal(calls.length, 1, "a probe that never came up is not asked for its model list");
+});
+
+test("a probe that hangs without saying anything stays a timeout", async () => {
+  const { run } = runnerReturning({ timedOut: true, stderr: "" });
+  const verdict = await probeSession({ agent: "pi", sessionName: "probe", timeoutMs: 10_000, run });
+
+  assert.equal(verdict.verdict, "timeout", "an unexplained hang must not be given a name it did not earn");
+  assert.match(verdict.detail, /no answer in 10s/, "the detail names the wait the user actually paid");
+});
+
+test("a killed probe is never reported as `not installed`", async () => {
+  // The distinction that matters to the person reading the exhausted-ladder table:
+  // `unreachable` tells them to install a CLI, which is wrong advice for one that is
+  // installed and merely wedged.
+  for (const stderr of ["", "starting adapter...\n", "[acpx] error: TIMEOUT prompt exceeded 300s\n"]) {
+    const { run } = runnerReturning({ timedOut: true, stderr });
+    const verdict = await probeSession({ agent: "codex", sessionName: "probe", timeoutMs: 10_000, run });
+    assert.equal(verdict.verdict, "timeout", `unclassifiable stderr ${JSON.stringify(stderr)} is a timeout`);
+  }
+});

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -163,6 +163,10 @@ test("claude is decided by `claude auth status`, not by the acpx session probe",
       { agent: "claude", model: "claude-sonnet-5" },
       {
         sessionName: "t",
+        // Generous on purpose: the fake exits at once, so this only rules out a loaded
+        // CI box tripping the real 5s budget and turning a scripted verdict into a
+        // timeout. Seen failing this way under a parallel suite run.
+        nativeTimeoutMs: 60_000,
         probeSession: async () => {
           acpxProbed = true;
           fs.writeFileSync(marker, "");
@@ -183,6 +187,7 @@ test("claude is decided by `claude auth status`, not by the acpx session probe",
       { agent: "claude", model: "claude-sonnet-5" },
       {
         sessionName: "t",
+        nativeTimeoutMs: 60_000,
         probeSession: async () => ({ verdict: "ok", detail: "", availableModels: ["default", "sonnet"] }),
       },
     );
@@ -444,4 +449,77 @@ test("acpx failure classification and the per-adapter tables", () => {
   assert.equal(effortOptionKey("claude"), "effort");
   assert.equal(effortOptionKey("pi"), "thought_level");
   assert.equal(effortOptionKey("grok"), null);
+});
+
+test("a native status call that never answers is a timeout, not `not installed`", async () => {
+  // The failure this pins: a killed `claude auth status` exits non-zero with unparseable
+  // output, which read as `unreachable` - whose hint is "install the claude CLI", to a
+  // user whose claude is installed and logged in.
+  const bin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-hangbin-"));
+  const script = path.join(bin, "claude");
+  fs.writeFileSync(script, "#!/bin/sh\nexec sleep 30\n");
+  fs.chmodSync(script, 0o755);
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${bin}${path.delimiter}${oldPath}`;
+  try {
+    const verdict = await probeCandidate(
+      { agent: "claude", model: "claude-sonnet-5" },
+      {
+        sessionName: "t",
+        nativeTimeoutMs: 150,
+        probeSession: async () => assert.fail("a hung native check must not fall through to the acpx probe"),
+      },
+    );
+    assert.equal(verdict.verdict, "timeout");
+    assert.match(verdict.detail, /did not answer/);
+  } finally {
+    process.env.PATH = oldPath;
+  }
+});
+
+test("an adapter that never answers is waited on once, not once per rung it appears in", async () => {
+  // The default analysis ladder lists pi and opencode twice each. Before this, a harness
+  // that is not spawnable was probed - and waited on - once per rung, so the cost of
+  // declaring the ladder empty was paid seven times for five harnesses.
+  const { resolver, calls } = resolverWith({});
+  await assert.rejects(() => resolver.resolve("analysis"), UserError);
+  assert.deepEqual(calls, [
+    "pi|gpt-5.6-luna",
+    "opencode|gpt-5.6-luna",
+    "codex|gpt-5.6-luna",
+    "claude|claude-sonnet-5",
+    "grok|grok-4.6",
+  ]);
+});
+
+test("a timed-out adapter retires for the run, but a rejected model does not", async () => {
+  const hung = resolverWith({ "pi|gpt-5.6-luna": "timeout" });
+  await assert.rejects(() => hung.resolver.resolve("analysis"), UserError);
+  assert.equal(
+    hung.calls.filter((c) => c.startsWith("pi|")).length,
+    1,
+    "an adapter that never answered cannot answer differently for another model",
+  );
+
+  // `model-unavailable` is a fact about the model, not the adapter: pi must be asked again.
+  const picky = resolverWith({
+    "pi|gpt-5.6-luna": "model-unavailable",
+    "pi|grok-4.6": { resolvedModel: "xai/grok-4.6" },
+  });
+  const pick = await picky.resolver.resolve("analysis");
+  assert.equal(pick.agent, "pi");
+  assert.equal(pick.model, "xai/grok-4.6");
+  assert.equal(picky.calls.filter((c) => c.startsWith("pi|")).length, 2);
+});
+
+test("an exhausted ladder names a command for every row, including the hung ones", async () => {
+  const { resolver } = resolverWith({ "pi|gpt-5.6-luna": "timeout", "claude|claude-sonnet-5": "unauthenticated" });
+  const err = await resolver.resolve("analysis").then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err instanceof UserError);
+  assert.match(err.message, /acpx pi sessions new/, "a hung adapter names the command that reproduces the hang");
+  assert.match(err.message, /claude auth login/);
+  assert.match(err.message, /install the codex CLI/);
 });


### PR DESCRIPTION
An adapter that never answers was the most expensive way for agent selection to fail, and the least explanatory. `sessions new` was capped at 20s per candidate, the same harness was waited on once per rung it appears in, a killed probe threw away whatever acpx had already printed, and the resulting `probe timed out` row was the only one in the exhausted-ladder table with no command next to it.

Observed on 0.1.1 with pi/opencode/grok absent and claude/codex present: both reachable harnesses timed out at 20s each and the ladder emptied with nothing actionable to show for the wait.

- Cap `sessions new` at 10s for every adapter. It spawns the adapter and handshakes; it does no model work, so 20s was a hang budget rather than a handshake budget. This subsumes opencode's per-agent exception, which was already 10s for the same reason.
- Classify a killed probe from what it had already written before declaring it a timeout, so an AUTH_REQUIRED that arrived before the wedge is reported as "not logged in" with a login command. Whether a killed child's buffered output reaches us is timing-dependent, so this is an opportunistic upgrade and is documented as one.
- Retire an agent for the rest of the run on `unreachable` or `timeout`. Both describe the adapter, not the model, and the default ladders list pi and opencode twice each - so declaring the ladder empty cost seven waits for five harnesses. `model-unavailable` is unchanged: that is a fact about the model, and the harness is asked again.
- Report a timed-out `claude auth status` as a timeout. A killed status call exits non-zero with unparseable output, which fell through to `unreachable` - whose hint is "install the claude CLI", told to a user whose claude is installed and logged in.
- Give `timeout` a hint, so every row in the exhausted-ladder error names a command.

The existing claude native-probe test could hit the real 5s budget on a loaded box and fail the same way; it now pins its own timeout.


Claude-Session: https://claude.ai/code/session_01GctVrxJgQqNXte39AHVXWK