### PR TITLE
fix(apply): prevent partial writes from stale proposals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
-  Nothing is written until three gates pass: the memory file still exists and hashes to
-  `proposal.memoryFile.hash` (`memoryFileSnapshot`, using `memoryTextHash` from `src/memory.js`
-  so the check and the proposal cannot disagree), the accepted subset clears
+  For proposals carrying a memory-file hash, nothing is written until three gates pass:
+  the memory file still exists and hashes to `proposal.memoryFile.hash` (`memoryFileSnapshot`,
+  using `memoryTextHash` from `src/memory.js` so the check and the proposal cannot disagree), the
+  accepted subset clears
   `budgetGateKind` (`src/tokens.js`), and every accepted edit for a file composes against
   that file's one pre-write image. Any of them failing writes nothing and records no
   rejection. A file is therefore applied whole or not at all, and a skill is written only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `budgetGateKind` (`src/tokens.js`), and every accepted edit for a file composes against
   that file's one pre-write image. Any of them failing writes nothing and records no
   rejection. A file is therefore applied whole or not at all, and a skill is written only
-  when the memory-file edit pointing at it lands - skills go in first, so an interrupt
-  leaves an unreferenced skill rather than a memory file naming one that is missing.
+  when the memory-file edit pointing at it has composed and is ready to land - skills go
+  in first, so an interrupt or later write failure leaves an unreferenced skill rather
+  than a memory file naming one that is missing.
 - **Synthesis edits natively, in a staging copy, never by describing text.** The agent
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `budgetGateKind` (`src/tokens.js`), and every accepted edit for a file composes against
   that file's one pre-write image. Any of them failing writes nothing and records no
   rejection. A file is therefore applied whole or not at all, and a skill is written only
-  when the memory-file edit pointing at it has composed and is ready to land. Commit holds
-  `.backpass/apply.lock`; handled write failures compensate earlier file and layout changes.
-  Skills still go first, so a process interruption can leave an inert unreferenced skill
-  rather than a memory file naming one that is missing.
+  when the memory-file edit pointing at it has composed and is ready to land - skills go
+  in first, so an interrupt or later write failure leaves an unreferenced skill rather
+  than a memory file naming one that is missing.
 - **Synthesis edits natively, in a staging copy, never by describing text.** The agent
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,14 +58,21 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
-  Apply revalidates the accepted subset with `budgetGateKind` (`src/tokens.js`) before any
-  write; a failing subset writes nothing and does not record rejections.
+  Nothing is written until three gates pass: the memory file still hashes to
+  `proposal.memoryFile.hash` (`memoryFileDrift`, using `memoryTextHash` from `src/memory.js`
+  so the check and the proposal cannot disagree), the accepted subset clears
+  `budgetGateKind` (`src/tokens.js`), and every accepted edit for a file composes against
+  that file's one pre-write image. Any of them failing writes nothing and records no
+  rejection. A file is therefore applied whole or not at all, and a skill is written only
+  when the memory-file edit pointing at it lands - skills go in first, so an interrupt
+  leaves an unreferenced skill rather than a memory file naming one that is missing.
 - **Synthesis edits natively, in a staging copy, never by describing text.** The agent
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,
   `anchoredHunks`) and the agent annotates the measured changes by id in a second turn of
   the same session. The model never supplies `find` text - every hunk is cut from the raw
-  file, widened until unique, so "find text does not appear" cannot recur. Never pass
+  file, widened until unique, so a hunk can only go stale by the file itself changing after
+  the proposal, which apply refuses rather than part-applies. Never pass
   `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that
   writes there fails the run loudly.
 - **Skills only count if a harness loads them.** Extractions target `.agents/skills` with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `budgetGateKind` (`src/tokens.js`), and every accepted edit for a file composes against
   that file's one pre-write image. Any of them failing writes nothing and records no
   rejection. A file is therefore applied whole or not at all, and a skill is written only
-  when the memory-file edit pointing at it has composed and is ready to land - skills go
-  in first, so an interrupt or later write failure leaves an unreferenced skill rather
-  than a memory file naming one that is missing.
+  when the memory-file edit pointing at it has composed and is ready to land. Commit holds
+  `.backpass/apply.lock`; handled write failures compensate earlier file and layout changes.
+  Skills still go first, so a process interruption can leave an inert unreferenced skill
+  rather than a memory file naming one that is missing.
 - **Synthesis edits natively, in a staging copy, never by describing text.** The agent
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
-  Nothing is written until three gates pass: the memory file still hashes to
-  `proposal.memoryFile.hash` (`memoryFileDrift`, using `memoryTextHash` from `src/memory.js`
+  Nothing is written until three gates pass: the memory file still exists and hashes to
+  `proposal.memoryFile.hash` (`memoryFileSnapshot`, using `memoryTextHash` from `src/memory.js`
   so the check and the proposal cannot disagree), the accepted subset clears
   `budgetGateKind` (`src/tokens.js`), and every accepted edit for a file composes against
   that file's one pre-write image. Any of them failing writes nothing and records no

--- a/README.md
+++ b/README.md
@@ -253,9 +253,10 @@ a compatible set and try again. If the run shrinks the file but leaves it above 
 that is progress, not a failure: it is written, and the remaining overage is printed.
 
 Apply is all-or-nothing. Every edit was cut from one exact version of your memory file, so
-before writing anything apply checks the file is still that version. If it changed since -
-you pulled, or edited it by hand, or another agent did - the edits no longer describe what
-is on disk, so nothing is written at all and you are told to run `backpass` again to
+before writing anything apply checks the file still exists and is still that version. If it
+was removed or changed since - you pulled, edited it by hand, or another agent did - the
+edits no longer describe what is on disk, so nothing is written at all and you are told to
+run `backpass` again to
 re-propose against the current file. Within a run the same rule holds per file: it takes
 every accepted edit or none of them. Skills are written only after every edit has composed,
 and before the memory file, so a later write failure cannot leave the memory file pointing

--- a/README.md
+++ b/README.md
@@ -257,8 +257,9 @@ before writing anything apply checks the file is still that version. If it chang
 you pulled, or edited it by hand, or another agent did - the edits no longer describe what
 is on disk, so nothing is written at all and you are told to run `backpass` again to
 re-propose against the current file. Within a run the same rule holds per file: it takes
-every accepted edit or none of them, and a skill is only created once the edit that points
-at it has landed.
+every accepted edit or none of them. Skills are written only after every edit has composed,
+and before the memory file, so a later write failure cannot leave the memory file pointing
+at a missing skill.
 
 ```sh
 backpass apply --no-ui     # same decision, in the terminal

--- a/README.md
+++ b/README.md
@@ -249,7 +249,16 @@ edit is not proposed again unless materially new evidence arrives.
 The live budget gauge is not just a readout. Apply rechecks the accepted subset against
 the same budget gate as synthesis: stay under the cap, or shrink if the file is already
 over. An incompatible set writes nothing and does not record rejections, so you can pick
-a compatible set and try again.
+a compatible set and try again. If the run shrinks the file but leaves it above the cap,
+that is progress, not a failure: it is written, and the remaining overage is printed.
+
+Apply is all-or-nothing. Every edit was cut from one exact version of your memory file, so
+before writing anything apply checks the file is still that version. If it changed since -
+you pulled, or edited it by hand, or another agent did - the edits no longer describe what
+is on disk, so nothing is written at all and you are told to run `backpass` again to
+re-propose against the current file. Within a run the same rule holds per file: it takes
+every accepted edit or none of them, and a skill is only created once the edit that points
+at it has landed.
 
 ```sh
 backpass apply --no-ui     # same decision, in the terminal

--- a/README.md
+++ b/README.md
@@ -252,18 +252,21 @@ over. An incompatible set writes nothing and does not record rejections, so you 
 a compatible set and try again. If the run shrinks the file but leaves it above the cap,
 that is progress, not a failure: it is written, and the remaining overage is printed.
 
-Apply preflights the accepted run all-or-nothing. Every edit was cut from one exact version
-of your memory file, so before writing anything apply checks the file still exists and is
-still that version. If it was removed or changed since - you pulled, edited it by hand, or
-another agent did - the edits no longer describe what is on disk, so nothing is written at
-all and you are told to run `backpass` again to re-propose against the current file. Within
-a run the same rule holds per file: it takes every accepted edit or none of them. Skills are
-written only after every edit has composed, and before the memory file, so a later write
-failure cannot leave the memory file pointing at a missing skill.
+Apply preflights every accepted edit before writing. The proposal was measured against one
+exact version of your memory file, so apply first checks the file still exists and is still
+that version. If it was removed or changed since - you pulled, edited it by hand, or another
+agent did - the edits no longer describe what is on disk, so nothing is written and you are
+told to run `backpass` again to re-propose against the current file. Within a run every file
+is composed from one version: it takes every accepted edit or none of them.
+
+Skills are written only after every edit has composed, and before the memory file, so a
+write failure cannot leave the memory file pointing at a missing skill. If one skill write
+fails after another succeeded, apply names the unreferenced skill paths to remove before
+retrying.
 
 For compatibility, proposals created by older backpass versions that do not contain a
-memory-file hash retain their legacy apply behavior. Regenerate such a proposal before
-applying it if the repository may have changed.
+memory-file hash skip the freshness check. Regenerate such a proposal before applying it if
+the repository may have changed.
 
 ```sh
 backpass apply --no-ui     # same decision, in the terminal

--- a/README.md
+++ b/README.md
@@ -252,15 +252,18 @@ over. An incompatible set writes nothing and does not record rejections, so you 
 a compatible set and try again. If the run shrinks the file but leaves it above the cap,
 that is progress, not a failure: it is written, and the remaining overage is printed.
 
