### PR TITLE
fix(apply): consume decided proposals and keep skipped ones reviewable

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ For compatibility, proposals created by older backpass versions that do not cont
 memory-file hash skip the freshness check. Regenerate such a proposal before applying it if
 the repository may have changed.
 
+A decided apply (any accept or reject, and no write failures) **consumes** the saved
+proposal: `backpass apply` refuses a replay. Skip every edit, or hit a write failure, and
+the proposal stays reviewable. `--dry-run` never consumes it. `backpass status` only
+hints `review with backpass apply` while the proposal is still open.
+
 ```sh
 backpass apply --no-ui     # same decision, in the terminal
 backpass apply --no-open   # print the surface URL, don't launch a browser
@@ -405,7 +410,7 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   scan-cache.json        collect-samples verdicts by path + mtime + size
   evidence/<id>.json     per-transcript loss
   evidence-summary.json  aggregated gradients
-  proposal.json          the latest gradient-descent step
+  proposal.json          the latest gradient-descent step (stamped when consumed)
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -72,7 +72,8 @@ export async function cmdApply(ctx, deps = {}) {
 
   if (surfaceFile) await closeApplySurface(surfaceFile);
 
-  if (!ctx.flags["dry-run"] && !results.failed.length) {
+  const decided = results.accepted + results.rejected > 0;
+  if (!ctx.flags["dry-run"] && decided && !results.failed.length) {
     proposal.appliedAt = new Date().toISOString();
     proposal.appliedBy = "apply";
     config.state.writeProposal(proposal);

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -12,6 +12,10 @@ import { budgetBar, formatTokens } from "../tokens.js";
  * structured decision vector; `--no-ui` keeps the same ACCEPT/REJECT decision in the
  * terminal. `applyDecisions` owns the pre-write freshness, budget, and composition gates;
  * a failing gate records no rejections.
+ *
+ * A decided apply (any accept or reject, no write failures, not `--dry-run`) stamps
+ * `appliedAt`/`appliedBy` on the saved proposal so a second apply refuses. An all-skip
+ * or a failed write leaves the proposal reviewable.
  */
 export async function cmdApply(ctx, deps = {}) {
   const { config, repo } = ctx;

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -13,8 +13,9 @@ import { budgetBar, formatTokens } from "../tokens.js";
  * terminal. `applyDecisions` owns the pre-write freshness, budget, and composition gates;
  * a failing gate records no rejections.
  */
-export async function cmdApply(ctx) {
+export async function cmdApply(ctx, deps = {}) {
   const { config, repo } = ctx;
+  const review = deps.review || reviewInTerminal;
   const proposal = config.state.readProposal();
 
   if (!proposal) {
@@ -42,7 +43,7 @@ export async function cmdApply(ctx) {
   let surfaceFile = null;
 
   if (ctx.flags["no-ui"]) {
-    decisions = await reviewInTerminal(proposal);
+    decisions = await review(proposal);
   } else {
     surfaceFile = renderApplySurface(proposal, config.state, ctx.version);
     const url = await openApplySurface(surfaceFile);
@@ -70,6 +71,12 @@ export async function cmdApply(ctx) {
   });
 
   if (surfaceFile) await closeApplySurface(surfaceFile);
+
+  if (!ctx.flags["dry-run"] && !results.failed.length) {
+    proposal.appliedAt = new Date().toISOString();
+    proposal.appliedBy = "apply";
+    config.state.writeProposal(proposal);
+  }
 
   if (ctx.flags.json) {
     json({ decisions, results });

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -112,7 +112,8 @@ export async function cmdStatus(ctx) {
     );
     const surface = path.join(state.applyDir, "apply.html");
     if (fs.existsSync(surface)) out(color.dim(`  surface         ${surface}`));
-    if (!proposal.appliedAt && !proposal.violations?.length && proposal.edits.length) out("  review with `backpass apply`");
+    if (!proposal.appliedAt && !proposal.violations?.length && proposal.edits.length)
+      out("  review with `backpass apply`");
   }
 
   out("");

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -112,7 +112,7 @@ export async function cmdStatus(ctx) {
     );
     const surface = path.join(state.applyDir, "apply.html");
     if (fs.existsSync(surface)) out(color.dim(`  surface         ${surface}`));
-    if (!proposal.violations?.length && proposal.edits.length) out("  review with `backpass apply`");
+    if (!proposal.appliedAt && !proposal.violations?.length && proposal.edits.length) out("  review with `backpass apply`");
   }
 
   out("");

--- a/src/state.js
+++ b/src/state.js
@@ -18,7 +18,7 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   scan-cache.json        path+mtime+size -> association verdict (design section 2.2)
  *   evidence/<id>.json     per-transcript tier-1 analysis output (design section 3)
  *   evidence-summary.json  folded evidence (stage 2)
- *   proposal.json          latest tier-2 synthesis (stage 3)
+ *   proposal.json          latest tier-2 synthesis (stage 3); stamped appliedAt/appliedBy when consumed
  *   rejections.json        edits the human rejected, and the evidence weight behind them
  *   gap-ledger.json        gap observations by gap and session, accumulated across runs (src/gap-ledger.js)
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -15,6 +15,7 @@ import {
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
+import { cmdApply } from "../src/commands/apply.js";
 import { injectPayload, parseDecisions } from "../src/apply/lavish.js";
 import { extractJson, parseTokenLine, stripAcpxNoise } from "../src/acpx.js";
 import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
@@ -770,6 +771,50 @@ test("a failed later skill write names skill paths already written", () => {
         /already written/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
     ),
   );
+});
+
+test("a successful apply marks the proposal as consumed and prevents replay", async () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
+  });
+  state.writeProposal(proposal);
+  const ctx = {
+    repo,
+    config: { ...config(), state },
+    flags: { "no-ui": true, json: true },
+  };
+  let reviews = 0;
+  const review = async () => {
+    reviews += 1;
+    return { e1: "accepted" };
+  };
+
+  assert.equal(await cmdApply(ctx, { review }), 0);
+  const applied = state.readProposal();
+  assert.equal(applied.appliedBy, "apply");
+  assert.match(applied.appliedAt, /^\d{4}-\d{2}-\d{2}T/);
+  await assert.rejects(() => cmdApply(ctx, { review }), /already applied by apply/);
+  assert.equal(reviews, 1, "the consumed proposal is rejected before reopening review");
+});
+
+test("a failed apply leaves the proposal available for retry", async () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
+  });
+  state.writeProposal(proposal);
+  fs.writeFileSync(path.join(repo.root, "AGENTS.md"), MEMORY_TEXT.replace("Node 18", "Node 22"));
+  const ctx = {
+    repo,
+    config: { ...config(), state },
+    flags: { "no-ui": true, json: true },
+  };
+
+  assert.equal(await cmdApply(ctx, { review: async () => ({ e1: "accepted" }) }), 1);
+  const unapplied = state.readProposal();
+  assert.equal(unapplied.appliedAt, undefined);
+  assert.equal(unapplied.appliedBy, undefined);
 });
 
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -798,6 +798,29 @@ test("a successful apply marks the proposal as consumed and prevents replay", as
   assert.equal(reviews, 1, "the consumed proposal is rejected before reopening review");
 });
 
+test("an all-skipped apply leaves the proposal available for review", async () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
+  });
+  state.writeProposal(proposal);
+  const ctx = {
+    repo,
+    config: { ...config(), state },
+    flags: { "no-ui": true, json: true },
+  };
+  let reviews = 0;
+  const review = async () => {
+    reviews += 1;
+    return { e1: "skipped" };
+  };
+
+  assert.equal(await cmdApply(ctx, { review }), 0);
+  assert.equal(state.readProposal().appliedAt, undefined);
+  assert.equal(await cmdApply(ctx, { review }), 0);
+  assert.equal(reviews, 2, "an untouched proposal reopens for a later decision");
+});
+
 test("a failed apply leaves the proposal available for retry", async () => {
   const { proposal, repo, state } = gate({
     edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),


### PR DESCRIPTION
## What Changed
- Stamp `appliedAt`/`appliedBy` after a non-dry-run apply that accepts or rejects at least one edit and writes without failures, so a second `backpass apply` refuses replay.
- Leave the saved proposal reviewable when every edit is skipped or a write fails.
- Hide the `review with backpass apply` status hint once the proposal is consumed.

## Risk Assessment

✅ Low: Consume is gated on accept/reject, dry-run, and apply failures, replay is covered, and the stale apply hint is fixed.

## Testing

Ran the consume/skip/fail apply unit tests, then walked a seeded git repo through the real CLI: status showed the apply hint, accepting in --no-ui wrote AGENTS.md and stamped proposal.json, a second apply was blocked, and quit/failed applies stayed unmarked and still hinted.

<details>
<summary>Evidence: CLI walkthrough: status hint, accept, consumed stamp, replay block, quit/fail stay reviewable</summary>

```text
# backpass apply consumes a decided proposal

