### PR TITLE
fix(discovery): scan CLAUDE_CONFIG_DIR alongside the default claude store

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ backpass reads the local transcript stores of seven harnesses directly. No API, 
 | **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                                   |
 | **hermes**     | `~/.hermes/state.db` (sqlite)                  | session cwd, with CLI prompt / ACP config fallbacks |
 
+Claude collection covers `$CLAUDE_CONFIG_DIR/projects` alongside the default store, so a
+profile you only reach through an alias (`CLAUDE_CONFIG_DIR=~/.claude-work claude`) is read too.
+
 Hermes collection includes CLI and ACP sessions only. Gateway, cron, and WhatsApp sessions
 are excluded because their recorded cwd belongs to the shared gateway process, not a project.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ backpass reads the local transcript stores of seven harnesses directly. No API, 
 | **hermes**     | `~/.hermes/state.db` (sqlite)                  | session cwd, with CLI prompt / ACP config fallbacks |
 
 Claude collection covers `$CLAUDE_CONFIG_DIR/projects` alongside the default store, so a
-profile you only reach through an alias (`CLAUDE_CONFIG_DIR=~/.claude-work claude`) is read too.
+relocated config dir does not hide its sessions. The variable is read from backpass's own
+environment: if you reach that profile through an alias that only prefixes `claude`, set it
+for the backpass run too (`CLAUDE_CONFIG_DIR=~/.claude-work backpass`, or export it).
 
 Hermes collection includes CLI and ACP sessions only. Gateway, cron, and WhatsApp sessions
 are excluded because their recorded cwd belongs to the shared gateway process, not a project.