-Apply is all-or-nothing. Every edit was cut from one exact version of your memory file, so
-before writing anything apply checks the file still exists and is still that version. If it
-was removed or changed since - you pulled, edited it by hand, or another agent did - the
-edits no longer describe what is on disk, so nothing is written at all and you are told to
-run `backpass` again to
-re-propose against the current file. Within a run the same rule holds per file: it takes
-every accepted edit or none of them. Skills are written only after every edit has composed,
-and before the memory file, so a later write failure cannot leave the memory file pointing
-at a missing skill.
+Apply preflights the accepted run all-or-nothing. Every edit was cut from one exact version
+of your memory file, so before writing anything apply checks the file still exists and is
+still that version. If it was removed or changed since - you pulled, edited it by hand, or
+another agent did - the edits no longer describe what is on disk, so nothing is written at
+all and you are told to run `backpass` again to re-propose against the current file. Within
+a run the same rule holds per file: it takes every accepted edit or none of them. Skills are
+written only after every edit has composed, and before the memory file, so a later write
+failure cannot leave the memory file pointing at a missing skill.
+
+For compatibility, proposals created by older backpass versions that do not contain a
+memory-file hash retain their legacy apply behavior. Regenerate such a proposal before
+applying it if the repository may have changed.
 
 ```sh
 backpass apply --no-ui     # same decision, in the terminal

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -7,14 +7,14 @@ import { budgetGateKind, budgetStatus, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
 import { writeSkill } from "../skills.js";
 
-function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens }) {
+function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText }) {
   if (!accepted.length) return null;
 
   const relative = proposal.memoryFile.path;
   const absolute = path.join(repo.root, relative);
-  if (!fs.existsSync(absolute)) return null;
+  if (memoryText === null && !fs.existsSync(absolute)) return null;
 
-  const before = fs.readFileSync(absolute, "utf8");
+  const before = memoryText ?? fs.readFileSync(absolute, "utf8");
   const { budget } = projectWithDecisions(
     before,
     accepted,
@@ -46,31 +46,48 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens }) {
  * Freshness before mutation.
  *
  * Every hunk was cut from one exact image of the memory file, and the proposal records
- * that image's hash. If the file has changed since - an upstream merge, a hand edit,
- * another agent - then the hunks describe text that may no longer exist, and the ones
+ * that image's hash. If the file has disappeared or changed since - an upstream merge,
+ * a hand edit, another agent - then the hunks describe text that may no longer exist, and the ones
  * that still happen to match would leave the file half-descended: part of a shrink plan
  * applied against a file the plan was never measured against. So the run is refused
  * before it writes anything, and the fix is to re-measure, not to salvage.
  *
  * A proposal saved before this field existed carries no hash and is left alone.
  */
-function memoryFileDrift(proposal, repo) {
+function memoryFileSnapshot(proposal, repo) {
   const expected = proposal.memoryFile?.hash;
   const relative = proposal.memoryFile?.path;
-  if (!expected || !relative) return null;
+  if (!relative) return { text: null };
 
   const absolute = path.join(repo.root, relative);
-  if (!fs.existsSync(absolute)) return null;
+  if (!fs.existsSync(absolute)) {
+    if (!expected) return { text: null };
+    return {
+      text: null,
+      failure: {
+        file: relative,
+        error:
+          `${relative} no longer exists, so its edits no longer describe the file on disk; nothing was written. ` +
+          `Run \`backpass\` to re-propose against the current repository.`,
+      },
+    };
+  }
 
-  const observed = memoryTextHash(fs.readFileSync(absolute, "utf8"));
-  if (observed === expected) return null;
+  const text = fs.readFileSync(absolute, "utf8");
+  if (!expected) return { text };
+
+  const observed = memoryTextHash(text);
+  if (observed === expected) return { text };
 
   return {
-    file: relative,
-    error:
-      `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
-      `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
-      `against the current ${relative}.`,
+    text,
+    failure: {
+      file: relative,
+      error:
+        `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
+        `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
+        `against the current ${relative}.`,
+    },
   };
 }
 
@@ -87,7 +104,7 @@ function overBudgetWarning(relative, budget) {
  * Everything upstream is read-only analysis; a run only changes the weights here, after
  * a human accepted specific edits. Three gates run before the first byte is written:
  * the memory file must still be the file the proposal was measured against
- * (`memoryFileDrift`), the accepted subset must clear the same cap/shrink budget gate as
+ * (`memoryFileSnapshot`), the accepted subset must clear the same cap/shrink budget gate as
  * the full proposal (`budgetGateKind`), and every accepted edit for a file must compose
  * against that file's single pre-write image. Any of them failing writes nothing and
  * records no rejection.
@@ -110,12 +127,14 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     rejectionsRecorded: false,
   };
 
+  let memoryText = null;
   if (accepted.length || rejected.length) {
-    const drift = memoryFileDrift(proposal, repo);
-    if (drift) {
-      results.failed.push(drift);
+    const snapshot = memoryFileSnapshot(proposal, repo);
+    if (snapshot.failure) {
+      results.failed.push(snapshot.failure);
       return results;
     }
+    memoryText = snapshot.text;
   }
 
   const budgetFailure = acceptedSubsetBudgetFailure({
@@ -123,6 +142,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     accepted,
     repo,
     capTokens: config.budgetTokens,
+    memoryText,
   });
   if (budgetFailure) {
     results.failed.push(budgetFailure);
@@ -146,7 +166,10 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
       continue;
     }
 
-    const before = fs.readFileSync(absolute, "utf8");
+    const before =
+      relative === proposal.memoryFile?.path && memoryText !== null
+        ? memoryText
+        : fs.readFileSync(absolute, "utf8");
     let text = before;
     const applied = [];
     const failures = [];

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -98,6 +98,41 @@ function overBudgetWarning(relative, budget) {
   );
 }
 
