### PR TITLE
fix(apply): revalidate accepted edit subsets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
+  Apply revalidates the accepted subset with `budgetGateKind` (`src/tokens.js`) before any
+  write; a failing subset writes nothing and does not record rejections.
 - **Synthesis edits natively, in a staging copy, never by describing text.** The agent
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ Thanks for wanting to contribute.
 
 Do not open the pull request manually. The repository gate requires the signature and
 head-SHA-bound pipeline attestation that no-mistakes writes to the pull request body.
+`review`, `test`, and `document` must be `completed` in that attestation; a signature-only
+body from no-mistakes older than 1.46.0 is not enough.
 
 CI runs lint, format:check, typecheck, and the test suite on every PR; a guard also
 rejects hand-edits to release-please-generated files.

--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ a headless box or `--no-open` just hands you the link.
 There is no DEFER button, and it isn't missing: **rejections are remembered.** A rejected
 edit is not proposed again unless materially new evidence arrives.
 
+The live budget gauge is not just a readout. Apply rechecks the accepted subset against
+the same budget gate as synthesis: stay under the cap, or shrink if the file is already
+over. An incompatible set writes nothing and does not record rejections, so you can pick
+a compatible set and try again.
+
 ```sh
 backpass apply --no-ui     # same decision, in the terminal
 backpass apply --no-open   # print the surface URL, don't launch a browser

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -45,8 +45,10 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens }) {
  * The only place in backpass that writes to the repo.
  *
  * Everything upstream is read-only analysis; a run only changes the weights here, after
- * a human accepted specific edits. Writes are grouped per file so a memory file is
- * rewritten once, atomically, rather than edit by edit.
+ * a human accepted specific edits. The accepted subset is rechecked with the same
+ * cap/shrink budget gate as the full proposal (`budgetGateKind`); a failing subset
+ * returns with no writes and no rejection ledger. Writes are grouped per file so a
+ * memory file is rewritten once, atomically, rather than edit by edit.
  */
 export function applyDecisions({ proposal, decisions, repo, state, config, dryRun = false }) {
   const accepted = proposal.edits.filter((e) => decisions[e.id] === "accepted");

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -6,6 +6,44 @@ import { budgetStatus } from "../tokens.js";
 import { recordRejection } from "../state.js";
 import { writeSkill } from "../skills.js";
 
+function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens }) {
+  if (!accepted.length) return null;
+
+  const relative = proposal.memoryFile.path;
+  const absolute = path.join(repo.root, relative);
+  if (!fs.existsSync(absolute)) return { file: relative, error: "file does not exist" };
+
+  const before = fs.readFileSync(absolute, "utf8");
+  let projected = before;
+  for (const edit of accepted.filter((candidate) => candidate.targetsMemoryFile)) {
+    try {
+      projected = applyEdit(projected, edit);
+    } catch (err) {
+      return { file: relative, edit: edit.id, error: err.message };
+    }
+  }
+
+  const budget = budgetStatus(before, projected, capTokens);
+  if (budget.current <= capTokens && !budget.withinBudget) {
+    return {
+      file: relative,
+      error:
+        `accepted edits leave ${relative} at ${budget.projected} tokens, ${budget.over} over the ` +
+        `${capTokens}-token budget; choose a compatible set of edits`,
+    };
+  }
+  if (budget.current > capTokens && budget.delta >= 0) {
+    return {
+      file: relative,
+      error:
+        `${relative} is already ${budget.current - capTokens} tokens over the ${capTokens}-token budget, ` +
+        `so accepted edits must shrink it, but they change it by ${budget.delta >= 0 ? "+" : ""}${budget.delta} ` +
+        "tokens; choose a compatible set of edits",
+    };
+  }
+  return null;
+}
+
 /**
  * The only place in backpass that writes to the repo.
  *
@@ -26,6 +64,17 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     accepted: accepted.length,
     rejected: rejected.length,
   };
+
+  const budgetFailure = acceptedSubsetBudgetFailure({
+    proposal,
+    accepted,
+    repo,
+    capTokens: config.budgetTokens,
+  });
+  if (budgetFailure) {
+    results.failed.push(budgetFailure);
+    return results;
+  }
 
   for (const edit of accepted) {
     if (!byFile.has(edit.file)) byFile.set(edit.file, []);

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { applyEdit } from "../proposal.js";
-import { budgetStatus } from "../tokens.js";
+import { applyEdit, projectWithDecisions } from "../proposal.js";
+import { budgetGateKind, budgetStatus } from "../tokens.js";
 import { recordRejection } from "../state.js";
 import { writeSkill } from "../skills.js";
 
@@ -11,20 +11,17 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens }) {
 
   const relative = proposal.memoryFile.path;
   const absolute = path.join(repo.root, relative);
-  if (!fs.existsSync(absolute)) return { file: relative, error: "file does not exist" };
+  if (!fs.existsSync(absolute)) return null;
 
   const before = fs.readFileSync(absolute, "utf8");
-  let projected = before;
-  for (const edit of accepted.filter((candidate) => candidate.targetsMemoryFile)) {
-    try {
-      projected = applyEdit(projected, edit);
-    } catch (err) {
-      return { file: relative, edit: edit.id, error: err.message };
-    }
-  }
-
-  const budget = budgetStatus(before, projected, capTokens);
-  if (budget.current <= capTokens && !budget.withinBudget) {
+  const { budget } = projectWithDecisions(
+    before,
+    accepted,
+    accepted.map((edit) => edit.id),
+    capTokens,
+  );
+  const gate = budgetGateKind(budget);
+  if (gate === "cap") {
     return {
       file: relative,
       error:
@@ -32,7 +29,7 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens }) {
         `${capTokens}-token budget; choose a compatible set of edits`,
     };
   }
-  if (budget.current > capTokens && budget.delta >= 0) {
+  if (gate === "shrink") {
     return {
       file: relative,
       error:
@@ -63,6 +60,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     warnings: [],
     accepted: accepted.length,
     rejected: rejected.length,
+    rejectionsRecorded: false,
   };
 
   const budgetFailure = acceptedSubsetBudgetFailure({
@@ -125,6 +123,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     const rejections = state.readRejections();
     for (const edit of rejected) recordRejection(edit, rejections);
     state.writeRejections(rejections);
+    results.rejectionsRecorded = true;
   }
 
   return results;

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -97,7 +97,7 @@ export async function cmdApply(ctx) {
     out(`  ${color.red("failed")} ${failure.file}${failure.edit ? ` (${failure.edit})` : ""}: ${failure.error}`);
   }
 
-  if (results.rejected) {
+  if (results.rejectionsRecorded) {
     out(color.dim("  rejections recorded - they will not be re-proposed without new evidence"));
   }
   if (!results.written.length && !results.skills.length) out("  nothing written");

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -10,7 +10,8 @@ import { budgetBar, formatTokens } from "../tokens.js";
  *
  * By default it serves the shipped static template through lavish-axi and waits for one
  * structured decision vector; `--no-ui` keeps the same ACCEPT/REJECT decision in the
- * terminal.
+ * terminal. `applyDecisions` revalidates the accepted subset against the budget before
+ * writing; a failing set records no rejections.
  */
 export async function cmdApply(ctx) {
   const { config, repo } = ctx;

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,5 +1,5 @@
 import { renderHunkLines } from "./diff.js";
-import { budgetStatus, estimateTokens } from "./tokens.js";
+import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 
 /**
  * The proposal model: what a synthesis pass is allowed to produce, and the mechanical
@@ -355,12 +355,13 @@ export function buildProposal(rawResult, context) {
   budget.mode = memoryFile.tokens > config.budgetTokens ? "shrink" : "cap";
   budget.startedOverBudget = budget.mode === "shrink";
 
-  if (budget.mode === "cap" && !budget.withinBudget) {
+  const gate = budgetGateKind(budget);
+  if (gate === "cap") {
     violations.push(
       `applying every proposed edit leaves ${memoryFile.path} at ${budget.projected} tokens, ` +
         `${budget.over} over the ${config.budgetTokens}-token budget`,
     );
-  } else if (budget.mode === "shrink" && budget.delta >= 0) {
+  } else if (gate === "shrink") {
     violations.push(
       `${memoryFile.path} is already ${budget.current - config.budgetTokens} tokens over the ` +
         `${config.budgetTokens}-token budget, so this run must shrink it, but the proposed edits ` +

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -3,7 +3,8 @@ import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 
 /**
  * The proposal model: what a synthesis pass is allowed to produce, and the mechanical
- * gates it must clear before a human ever sees it (design sections 3, 6, 7).
+ * gates it must clear before a human ever sees it (design sections 3, 6, 7). The
+ * budget gate (`budgetGateKind`) runs again on the accepted subset at apply.
  *
  * The synthesis agent edits a staging copy of the memory file natively
  * (`src/workspace.js`); backpass measures the result as anchored hunks (`src/diff.js`)

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -40,6 +40,13 @@ export function budgetStatus(currentText, projectedText, capTokens) {
   };
 }
 
+/** Cap: stay under. Shrink: already over, so the delta must be negative. */
+export function budgetGateKind(budget) {
+  if (budget.current <= budget.capTokens && !budget.withinBudget) return "cap";
+  if (budget.current > budget.capTokens && budget.delta >= 0) return "shrink";
+  return null;
+}
+
 /** Fixed-width ASCII gauge for `backpass status`. */
 export function budgetBar(status, width = 32) {
   const filled = Math.min(width, Math.round(status.utilization * width));

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { budgetBar, budgetStatus, estimateTokens, formatTokens } from "../src/tokens.js";
+import { budgetBar, budgetGateKind, budgetStatus, estimateTokens, formatTokens } from "../src/tokens.js";
 import { parseMemoryUnits, similarity, reanchor, unitHash } from "../src/memory.js";
 import { extractionBudgetEffect, parseFrontmatter, renderSkillFile } from "../src/skills.js";
 
@@ -29,6 +29,10 @@ test("budgetStatus reports the delta, the overage, and whether the gate passes",
   assert.equal(over.delta, 2000);
   assert.equal(over.withinBudget, false);
   assert.equal(over.over, 1000);
+  assert.equal(budgetGateKind(within), null);
+  assert.equal(budgetGateKind(over), "cap");
+  assert.equal(budgetGateKind(budgetStatus(grown, grown, 5000)), "shrink");
+  assert.equal(budgetGateKind(budgetStatus(grown, current, 5000)), null);
 });
 
 test("a shrinking edit is within budget even when the file started over it", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -535,13 +535,11 @@ test("apply preflight skips inapplicable accepted edits and still writes the res
     edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
     annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
   });
-  proposal.edits.push({
-    id: "e-stale",
-    file: proposal.memoryFile.path,
-    targetsMemoryFile: true,
-    find: "text that is not in the file at all",
-    replace: "x",
-  });
+  const stale = structuredClone(proposal.edits[0]);
+  stale.id = "e-stale";
+  stale.hunks[0].find = "text that is not in the file at all";
+  stale.hunks[0].replace = "x";
+  proposal.edits.push(stale);
 
   const results = applyDecisions({
     proposal,

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -426,6 +426,7 @@ test("applying decisions writes accepted edits, skips rejected ones, and remembe
   assert.ok(written.includes("include its URL."), "the rejected rewrite is not applied");
   assert.equal(results.accepted, 1);
   assert.equal(results.rejected, 1);
+  assert.equal(results.rejectionsRecorded, true);
   assert.equal(results.failed.length, 0);
   assert.ok(results.written[0].budget.delta < 0);
 
@@ -468,6 +469,7 @@ test("apply refuses an accepted subset that exceeds the memory cap before writin
   });
 
   assert.match(results.failed[0].error, /accepted edits leave AGENTS\.md .* over the .* budget/);
+  assert.equal(results.rejectionsRecorded, false);
   assert.deepEqual(results.written, []);
   assert.deepEqual(results.skills, []);
   assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
@@ -499,6 +501,7 @@ test("apply refuses a non-shrinking accepted subset when memory already exceeds 
   });
 
   assert.match(results.failed[0].error, /accepted edits must shrink it, but they change it by \+/);
+  assert.equal(results.rejectionsRecorded, false);
   assert.deepEqual(results.written, []);
   assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
   assert.equal(Object.keys(state.readRejections().entries).length, 0, "the reviewer can retry with a valid subset");
@@ -523,7 +526,35 @@ test("rejecting every edit remains valid when memory already exceeds the cap", (
 
   assert.deepEqual(results.failed, []);
   assert.deepEqual(results.written, []);
+  assert.equal(results.rejectionsRecorded, true);
   assert.equal(Object.keys(state.readRejections().entries).length, 1);
+});
+
+test("apply preflight skips inapplicable accepted edits and still writes the rest", () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
+  });
+  proposal.edits.push({
+    id: "e-stale",
+    file: proposal.memoryFile.path,
+    targetsMemoryFile: true,
+    find: "text that is not in the file at all",
+    replace: "x",
+  });
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted", "e-stale": "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.equal(results.written.length, 1);
+  assert.equal(results.failed.length, 1);
+  assert.equal(results.failed[0].edit, "e-stale");
+  assert.ok(!fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8").includes("Node 18"));
 });
 
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -433,6 +433,99 @@ test("applying decisions writes accepted edits, skips rejected ones, and remembe
   assert.equal(Object.keys(remembered.entries).length, 1);
 });
 
+test("apply refuses an accepted subset that exceeds the memory cap before writing any file", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const cap = estimateTokens(MEMORY_TEXT);
+  const { proposal, violations, repo, state } = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text
+          .replace("- Use Node 18 via nvm before running any script.\n", "")
+          .replace("include its URL.", "include its full https:// URL."),
+      );
+      writeIn(root, ".agents/skills/db/SKILL.md", (text) =>
+        text.replace("old trigger", "Load before touching the database."),
+      );
+    },
+    annotation: {
+      edits: [
+        claim(["H2"], { kind: "remove", title: "drop node pin" }),
+        claim(["H1"], { title: "expand URL rule" }),
+        claim(["H3"], { title: "fix skill trigger" }),
+      ],
+    },
+    config: config({ budgetTokens: cap }),
+  });
+  assert.deepEqual(violations, [], "the complete proposal is valid because the removal pays for the addition");
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "rejected", e2: "accepted", e3: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: cap },
+  });
+
+  assert.match(results.failed[0].error, /accepted edits leave AGENTS\.md .* over the .* budget/);
+  assert.deepEqual(results.written, []);
+  assert.deepEqual(results.skills, []);
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
+  assert.equal(fs.readFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), "utf8"), skill);
+  assert.equal(Object.keys(state.readRejections().entries).length, 0, "the reviewer can retry with a valid subset");
+});
+
+test("apply refuses a non-shrinking accepted subset when memory already exceeds the cap", () => {
+  const cap = estimateTokens(MEMORY_TEXT) - 1;
+  const { proposal, violations, repo, state } = gate({
+    edit: memoryEdit((text) =>
+      text
+        .replace("- Use Node 18 via nvm before running any script.\n", "")
+        .replace("include its URL.", "include its full https:// URL."),
+    ),
+    annotation: {
+      edits: [claim(["H2"], { kind: "remove", title: "drop node pin" }), claim(["H1"], { title: "expand URL rule" })],
+    },
+    config: config({ budgetTokens: cap }),
+  });
+  assert.deepEqual(violations, [], "the complete proposal is a valid shrink step");
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "rejected", e2: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: cap },
+  });
+
+  assert.match(results.failed[0].error, /accepted edits must shrink it, but they change it by \+/);
+  assert.deepEqual(results.written, []);
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
+  assert.equal(Object.keys(state.readRejections().entries).length, 0, "the reviewer can retry with a valid subset");
+});
+
+test("rejecting every edit remains valid when memory already exceeds the cap", () => {
+  const cap = estimateTokens(MEMORY_TEXT) - 1;
+  const { proposal, violations, repo, state } = gate({
+    edit: memoryEdit((text) => text.replace("- Use Node 18 via nvm before running any script.\n", "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
+    config: config({ budgetTokens: cap }),
+  });
+  assert.deepEqual(violations, []);
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "rejected" },
+    repo,
+    state,
+    config: { budgetTokens: cap },
+  });
+
+  assert.deepEqual(results.failed, []);
+  assert.deepEqual(results.written, []);
+  assert.equal(Object.keys(state.readRejections().entries).length, 1);
+});
+
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {
   const skillText =
     "---\nname: release-signing\ndescription: Load before tagging a release.\n---\n\n## Steps\n\n1. sign\n";


### PR DESCRIPTION
## What Changed
- Apply rechecks the accepted subset with the same cap/shrink gate (`budgetGateKind`) as synthesis before any write.
- A subset that exceeds the cap or fails to shrink an already-over file writes nothing and does not record rejections, so a compatible set can be retried.
- The apply CLI reports recorded rejections only after that gate passes.

## Risk Assessment

✅ Low: The apply-time budget recheck is a small, well-tested fail-closed gate that matches the existing proposal invariant.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d20704619db57c8c015a7a8113e3da72b64e8bdc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