User-facing CLI walkthrough on a temp git repo with a seeded `.backpass/proposal.json`.

## $ backpass status  (proposal waiting)

`` `
$ backpass status
backpass-e2e-accept-KaHuaT /private/var/folders/82/zhg0h4_s65dclyhhbl88x45w0000gn/T/backpass-e2e-accept-KaHuaT

BUDGET (always-loaded)
  AGENTS.md      [................................] 40 / 5,000 tok · 3 instructions

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  generated       2026-08-25T01:31:02.797Z
  edits           1
  review with `backpass apply`

MODELS
  analysis        cursor/gpt-5.6-luna (effort medium, configured)
  synthesis       cursor/gpt-5.6-sol (effort high, configured)
`` `

## $ backpass apply --no-ui  (accept)

`` `
$ backpass apply --no-ui

backpass apply · backpass-e2e-accept-KaHuaT · AGENTS.md · 1 proposed edit(s)
budget: 40 -> 27 / 5,000 tok if all accepted

[1/1] REMOVE  -13 tok
  drop node pin
  file: AGENTS.md

  - - Use Node 18 via nvm before running any script.

  evidence (3 transcript(s)):
    - "nvm is gone"
      claude · abc · turn 3

  [a]ccept / [r]eject / [q]uit > a


1 accepted · 0 rejected
  wrote AGENTS.md (e1)
    budget [................................] 40 -> 27 / 5,000 tok
`` `