+function currentMemoryFailure(proposal, repo) {
+  if (!proposal.memoryFile?.hash) return null;
+  return memoryFileSnapshot(proposal, repo).failure ?? null;
+}
+
+function skillWritePreflight(repoRoot, edits) {
+  const targets = edits.map((edit) => path.resolve(repoRoot, edit.skill.path));
+  for (let index = 0; index < edits.length; index += 1) {
+    const edit = edits[index];
+    const target = targets[index];
+    if (targets.some((other, otherIndex) => otherIndex !== index && other.startsWith(`${target}${path.sep}`))) {
+      return { file: edit.skill.path, edit: edit.id, error: "skill path is not a file" };
+    }
+    try {
+      if (fs.existsSync(target)) {
+        if (!fs.statSync(target).isFile()) {
+          return { file: edit.skill.path, edit: edit.id, error: "skill path is not a file" };
+        }
+        fs.accessSync(target, fs.constants.W_OK);
+        continue;
+      }
+
+      let parent = path.dirname(target);
+      while (!fs.existsSync(parent)) parent = path.dirname(parent);
+      if (!fs.statSync(parent).isDirectory()) {
+        return { file: edit.skill.path, edit: edit.id, error: "skill parent path is not a directory" };
+      }
+      fs.accessSync(parent, fs.constants.W_OK);
+    } catch (err) {
+      return { file: edit.skill.path, edit: edit.id, error: err.message };
+    }
+  }
+  return null;
+}
+
 /**
  * The only place in backpass that writes to the repo.
  *
@@ -199,41 +234,47 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
   if (results.failed.length) return results;
 
-  // Skills go in before the memory file. A skill nothing points at yet is inert, while a
-  // memory file pointing at a skill that is not there is actively wrong - so if a skill
-  // cannot be written, the files that would reference it are left alone.
-  const skillFailures = [];
-  const writtenSkillPaths = [];
-  for (const edit of accepted) {
-    if (edit.kind !== "extract" || !edit.skill) continue;
-    if (!landed.has(edit.id)) continue;
-    try {
-      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
-      results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
-      if (!dryRun) writtenSkillPaths.push(edit.skill.path);
-      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
-    } catch (err) {
-      skillFailures.push({ file: edit.skill.path, edit: edit.id, error: err.message });
-    }
-  }
-
-  if (skillFailures.length) {
-    results.failed.push(...skillFailures);
-    if (writtenSkillPaths.length) {
-      results.failed.push({
-        error: `skill paths already written in this round: ${writtenSkillPaths.join(", ")}; remove them before retrying`,
-      });
-    }
-    for (const { relative } of planned) {
-      results.failed.push({
-        file: relative,
-        error: `${relative} was left unchanged: its edits point at a skill that could not be written`,
-      });
-    }
+  // Skills go in before the memory file. Preflight every target before the first write,
+  // so a malformed or unwritable later target cannot leave an earlier skill behind.
+  const skillEdits = accepted.filter((edit) => edit.kind === "extract" && edit.skill && landed.has(edit.id));
+  const skillFailure = skillWritePreflight(repo.root, skillEdits);
+  if (skillFailure) {
+    results.failed.push(skillFailure);
     return results;
   }
 
-  for (const { relative, absolute, before, text, applied } of planned) {
+  // Planning can take time. Revalidate at the shared pre-write boundary rather than
+  // relying only on the snapshot used for composition.
+  const preWriteFailure = currentMemoryFailure(proposal, repo);
+  if (preWriteFailure) {
+    results.failed.push(preWriteFailure);
+    return results;
+  }
+
+  for (const edit of skillEdits) {
+    try {
+      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
+      results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
+      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
+    } catch (err) {
+      results.failed.push({ file: edit.skill.path, edit: edit.id, error: err.message });
+      return results;
+    }
+  }
+
+  // Write the memory file last, after one final freshness check. If skill I/O was slow
+  // enough for another process to change memory, its new content is never overwritten.
+  const ordered = [...planned].sort(
+    (a, b) => Number(a.relative === proposal.memoryFile.path) - Number(b.relative === proposal.memoryFile.path),
+  );
+  for (const { relative, absolute, before, text, applied } of ordered) {
+    if (relative === proposal.memoryFile.path) {
+      const failure = currentMemoryFailure(proposal, repo);
+      if (failure) {
+        results.failed.push(failure);
+        return results;
+      }
+    }
     const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
 
     if (!dryRun) fs.writeFileSync(absolute, text);

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -98,132 +98,6 @@ function overBudgetWarning(relative, budget) {
   );
 }
 
-function currentMemoryFailure(proposal, repo) {
-  if (!proposal.memoryFile?.hash) return null;
-  return memoryFileSnapshot(proposal, repo).failure ?? null;
-}
-
-function acquireApplyLock(repoRoot) {
-  const stateDir = path.join(repoRoot, ".backpass");
-  fs.mkdirSync(stateDir, { recursive: true });
-  const lock = path.join(stateDir, "apply.lock");
-
-  let fd;
-  try {
-    fd = fs.openSync(lock, "wx");
-  } catch (err) {
-    if (err.code !== "EEXIST") throw err;
-    const owner = Number.parseInt(fs.readFileSync(lock, "utf8"), 10);
-    let live = Number.isInteger(owner);
-    if (live) {
-      try {
-        process.kill(owner, 0);
-      } catch (probeError) {
-        live = probeError.code === "EPERM";
-      }
-    }
-    if (live) throw new Error(`another backpass apply is running (pid ${owner})`, { cause: err });
-    fs.rmSync(lock, { force: true });
-    fd = fs.openSync(lock, "wx");
-  }
-  fs.writeFileSync(fd, String(process.pid));
-
-  return () => {
-    fs.closeSync(fd);
-    fs.rmSync(lock, { force: true });
-  };
-}
-
-function fileSnapshot(target) {
-  if (!fs.existsSync(target)) return { target, existed: false };
-  return { target, existed: true, text: fs.readFileSync(target), mode: fs.statSync(target).mode };
-}
-
-function restoreSnapshot(snapshot) {
-  if (!snapshot.existed) {
-    fs.rmSync(snapshot.target, { force: true });
-    return;
-  }
-  fs.writeFileSync(snapshot.target, snapshot.text, { mode: snapshot.mode });
-  fs.chmodSync(snapshot.target, snapshot.mode);
-}
-
-function layoutSnapshot(repoRoot) {
-  return [".agents", ".agents/skills", ".claude", ".claude/skills"].map((relative) => {
-    let existed = true;
-    try {
-      fs.lstatSync(path.join(repoRoot, relative));
-    } catch (err) {
-      if (err.code !== "ENOENT") throw err;
-      existed = false;
-    }
-    return { relative, existed };
-  });
-}
-
-function removeCreatedLayout(repoRoot, snapshot) {
-  for (const { relative, existed } of [...snapshot].reverse()) {
-    if (existed) continue;
-    const target = path.join(repoRoot, relative);
-    try {
-      const stat = fs.lstatSync(target);
-      if (stat.isSymbolicLink()) fs.unlinkSync(target);
-      else if (stat.isDirectory() && fs.readdirSync(target).length === 0) fs.rmdirSync(target);
-    } catch (err) {
-      if (err.code !== "ENOENT") throw err;
-    }
-  }
-}
-
-function rollbackApply(repoRoot, fileSnapshots, layout, results) {
-  const failures = [];
-  for (const snapshot of [...fileSnapshots].reverse()) {
-    try {
-      restoreSnapshot(snapshot);
-    } catch (err) {
-      failures.push({ file: path.relative(repoRoot, snapshot.target), error: `rollback failed: ${err.message}` });
-    }
-  }
-  try {
-    removeCreatedLayout(repoRoot, layout);
-  } catch (err) {
-    failures.push({ file: ".agents/skills", error: `layout rollback failed: ${err.message}` });
-  }
-  results.written = [];
-  results.skills = [];
-  results.failed.push(...failures);
-}
-
-function skillWritePreflight(repoRoot, edits) {
-  const targets = edits.map((edit) => path.resolve(repoRoot, edit.skill.path));
-  for (let index = 0; index < edits.length; index += 1) {
-    const edit = edits[index];
-    const target = targets[index];
-    if (targets.some((other, otherIndex) => otherIndex !== index && other.startsWith(`${target}${path.sep}`))) {
-      return { file: edit.skill.path, edit: edit.id, error: "skill path is not a file" };
-    }
-    try {
-      if (fs.existsSync(target)) {
-        if (!fs.statSync(target).isFile()) {
-          return { file: edit.skill.path, edit: edit.id, error: "skill path is not a file" };
-        }
-        fs.accessSync(target, fs.constants.W_OK);
-        continue;
-      }
-
-      let parent = path.dirname(target);
-      while (!fs.existsSync(parent)) parent = path.dirname(parent);
-      if (!fs.statSync(parent).isDirectory()) {
-        return { file: edit.skill.path, edit: edit.id, error: "skill parent path is not a directory" };
-      }
-      fs.accessSync(parent, fs.constants.W_OK);
-    } catch (err) {
-      return { file: edit.skill.path, edit: edit.id, error: err.message };
-    }
-  }
-  return null;
-}
-
 /**
  * The only place in backpass that writes to the repo.
  *
@@ -236,8 +110,7 @@ function skillWritePreflight(repoRoot, edits) {
  * records no rejection.
  *
  * A file is therefore applied all at once or not at all. Skills are written only after
- * every accepted edit has composed, and before the files that reference them. The commit
- * holds an apply lock, and a handled I/O failure compensates earlier writes before returning.
+ * every accepted edit has composed, and before the files that reference them.
  */
 export function applyDecisions({ proposal, decisions, repo, state, config, dryRun = false }) {
   const accepted = proposal.edits.filter((e) => decisions[e.id] === "accepted");
@@ -326,83 +199,48 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
   if (results.failed.length) return results;
 
-  // Skills go in before the memory file. Preflight every target before the first write,
-  // so a malformed or unwritable later target cannot leave an earlier skill behind.
-  const skillEdits = accepted.filter((edit) => edit.kind === "extract" && edit.skill && landed.has(edit.id));
-  const skillFailure = skillWritePreflight(repo.root, skillEdits);
-  if (skillFailure) {
-    results.failed.push(skillFailure);
+  // Skills go in before the memory file. A skill nothing points at yet is inert, while a
+  // memory file pointing at a skill that is not there is actively wrong - so if a skill
+  // cannot be written, the files that would reference it are left alone.
+  const skillFailures = [];
+  const writtenSkillPaths = [];
+  for (const edit of accepted) {
+    if (edit.kind !== "extract" || !edit.skill) continue;
+    if (!landed.has(edit.id)) continue;
+    try {
+      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
+      results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
+      if (!dryRun) writtenSkillPaths.push(edit.skill.path);
+      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
+    } catch (err) {
+      skillFailures.push({ file: edit.skill.path, edit: edit.id, error: err.message });
+    }
+  }
+
+  if (skillFailures.length) {
+    results.failed.push(...skillFailures);
+    if (writtenSkillPaths.length) {
+      results.failed.push({
+        error: `skill paths already written in this round: ${writtenSkillPaths.join(", ")}; remove them before retrying`,
+      });
+    }
+    for (const { relative } of planned) {
+      results.failed.push({
+        file: relative,
+        error: `${relative} was left unchanged: its edits point at a skill that could not be written`,
+      });
+    }
     return results;
   }
 
-  const ordered = [...planned].sort(
-    (a, b) => Number(a.relative === proposal.memoryFile.path) - Number(b.relative === proposal.memoryFile.path),
-  );
+  for (const { relative, absolute, before, text, applied } of planned) {
+    const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
 
-  if (dryRun) {
-    for (const edit of skillEdits) results.skills.push({ path: edit.skill.path, dryRun: true, created: [] });
-    for (const { relative, before, text, applied } of ordered) {
-      const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
-      results.written.push({ file: relative, edits: applied, budget, dryRun: true });
-      if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
-    }
-  } else {
-    let releaseLock;
-    try {
-      releaseLock = acquireApplyLock(repo.root);
-    } catch (err) {
-      results.failed.push({ file: proposal.memoryFile.path, error: `could not lock apply: ${err.message}` });
-      return results;
-    }
+    if (!dryRun) fs.writeFileSync(absolute, text);
+    results.written.push({ file: relative, edits: applied, budget, dryRun });
 
-    const skillSnapshots = skillEdits.map((edit) => fileSnapshot(path.join(repo.root, edit.skill.path)));
-    const changedSnapshots = [];
-    const layoutBefore = layoutSnapshot(repo.root);
-    let commitFailed = false;
-
-    try {
-      // Planning can take time. Hold the apply lock and revalidate at the shared
-      // pre-write boundary so two backpass processes cannot race this check.
-      const preWriteFailure = currentMemoryFailure(proposal, repo);
-      if (preWriteFailure) {
-        results.failed.push(preWriteFailure);
-        commitFailed = true;
-      }
-
-      if (!commitFailed) {
-        for (const edit of skillEdits) {
-          const layout = writeSkill(repo.root, edit.skill);
-          results.skills.push({ path: edit.skill.path, dryRun: false, created: layout.created });
-          for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
-        }
-
-        // The memory file remains last. Revalidate while still holding the lock after
-        // skill I/O, then compensate every earlier write if this or any write fails.
-        for (const { relative, absolute, before, text, applied } of ordered) {
-          if (relative === proposal.memoryFile.path) {
-            const failure = currentMemoryFailure(proposal, repo);
-            if (failure) {
-              results.failed.push(failure);
-              commitFailed = true;
-              break;
-            }
-          }
-          const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
-          changedSnapshots.push(fileSnapshot(absolute));
-          fs.writeFileSync(absolute, text);
-          results.written.push({ file: relative, edits: applied, budget, dryRun: false });
-          if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
-        }
-      }
-    } catch (err) {
-      results.failed.push({ file: proposal.memoryFile.path, error: err.message });
-      commitFailed = true;
-    } finally {
-      if (commitFailed) rollbackApply(repo.root, [...skillSnapshots, ...changedSnapshots], layoutBefore, results);
-      releaseLock();
-    }
-
-    if (commitFailed) return results;
+    // Shrinking over several runs is the design, so this is a heading, not a failure.
+    if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
   }
 
   // Rejections are remembered so the same edit is not re-proposed without new evidence.

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -103,6 +103,97 @@ function currentMemoryFailure(proposal, repo) {
   return memoryFileSnapshot(proposal, repo).failure ?? null;
 }
 
+function acquireApplyLock(repoRoot) {
+  const stateDir = path.join(repoRoot, ".backpass");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const lock = path.join(stateDir, "apply.lock");
+
+  let fd;
+  try {
+    fd = fs.openSync(lock, "wx");
+  } catch (err) {
+    if (err.code !== "EEXIST") throw err;
+    const owner = Number.parseInt(fs.readFileSync(lock, "utf8"), 10);
+    let live = Number.isInteger(owner);
+    if (live) {
+      try {
+        process.kill(owner, 0);
+      } catch (probeError) {
+        live = probeError.code === "EPERM";
+      }
+    }
+    if (live) throw new Error(`another backpass apply is running (pid ${owner})`, { cause: err });
+    fs.rmSync(lock, { force: true });
+    fd = fs.openSync(lock, "wx");
+  }
+  fs.writeFileSync(fd, String(process.pid));
+
+  return () => {
+    fs.closeSync(fd);
+    fs.rmSync(lock, { force: true });
+  };
+}
+
+function fileSnapshot(target) {
+  if (!fs.existsSync(target)) return { target, existed: false };
+  return { target, existed: true, text: fs.readFileSync(target), mode: fs.statSync(target).mode };
+}
+
+function restoreSnapshot(snapshot) {
+  if (!snapshot.existed) {
+    fs.rmSync(snapshot.target, { force: true });
+    return;
+  }
+  fs.writeFileSync(snapshot.target, snapshot.text, { mode: snapshot.mode });
+  fs.chmodSync(snapshot.target, snapshot.mode);
+}
+
+function layoutSnapshot(repoRoot) {
+  return [".agents", ".agents/skills", ".claude", ".claude/skills"].map((relative) => {
+    let existed = true;
+    try {
+      fs.lstatSync(path.join(repoRoot, relative));
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+      existed = false;
+    }
+    return { relative, existed };
+  });
+}
+
+function removeCreatedLayout(repoRoot, snapshot) {
+  for (const { relative, existed } of [...snapshot].reverse()) {
+    if (existed) continue;
+    const target = path.join(repoRoot, relative);
+    try {
+      const stat = fs.lstatSync(target);
+      if (stat.isSymbolicLink()) fs.unlinkSync(target);
+      else if (stat.isDirectory() && fs.readdirSync(target).length === 0) fs.rmdirSync(target);
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+}
+
+function rollbackApply(repoRoot, fileSnapshots, layout, results) {
+  const failures = [];
+  for (const snapshot of [...fileSnapshots].reverse()) {
+    try {
+      restoreSnapshot(snapshot);
+    } catch (err) {
+      failures.push({ file: path.relative(repoRoot, snapshot.target), error: `rollback failed: ${err.message}` });
+    }
+  }
+  try {
+    removeCreatedLayout(repoRoot, layout);
+  } catch (err) {
+    failures.push({ file: ".agents/skills", error: `layout rollback failed: ${err.message}` });
+  }
+  results.written = [];
+  results.skills = [];
+  results.failed.push(...failures);
+}
+
 function skillWritePreflight(repoRoot, edits) {
   const targets = edits.map((edit) => path.resolve(repoRoot, edit.skill.path));
   for (let index = 0; index < edits.length; index += 1) {
@@ -145,7 +236,8 @@ function skillWritePreflight(repoRoot, edits) {
  * records no rejection.
  *
  * A file is therefore applied all at once or not at all. Skills are written only after
- * every accepted edit has composed, and before the files that reference them.
+ * every accepted edit has composed, and before the files that reference them. The commit
+ * holds an apply lock, and a handled I/O failure compensates earlier writes before returning.
  */
 export function applyDecisions({ proposal, decisions, repo, state, config, dryRun = false }) {
   const accepted = proposal.edits.filter((e) => decisions[e.id] === "accepted");
@@ -243,45 +335,74 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     return results;
   }
 
-  // Planning can take time. Revalidate at the shared pre-write boundary rather than
-  // relying only on the snapshot used for composition.
-  const preWriteFailure = currentMemoryFailure(proposal, repo);
-  if (preWriteFailure) {
-    results.failed.push(preWriteFailure);
-    return results;
-  }
-
-  for (const edit of skillEdits) {
-    try {
-      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
-      results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
-      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
-    } catch (err) {
-      results.failed.push({ file: edit.skill.path, edit: edit.id, error: err.message });
-      return results;
-    }
-  }
-
-  // Write the memory file last, after one final freshness check. If skill I/O was slow
-  // enough for another process to change memory, its new content is never overwritten.
   const ordered = [...planned].sort(
     (a, b) => Number(a.relative === proposal.memoryFile.path) - Number(b.relative === proposal.memoryFile.path),
   );
-  for (const { relative, absolute, before, text, applied } of ordered) {
-    if (relative === proposal.memoryFile.path) {
-      const failure = currentMemoryFailure(proposal, repo);
-      if (failure) {
-        results.failed.push(failure);
-        return results;
-      }
+
+  if (dryRun) {
+    for (const edit of skillEdits) results.skills.push({ path: edit.skill.path, dryRun: true, created: [] });
+    for (const { relative, before, text, applied } of ordered) {
+      const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
+      results.written.push({ file: relative, edits: applied, budget, dryRun: true });
+      if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
     }
-    const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
+  } else {
+    let releaseLock;
+    try {
+      releaseLock = acquireApplyLock(repo.root);
+    } catch (err) {
+      results.failed.push({ file: proposal.memoryFile.path, error: `could not lock apply: ${err.message}` });
+      return results;
+    }
 
-    if (!dryRun) fs.writeFileSync(absolute, text);
-    results.written.push({ file: relative, edits: applied, budget, dryRun });
+    const skillSnapshots = skillEdits.map((edit) => fileSnapshot(path.join(repo.root, edit.skill.path)));
+    const changedSnapshots = [];
+    const layoutBefore = layoutSnapshot(repo.root);
+    let commitFailed = false;
 
-    // Shrinking over several runs is the design, so this is a heading, not a failure.
-    if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
+    try {
+      // Planning can take time. Hold the apply lock and revalidate at the shared
+      // pre-write boundary so two backpass processes cannot race this check.
+      const preWriteFailure = currentMemoryFailure(proposal, repo);
+      if (preWriteFailure) {
+        results.failed.push(preWriteFailure);
+        commitFailed = true;
+      }
+
+      if (!commitFailed) {
+        for (const edit of skillEdits) {
+          const layout = writeSkill(repo.root, edit.skill);
+          results.skills.push({ path: edit.skill.path, dryRun: false, created: layout.created });
+          for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
+        }
+
+        // The memory file remains last. Revalidate while still holding the lock after
+        // skill I/O, then compensate every earlier write if this or any write fails.
+        for (const { relative, absolute, before, text, applied } of ordered) {
+          if (relative === proposal.memoryFile.path) {
+            const failure = currentMemoryFailure(proposal, repo);
+            if (failure) {
+              results.failed.push(failure);
+              commitFailed = true;
+              break;
+            }
+          }
+          const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
+          changedSnapshots.push(fileSnapshot(absolute));
+          fs.writeFileSync(absolute, text);
+          results.written.push({ file: relative, edits: applied, budget, dryRun: false });
+          if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
+        }
+      }
+    } catch (err) {
+      results.failed.push({ file: proposal.memoryFile.path, error: err.message });
+      commitFailed = true;
+    } finally {
+      if (commitFailed) rollbackApply(repo.root, [...skillSnapshots, ...changedSnapshots], layoutBefore, results);
+      releaseLock();
+    }
+
+    if (commitFailed) return results;
   }
 
   // Rejections are remembered so the same edit is not re-proposed without new evidence.

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { applyEdit, projectWithDecisions } from "../proposal.js";
-import { budgetGateKind, budgetStatus } from "../tokens.js";
+import { memoryTextHash } from "../memory.js";
+import { budgetGateKind, budgetStatus, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
 import { writeSkill } from "../skills.js";
 
@@ -42,13 +43,58 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens }) {
 }
 
 /**
+ * Freshness before mutation.
+ *
+ * Every hunk was cut from one exact image of the memory file, and the proposal records
+ * that image's hash. If the file has changed since - an upstream merge, a hand edit,
+ * another agent - then the hunks describe text that may no longer exist, and the ones
+ * that still happen to match would leave the file half-descended: part of a shrink plan
+ * applied against a file the plan was never measured against. So the run is refused
+ * before it writes anything, and the fix is to re-measure, not to salvage.
+ *
+ * A proposal saved before this field existed carries no hash and is left alone.
+ */
+function memoryFileDrift(proposal, repo) {
+  const expected = proposal.memoryFile?.hash;
+  const relative = proposal.memoryFile?.path;
+  if (!expected || !relative) return null;
+
+  const absolute = path.join(repo.root, relative);
+  if (!fs.existsSync(absolute)) return null;
+
+  const observed = memoryTextHash(fs.readFileSync(absolute, "utf8"));
+  if (observed === expected) return null;
+
+  return {
+    file: relative,
+    error:
+      `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
+      `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
+      `against the current ${relative}.`,
+  };
+}
+
+function overBudgetWarning(relative, budget) {
+  return (
+    `${relative} is still ${formatTokens(budget.over)} tokens over the ${formatTokens(budget.capTokens)}-token ` +
+    "budget; run `backpass` again for the next shrink step"
+  );
+}
+
+/**
  * The only place in backpass that writes to the repo.
  *
  * Everything upstream is read-only analysis; a run only changes the weights here, after
- * a human accepted specific edits. The accepted subset is rechecked with the same
- * cap/shrink budget gate as the full proposal (`budgetGateKind`); a failing subset
- * returns with no writes and no rejection ledger. Writes are grouped per file so a
- * memory file is rewritten once, atomically, rather than edit by edit.
+ * a human accepted specific edits. Three gates run before the first byte is written:
+ * the memory file must still be the file the proposal was measured against
+ * (`memoryFileDrift`), the accepted subset must clear the same cap/shrink budget gate as
+ * the full proposal (`budgetGateKind`), and every accepted edit for a file must compose
+ * against that file's single pre-write image. Any of them failing writes nothing and
+ * records no rejection.
+ *
+ * A file is therefore applied all at once or not at all, and a skill is written only
+ * when the memory-file edit that points at it lands - otherwise the repo would hold the
+ * same instructions twice, once inline and once in a skill nothing references.
  */
 export function applyDecisions({ proposal, decisions, repo, state, config, dryRun = false }) {
   const accepted = proposal.edits.filter((e) => decisions[e.id] === "accepted");
@@ -64,6 +110,14 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     rejected: rejected.length,
     rejectionsRecorded: false,
   };
+
+  if (accepted.length) {
+    const drift = memoryFileDrift(proposal, repo);
+    if (drift) {
+      results.failed.push(drift);
+      return results;
+    }
+  }
 
   const budgetFailure = acceptedSubsetBudgetFailure({
     proposal,
@@ -81,6 +135,11 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     byFile.get(edit.file).push(edit);
   }
 
+  // Compose first, write later. Each file's accepted edits are applied to one immutable
+  // image of that file; only a set that composes completely earns a write.
+  const planned = [];
+  const landed = new Set();
+
   for (const [relative, edits] of byFile) {
     const absolute = path.join(repo.root, relative);
     if (!fs.existsSync(absolute)) {
@@ -91,33 +150,68 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     const before = fs.readFileSync(absolute, "utf8");
     let text = before;
     const applied = [];
+    const failures = [];
 
     for (const edit of edits) {
       try {
         text = applyEdit(text, edit);
         applied.push(edit.id);
       } catch (err) {
-        results.failed.push({ file: relative, edit: edit.id, error: err.message });
+        failures.push({ file: relative, edit: edit.id, error: err.message });
       }
     }
 
+    if (failures.length) {
+      results.failed.push(...failures);
+      if (applied.length) {
+        results.failed.push({
+          file: relative,
+          error: `${relative} was left unchanged: a file takes every accepted edit or none of them`,
+        });
+      }
+      continue;
+    }
+
     if (text === before) continue;
-
-    const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
-
-    if (!dryRun) fs.writeFileSync(absolute, text);
-    results.written.push({ file: relative, edits: applied, budget, dryRun });
+    planned.push({ relative, absolute, before, text, applied });
+    for (const id of applied) landed.add(id);
   }
 
+  // Skills go in before the memory file. A skill nothing points at yet is inert, while a
+  // memory file pointing at a skill that is not there is actively wrong - so if a skill
+  // cannot be written, the files that would reference it are left alone.
+  const skillFailures = [];
   for (const edit of accepted) {
     if (edit.kind !== "extract" || !edit.skill) continue;
+    if (!landed.has(edit.id)) continue;
     try {
       const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
       results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {
-      results.failed.push({ file: edit.skill.path, edit: edit.id, error: err.message });
+      skillFailures.push({ file: edit.skill.path, edit: edit.id, error: err.message });
     }
+  }
+
+  if (skillFailures.length) {
+    results.failed.push(...skillFailures);
+    for (const { relative } of planned) {
+      results.failed.push({
+        file: relative,
+        error: `${relative} was left unchanged: its edits point at a skill that could not be written`,
+      });
+    }
+    return results;
+  }
+
+  for (const { relative, absolute, before, text, applied } of planned) {
+    const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
+
+    if (!dryRun) fs.writeFileSync(absolute, text);
+    results.written.push({ file: relative, edits: applied, budget, dryRun });
+
+    // Shrinking over several runs is the design, so this is a heading, not a failure.
+    if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
   }
 
   // Rejections are remembered so the same edit is not re-proposed without new evidence.

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -92,9 +92,8 @@ function overBudgetWarning(relative, budget) {
  * against that file's single pre-write image. Any of them failing writes nothing and
  * records no rejection.
  *
- * A file is therefore applied all at once or not at all, and a skill is written only
- * when the memory-file edit that points at it lands - otherwise the repo would hold the
- * same instructions twice, once inline and once in a skill nothing references.
+ * A file is therefore applied all at once or not at all. Skills are written only after
+ * every accepted edit has composed, and before the files that reference them.
  */
 export function applyDecisions({ proposal, decisions, repo, state, config, dryRun = false }) {
   const accepted = proposal.edits.filter((e) => decisions[e.id] === "accepted");
@@ -111,7 +110,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     rejectionsRecorded: false,
   };
 
-  if (accepted.length) {
+  if (accepted.length || rejected.length) {
     const drift = memoryFileDrift(proposal, repo);
     if (drift) {
       results.failed.push(drift);
@@ -177,16 +176,20 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     for (const id of applied) landed.add(id);
   }
 
+  if (results.failed.length) return results;
+
   // Skills go in before the memory file. A skill nothing points at yet is inert, while a
   // memory file pointing at a skill that is not there is actively wrong - so if a skill
   // cannot be written, the files that would reference it are left alone.
   const skillFailures = [];
+  const writtenSkillPaths = [];
   for (const edit of accepted) {
     if (edit.kind !== "extract" || !edit.skill) continue;
     if (!landed.has(edit.id)) continue;
     try {
       const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
       results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
+      if (!dryRun) writtenSkillPaths.push(edit.skill.path);
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {
       skillFailures.push({ file: edit.skill.path, edit: edit.id, error: err.message });
@@ -195,6 +198,11 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
   if (skillFailures.length) {
     results.failed.push(...skillFailures);
+    if (writtenSkillPaths.length) {
+      results.failed.push({
+        error: `skill paths already written in this round: ${writtenSkillPaths.join(", ")}; remove them before retrying`,
+      });
+    }
     for (const { relative } of planned) {
       results.failed.push({
         file: relative,

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -167,9 +167,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     }
 
     const before =
-      relative === proposal.memoryFile?.path && memoryText !== null
-        ? memoryText
-        : fs.readFileSync(absolute, "utf8");
+      relative === proposal.memoryFile?.path && memoryText !== null ? memoryText : fs.readFileSync(absolute, "utf8");
     let text = before;
     const applied = [];
     const failures = [];

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -10,8 +10,8 @@ import { budgetBar, formatTokens } from "../tokens.js";
  *
  * By default it serves the shipped static template through lavish-axi and waits for one
  * structured decision vector; `--no-ui` keeps the same ACCEPT/REJECT decision in the
- * terminal. `applyDecisions` revalidates the accepted subset against the budget before
- * writing; a failing set records no rejections.
+ * terminal. `applyDecisions` owns the pre-write freshness, budget, and composition gates;
+ * a failing gate records no rejections.
  */
 export async function cmdApply(ctx) {
   const { config, repo } = ctx;

--- a/src/memory.js
+++ b/src/memory.js
@@ -116,6 +116,15 @@ export function parseMemoryUnits(text) {
   }));
 }
 
+/**
+ * The fingerprint of one memory file's exact bytes. It is written into the proposal and
+ * re-checked at apply, so it has exactly one definition: a proposal and the freshness
+ * check that guards it can never disagree about what "unchanged" means.
+ */
+export function memoryTextHash(text) {
+  return `sha256:${sha256(text).slice(0, 16)}`;
+}
+
 export function readMemoryFile(repoRoot, relativePath) {
   const absolute = path.join(repoRoot, relativePath);
   if (!fs.existsSync(absolute)) return null;
@@ -124,7 +133,7 @@ export function readMemoryFile(repoRoot, relativePath) {
     path: relativePath,
     absolute,
     text,
-    hash: `sha256:${sha256(text).slice(0, 16)}`,
+    hash: memoryTextHash(text),
     tokens: estimateTokens(text),
     units: parseMemoryUnits(text),
   };

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -47,9 +47,16 @@ export function budgetGateKind(budget) {
   return null;
 }
 
-/** Fixed-width ASCII gauge for `backpass status`. */
+/**
+ * Fixed-width ASCII gauge for `backpass status`.
+ *
+ * Over budget the `!!` marker gets its own cells rather than the leftover ones, because
+ * past 100% there are no leftover cells: a file at twice its cap must not render as a
+ * merely-full bar.
+ */
 export function budgetBar(status, width = 32) {
-  const filled = Math.min(width, Math.round(status.utilization * width));
-  const overflow = status.withinBudget ? 0 : Math.min(width - filled, 2);
-  return `[${"#".repeat(filled)}${"!".repeat(overflow)}${".".repeat(Math.max(0, width - filled - overflow))}]`;
+  const overflow = status.withinBudget ? 0 : Math.min(width, 2);
+  const cells = width - overflow;
+  const filled = Math.min(cells, Math.round(status.utilization * width));
+  return `[${"#".repeat(filled)}${"!".repeat(overflow)}${".".repeat(Math.max(0, cells - filled))}]`;
 }

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -1,0 +1,251 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { buildProposal } from "../src/proposal.js";
+import { stageAndMeasure } from "./helpers/staging.js";
+
+/**
+ * The propose-then-drift-then-apply path, through the real CLI.
+ *
+ * This is the shape that produced the 0.1.6 partial apply: a proposal measured against
+ * one image of AGENTS.md, an upstream commit that rewrites text inside a hunk's window,
+ * and an apply that then walks into a file it never measured. The assertions are the
+ * ones a user can check - the process exit code, what it printed, and what is on disk -
+ * so they stay true however the writer is refactored.
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CLI = path.join(ROOT, "bin", "backpass");
+const FAKE_LAVISH = path.join(ROOT, "test", "fixtures", "fake-lavish", "lavish-axi");
+
+const MEMORY_TEXT = [
+  "# Demo agent memory",
+  "",
+  "## Build",
+  "",
+  "- Run `make build` before every push.",
+  "",
+  "## CI",
+  "",
+  "- `ci_timeout` is an idle timeout, not an absolute deadline; only the anchor re-arms.",
+  "- CI readiness never treats an empty check list as green.",
+  "- A cancelled check is never a job verdict, so the rerun runs before any fix round.",
+  "",
+  "## Release",
+  "",
+  "- Every macOS artifact is Developer ID signed on a macOS runner.",
+  "- The executable identifier and Team ID are permanent and must never change.",
+  "",
+  "## Style",
+  "",
+  "- Never use the em dash.",
+  "",
+].join("\n");
+
+/** The upstream commit that lands inside the CI hunk's window between propose and apply. */
+const DRIFT_BULLET = "- GitHub's raw rollup returns superseded check runs; collapse them.\n";
+
+function git(args, cwd) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function initRepo() {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-apply-cli-")));
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  fs.writeFileSync(path.join(dir, "AGENTS.md"), MEMORY_TEXT);
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "-m", "memory"], dir);
+  return dir;
+}
+
+const sectionBody = (text, heading) => new RegExp(`(?<=## ${heading}\\n\\n)[\\s\\S]*?(?=\\n## )`).exec(text)[0];
+
+/**
+ * Produce a real proposal the way a run does: stage the memory file, let a stand-in
+ * synthesis harness edit the staging copy with plain writes, measure it, and annotate
+ * the measured changes. No model is involved and nothing textual is invented - the
+ * hunks are cut from the file, exactly as in production.
+ */
+function proposeExtractions(dir) {
+  const repo = { root: dir, realRoot: dir, name: path.basename(dir), worktrees: [dir], remotes: [] };
+  const config = {
+    budgetTokens: 5000,
+    maxEditsPerRun: 20,
+    minGapEvidence: 2,
+    skillsDir: ".agents/skills",
+    analysis: {},
+    synthesis: {},
+  };
+
+  const staged = stageAndMeasure({
+    repo,
+    edit: (workspace) => {
+      const memory = path.join(workspace, "AGENTS.md");
+      let text = fs.readFileSync(memory, "utf8");
+      for (const [heading, skill] of [
+        ["CI", "ci-details"],
+        ["Release", "release-details"],
+      ]) {
+        const body = sectionBody(text, heading);
+        text = text.replace(body, `- Load \`${skill}\` for this topic.`);
+        const dir_ = path.join(workspace, ".agents/skills", skill);
+        fs.mkdirSync(dir_, { recursive: true });
+        fs.writeFileSync(
+          path.join(dir_, "SKILL.md"),
+          `---\nname: ${skill}\ndescription: Use when touching ${heading.toLowerCase()}.\n---\n\n${body}\n`,
+        );
+      }
+      fs.writeFileSync(memory, text);
+    },
+  });
+
+  const hunks = staged.measured.changes.filter((c) => c.kind === "hunk");
+  const created = staged.measured.changes.filter((c) => c.kind === "created");
+  const skillOf = (name) => created.find((c) => c.file.includes(name)).id;
+  const evidence = (text) => [{ polarity: "negative", text, source: "claude · fixture · turn 1" }];
+
+  const { proposal, violations } = buildProposal(
+    {
+      edits: [
+        {
+          kind: "extract",
+          title: "Move CI detail into a triggered skill",
+          rationale: "always-loaded detail that few sessions need",
+          changes: [hunks[0].id, skillOf("ci-details")],
+          evidence: evidence("it re-read the CI section it never used"),
+          transcripts: 3,
+        },
+        {
+          kind: "extract",
+          title: "Move release detail into a triggered skill",
+          rationale: "same",
+          changes: [hunks[1].id, skillOf("release-details")],
+          evidence: evidence("release detail loaded on every turn"),
+          transcripts: 3,
+        },
+      ],
+    },
+    {
+      memoryFile: staged.memoryFile,
+      config,
+      repo,
+      summary: { analyzedSessions: 3, totals: { positive: 1, negative: 2, gapClusters: 0 } },
+      measured: staged.measured,
+    },
+  );
+  assert.deepEqual(violations, [], "the fixture proposal must clear the gates");
+  assert.equal(proposal.edits.length, 2);
+  staged.state.writeProposal(proposal);
+  return proposal;
+}
+
+/** Run `backpass apply` for real, with the fake review surface accepting every edit. */
+function runApply(dir, editIds) {
+  const decisions = editIds.map((id) => `${id}=accepted`).join(" ");
+  // Outside the repo: the assertions below read `git status`, so the harness must not
+  // leave a file there itself.
+  const scenario = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-lavish-")), "scenario.json");
+  fs.writeFileSync(
+    scenario,
+    JSON.stringify({
+      polls: [
+        `prompts[1]{uid,prompt,selector,tag,text}:\n  "1","BACKPASS_DECISIONS ${decisions}",button#btn-apply,choice,${decisions}`,
+      ],
+    }),
+  );
+
+  const result = spawnSync(process.execPath, [CLI, "apply", "--no-open"], {
+    cwd: dir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+      BACKPASS_LAVISH_BIN: FAKE_LAVISH,
+      FAKE_LAVISH_SCENARIO: scenario,
+    },
+  });
+  return { ...result, output: `${result.stdout}${result.stderr}` };
+}
+
+const porcelain = (dir) => execFileSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8" }).trim();
+
+test("a memory file that changed after the proposal is left untouched by apply", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+
+  // Upstream lands one bullet inside the CI hunk's window, exactly as #855 did.
+  const memory = path.join(dir, "AGENTS.md");
+  const drifted = fs
+    .readFileSync(memory, "utf8")
+    .replace("- CI readiness never treats an empty check list as green.\n", (line) => `${DRIFT_BULLET}${line}`);
+  fs.writeFileSync(memory, drifted);
+  git(["commit", "-qam", "upstream: collapse superseded check runs"], dir);
+  assert.equal(porcelain(dir), "", "the repo is clean going in");
+
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+
+  assert.equal(applied.status, 1, `apply should fail:\n${applied.output}`);
+  assert.equal(fs.readFileSync(memory, "utf8"), drifted, "AGENTS.md is byte-identical to what apply found");
+  assert.equal(fs.existsSync(path.join(dir, ".agents")), false, "no skills directory");
+  assert.equal(fs.existsSync(path.join(dir, ".claude")), false, "no .claude/skills symlink");
+  assert.equal(porcelain(dir), "", "nothing at all landed in the project");
+
+  assert.match(applied.output, /changed after this proposal was made/);
+  assert.match(applied.output, new RegExp(proposal.memoryFile.hash), "names the image the edits were measured on");
+  assert.match(applied.output, /nothing was written/);
+  assert.match(applied.output, /Run `backpass`/, "names the command that regenerates against the current file");
+});
+
+test("an unchanged memory file applies every accepted edit and its skills", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+
+  assert.equal(applied.status, 0, `apply should succeed:\n${applied.output}`);
+
+  const memory = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8");
+  assert.match(memory, /- Load `ci-details` for this topic\./);
+  assert.match(memory, /- Load `release-details` for this topic\./);
+  assert.ok(!memory.includes("A cancelled check is never a job verdict"), "the extracted body left the memory file");
+
+  assert.match(
+    fs.readFileSync(path.join(dir, ".agents/skills/ci-details/SKILL.md"), "utf8"),
+    /A cancelled check is never a job verdict/,
+  );
+  assert.ok(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")));
+  assert.equal(fs.lstatSync(path.join(dir, ".claude/skills")).isSymbolicLink(), true);
+
+  assert.match(applied.output, /wrote AGENTS\.md \(e1, e2\)/);
+  assert.equal(porcelain(dir).includes(".backpass"), false, "run state stays out of the working tree");
+});
+
+test("apply names a memory file left over budget without refusing the shrink", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  // A cap this small cannot be met in one pass; the run is still legitimate progress.
+  fs.writeFileSync(path.join(dir, ".backpassrc.json"), JSON.stringify({ budgetTokens: 20 }));
+
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+
+  assert.equal(applied.status, 0, `a shrinking run must not be refused:\n${applied.output}`);
+  assert.match(applied.output, /wrote AGENTS\.md/);
+  assert.match(applied.output, /is still \d+ tokens over the 20-token budget/);
+  assert.match(applied.output, /run `backpass` again for the next shrink step/);
+});

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -47,8 +47,9 @@ test("the budget bar marks overflow distinctly from a full bar", () => {
   const full = budgetBar(budgetStatus("x".repeat(20000), null, 5000), 10);
   const over = budgetBar(budgetStatus("x".repeat(40000), null, 5000), 10);
   assert.equal(full, "[##########]");
-  assert.ok(over.includes("#"));
-  assert.equal(over.length, 12);
+  assert.notEqual(over, full, "twice the cap must not render as merely full");
+  assert.match(over, /!!\]$/, "the overflow marker gets its own cells past 100%");
+  assert.equal(over.length, full.length, "both bars stay the same width");
 });
 
 test("formatTokens groups thousands for the gauge readout", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -657,6 +657,29 @@ test("memory drift also refuses an all-rejected decision without recording it", 
   assert.match(results.failed[0].error, /changed after this proposal was made/);
 });
 
+test("a missing memory file refuses an all-rejected decision without recording it", () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((text) => text.replace("- Prefer small commits.", "- Prefer small, reviewable commits.")),
+    annotation: { edits: [claim(["H1"], { title: "sharpen the commit rule" })] },
+  });
+  const memory = path.join(repo.root, "AGENTS.md");
+  fs.rmSync(memory);
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "rejected" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.written, []);
+  assert.equal(results.rejectionsRecorded, false);
+  assert.equal(Object.keys(state.readRejections().entries).length, 0);
+  assert.match(results.failed[0].error, /AGENTS\.md no longer exists/);
+  assert.match(results.failed[0].error, /Run `backpass`/);
+});
+
 test("an unchanged memory file still applies, so the freshness check costs nothing", () => {
   const { proposal, repo, state } = gate({
     edit: memoryEdit((t) => t.replace("- Prefer small commits.", "- Prefer small, reviewable commits.")),

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -798,6 +798,92 @@ test("an accepted extract writes the skill the agent drafted, in the canonical l
   assert.ok(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8").includes("See the release-signing skill."));
 });
 
+test("memory drift during skill I/O removes the skill and preserves the concurrent edit", () => {
+  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
+  const { proposal, repo, state } = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text.replace("- Use Node 18 via nvm before running any script.", "- Load the node-setup skill."),
+      );
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillText);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract node setup" })] },
+  });
+  const memory = path.join(repo.root, "AGENTS.md");
+  const skill = path.join(repo.root, ".agents/skills/node-setup/SKILL.md");
+  const concurrent = MEMORY_TEXT.replace("- Prefer small commits.", "- Prefer tiny commits.");
+  const originalWrite = fs.writeFileSync;
+  fs.writeFileSync = function writeAndDrift(target, ...args) {
+    const result = originalWrite.call(this, target, ...args);
+    if (typeof target === "string" && path.resolve(target) === skill) originalWrite(memory, concurrent);
+    return result;
+  };
+
+  let results;
+  try {
+    results = applyDecisions({
+      proposal,
+      decisions: { e1: "accepted" },
+      repo,
+      state,
+      config: { budgetTokens: 5000 },
+    });
+  } finally {
+    fs.writeFileSync = originalWrite;
+  }
+
+  assert.match(results.failed[0].error, /changed after this proposal was made/);
+  assert.equal(fs.readFileSync(memory, "utf8"), concurrent);
+  assert.equal(fs.existsSync(skill), false);
+  assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false);
+  assert.deepEqual(results.skills, []);
+  assert.deepEqual(results.written, []);
+});
+
+test("a memory write failure compensates skills already written", () => {
+  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
+  const { proposal, repo, state } = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text.replace("- Use Node 18 via nvm before running any script.", "- Load the node-setup skill."),
+      );
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillText);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract node setup" })] },
+  });
+  const memory = path.join(repo.root, "AGENTS.md");
+  const skill = path.join(repo.root, ".agents/skills/node-setup/SKILL.md");
+  const originalWrite = fs.writeFileSync;
+  let refused = false;
+  fs.writeFileSync = function failMemoryOnce(target, ...args) {
+    if (!refused && typeof target === "string" && path.resolve(target) === memory) {
+      refused = true;
+      throw new Error("simulated memory write failure");
+    }
+    return originalWrite.call(this, target, ...args);
+  };
+
+  let results;
+  try {
+    results = applyDecisions({
+      proposal,
+      decisions: { e1: "accepted" },
+      repo,
+      state,
+      config: { budgetTokens: 5000 },
+    });
+  } finally {
+    fs.writeFileSync = originalWrite;
+  }
+
+  assert.match(results.failed[0].error, /simulated memory write failure/);
+  assert.equal(fs.readFileSync(memory, "utf8"), MEMORY_TEXT);
+  assert.equal(fs.existsSync(skill), false);
+  assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false);
+  assert.deepEqual(results.skills, []);
+  assert.deepEqual(results.written, []);
+});
+
 test("a dry run reports what it would write without touching the file", () => {
   const { proposal, repo, state } = gate({
     edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -530,7 +530,7 @@ test("rejecting every edit remains valid when memory already exceeds the cap", (
   assert.equal(Object.keys(state.readRejections().entries).length, 1);
 });
 
-test("apply preflight skips inapplicable accepted edits and still writes the rest", () => {
+test("one inapplicable accepted edit leaves the whole file unwritten", () => {
   const { proposal, repo, state } = gate({
     edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),
     annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop node pin" })] },
@@ -549,10 +549,93 @@ test("apply preflight skips inapplicable accepted edits and still writes the res
     config: { budgetTokens: 5000 },
   });
 
-  assert.equal(results.written.length, 1);
+  assert.deepEqual(results.written, [], "a file takes every accepted edit or none of them");
+  assert.equal(
+    fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"),
+    MEMORY_TEXT,
+    "the applicable edit is not written either",
+  );
+  assert.ok(
+    results.failed.some((f) => f.edit === "e-stale" && /does not appear/.test(f.error)),
+    "the edit that could not apply is named",
+  );
+  assert.ok(
+    results.failed.some((f) => !f.edit && /left unchanged/.test(f.error)),
+    "and so is the consequence for the file",
+  );
+});
+
+test("apply refuses every edit once the memory file changed under the proposal", () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) => t.replace("- Prefer small commits.", "- Prefer small, reviewable commits.")),
+    annotation: { edits: [claim(["H1"], { title: "sharpen the commit rule" })] },
+  });
+
+  // The drift is somewhere else in the file, so the hunk itself would still apply.
+  const memory = path.join(repo.root, "AGENTS.md");
+  const drifted = MEMORY_TEXT.replace("## Rules\n", "## Rules\n\n- Run the linter before pushing.\n");
+  fs.writeFileSync(memory, drifted);
+  assert.doesNotThrow(() => applyEdit(drifted, proposal.edits[0]), "the edit still composes; only the file moved");
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.written, []);
+  assert.equal(fs.readFileSync(memory, "utf8"), drifted, "the drifted file is left exactly as found");
   assert.equal(results.failed.length, 1);
-  assert.equal(results.failed[0].edit, "e-stale");
-  assert.ok(!fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8").includes("Node 18"));
+  assert.match(results.failed[0].error, /changed after this proposal was made/);
+  assert.match(results.failed[0].error, new RegExp(proposal.memoryFile.hash), "names the image it was measured on");
+  assert.match(results.failed[0].error, /Run `backpass`/, "names the command that re-measures");
+});
+
+test("an unchanged memory file still applies, so the freshness check costs nothing", () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((t) => t.replace("- Prefer small commits.", "- Prefer small, reviewable commits.")),
+    annotation: { edits: [claim(["H1"], { title: "sharpen the commit rule" })] },
+  });
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.failed, []);
+  assert.equal(results.written.length, 1);
+  assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /small, reviewable commits/);
+});
+
+test("a skill is written only when the memory-file edit that points at it lands", () => {
+  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
+  const { proposal, repo, state } = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) =>
+        t.replace("- Use Node 18 via nvm before running any script.", "- Load the node-setup skill."),
+      );
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillText);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract the node pin" })] },
+  });
+  proposal.edits[0].hunks[0].find = "text that is not in the file at all";
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.skills, [], "no skill for an edit that did not land");
+  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false, "and no layout side effects");
 });
 
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -565,6 +565,46 @@ test("one inapplicable accepted edit leaves the whole file unwritten", () => {
   );
 });
 