--- a/src/discovery/adapters/claude.js
+++ b/src/discovery/adapters/claude.js
@@ -19,23 +19,32 @@ import {
  * directory name is a lossy munge of the cwd (slashes and dots both become dashes),
  * so it is only used to narrow the search - the per-line `cwd` is the authority.
  * No git remote is recorded, so a deleted worktree can only reach tier 3.
+ *
+ * `CLAUDE_CONFIG_DIR` relocates the whole config dir, and it is commonly set per
+ * invocation (a shell alias for a work profile), which leaves a machine's sessions
+ * split across two stores - so both are scanned.
  */
 
 const HEADER_LINES = 40;
 
 export const name = "claude";
 
-export function storeRoot() {
-  return home(".claude", "projects");
+export function storeRoots() {
+  const roots = [home(".claude", "projects")];
+  const configured = process.env.CLAUDE_CONFIG_DIR;
+  if (configured) roots.push(path.join(configured, "projects"));
+  return [...new Set(roots)];
 }
 
 export function enumerate() {
   const out = [];
-  for (const dir of listDirs(storeRoot())) {
-    for (const file of listFiles(dir, ".jsonl")) {
-      const stat = statOrNull(file);
-      if (!stat) continue;
-      out.push({ key: file, path: file, mtimeMs: stat.mtimeMs, bytes: stat.size });
+  for (const root of storeRoots()) {
+    for (const dir of listDirs(root)) {
+      for (const file of listFiles(dir, ".jsonl")) {
+        const stat = statOrNull(file);
+        if (!stat) continue;
+        out.push({ key: file, path: file, mtimeMs: stat.mtimeMs, bytes: stat.size });
+      }
     }
   }
   return out;

--- a/src/discovery/adapters/claude.js
+++ b/src/discovery/adapters/claude.js
@@ -21,8 +21,9 @@ import {
  * No git remote is recorded, so a deleted worktree can only reach tier 3.
  *
  * `CLAUDE_CONFIG_DIR` relocates the whole config dir, and it is commonly set per
- * invocation (a shell alias for a work profile), which leaves a machine's sessions
- * split across two stores - so both are scanned.
+ * invocation (a shell alias for a work profile), which splits a machine's sessions across
+ * two stores rather than moving them - so both roots are scanned. The variable is read
+ * from this process's environment; an alias that only prefixes `claude` never reaches it.
  */
 
 const HEADER_LINES = 40;

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -56,6 +56,42 @@ test("claude adapter reads messages, folds tool results, and drops sidechains", 
   assert.equal(toolCall.result, "2 passing");
 });
 
+function writeClaudeStore(configRoot, sessionName) {
+  const dir = path.join(configRoot, "projects", "-repo-demo");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.copyFileSync(path.join(FIXTURES, "claude-session.jsonl"), path.join(dir, `${sessionName}.jsonl`));
+}
+
+function enumerateClaude(homeDir, configDir) {
+  const prevHome = process.env.HOME;
+  const prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.HOME = homeDir;
+  if (configDir) process.env.CLAUDE_CONFIG_DIR = configDir;
+  else delete process.env.CLAUDE_CONFIG_DIR;
+  try {
+    return claude
+      .enumerate()
+      .map((candidate) => path.basename(candidate.path))
+      .sort();
+  } finally {
+    process.env.HOME = prevHome;
+    if (prevConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+  }
+}
+
+test("claude adapter enumerates the default store and CLAUDE_CONFIG_DIR, without double-counting", () => {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-claude-home-"));
+  const defaultRoot = path.join(fakeHome, ".claude");
+  const workRoot = path.join(fakeHome, ".claude-work");
+  writeClaudeStore(defaultRoot, "personal");
+  writeClaudeStore(workRoot, "work");
+
+  assert.deepEqual(enumerateClaude(fakeHome, workRoot), ["personal.jsonl", "work.jsonl"]);
+  assert.deepEqual(enumerateClaude(fakeHome, null), ["personal.jsonl"]);
+  assert.deepEqual(enumerateClaude(fakeHome, defaultRoot), ["personal.jsonl"]);
+});
+
 test("codex adapter reads the recorded git remote, enabling tier-2 association", () => {
   const file = path.join(FIXTURES, "codex-rollout.jsonl");
   const descriptor = codex.classify(candidateFor(file));


### PR DESCRIPTION
## What Changed

- `src/discovery/adapters/claude.js`: renamed `storeRoot()` to `storeRoots()`, which now returns both `~/.claude/projects` and `$CLAUDE_CONFIG_DIR/projects` (deduped) when `CLAUDE_CONFIG_DIR` is set, so `enumerate()` scans sessions from a relocated config dir alongside the default store instead of only one.
- `test/adapters.test.js`: adds a test that writes fixture sessions into both a default `.claude` home and a `CLAUDE_CONFIG_DIR`-relocated store, verifying enumeration picks up both without double-counting when the configured dir matches the default.
- `README.md`: documents that Claude collection covers both roots and that `CLAUDE_CONFIG_DIR` is read from backpass's own process environment, so it must be set for the backpass invocation itself when reached via an alias.

## Risk Assessment

✅ Low: Small, self-contained change to a single adapter (storeRoot -> storeRoots), correctly deduped and fail-soft on missing dirs, with no other call sites depending on the old signature, and covered by a behavioral test that exercises enumerate() against real temp fixtures rather than source text.

## Testing

`Ran the targeted adapter test suite (test/adapters.test.js): all 10 tests pass at the target commit, including the new "claude adapter enumerates the default store and CLAUDE_CONFIG_DIR, without double-counting" case. Confirmed the test is a genuine regression check by temporarily reverting src/discovery/adapters/claude.js to the base commit — the new test failed as expected (only found the default-store session, missing the CLAUDE_CONFIG_DIR one) — then restored the file to the target commit, leaving a clean working tree. No other adapter imports the renamed storeRoot->storeRoots export, so the rename is safe.`

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8db405d30830544003ce5630e58020eeda600b64","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/adapters.test.js (all 10 pass on target commit 8db405d)`
- `Reverted src/discovery/adapters/claude.js to base commit 1664832 and reran the new test — it failed (missed CLAUDE_CONFIG_DIR sessions), confirming it's a real regression test; restored to 8db405d afterward`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