## persisted proposal.json after accept

`` `
{
  "appliedAt": "2026-08-25T01:31:03.091Z",
  "appliedBy": "apply"
}
`` `

## AGENTS.md after accept

`` `
# Demo agent instructions

## Rules

- Whenever a PR is mentioned, include its URL.
- Prefer small commits.
`` `

## $ backpass status  (consumed — no apply hint)

`` `
$ backpass status
backpass-e2e-accept-KaHuaT /private/var/folders/82/zhg0h4_s65dclyhhbl88x45w0000gn/T/backpass-e2e-accept-KaHuaT

BUDGET (always-loaded)
  AGENTS.md      [................................] 27 / 5,000 tok · 2 instructions

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  generated       2026-08-25T01:31:02.797Z
  edits           1

MODELS
  analysis        cursor/gpt-5.6-luna (effort medium, configured)
  synthesis       cursor/gpt-5.6-sol (effort high, configured)
`` `

## $ backpass apply --no-ui  (replay blocked)

`` `
$ backpass apply --no-ui
exit 1
error the last proposal was already applied by apply (2026-08-25T01:31:03.091Z)
  run `backpass` again to produce a fresh one
`` `

## $ backpass apply --no-ui  (quit / no decision)

`` `
$ backpass apply --no-ui

backpass apply · backpass-e2e-skip-4mC4te · AGENTS.md · 1 proposed edit(s)
budget: 40 -> 27 / 5,000 tok if all accepted

[1/1] REMOVE  -13 tok
  drop node pin
  file: AGENTS.md

  - - Use Node 18 via nvm before running any script.

  evidence (3 transcript(s)):
    - "nvm is gone"
      claude · abc · turn 3

  [a]ccept / [r]eject / [q]uit > q

No decisions received - nothing was written.
`` `

## proposal after quit (still reviewable)

`` `
{
  "appliedAt": null,
  "appliedBy": null
}
`` `

## $ backpass status  (still hints apply)

`` `
$ backpass status
backpass-e2e-skip-4mC4te /private/var/folders/82/zhg0h4_s65dclyhhbl88x45w0000gn/T/backpass-e2e-skip-4mC4te

BUDGET (always-loaded)
  AGENTS.md      [................................] 40 / 5,000 tok · 3 instructions

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  generated       2026-08-25T01:31:03.489Z
  edits           1
  review with `backpass apply`

MODELS
  analysis        cursor/gpt-5.6-luna (effort medium, configured)
  synthesis       cursor/gpt-5.6-sol (effort high, configured)
`` `