+test("a stale edit in another file aborts the whole accepted run", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const { proposal, repo, state } = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text
+          .replace("- Use Node 18 via nvm before running any script.\n", "")
+          .replace("include its URL.", "include its full https:// URL."),
+      );
+      writeIn(root, ".agents/skills/db/SKILL.md", (text) =>
+        text.replace("old trigger", "Load before touching the database."),
+      );
+    },
+    annotation: {
+      edits: [
+        claim(["H2"], { kind: "remove", title: "drop node pin" }),
+        claim(["H1"], { title: "expand URL rule" }),
+        claim(["H3"], { title: "fix skill trigger" }),
+      ],
+    },
+  });
+  proposal.edits[2].hunks[0].find = "stale skill text";
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted", e2: "rejected", e3: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.written, []);
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
+  assert.equal(fs.readFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), "utf8"), skill);
+  assert.equal(results.rejectionsRecorded, false);
+  assert.equal(Object.keys(state.readRejections().entries).length, 0);
+  assert.ok(results.failed.some((failure) => failure.edit === "e3" && /does not appear/.test(failure.error)));
+});
+
 test("apply refuses every edit once the memory file changed under the proposal", () => {
   const { proposal, repo, state } = gate({
     edit: memoryEdit((t) => t.replace("- Prefer small commits.", "- Prefer small, reviewable commits.")),
@@ -591,6 +631,30 @@ test("apply refuses every edit once the memory file changed under the proposal",
   assert.match(results.failed[0].error, /changed after this proposal was made/);
   assert.match(results.failed[0].error, new RegExp(proposal.memoryFile.hash), "names the image it was measured on");
   assert.match(results.failed[0].error, /Run `backpass`/, "names the command that re-measures");
+});
+
+test("memory drift also refuses an all-rejected decision without recording it", () => {
+  const { proposal, repo, state } = gate({
+    edit: memoryEdit((text) => text.replace("- Prefer small commits.", "- Prefer small, reviewable commits.")),
+    annotation: { edits: [claim(["H1"], { title: "sharpen the commit rule" })] },
+  });
+  const memory = path.join(repo.root, "AGENTS.md");
+  const drifted = MEMORY_TEXT.replace("## Rules\n", "## Rules\n\n- Run the linter before pushing.\n");
+  fs.writeFileSync(memory, drifted);
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "rejected" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.written, []);
+  assert.equal(fs.readFileSync(memory, "utf8"), drifted);
+  assert.equal(results.rejectionsRecorded, false);
+  assert.equal(Object.keys(state.readRejections().entries).length, 0);
+  assert.match(results.failed[0].error, /changed after this proposal was made/);
 });
 
 test("an unchanged memory file still applies, so the freshness check costs nothing", () => {
@@ -636,6 +700,52 @@ test("a skill is written only when the memory-file edit that points at it lands"
   assert.deepEqual(results.skills, [], "no skill for an edit that did not land");
   assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), false);
   assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false, "and no layout side effects");
+});
+
+test("a failed later skill write names skill paths already written", () => {
+  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
+  const { proposal, repo, state } = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text.replace("- Use Node 18 via nvm before running any script.", "- Load the node-setup skill."),
+      );
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillText);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract the node pin" })] },
+  });
+  const second = structuredClone(proposal.edits[0]);
+  second.id = "e2";
+  second.hunks = [
+    {
+      id: "H-extra",
+      find: "- Whenever a PR is mentioned, include its URL.",
+      replace: "- See the url-policy skill.",
+    },
+  ];
+  second.skill = {
+    ...second.skill,
+    name: "url-policy",
+    path: ".agents/skills",
+    body: "Always include the full URL.",
+  };
+  proposal.edits.push(second);
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted", e2: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.written, []);
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
+  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), true);
+  assert.ok(
+    results.failed.some(
+      (failure) => /already written/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
+    ),
+  );
 });
 
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -725,7 +725,7 @@ test("a skill is written only when the memory-file edit that points at it lands"
   assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false, "and no layout side effects");
 });
 
