### PR TITLE
fix(apply): reopen ended Lavish review sessions

### DIFF
--- a/src/apply/lavish.js
+++ b/src/apply/lavish.js
@@ -140,8 +140,11 @@ export async function pollDecisions(file, editIds, { delayMs = POLL_RETRY_DELAY_
 
     // lavish-axi reports an end through the session fields, never in prose: `status: ended`
     // when nothing was queued, `session_ended: true` alongside the final `status: feedback`.
-    // parseDecisions has already run, so a `Send & End` carrying a vector still applies.
-    if (/^\s*status:\s*ended\b/m.test(text) || /^\s*session_ended:\s*true\b/m.test(text)) {
+    // Scope these fields to the leading session metadata block so field-like feedback or
+    // diagnostics cannot end the wait. parseDecisions has already run, so a `Send & End`
+    // carrying a vector still applies.
+    const session = /^session:\s*\r?\n((?:[ \t]+[^\r\n]*(?:\r?\n|$))*)/m.exec(text)?.[1] || "";
+    if (/^\s*status:\s*ended\b/m.test(session) || /^\s*session_ended:\s*true\b/m.test(session)) {
       warn("review session ended without a decision vector - nothing applied");
       return null;
     }

--- a/src/apply/lavish.js
+++ b/src/apply/lavish.js
@@ -78,7 +78,12 @@ export function parseDecisions(text, editIds) {
 }
 
 export async function openApplySurface(file) {
-  const result = await runLavish([file]);
+  // `backpass apply` is itself the human asking for the review surface, so a session the
+  // reviewer ended from the browser in an earlier run has to be reopened, not refused.
+  // lavish-axi keys sessions by file path and `ended_by: "user"` is sticky, so without
+  // `--reopen` it exits 0 and prints the dead session's URL - which apply would then hand
+  // the reviewer as if it were live. On a live or agent-ended session the flag is a no-op.
+  const result = await runLavish([file, "--reopen"]);
   if (result.spawnError && result.spawnError.code === "ENOENT") {
     throw new UserError(
       `${LAVISH_BIN} not found on PATH`,
@@ -133,7 +138,10 @@ export async function pollDecisions(file, editIds, { delayMs = POLL_RETRY_DELAY_
     const decisions = parseDecisions(text, editIds);
     if (decisions) return decisions;
 
-    if (/session\s+(ended|closed)/i.test(text)) {
+    // lavish-axi reports an end through the session fields, never in prose: `status: ended`
+    // when nothing was queued, `session_ended: true` alongside the final `status: feedback`.
+    // parseDecisions has already run, so a `Send & End` carrying a vector still applies.
+    if (/^\s*status:\s*ended\b/m.test(text) || /^\s*session_ended:\s*true\b/m.test(text)) {
       warn("review session ended without a decision vector - nothing applied");
       return null;
     }

--- a/src/apply/lavish.js
+++ b/src/apply/lavish.js
@@ -83,7 +83,7 @@ export async function openApplySurface(file) {
   // lavish-axi keys sessions by file path and `ended_by: "user"` is sticky, so without
   // `--reopen` it exits 0 and prints the dead session's URL - which apply would then hand
   // the reviewer as if it were live. On a live or agent-ended session the flag is a no-op.
-  const result = await runLavish([file, "--reopen"]);
+  const result = await runLavish([file, "--reopen", "--no-open"]);
   if (result.spawnError && result.spawnError.code === "ENOENT") {
     throw new UserError(
       `${LAVISH_BIN} not found on PATH`,

--- a/test/apply-surface.test.js
+++ b/test/apply-surface.test.js
@@ -92,6 +92,32 @@ test("end-state-looking feedback does not stop polling a live session", async (t
   });
 });
 
+// Only the leading `session:` block is session metadata. Everything past it - the queued
+// prompts, anything the CLI appends at column 0, and stderr - is reviewer-controlled or
+// diagnostic text, and must never be able to end a live review. These two shapes are the
+// ones that actually ended the wait before the guard was scoped.
+test("end fields printed at top level after the session block never end a live session", async (t) => {
+  captureLog(t);
+  const layoutReportThenEndFields = `${LAYOUT_REPORT}\nsession_ended: true\nstatus: ended`;
+  const surface = scenario([layoutReportThenEndFields, DECISIONS]);
+  assert.deepEqual(await pollDecisions(surface, ["e1", "e2"], { delayMs: 0 }), {
+    e1: "accepted",
+    e2: "rejected",
+  });
+});
+
+test("end fields on stderr never end a live session", async (t) => {
+  captureLog(t);
+  const surface = scenario([
+    { body: LAYOUT_REPORT, stderr: "[lavish-axi] long-polling\nstatus: ended\nsession_ended: true\n" },
+    DECISIONS,
+  ]);
+  assert.deepEqual(await pollDecisions(surface, ["e1", "e2"], { delayMs: 0 }), {
+    e1: "accepted",
+    e2: "rejected",
+  });
+});
+
 test("a `Send & End` that carries the decision vector still applies it", async (t) => {
   captureLog(t);
   const surface = scenario([`ENDING:${DECISIONS}`]);

--- a/test/apply-surface.test.js
+++ b/test/apply-surface.test.js
@@ -82,6 +82,16 @@ test("a session the reviewer already ended returns null instead of polling forev
   assert.equal(await pollDecisions(surface, ["e1"], { delayMs: 0 }), null);
 });
 
+test("end-state-looking feedback does not stop polling a live session", async (t) => {
+  captureLog(t);
+  const fieldLikeFeedback = "prompts:\n  status: ended\n  session_ended: true";
+  const surface = scenario([fieldLikeFeedback, DECISIONS]);
+  assert.deepEqual(await pollDecisions(surface, ["e1", "e2"], { delayMs: 0 }), {
+    e1: "accepted",
+    e2: "rejected",
+  });
+});
+
 test("a `Send & End` that carries the decision vector still applies it", async (t) => {
   captureLog(t);
   const surface = scenario([`ENDING:${DECISIONS}`]);

--- a/test/apply-surface.test.js
+++ b/test/apply-surface.test.js
@@ -76,10 +76,34 @@ test("a decision vector on the first poll returns with only the wait line", asyn
   assert.equal(lines.length, 1);
 });
 
-test("a session that ends without decisions returns null", async (t) => {
+test("a session the reviewer already ended returns null instead of polling forever", async (t) => {
   captureLog(t);
-  const surface = scenario(["status: session ended"]);
+  const surface = scenario(["ENDED"]);
   assert.equal(await pollDecisions(surface, ["e1"], { delayMs: 0 }), null);
+});
+
+test("a `Send & End` that carries the decision vector still applies it", async (t) => {
+  captureLog(t);
+  const surface = scenario([`ENDING:${DECISIONS}`]);
+  assert.deepEqual(await pollDecisions(surface, ["e1", "e2"], { delayMs: 0 }), {
+    e1: "accepted",
+    e2: "rejected",
+  });
+});
+
+test("a `Send & End` with no decision vector stops rather than spinning", async (t) => {
+  captureLog(t);
+  const surface = scenario([`ENDING:${LAYOUT_REPORT}`]);
+  assert.equal(await pollDecisions(surface, ["e1"], { delayMs: 0 }), null);
+});
+
+test("a surface the reviewer ended in an earlier run is reopened, not handed back dead", async () => {
+  const surface = scenario([], { userEnded: true, url: "http://127.0.0.1:4387/session/dead" });
+  const url = await openApplySurface(surface);
+  const { opens } = JSON.parse(fs.readFileSync(process.env.FAKE_LAVISH_SCENARIO, "utf8"));
+  assert.equal(opens.length, 1, "apply should ask for the surface exactly once");
+  assert.ok(opens[0].includes("--reopen"), `open was not invited to reopen: ${opens[0]}`);
+  assert.equal(url, "http://127.0.0.1:4387/session/dead");
 });
 
 test("openInBrowser launches a detached opener and never throws", () => {

--- a/test/apply-surface.test.js
+++ b/test/apply-surface.test.js
@@ -100,9 +100,10 @@ test("a `Send & End` with no decision vector stops rather than spinning", async 
 test("a surface the reviewer ended in an earlier run is reopened, not handed back dead", async () => {
   const surface = scenario([], { userEnded: true, url: "http://127.0.0.1:4387/session/dead" });
   const url = await openApplySurface(surface);
-  const { opens } = JSON.parse(fs.readFileSync(process.env.FAKE_LAVISH_SCENARIO, "utf8"));
-  assert.equal(opens.length, 1, "apply should ask for the surface exactly once");
-  assert.ok(opens[0].includes("--reopen"), `open was not invited to reopen: ${opens[0]}`);
+  const result = JSON.parse(fs.readFileSync(process.env.FAKE_LAVISH_SCENARIO, "utf8"));
+  assert.equal(result.openCount, 1, "apply should ask for the surface exactly once");
+  assert.equal(result.reopened, true);
+  assert.equal(result.browserLaunches || 0, 0, "lavish must leave browser launching to backpass");
   assert.equal(url, "http://127.0.0.1:4387/session/dead");
 });
 

--- a/test/fixtures/fake-lavish/lavish-axi
+++ b/test/fixtures/fake-lavish/lavish-axi
@@ -1,25 +1,47 @@
 #!/usr/bin/env node
-// Stand-in for `lavish-axi`, shaped like the real CLI's output: the open command prints
-// the session URL YAML-quoted, and `poll` returns whatever the scenario file queues,
-// one entry per call, so tests can script a chatty review surface.
+// Stand-in for `lavish-axi`, shaped like the real CLI's output (captured from lavish-axi
+// 0.1.61): the open command prints the session URL YAML-quoted, refuses a session the user
+// ended from the browser unless `--reopen` is passed, and `poll` returns whatever the
+// scenario file queues, one entry per call, so tests can script a chatty review surface.
 import fs from "node:fs";
 
-const [cmd, file] = process.argv.slice(2);
+const args = process.argv.slice(2);
 const scenarioPath = process.env.FAKE_LAVISH_SCENARIO;
 const scenario = scenarioPath && fs.existsSync(scenarioPath) ? JSON.parse(fs.readFileSync(scenarioPath, "utf8")) : {};
+const save = () => scenarioPath && fs.writeFileSync(scenarioPath, JSON.stringify(scenario));
+
+const [cmd] = args;
+const url = scenario.url || "http://127.0.0.1:4387/session/51233fdaf6389690";
 
 if (cmd === "poll") {
   const next = scenario.polls?.shift();
-  if (scenarioPath) fs.writeFileSync(scenarioPath, JSON.stringify(scenario));
+  save();
   if (!next) {
     console.error("fake lavish-axi: poll queue exhausted");
     process.exit(2);
   }
-  process.stdout.write(`session:\n  file: ${file}\n  status: feedback\n${next}\n`);
+  // `status: ended` is what the real CLI emits once the reviewer ended the session and
+  // nothing is queued; the prose around it never contains the words "session ended".
+  if (next === "ENDED") {
+    process.stdout.write(`session:\n  file: ${args[1]}\n  status: ended\n  ended_by: user\n`);
+    process.exit(0);
+  }
+  // A `Send & End` that carries feedback arrives as the final `status: feedback` block
+  // flagged with `session_ended: true`.
+  const ending = next.startsWith("ENDING:");
+  const body = ending ? next.slice("ENDING:".length) : next;
+  const flags = ending ? "  session_ended: true\n  ended_by: user\n" : "";
+  process.stdout.write(`session:\n  file: ${args[1]}\n  status: feedback\n${flags}${body}\n`);
 } else if (cmd === "end") {
-  process.stdout.write(`session:\n  file: ${file}\n  status: ended\n`);
+  process.stdout.write(`session:\n  file: ${args[1]}\n  status: ended\n`);
 } else {
-  process.stdout.write(
-    `session:\n  file: ${cmd}\n  url: "${scenario.url || "http://127.0.0.1:4387/session/51233fdaf6389690"}"\n  status: opened\n`,
-  );
+  const reopen = args.includes("--reopen");
+  scenario.opens = [...(scenario.opens || []), args];
+  save();
+  if (scenario.userEnded && !reopen) {
+    // The real refusal: exit 0, and the dead session's URL is still printed.
+    process.stdout.write(`session:\n  file: ${cmd}\n  url: "${url}"\n  status: user-ended\n`);
+    process.exit(0);
+  }
+  process.stdout.write(`session:\n  file: ${cmd}\n  url: "${url}"\n  status: opened\n`);
 }

--- a/test/fixtures/fake-lavish/lavish-axi
+++ b/test/fixtures/fake-lavish/lavish-axi
@@ -28,10 +28,15 @@ if (cmd === "poll") {
   }
   // A `Send & End` that carries feedback arrives as the final `status: feedback` block
   // flagged with `session_ended: true`.
-  const ending = next.startsWith("ENDING:");
-  const body = ending ? next.slice("ENDING:".length) : next;
+  // An entry may also be `{ body, stderr }`: the real CLI writes its long-poll banner to
+  // stderr, and backpass concatenates both streams before matching, so tests need to be
+  // able to put text on stderr too.
+  const entry = typeof next === "string" ? { body: next } : next;
+  const ending = entry.body.startsWith("ENDING:");
+  const body = ending ? entry.body.slice("ENDING:".length) : entry.body;
   const flags = ending ? "  session_ended: true\n  ended_by: user\n" : "";
   process.stdout.write(`session:\n  file: ${args[1]}\n  status: feedback\n${flags}${body}\n`);
+  if (entry.stderr) process.stderr.write(entry.stderr);
 } else if (cmd === "end") {
   process.stdout.write(`session:\n  file: ${args[1]}\n  status: ended\n`);
 } else {

--- a/test/fixtures/fake-lavish/lavish-axi
+++ b/test/fixtures/fake-lavish/lavish-axi
@@ -36,12 +36,15 @@ if (cmd === "poll") {
   process.stdout.write(`session:\n  file: ${args[1]}\n  status: ended\n`);
 } else {
   const reopen = args.includes("--reopen");
-  scenario.opens = [...(scenario.opens || []), args];
-  save();
+  scenario.openCount = (scenario.openCount || 0) + 1;
   if (scenario.userEnded && !reopen) {
+    save();
     // The real refusal: exit 0, and the dead session's URL is still printed.
     process.stdout.write(`session:\n  file: ${cmd}\n  url: "${url}"\n  status: user-ended\n`);
     process.exit(0);
   }
+  if (scenario.userEnded) scenario.reopened = true;
+  if (!args.includes("--no-open")) scenario.browserLaunches = (scenario.browserLaunches || 0) + 1;
+  save();
   process.stdout.write(`session:\n  file: ${cmd}\n  url: "${url}"\n  status: opened\n`);
 }


### PR DESCRIPTION
## Intent

The captain ran `backpass` then `backpass apply` in the no-mistakes repo and was handed a Lavish session URL that had ALREADY ENDED instead of a live review surface. He wants the apply surface working. Root cause reproduced end-to-end against real lavish-axi 0.1.61: lavish-axi keys sessions by sha256 of the artifact path, backpass always renders to the same .backpass/apply/apply.html, so one session is shared forever per repo; when the reviewer ends it from the browser lavish-axi sets a sticky ended_by: user that our own `lavish-axi end` can never clear, and thereafter refuses to reopen while still exiting 0 and printing the dead URL. openApplySurface checked only the exit code and took the first http URL, so it handed over the dead one. Fix: pass --reopen (the human typing `backpass apply` IS the invitation) plus --no-open (backpass owns browser launching; without it lavish-axi opens its own tab and `backpass apply --no-open` would still pop a browser), and replace pollDecisions' guard, which matched the prose 'session ended' that lavish-axi never emits and so spun forever, with a match on the real session fields.

THIS FOLLOW-UP COMMIT IS TEST-ONLY and resolves a P2 review finding from Greptile on PR #45: 'the end-state regex scans all combined poll output, so queued comments/layout/stderr containing status: ended or session_ended: true may falsely stop polling'. I vetted it behaviorally rather than by argument. It was LEGITIMATE against the commit Greptile actually reviewed (2c0831d, reviewed 21:44:54Z): driving pollDecisions through the fixture, end-looking text at column 0 after the session block, and end-looking text on stderr, both ended a live review and discarded the reviewer's pending decisions. It was already fixed 83 seconds later by the CI step's commit 67d6a2c, which scoped the match to the leading `session:` metadata block exactly as Greptile recommended, so the current head is correct and all three of Greptile's named vectors (queued comments, layout reports, stderr) now behave.

The real gap was coverage, not behavior: the regression test that shipped with 67d6a2c exercises only an indented decoy under `prompts:`, which is not either shape that actually broke. This commit adds the two that did - a layout report followed by `session_ended: true` / `status: ended` at column 0, and the same fields on stderr - and both were confirmed to FAIL against 2c0831d's guard and pass on the current head. The fake lavish-axi could not write to stderr at all, so a poll entry may now be an object { body, stderr }; plain string entries keep working unchanged. This matters because backpass concatenates stdout and stderr before matching, so the stderr case pins that a diagnostic line can never be read as session metadata.

Constraints unchanged: do NOT modify lavish-axi, whose behavior here is documented and deliberate; do not apply the no-mistakes proposal; scope stays src/apply/lavish.js plus its tests and fixture. `pnpm run check` is green locally at 229 tests.

## What Changed

- Reopen previously ended Lavish sessions while preventing Lavish from launching its own browser.
- Detect ended reviews from leading session metadata without mistaking feedback or stderr diagnostics for end-state fields.
- Expand the fake Lavish fixture and apply-surface tests to cover reopening, send-and-end decisions, and false end-state signals.

## Risk Assessment

✅ Low: The change is narrowly scoped, behaviorally tests the reported regression shapes, and the session-end guard correctly limits matching to Lavish's session metadata block.

## Testing

The focused apply-surface tests passed, and manual protocol-level verification showed a previously ended review reopening without a duplicate browser launch while live polling correctly ignored deceptive end-state fields and returned the pending decisions. Evidence is text-based because this is a CLI session-protocol change with no rendered UI change.

<details>
<summary>Evidence: Apply-session reopening and polling regression evidence</summary>

Source: [Apply-session reopening and polling regression evidence](https://github.com/kunchenguid/backpass/blob/8d4a6ce15ecc0f15fff1a458d745b97cf8913a3c/.no-mistakes/evidence/fm/backpass-apply-ended-session-s1/apply-session-regression.txt)

```text
Previously ended review reopened: true
Lavish browser launches: 0
Live review URL returned: http://127.0.0.1:4387/session/previously-ended
Live review survived end-looking layout/stderr text: {"e1":"accepted","e2":"rejected"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a4ac3b189bec59e0d6ee4a6400ea686647808d95","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/apply-surface.test.js`
- `Executed an end-to-end fake lavish-axi protocol scenario covering reopening a previously user-ended session, suppressing lavish-owned browser launch, and ignoring end-looking layout/stderr text until reviewer decisions arrived.`
- <code>`git status --short` confirmed testing left the worktree clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