## $ backpass apply --no-ui  (accept against drifted file)

`` `
$ backpass apply --no-ui

backpass apply · backpass-e2e-fail-Knwy8T · AGENTS.md · 1 proposed edit(s)
budget: 40 -> 27 / 5,000 tok if all accepted

[1/1] REMOVE  -13 tok
  drop node pin
  file: AGENTS.md

  - - Use Node 18 via nvm before running any script.

  evidence (3 transcript(s)):
    - "nvm is gone"
      claude · abc · turn 3

  [a]ccept / [r]eject / [q]uit > a


1 accepted · 0 rejected
  failed AGENTS.md (e1): edit e1 (H1): "find" text does not appear in AGENTS.md
  nothing written
`` `

## proposal after failed apply (retryable)

`` `
{
  "appliedAt": null,
  "appliedBy": null
}
`` `
```
</details>
<details>
<summary>Evidence: status before apply still hints review</summary>

<code>PROPOSAL&#10;generated 2026-08-25T01:31:02.797Z&#10;edits 1&#10;review with `backpass apply`</code>

```text
backpass-e2e-accept-KaHuaT /private/var/folders/82/zhg0h4_s65dclyhhbl88x45w0000gn/T/backpass-e2e-accept-KaHuaT

BUDGET (always-loaded)
  AGENTS.md      [................................] 40 / 5,000 tok · 3 instructions

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  generated       2026-08-25T01:31:02.797Z
  edits           1
  review with `backpass apply`

MODELS
  analysis        cursor/gpt-5.6-luna (effort medium, configured)
  synthesis       cursor/gpt-5.6-sol (effort high, configured)
```
</details>
<details>
<summary>Evidence: status after consume drops the apply hint</summary>

<code>PROPOSAL&#10;generated 2026-08-25T01:31:02.797Z&#10;edits 1</code>

```text
backpass-e2e-accept-KaHuaT /private/var/folders/82/zhg0h4_s65dclyhhbl88x45w0000gn/T/backpass-e2e-accept-KaHuaT

BUDGET (always-loaded)
  AGENTS.md      [................................] 27 / 5,000 tok · 2 instructions

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  generated       2026-08-25T01:31:02.797Z
  edits           1

MODELS
  analysis        cursor/gpt-5.6-luna (effort medium, configured)
  synthesis       cursor/gpt-5.6-sol (effort high, configured)
```
</details>
<details>
<summary>Evidence: second apply rejected as already consumed</summary>

<code>error the last proposal was already applied by apply (2026-08-25T01:31:03.091Z)&#10;run `backpass` again to produce a fresh one</code>

```text
error the last proposal was already applied by apply (2026-08-25T01:31:03.091Z)
  run `backpass` again to produce a fresh one
```
</details>
<details>
<summary>Evidence: proposal.json appliedAt/appliedBy after accept</summary>

<code>{&#10;&#34;appliedAt&#34;: &#34;2026-08-25T01:31:03.091Z&#34;,&#10;&#34;appliedBy&#34;: &#34;apply&#34;&#10;}</code>

```text
{
  "appliedAt": "2026-08-25T01:31:03.091Z",
  "appliedBy": "apply"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e475b33daba5eb9fffdabe1e48a4762765b705ab","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/commands/apply.js:74` - Any accept/reject stamps the proposal even when other edits were defaulted to skipped (line 61). Lavish parseDecisions can return a subset of ids, so leftover edits become unreviewable. Confirm consume should run on any decision, or only when every edit is accepted or rejected.
- ⚠️ `src/commands/status.js:115` - Status still prints “review with `backpass apply`” for any gated proposal with edits, including after appliedAt is set. That next step now throws. Skip the hint when proposal.appliedAt is set.

🔧 Fix: Skip apply hint after proposal is consumed
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='successful apply|all-skipped apply|failed apply|applied proposal skips' test/proposal.test.js test/usage-output.test.js`
- <code>`node /var/folders/82/zhg0h4_s65dclyhhbl88x45w0000gn/T/no-mistakes-evidence/01M0V85SKKE97WT7BSCGXC7HZE/demo-apply-consumed.mjs` (real `backpass status` + PTY `backpass apply --no-ui` accept/quit/fail)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