-test("a failed later skill target is refused before any skill is written", () => {
+test("a failed later skill write names skill paths already written", () => {
   const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
   const { proposal, repo, state } = gate({
     edit: (root) => {
@@ -762,11 +762,14 @@ test("a failed later skill target is refused before any skill is written", () =>
   });
 
   assert.deepEqual(results.written, []);
-  assert.deepEqual(results.skills, []);
   assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
-  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), false);
-  assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false, "preflight has no layout side effects");
-  assert.ok(results.failed.some((failure) => failure.edit === "e2" && /not a file/.test(failure.error)));
+  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), true);
+  assert.ok(
+    results.failed.some(
+      (failure) =>
+        /already written/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
+    ),
+  );
 });
 
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {
@@ -796,92 +799,6 @@ test("an accepted extract writes the skill the agent drafted, in the canonical l
   );
   assert.ok(written.endsWith("## Steps\n\n1. sign\n"));
   assert.ok(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8").includes("See the release-signing skill."));
-});
-
-test("memory drift during skill I/O removes the skill and preserves the concurrent edit", () => {
-  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
-  const { proposal, repo, state } = gate({
-    edit: (root) => {
-      writeIn(root, "AGENTS.md", (text) =>
-        text.replace("- Use Node 18 via nvm before running any script.", "- Load the node-setup skill."),
-      );
-      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillText);
-    },
-    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract node setup" })] },
-  });
-  const memory = path.join(repo.root, "AGENTS.md");
-  const skill = path.join(repo.root, ".agents/skills/node-setup/SKILL.md");
-  const concurrent = MEMORY_TEXT.replace("- Prefer small commits.", "- Prefer tiny commits.");
-  const originalWrite = fs.writeFileSync;
-  fs.writeFileSync = function writeAndDrift(target, ...args) {
-    const result = originalWrite.call(this, target, ...args);
-    if (typeof target === "string" && path.resolve(target) === skill) originalWrite(memory, concurrent);
-    return result;
-  };
-
-  let results;
-  try {
-    results = applyDecisions({
-      proposal,
-      decisions: { e1: "accepted" },
-      repo,
-      state,
-      config: { budgetTokens: 5000 },
-    });
-  } finally {
-    fs.writeFileSync = originalWrite;
-  }
-
-  assert.match(results.failed[0].error, /changed after this proposal was made/);
-  assert.equal(fs.readFileSync(memory, "utf8"), concurrent);
-  assert.equal(fs.existsSync(skill), false);
-  assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false);
-  assert.deepEqual(results.skills, []);
-  assert.deepEqual(results.written, []);
-});
-
-test("a memory write failure compensates skills already written", () => {
-  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
-  const { proposal, repo, state } = gate({
-    edit: (root) => {
-      writeIn(root, "AGENTS.md", (text) =>
-        text.replace("- Use Node 18 via nvm before running any script.", "- Load the node-setup skill."),
-      );
-      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillText);
-    },
-    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract node setup" })] },
-  });
-  const memory = path.join(repo.root, "AGENTS.md");
-  const skill = path.join(repo.root, ".agents/skills/node-setup/SKILL.md");
-  const originalWrite = fs.writeFileSync;
-  let refused = false;
-  fs.writeFileSync = function failMemoryOnce(target, ...args) {
-    if (!refused && typeof target === "string" && path.resolve(target) === memory) {
-      refused = true;
-      throw new Error("simulated memory write failure");
-    }
-    return originalWrite.call(this, target, ...args);
-  };
-
-  let results;
-  try {
-    results = applyDecisions({
-      proposal,
-      decisions: { e1: "accepted" },
-      repo,
-      state,
-      config: { budgetTokens: 5000 },
-    });
-  } finally {
-    fs.writeFileSync = originalWrite;
-  }
-
-  assert.match(results.failed[0].error, /simulated memory write failure/);
-  assert.equal(fs.readFileSync(memory, "utf8"), MEMORY_TEXT);
-  assert.equal(fs.existsSync(skill), false);
-  assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false);
-  assert.deepEqual(results.skills, []);
-  assert.deepEqual(results.written, []);
 });
 
 test("a dry run reports what it would write without touching the file", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -725,7 +725,7 @@ test("a skill is written only when the memory-file edit that points at it lands"
   assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false, "and no layout side effects");
 });
 
-test("a failed later skill write names skill paths already written", () => {
+test("a failed later skill target is refused before any skill is written", () => {
   const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
   const { proposal, repo, state } = gate({
     edit: (root) => {
@@ -762,14 +762,11 @@ test("a failed later skill write names skill paths already written", () => {
   });
 
   assert.deepEqual(results.written, []);
+  assert.deepEqual(results.skills, []);
   assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
-  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), true);
-  assert.ok(
-    results.failed.some(
-      (failure) =>
-        /already written/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
-    ),
-  );
+  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false, "preflight has no layout side effects");
+  assert.ok(results.failed.some((failure) => failure.edit === "e2" && /not a file/.test(failure.error)));
 });
 
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -766,7 +766,8 @@ test("a failed later skill write names skill paths already written", () => {
   assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), true);
   assert.ok(
     results.failed.some(
-      (failure) => /already written/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
+      (failure) =>
+        /already written/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
     ),
   );
 });


### PR DESCRIPTION
## Intent

Stop backpass apply from part-applying a proposal whose memory file changed after the proposal was made: check the recorded memory-file hash before any write, compose every accepted edit for a file against one immutable image so a file takes all its edits or none, write a skill only when the memory-file edit pointing at it lands, and warn when the result is still over budget. Keep it a local single-user command: no apply lock and no rollback state machine.

## What Changed

- Verify the recorded memory-file hash before writing and compose all accepted edits against immutable file snapshots, leaving every file fully applied or unchanged.
- Write extracted skills only after their referencing edits compose and before memory-file updates, with actionable cleanup details on partial skill-write failures.
- Warn when an applied shrink remains over budget and render overflow clearly in the budget gauge.

## Risk Assessment

✅ Low: The change is well-bounded and satisfies the freshness, whole-run preflight, per-file composition, skill ordering, budget warning, and single-user constraints without material source issues found.

## Testing

Inspected the change and exercised the real apply CLI plus focused writer and budget behaviors. Apply refused a drifted or missing memory file without writes or rejection records, aborted whole-run composition failures, applied unchanged proposals with skills, and warned after a valid shrink remained over budget. All targeted checks passed. No screenshot was captured because the changed user surface is CLI and filesystem behavior, not visual review UI; the reviewer-visible CLI transcript is attached.

<details>
<summary>Evidence: End-to-end backpass apply CLI transcript showing drift refusal, successful apply with skills, and over-budget warning</summary>

Source: [End-to-end backpass apply CLI transcript showing drift refusal, successful apply with skills, and over-budget warning](https://github.com/kunchenguid/backpass/blob/880269ee58027fb8a965cd33796abca60ed09ced/.no-mistakes/evidence/fm/backpass-partial-apply-anchor-failure-s1/apply-cli-transcript.txt)

```text

===== DRIFT REFUSAL: USER-VISIBLE CLI OUTPUT =====
2 accepted · 0 rejected
  failed AGENTS.md: AGENTS.md changed after this proposal was made (sha256:f4826be6a1cea07a -> sha256:d34085de1c52c18a), so its edits no longer describe the file on disk; nothing was written. Run `backpass` to re-propose against the current AGENTS.md.
  nothing written
· review surface: http://127.0.0.1:4387/session/51233fdaf6389690
waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)
===== END DRIFT REFUSAL =====


===== SUCCESSFUL APPLY: USER-VISIBLE CLI OUTPUT =====
2 accepted · 0 rejected
  wrote AGENTS.md (e1, e2)
    budget [................................] 124 -> 51 / 5,000 tok
  wrote .agents/skills/ci-details/SKILL.md (new skill)
    created .agents/skills
    created .claude/skills -> ../.agents/skills
  wrote .agents/skills/release-details/SKILL.md (new skill)
· review surface: http://127.0.0.1:4387/session/51233fdaf6389690
waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)
===== END SUCCESSFUL APPLY =====


===== OVER-BUDGET SHRINK: USER-VISIBLE CLI OUTPUT =====
2 accepted · 0 rejected
  wrote AGENTS.md (e1, e2)
    budget [##############################!!] 124 -> 51 / 20 tok
  wrote .agents/skills/ci-details/SKILL.md (new skill)
    created .agents/skills
    created .claude/skills -> ../.agents/skills
  wrote .agents/skills/release-details/SKILL.md (new skill)
· review surface: http://127.0.0.1:4387/session/51233fdaf6389690
waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)
warn AGENTS.md is still 31 tokens over the 20-token budget; run `backpass` again for the next shrink step
===== END OVER-BUDGET SHRINK =====

✔ a memory file that changed after the proposal is left untouched by apply (173.268ms)
✔ an unchanged memory file applies every accepted edit and its skills (156.952208ms)
✔ apply names a memory file left over budget without refusing the shrink (163.547833ms)
ℹ tests 3
ℹ suites 0
ℹ pass 3
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 525.8275
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e56c43cea7440e1407896b641a8723b906d58854","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat` and targeted diff inspection from base `4a5670c` to target `fff5aac`</code>
- `node --test test/apply-cli.test.js`
- `node --test --test-name-pattern='one inapplicable accepted edit|stale edit in another file|memory file changed|memory drift also|missing memory file|unchanged memory file still|skill is written only|failed later skill write|accepted extract writes|dry run reports|accepted subset|rejecting every edit' test/proposal.test.js`
- `node --test test/budget.test.js`
- `Ran a temporary instrumented copy of the end-to-end CLI test to capture drift refusal, successful skill extraction, and over-budget shrink output, then removed the temporary test file`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
