### PR TITLE
fix: keep harness model and effort overrides invocation-scoped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,13 +108,18 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   CLI change has one blast radius. v1 uses plain `exec` and named sessions only; acpx flows
   are deferred until they are stable upstream. The one sanctioned exception is the
   per-harness native status table in `src/agents.js` (`claude auth status`, `opencode models`).
+- **Model and effort overrides are invocation-scoped.** Never ACP `set model` / Pi
+  `set thought_level` (those rewrite `~/.pi/agent/settings.json`) and never edit-then-restore
+  harness defaults. `src/harness-invoke.js` is the table: Pi `--model`/`--thinking` on the
+  inner process, Grok `-m`/`--reasoning-effort`, Claude/Codex acpx `--model` at session
+  create plus session-local `set effort`. A harness without a proven overlay must stop, not
+  pretend. Preserve current spawn when no override is requested.
 - **Agent auto-pick is probe-then-verify, never probe-only.** `src/agents.js` walks each
   role's ladder with a zero-token probe, but the claude adapter cannot be pre-verified by
   acpx (sessions succeed while logged out), so every real call runs under
   `AgentResolver.withFallthrough`, which demotes a candidate on a classifiable failure
-  (`classifyAcpxFailure`). Reasoning effort is a per-adapter session option
-  (`EFFORT_OPTION_KEYS`), so effortful calls always go through `sessionPrompt`. Verdicts
-  cache in `.backpass/agent-probe-cache.json`.
+  (`classifyAcpxFailure`). Effortful calls go through `sessionPrompt` so the overlay in
+  `src/harness-invoke.js` can apply. Verdicts cache in `.backpass/agent-probe-cache.json`.
 - **The Lavish apply surface is chatty and its output is YAML-quoted.** `lavish-axi poll`
   can return feedback that is not a decision vector (a comment, a queued layout report) any
   number of times before the real one; `pollDecisions` in `src/apply/lavish.js` announces

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   per-harness native status table in `src/agents.js` (`claude auth status`, `opencode models`).
 - **Model and effort overrides are invocation-scoped.** Never ACP `set model` / Pi
   `set thought_level` (those rewrite `~/.pi/agent/settings.json`) and never edit-then-restore
-  harness defaults. `src/harness-invoke.js` is the table: Pi `--model`/`--thinking` on the
-  inner process, Grok `-m`/`--reasoning-effort`, Claude/Codex acpx `--model` at session
-  create plus session-local `set effort`. A harness without a proven overlay must stop, not
-  pretend. Preserve current spawn when no override is requested.
+  harness defaults. `src/harness-invoke.js` owns the harness overlay mechanisms and
+  `src/acpx.js` owns verification and fallback. An unproven overlay must stop rather than
+  pretend; OpenCode effort alone is skipped with a report note. Preserve the current spawn
+  when no override is requested.
 - **Agent auto-pick is probe-then-verify, never probe-only.** `src/agents.js` walks each
   role's ladder with a zero-token probe, but the claude adapter cannot be pre-verified by
   acpx (sessions succeed while logged out), so every real call runs under

--- a/README.md
+++ b/README.md
@@ -352,9 +352,10 @@ backpass \
   --synthesis-agent claude --synthesis-model claude-opus-5 --synthesis-effort high
 ```
 
-`--no-auto-agent` pins the pre-ladder defaults (codex / claude). If an adapter does not
-advertise reasoning effort, backpass says so in the run report rather than pretending it
-applied.
+`--no-auto-agent` pins the pre-ladder defaults (codex / claude). Model and effort
+overrides are one-off for that spawn (`src/harness-invoke.js`) so they never rewrite
+your harness defaults. If an adapter has no proven overlay, backpass stops rather than
+pretending it applied, except OpenCode effort which is skipped with a report note.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -353,9 +353,9 @@ backpass \
 ```
 
 `--no-auto-agent` pins the pre-ladder defaults (codex / claude). Model and effort
-overrides are one-off for that spawn (`src/harness-invoke.js`) so they never rewrite
-your harness defaults. If an adapter has no proven overlay, backpass stops rather than
-pretending it applied, except OpenCode effort which is skipped with a report note.
+overrides are scoped to that Backpass invocation, so they never rewrite your harness
+defaults. If an adapter has no proven overlay, backpass stops rather than pretending it
+applied, except OpenCode effort which is skipped with a report note.
 
 ### Configuration
 

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -330,10 +330,11 @@ export async function execOneShot({
  * effort for every harness, so an effortful call still goes through a session when
  * the overlay needs one. Synthesis also needs more than one turn in the same context:
  * the agent edits the staging copy, then annotates the changes backpass measured.
- * Adapters that cannot apply effort skip that overlay with a report line - never silently.
+ * OpenCode alone skips its unsupported effort overlay with a report line. Every other
+ * requested overlay without a proven mechanism stops rather than pretending it applied.
  *
  * Resolves to the handle, or throws an `AcpxError` (`unsupported: true` when the adapter
- * has no session support at all, which `sessionPrompt` turns into an exec fallback).
+ * has no session support; `sessionPrompt` only falls back when it can preserve the requested overlays).
  *
  * @returns {Promise<{ notes: string[],
  *   prompt: (options: { promptFile: string, timeoutSeconds?: number, promptRetries?: number,
@@ -463,8 +464,9 @@ function subtractUsage(current, previous) {
 
 /**
  * One prompt through a short-lived named session: open, prompt, close. The analysis
- * pass uses this whenever an effort is configured. An adapter without session support
- * falls back to a one-shot `exec`, and says so.
+ * pass uses this whenever an effort is configured. Without session support, it falls
+ * back to one-shot `exec` only when that preserves the requested overlays; otherwise it
+ * stops with actionable guidance. OpenCode effort remains the explicit reported skip.
  */
 export async function sessionPrompt({
   agent,

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -177,6 +177,48 @@ function invocationAgentArgs(invocation, agent) {
     : [acpxAgentName(agent)];
 }
 
+async function verifyHarnessInvocation(invocation, cwd) {
+  if (!invocation.requiredBuiltinAgent) return;
+  const args = [...(cwd ? ["--cwd", cwd] : []), "config", "show", "--format", "json"];
+  const result = await run(args, { timeoutMs: 10_000, cwd, env: invocation.env });
+  if (result.code !== 0) {
+    throw new UserError(
+      `cannot verify acpx adapter configuration for ${invocation.requiredBuiltinAgent}: ${firstLine(result.stderr) || `exit ${result.code}`}`,
+      "upgrade acpx or omit the model and effort override",
+    );
+  }
+
+  let config;
+  try {
+    config = JSON.parse(result.stdout);
+  } catch {
+    throw new UserError(
+      `cannot verify acpx adapter configuration for ${invocation.requiredBuiltinAgent}: config show returned invalid JSON`,
+      "upgrade acpx or omit the model and effort override",
+    );
+  }
+
+  if (
+    !config ||
+    typeof config !== "object" ||
+    Array.isArray(config) ||
+    !config.agents ||
+    typeof config.agents !== "object"
+  ) {
+    throw new UserError(
+      `cannot verify acpx adapter configuration for ${invocation.requiredBuiltinAgent}: config show omitted the resolved agents map`,
+      "upgrade acpx or omit the model and effort override",
+    );
+  }
+
+  if (Object.prototype.hasOwnProperty.call(config.agents, invocation.requiredBuiltinAgent)) {
+    throw new UserError(
+      `cannot safely apply model or effort overrides because acpx agents.${invocation.requiredBuiltinAgent} replaces the proven built-in adapter`,
+      `remove the agents.${invocation.requiredBuiltinAgent} replacement or omit the model and effort override`,
+    );
+  }
+}
+
 /** `acpx --version`, used to key the probe cache. Null when acpx is missing. */
 export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
   const result = await run(["--version"], { timeoutMs });
@@ -258,6 +300,7 @@ export async function execOneShot({
 
   const startedAt = Date.now();
   try {
+    await verifyHarnessInvocation(invocation, cwd);
     if (effort && invocation.setEffortKey) {
       throw new UserError(
         `${agent} cannot apply invocation-scoped effort=${effort} in an exec one-shot`,
@@ -305,6 +348,12 @@ export async function openSession({ agent, model = null, effort = null, sessionN
   const notes = [...invocation.notes];
   const acpxAgentArgs = invocationAgentArgs(invocation, agent);
   const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
+  try {
+    await verifyHarnessInvocation(invocation, cwd);
+  } catch (err) {
+    invocation.dispose();
+    throw err;
+  }
   const created = await run(
     [
       ...(invocation.acpxModel ? ["--model", invocation.acpxModel] : []),

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 
-import { warn } from "./logger.js";
+import { UserError, warn } from "./logger.js";
 import { runCapture } from "./subprocess.js";
 import { prepareHarnessInvocation } from "./harness-invoke.js";
 import * as piStore from "./discovery/adapters/pi.js";
@@ -171,6 +171,12 @@ function baseArgs({ cwd, model, timeoutSeconds, approveReads, approveAll = false
   return args;
 }
 
+function invocationAgentArgs(invocation, agent) {
+  return invocation.acpxAgentCommand
+    ? ["--agent", invocation.acpxAgentCommand]
+    : [acpxAgentName(agent)];
+}
+
 /** `acpx --version`, used to key the probe cache. Null when acpx is missing. */
 export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
   const result = await run(["--version"], { timeoutMs });
@@ -231,6 +237,7 @@ export async function probeSession({ agent, sessionName, cwd = undefined, timeou
 export async function execOneShot({
   agent,
   model = null,
+  effort = null,
   promptFile,
   cwd,
   timeoutSeconds = 300,
@@ -238,12 +245,12 @@ export async function execOneShot({
   approveReads = true,
   suppressReads = true,
 }) {
-  const invocation = prepareHarnessInvocation({ agent, model });
+  const invocation = prepareHarnessInvocation({ agent, model, effort });
   const args = [
     ...baseArgs({ cwd, model: invocation.acpxModel, timeoutSeconds, approveReads, suppressReads }),
     "--prompt-retries",
     String(promptRetries),
-    acpxAgentName(agent),
+    ...invocationAgentArgs(invocation, agent),
     "exec",
     "--file",
     promptFile,
@@ -251,6 +258,12 @@ export async function execOneShot({
 
   const startedAt = Date.now();
   try {
+    if (effort && invocation.setEffortKey) {
+      throw new UserError(
+        `${agent} cannot apply invocation-scoped effort=${effort} in an exec one-shot`,
+        "use a named session or omit the effort override",
+      );
+    }
     const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
     if (result.spawnError && result.spawnError.code === "ENOENT") throw notFoundError(result);
     if (result.timedOut) {
@@ -262,7 +275,7 @@ export async function execOneShot({
 
     const combined = `${result.stdout}\n${result.stderr}`;
     const usage = parseTokenLine(combined) ?? recoverUsageFromStore({ agent, promptFile, cwd, startedAt });
-    return { text: stripAcpxNoise(result.stdout), usage, raw: result.stdout };
+    return { text: stripAcpxNoise(result.stdout), usage, raw: result.stdout, notes: invocation.notes };
   } finally {
     invocation.dispose();
   }
@@ -290,12 +303,12 @@ export async function execOneShot({
 export async function openSession({ agent, model = null, effort = null, sessionName, cwd }) {
   const invocation = prepareHarnessInvocation({ agent, model, effort });
   const notes = [...invocation.notes];
-  const acpxAgent = acpxAgentName(agent);
+  const acpxAgentArgs = invocationAgentArgs(invocation, agent);
   const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
   const created = await run(
     [
       ...(invocation.acpxModel ? ["--model", invocation.acpxModel] : []),
-      acpxAgent,
+      ...acpxAgentArgs,
       "sessions",
       "new",
       "--name",
@@ -329,7 +342,7 @@ export async function openSession({ agent, model = null, effort = null, sessionN
   const close = async () => {
     if (closed) return;
     closed = true;
-    const result = await run([acpxAgent, "sessions", "close", sessionName], {
+    const result = await run([...acpxAgentArgs, "sessions", "close", sessionName], {
       timeoutMs: 30_000,
       cwd,
       env: invocation.env,
@@ -340,9 +353,12 @@ export async function openSession({ agent, model = null, effort = null, sessionN
 
   try {
     if (effort && invocation.setEffortKey) {
-      const set = await run([acpxAgent, "-s", sessionName, "set", invocation.setEffortKey, effort], runOpts);
+      const set = await run([...acpxAgentArgs, "-s", sessionName, "set", invocation.setEffortKey, effort], runOpts);
       if (set.code !== 0) {
-        notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${effort}`);
+        throw new AcpxError(
+          `acpx ${agent} could not apply invocation-scoped effort=${effort}: ${firstLine(set.stderr) || `exit ${set.code}`}`,
+          set,
+        );
       }
     }
   } catch (err) {
@@ -364,7 +380,7 @@ export async function openSession({ agent, model = null, effort = null, sessionN
       ...baseArgs({ cwd, model: null, timeoutSeconds, approveReads, approveAll, suppressReads }),
       "--prompt-retries",
       String(promptRetries),
-      acpxAgent,
+      ...acpxAgentArgs,
       "-s",
       sessionName,
       "--file",
@@ -420,11 +436,20 @@ export async function sessionPrompt({
     session = await openSession({ agent, model, effort, sessionName, cwd });
   } catch (err) {
     if (!(err instanceof AcpxError) || !err.unsupported) throw err;
+    if (effort && (agent === "claude" || agent === "codex")) {
+      throw new UserError(
+        `${agent} cannot apply invocation-scoped effort=${effort} because its acpx adapter does not support sessions`,
+        "upgrade acpx or omit the effort override",
+      );
+    }
     const notes = [`session unsupported for ${agent}; fell back to exec one-shot`];
-    if (effort) notes.push(`${agent} cannot set effort without a session; ran without effort=${effort}`);
+    if (effort && agent === "opencode") {
+      notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${effort}`);
+    }
     const fallback = await execOneShot({
       agent,
       model,
+      effort: agent === "opencode" ? null : effort,
       promptFile,
       cwd,
       timeoutSeconds,

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 
 import { warn } from "./logger.js";
 import { runCapture } from "./subprocess.js";
+import { prepareHarnessInvocation } from "./harness-invoke.js";
 import * as piStore from "./discovery/adapters/pi.js";
 import { readJsonl } from "./discovery/adapters/shared.js";
 
@@ -32,13 +33,13 @@ export function acpxAgentName(agent) {
 }
 
 /**
- * The session config-option id each adapter uses for reasoning effort. There is no
- * shared ACP name for it and `acpx status` does not expose config options, so this
- * small table is measured (see the ordered-defaults design report) rather than
- * derived. Adapters absent here (grok, opencode) advertise no effort option at all;
- * effort is then skipped with a report note, never silently.
+ * The session config-option id each adapter uses for reasoning effort when that
+ * `set` is session-local. Pi is absent: ACP `set thought_level` rewrites
+ * `~/.pi/agent/settings.json`, so Pi effort is process `--thinking` instead
+ * (`src/harness-invoke.js`). Grok uses process `--reasoning-effort`. OpenCode
+ * has no overlay; effort is skipped with a report note, never silently.
  */
-export const EFFORT_OPTION_KEYS = { codex: "reasoning_effort", claude: "effort", pi: "thought_level" };
+export const EFFORT_OPTION_KEYS = { codex: "reasoning_effort", claude: "effort" };
 
 export function effortOptionKey(agent) {
   return EFFORT_OPTION_KEYS[agent] || null;
@@ -60,7 +61,7 @@ export class AcpxError extends Error {
 
 /**
  * @param {string[]} args
- * @param {{ timeoutMs?: number, cwd?: string, input?: string }} [options]
+ * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv }} [options]
  */
 function run(args, options = {}) {
   return runCapture(ACPX_BIN, args, options);
@@ -237,8 +238,9 @@ export async function execOneShot({
   approveReads = true,
   suppressReads = true,
 }) {
+  const invocation = prepareHarnessInvocation({ agent, model });
   const args = [
-    ...baseArgs({ cwd, model, timeoutSeconds, approveReads, suppressReads }),
+    ...baseArgs({ cwd, model: invocation.acpxModel, timeoutSeconds, approveReads, suppressReads }),
     "--prompt-retries",
     String(promptRetries),
     acpxAgentName(agent),
@@ -248,28 +250,33 @@ export async function execOneShot({
   ];
 
   const startedAt = Date.now();
-  const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd });
-  if (result.spawnError && result.spawnError.code === "ENOENT") throw notFoundError(result);
-  if (result.timedOut) {
-    throw new AcpxError(`acpx ${agent} exec timed out after ${timeoutSeconds}s`, result);
-  }
-  if (result.code !== 0) {
-    throw new AcpxError(`acpx ${agent} exec failed (exit ${result.code})`, result);
-  }
+  try {
+    const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
+    if (result.spawnError && result.spawnError.code === "ENOENT") throw notFoundError(result);
+    if (result.timedOut) {
+      throw new AcpxError(`acpx ${agent} exec timed out after ${timeoutSeconds}s`, result);
+    }
+    if (result.code !== 0) {
+      throw new AcpxError(`acpx ${agent} exec failed (exit ${result.code})`, result);
+    }
 
-  const combined = `${result.stdout}\n${result.stderr}`;
-  const usage = parseTokenLine(combined) ?? recoverUsageFromStore({ agent, promptFile, cwd, startedAt });
-  return { text: stripAcpxNoise(result.stdout), usage, raw: result.stdout };
+    const combined = `${result.stdout}\n${result.stderr}`;
+    const usage = parseTokenLine(combined) ?? recoverUsageFromStore({ agent, promptFile, cwd, startedAt });
+    return { text: stripAcpxNoise(result.stdout), usage, raw: result.stdout };
+  } finally {
+    invocation.dispose();
+  }
 }
 
 /**
  * A named session that stays open across turns (design section 5).
  *
- * Reasoning effort is a session config option on every adapter that has one, and
- * `exec` cannot set it - so any call that wants effort applied goes through a session.
- * Synthesis also needs more than one turn in the same context: the agent edits the
- * staging copy, then annotates the changes backpass measured. Adapters that do not
- * advertise an effort option skip that step with a report line - never silently.
+ * Model and effort are applied as invocation-scoped overlays (`src/harness-invoke.js`),
+ * never by rewriting persistent harness defaults. `exec` cannot carry process-level
+ * effort for every harness, so an effortful call still goes through a session when
+ * the overlay needs one. Synthesis also needs more than one turn in the same context:
+ * the agent edits the staging copy, then annotates the changes backpass measured.
+ * Adapters that cannot apply effort skip that overlay with a report line - never silently.
  *
  * Resolves to the handle, or throws an `AcpxError` (`unsupported: true` when the adapter
  * has no session support at all, which `sessionPrompt` turns into an exec fallback).
@@ -281,11 +288,27 @@ export async function execOneShot({
  *   close: () => Promise<void> }>}
  */
 export async function openSession({ agent, model = null, effort = null, sessionName, cwd }) {
-  const notes = [];
+  const invocation = prepareHarnessInvocation({ agent, model, effort });
+  const notes = [...invocation.notes];
   const acpxAgent = acpxAgentName(agent);
-  const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs: 60_000, cwd });
-  if (created.spawnError && created.spawnError.code === "ENOENT") throw notFoundError(created);
+  const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
+  const created = await run(
+    [
+      ...(invocation.acpxModel ? ["--model", invocation.acpxModel] : []),
+      acpxAgent,
+      "sessions",
+      "new",
+      "--name",
+      sessionName,
+    ],
+    runOpts,
+  );
+  if (created.spawnError && created.spawnError.code === "ENOENT") {
+    invocation.dispose();
+    throw notFoundError(created);
+  }
   if (created.code !== 0) {
+    invocation.dispose();
     // An auth or spawn failure must surface as such so the caller can fall through.
     if (classifyAcpxFailure(created)) {
       throw new AcpxError(`acpx ${agent} session create failed: ${firstLine(created.stderr)}`, created);
@@ -306,26 +329,19 @@ export async function openSession({ agent, model = null, effort = null, sessionN
   const close = async () => {
     if (closed) return;
     closed = true;
-    const result = await run([acpxAgent, "sessions", "close", sessionName], { timeoutMs: 30_000, cwd });
+    const result = await run([acpxAgent, "sessions", "close", sessionName], {
+      timeoutMs: 30_000,
+      cwd,
+      env: invocation.env,
+    });
     if (result.code !== 0) warn(`could not close acpx session ${sessionName}`);
+    invocation.dispose();
   };
 
   try {
-    if (model) {
-      const set = await run([acpxAgent, "-s", sessionName, "set", "model", model], { timeoutMs: 60_000, cwd });
+    if (effort && invocation.setEffortKey) {
+      const set = await run([acpxAgent, "-s", sessionName, "set", invocation.setEffortKey, effort], runOpts);
       if (set.code !== 0) {
-        if (classifyAcpxFailure(set) === "model-unavailable") {
-          throw new AcpxError(`acpx ${agent} rejected model ${model}: ${firstLine(set.stderr)}`, set);
-        }
-        notes.push(`could not set model=${model} on ${agent}: ${firstLine(set.stderr)}`);
-      }
-    }
-    if (effort) {
-      const key = effortOptionKey(agent);
-      const set = key
-        ? await run([acpxAgent, "-s", sessionName, "set", key, effort], { timeoutMs: 60_000, cwd })
-        : null;
-      if (!set || set.code !== 0) {
         notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${effort}`);
       }
     }
@@ -354,7 +370,7 @@ export async function openSession({ agent, model = null, effort = null, sessionN
       "--file",
       promptFile,
     ];
-    const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd });
+    const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
     if (result.code !== 0) throw new AcpxError(`acpx ${agent} session prompt failed (exit ${result.code})`, result);
 

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -172,9 +172,7 @@ function baseArgs({ cwd, model, timeoutSeconds, approveReads, approveAll = false
 }
 
 function invocationAgentArgs(invocation, agent) {
-  return invocation.acpxAgentCommand
-    ? ["--agent", invocation.acpxAgentCommand]
-    : [acpxAgentName(agent)];
+  return invocation.acpxAgentCommand ? ["--agent", invocation.acpxAgentCommand] : [acpxAgentName(agent)];
 }
 
 async function verifyHarnessInvocation(invocation, cwd) {

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -137,8 +137,8 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
       timeoutSeconds: config.timeoutSeconds,
       promptRetries: config.promptRetries,
     };
-    // Effort is a session config option, so an effortful analysis call needs a
-    // (fresh, per-transcript) session; without effort the plain one-shot is cheaper.
+    // Route effortful calls through a fresh per-transcript session so each harness's
+    // invocation-scoped overlay or safe fallback is applied; otherwise one-shot is cheaper.
     if (!pick.effort) return execOneShot(call);
     callCounter += 1;
     return sessionPrompt({

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -8,7 +8,7 @@ import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt } from "./prompts.js";
 import { evidenceKey, isEvidenceFresh, safeFileName } from "./state.js";
 import { emitProgress } from "./progress.js";
-import { color, info, warn } from "./logger.js";
+import { UserError, color, info, warn } from "./logger.js";
 
 /**
  * Stage 1 of the pipeline (design section 3): one cheap model call per transcript,
@@ -265,6 +265,7 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
         emitProgress("analyze:evidence", { ...evidenceTotals });
       }
     } catch (err) {
+      if (err instanceof UserError) throw err;
       // Per-transcript fail-soft: recorded, listed by `backpass status`, retried next run.
       summary.failed += 1;
       warn(`${transcript.harness} ${transcriptLabel(transcript)}: ${err.message}`);

--- a/src/cli.js
+++ b/src/cli.js
@@ -99,10 +99,10 @@ MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
   Setting an agent pins that pass and skips its ladder.
   --analysis-agent <a>     acpx agent for the per-transcript pass       [auto]
   --analysis-model <id>    model id for the analysis pass (needs --analysis-agent)
-  --analysis-effort <e>    reasoning effort, when the adapter advertises it  [medium]
+  --analysis-effort <e>    one-off reasoning effort, when supported          [medium]
   --synthesis-agent <a>    acpx agent for the final proposal pass       [auto]
   --synthesis-model <id>   model id for the synthesis pass (needs --synthesis-agent)
-  --synthesis-effort <e>   reasoning effort for synthesis               [high]
+  --synthesis-effort <e>   one-off reasoning effort for synthesis            [high]
   --no-auto-agent          skip the ladders and pin codex / claude (the pre-0.2 defaults)
   --jobs <n>               parallel analysis calls                      [4]
 

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -16,7 +16,7 @@ import { UserError } from "./logger.js";
  *
  * How each invoked harness applies a requested overlay for this spawn:
  *   pi        process argv via `PI_ACP_PI_COMMAND` wrapper: `--model`, `--thinking`
- *   grok      process argv via a PATH wrapper: `-m`, `--reasoning-effort`
+ *   grok      process argv via acpx `--agent` wrapper: `-m`, `--reasoning-effort`
  *   claude    acpx `--model` at `sessions new` (session/new `_meta`); ACP `set effort`
  *   codex     acpx `--model` at `sessions new`; ACP `set reasoning_effort`
  *   opencode  acpx `--model` at `sessions new`; no effort overlay (report, never pretend)
@@ -34,6 +34,7 @@ const SESSION_LOCAL_EFFORT_KEYS = { codex: "reasoning_effort", claude: "effort" 
  *   env: Record<string, string> | undefined,
  *   acpxModel: string | null,
  *   setEffortKey: string | null,
+ *   acpxAgentCommand: string | null,
  *   notes: string[],
  *   dispose: () => void,
  * }} HarnessInvocation
@@ -60,7 +61,7 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
   const requestedEffort = typeof effort === "string" && effort.trim() ? effort.trim() : null;
 
   if (!requestedModel && !requestedEffort) {
-    return { env: undefined, acpxModel: null, setEffortKey: null, notes, dispose };
+    return { env: undefined, acpxModel: null, setEffortKey: null, acpxAgentCommand: null, notes, dispose };
   }
 
   try {
@@ -71,6 +72,7 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
         env: undefined,
         acpxModel: requestedModel,
         setEffortKey: requestedEffort ? SESSION_LOCAL_EFFORT_KEYS[agent] : null,
+        acpxAgentCommand: null,
         notes,
         dispose,
       };
@@ -79,7 +81,14 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
       if (requestedEffort) {
         notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${requestedEffort}`);
       }
-      return { env: undefined, acpxModel: requestedModel, setEffortKey: null, notes, dispose };
+      return {
+        env: undefined,
+        acpxModel: requestedModel,
+        setEffortKey: null,
+        acpxAgentCommand: null,
+        notes,
+        dispose,
+      };
     }
     throw new UserError(
       `${agent} has no proven invocation-scoped way to apply ${describeOverride(requestedModel, requestedEffort)} without writing persistent harness defaults`,
@@ -109,6 +118,7 @@ function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispos
     env: { PI_ACP_PI_COMMAND: wrapperPath },
     acpxModel: null,
     setEffortKey: null,
+    acpxAgentCommand: null,
     notes,
     dispose,
   };
@@ -118,6 +128,7 @@ function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, disp
   const extra = [];
   if (requestedModel) extra.push("-m", requestedModel);
   if (requestedEffort) extra.push("--reasoning-effort", requestedEffort);
+  extra.push("agent", "stdio");
   const real = resolveOnPath("grok");
   if (!real) {
     throw new UserError(
@@ -125,12 +136,13 @@ function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, disp
       "install the grok CLI, or pin a different agent / omit the model and effort override",
     );
   }
-  const { dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "grok" });
+  const { wrapperPath, dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "grok" });
   cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
   return {
-    env: { PATH: `${dir}${path.delimiter}${process.env.PATH || ""}` },
+    env: undefined,
     acpxModel: null,
     setEffortKey: null,
+    acpxAgentCommand: wrapperPath,
     notes,
     dispose,
   };

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { UserError } from "./logger.js";
+
+/**
+ * Invocation-scoped model and effort overlays (`src/acpx.js` is the caller).
+ *
+ * A one-off model or reasoning level must ride on this spawn only. Isolated Pi
+ * reproduction (throwaway `PI_CODING_AGENT_DIR`): RPC `set_model` /
+ * `set_thinking_level` rewrite `settings.json`; `pi --model` / `--thinking` at
+ * process start select the values for that process and leave defaults untouched.
+ * acpx `--model` after `session/new` is ACP `setSessionModel`, which is that
+ * persist path for Pi, so Pi never gets `--model` on acpx or a later `set`.
+ *
+ * How each invoked harness applies a requested overlay for this spawn:
+ *   pi        process argv via `PI_ACP_PI_COMMAND` wrapper: `--model`, `--thinking`
+ *   grok      process argv via a PATH wrapper: `-m`, `--reasoning-effort`
+ *   claude    acpx `--model` at `sessions new` (session/new `_meta`); ACP `set effort`
+ *   codex     acpx `--model` at `sessions new`; ACP `set reasoning_effort`
+ *   opencode  acpx `--model` at `sessions new`; no effort overlay (report, never pretend)
+ *
+ * No overlay requested means no wrapper, no `--model`, no `set` - same spawn as before.
+ * A requested overlay with no proven invocation-scoped mechanism throws rather than
+ * writing persistent defaults or silently ignoring the request.
+ */
+
+/** ACP session-config ids used only when that `set` is session-local, not a persist path. */
+const SESSION_LOCAL_EFFORT_KEYS = { codex: "reasoning_effort", claude: "effort" };
+
+/**
+ * @typedef {{
+ *   env: Record<string, string> | undefined,
+ *   acpxModel: string | null,
+ *   setEffortKey: string | null,
+ *   notes: string[],
+ *   dispose: () => void,
+ * }} HarnessInvocation
+ */
+
+/**
+ * @param {{ agent: string, model?: string | null, effort?: string | null }} options
+ * @returns {HarnessInvocation}
+ */
+export function prepareHarnessInvocation({ agent, model = null, effort = null }) {
+  const notes = [];
+  const cleanups = [];
+  const dispose = () => {
+    for (const fn of cleanups.splice(0)) {
+      try {
+        fn();
+      } catch {
+        // Temp wrappers are best-effort to remove.
+      }
+    }
+  };
+
+  const requestedModel = typeof model === "string" && model.trim() ? model.trim() : null;
+  const requestedEffort = typeof effort === "string" && effort.trim() ? effort.trim() : null;
+
+  if (!requestedModel && !requestedEffort) {
+    return { env: undefined, acpxModel: null, setEffortKey: null, notes, dispose };
+  }
+
+  try {
+    if (agent === "pi") return piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose });
+    if (agent === "grok") return grokInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose });
+    if (agent === "claude" || agent === "codex") {
+      return {
+        env: undefined,
+        acpxModel: requestedModel,
+        setEffortKey: requestedEffort ? SESSION_LOCAL_EFFORT_KEYS[agent] : null,
+        notes,
+        dispose,
+      };
+    }
+    if (agent === "opencode") {
+      if (requestedEffort) {
+        notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${requestedEffort}`);
+      }
+      return { env: undefined, acpxModel: requestedModel, setEffortKey: null, notes, dispose };
+    }
+    throw new UserError(
+      `${agent} has no proven invocation-scoped way to apply ${describeOverride(requestedModel, requestedEffort)} without writing persistent harness defaults`,
+      "pin pi, claude, codex, grok, or opencode, or omit the model and effort override",
+    );
+  } catch (err) {
+    dispose();
+    throw err;
+  }
+}
+
+function describeOverride(model, effort) {
+  const bits = [];
+  if (model) bits.push(`model=${model}`);
+  if (effort) bits.push(`effort=${effort}`);
+  return bits.join(" and ");
+}
+
+function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose }) {
+  const extra = [];
+  if (requestedModel) extra.push("--model", requestedModel);
+  if (requestedEffort) extra.push("--thinking", requestedEffort);
+  const real = process.env.PI_ACP_PI_COMMAND || "pi";
+  const { wrapperPath, dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "pi" });
+  cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return {
+    env: { PI_ACP_PI_COMMAND: wrapperPath },
+    acpxModel: null,
+    setEffortKey: null,
+    notes,
+    dispose,
+  };
+}
+
+function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose }) {
+  const extra = [];
+  if (requestedModel) extra.push("-m", requestedModel);
+  if (requestedEffort) extra.push("--reasoning-effort", requestedEffort);
+  const real = resolveOnPath("grok");
+  if (!real) {
+    throw new UserError(
+      `cannot apply ${describeOverride(requestedModel, requestedEffort)} as grok process flags because grok was not found on PATH`,
+      "install the grok CLI, or pin a different agent / omit the model and effort override",
+    );
+  }
+  const { dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "grok" });
+  cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return {
+    env: { PATH: `${dir}${path.delimiter}${process.env.PATH || ""}` },
+    acpxModel: null,
+    setEffortKey: null,
+    notes,
+    dispose,
+  };
+}
+
+/**
+ * Write a node wrapper that prepends `extraArgs` and execs `realCommand` with
+ * inherited stdio. Args are JSON-encoded so values with spaces or `$()` stay literal.
+ *
+ * @param {{ realCommand: string, extraArgs: string[], binName: string }} options
+ */
+function writeArgvWrapper({ realCommand, extraArgs, binName }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-wrap-"));
+  const wrapperPath = path.join(dir, binName);
+  const payload = JSON.stringify({ real: realCommand, extra: extraArgs });
+  fs.writeFileSync(
+    wrapperPath,
+    `#!${process.execPath}
+const { spawn } = require("node:child_process");
+const { real, extra } = ${payload};
+const child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
+child.on("error", (err) => {
+  console.error(err.message);
+  process.exit(1);
+});
+child.on("exit", (code, signal) => {
+  if (signal) {
+    try { process.kill(process.pid, signal); } catch {}
+  }
+  process.exit(code ?? 1);
+});
+`,
+  );
+  fs.chmodSync(wrapperPath, 0o755);
+  return { wrapperPath, dir };
+}
+
+function resolveOnPath(bin) {
+  if (path.isAbsolute(bin) && isExecutable(bin)) return bin;
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, bin);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+function isExecutable(file) {
+  try {
+    const st = fs.statSync(file);
+    return st.isFile() && Boolean(st.mode & 0o111);
+  } catch {
+    return false;
+  }
+}

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -128,7 +128,13 @@ function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispos
   const extra = [];
   if (requestedModel) extra.push("--model", requestedModel);
   if (requestedEffort) extra.push("--thinking", requestedEffort);
-  const real = "pi";
+  const real = resolveOnPath("pi");
+  if (!real || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(real))) {
+    throw new UserError(
+      `cannot apply ${describeOverride(requestedModel, requestedEffort)} as safe Pi process arguments on this platform`,
+      "install Pi as a directly executable binary, or omit the model and effort override",
+    );
+  }
   const { wrapperPath, dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "pi" });
   cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
   return {
@@ -143,6 +149,12 @@ function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispos
 }
 
 function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose }) {
+  if (process.platform === "win32") {
+    throw new UserError(
+      `cannot apply ${describeOverride(requestedModel, requestedEffort)} through acpx --agent on Windows`,
+      "pin pi, claude, codex, or opencode, or omit the model and effort override",
+    );
+  }
   const extra = [];
   if (requestedModel) extra.push("-m", requestedModel);
   if (requestedEffort) extra.push("--reasoning-effort", requestedEffort);
@@ -154,13 +166,13 @@ function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, disp
       "install the grok CLI, or pin a different agent / omit the model and effort override",
     );
   }
-  const { wrapperPath, dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "grok" });
+  const { nodeCommand, dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "grok" });
   cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
   return {
     env: undefined,
     acpxModel: null,
     setEffortKey: null,
-    acpxAgentCommand: wrapperPath,
+    acpxAgentCommand: nodeCommand,
     requiredBuiltinAgent: null,
     notes,
     dispose,
@@ -175,11 +187,11 @@ function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, disp
  */
 function writeArgvWrapper({ realCommand, extraArgs, binName }) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-wrap-"));
-  const wrapperPath = path.join(dir, binName);
+  const scriptPath = path.join(dir, `${binName}.cjs`);
   const payload = JSON.stringify({ real: realCommand, extra: extraArgs });
   fs.writeFileSync(
-    wrapperPath,
-    `#!${process.execPath}
+    scriptPath,
+    `#!/usr/bin/env node
 const { spawn } = require("node:child_process");
 const { real, extra } = ${payload};
 const child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
@@ -216,16 +228,33 @@ child.on("exit", (code, signal) => {
 });
 `,
   );
-  fs.chmodSync(wrapperPath, 0o755);
-  return { wrapperPath, dir };
+  let wrapperPath = scriptPath;
+  if (process.platform === "win32") {
+    wrapperPath = path.join(dir, `${binName}.cmd`);
+    fs.writeFileSync(wrapperPath, `@echo off\r\n${cmdQuote(process.execPath)} ${cmdQuote(scriptPath)} %*\r\n`);
+  } else {
+    fs.chmodSync(scriptPath, 0o755);
+  }
+  return { wrapperPath, nodeCommand: renderCommandArgv([process.execPath, scriptPath]), dir };
+}
+
+function renderCommandArgv(argv) {
+  return argv.map((arg) => JSON.stringify(arg)).join(" ");
+}
+
+function cmdQuote(value) {
+  return `"${value.replaceAll("%", "%%").replaceAll('"', '""')}"`;
 }
 
 function resolveOnPath(bin) {
   if (path.isAbsolute(bin) && isExecutable(bin)) return bin;
+  const extensions = process.platform === "win32" ? (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";") : [""];
   for (const dir of (process.env.PATH || "").split(path.delimiter)) {
     if (!dir) continue;
-    const candidate = path.join(dir, bin);
-    if (isExecutable(candidate)) return candidate;
+    for (const extension of extensions) {
+      const candidate = path.join(dir, process.platform === "win32" ? `${bin}${extension.toLowerCase()}` : bin);
+      if (isExecutable(candidate)) return candidate;
+    }
   }
   return null;
 }
@@ -233,7 +262,7 @@ function resolveOnPath(bin) {
 function isExecutable(file) {
   try {
     const st = fs.statSync(file);
-    return st.isFile() && Boolean(st.mode & 0o111);
+    return st.isFile() && (process.platform === "win32" || Boolean(st.mode & 0o111));
   } catch {
     return false;
   }

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -82,7 +82,7 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
         acpxModel: requestedModel,
         setEffortKey: requestedEffort ? SESSION_LOCAL_EFFORT_KEYS[agent] : null,
         acpxAgentCommand: null,
-        requiredBuiltinAgent: null,
+        requiredBuiltinAgent: agent,
         notes,
         dispose,
       };
@@ -96,7 +96,7 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
         acpxModel: requestedModel,
         setEffortKey: null,
         acpxAgentCommand: null,
-        requiredBuiltinAgent: null,
+        requiredBuiltinAgent: agent,
         notes,
         dispose,
       };
@@ -119,10 +119,16 @@ function describeOverride(model, effort) {
 }
 
 function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose }) {
+  if (process.env.PI_ACP_PI_COMMAND) {
+    throw new UserError(
+      "cannot safely apply Pi model or effort overrides when PI_ACP_PI_COMMAND replaces the proven Pi command",
+      "unset PI_ACP_PI_COMMAND or omit the model and effort override",
+    );
+  }
   const extra = [];
   if (requestedModel) extra.push("--model", requestedModel);
   if (requestedEffort) extra.push("--thinking", requestedEffort);
-  const real = process.env.PI_ACP_PI_COMMAND || "pi";
+  const real = "pi";
   const { wrapperPath, dir } = writeArgvWrapper({ realCommand: real, extraArgs: extra, binName: "pi" });
   cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
   return {

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -23,7 +23,8 @@ import { UserError } from "./logger.js";
  *
  * No overlay requested means no wrapper, no `--model`, no `set` - same spawn as before.
  * A requested overlay with no proven invocation-scoped mechanism throws rather than
- * writing persistent defaults or silently ignoring the request.
+ * writing persistent defaults or silently ignoring the request. OpenCode effort is the
+ * sole explicit exception: it is skipped with a report note.
  */
 
 /** ACP session-config ids used only when that `set` is session-local, not a persist path. */

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -178,9 +178,18 @@ const { spawn } = require("node:child_process");
 const { real, extra } = ${payload};
 const child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
 const signals = ["SIGTERM", "SIGINT", "SIGHUP"];
+let escalationTimer = null;
 const forwardSignal = (signal) => {
   if (child.exitCode !== null || child.signalCode !== null) return;
   try { child.kill(signal); } catch {}
+  if (!escalationTimer) {
+    escalationTimer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        try { child.kill("SIGKILL"); } catch {}
+      }
+    }, 4000);
+    escalationTimer.unref();
+  }
 };
 const signalHandlers = new Map(signals.map((signal) => [signal, () => forwardSignal(signal)]));
 for (const [signal, handler] of signalHandlers) process.on(signal, handler);
@@ -189,6 +198,7 @@ child.on("error", (err) => {
   process.exit(1);
 });
 child.on("exit", (code, signal) => {
+  if (escalationTimer) clearTimeout(escalationTimer);
   for (const [name, handler] of signalHandlers) process.removeListener(name, handler);
   if (signal) {
     try {

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -239,7 +239,7 @@ child.on("exit", (code, signal) => {
 }
 
 function renderCommandArgv(argv) {
-  return argv.map((arg) => JSON.stringify(arg)).join(" ");
+  return argv.map((arg) => `'${arg.replaceAll("'", "'\\''")}'`).join(" ");
 }
 
 function cmdQuote(value) {

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -35,6 +35,7 @@ const SESSION_LOCAL_EFFORT_KEYS = { codex: "reasoning_effort", claude: "effort" 
  *   acpxModel: string | null,
  *   setEffortKey: string | null,
  *   acpxAgentCommand: string | null,
+ *   requiredBuiltinAgent: string | null,
  *   notes: string[],
  *   dispose: () => void,
  * }} HarnessInvocation
@@ -61,7 +62,15 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
   const requestedEffort = typeof effort === "string" && effort.trim() ? effort.trim() : null;
 
   if (!requestedModel && !requestedEffort) {
-    return { env: undefined, acpxModel: null, setEffortKey: null, acpxAgentCommand: null, notes, dispose };
+    return {
+      env: undefined,
+      acpxModel: null,
+      setEffortKey: null,
+      acpxAgentCommand: null,
+      requiredBuiltinAgent: null,
+      notes,
+      dispose,
+    };
   }
 
   try {
@@ -73,6 +82,7 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
         acpxModel: requestedModel,
         setEffortKey: requestedEffort ? SESSION_LOCAL_EFFORT_KEYS[agent] : null,
         acpxAgentCommand: null,
+        requiredBuiltinAgent: null,
         notes,
         dispose,
       };
@@ -86,6 +96,7 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
         acpxModel: requestedModel,
         setEffortKey: null,
         acpxAgentCommand: null,
+        requiredBuiltinAgent: null,
         notes,
         dispose,
       };
@@ -119,6 +130,7 @@ function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispos
     acpxModel: null,
     setEffortKey: null,
     acpxAgentCommand: null,
+    requiredBuiltinAgent: "pi",
     notes,
     dispose,
   };
@@ -143,6 +155,7 @@ function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, disp
     acpxModel: null,
     setEffortKey: null,
     acpxAgentCommand: wrapperPath,
+    requiredBuiltinAgent: null,
     notes,
     dispose,
   };

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -177,13 +177,24 @@ function writeArgvWrapper({ realCommand, extraArgs, binName }) {
 const { spawn } = require("node:child_process");
 const { real, extra } = ${payload};
 const child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
+const signals = ["SIGTERM", "SIGINT", "SIGHUP"];
+const forwardSignal = (signal) => {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try { child.kill(signal); } catch {}
+};
+const signalHandlers = new Map(signals.map((signal) => [signal, () => forwardSignal(signal)]));
+for (const [signal, handler] of signalHandlers) process.on(signal, handler);
 child.on("error", (err) => {
   console.error(err.message);
   process.exit(1);
 });
 child.on("exit", (code, signal) => {
+  for (const [name, handler] of signalHandlers) process.removeListener(name, handler);
   if (signal) {
-    try { process.kill(process.pid, signal); } catch {}
+    try {
+      process.kill(process.pid, signal);
+      return;
+    } catch {}
   }
   process.exit(code ?? 1);
 });

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -8,12 +8,16 @@ import { spawn } from "node:child_process";
  *
  * @param {string} bin
  * @param {string[]} args
- * @param {{ timeoutMs?: number, cwd?: string, input?: string }} [options]
+ * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv }} [options]
  * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: NodeJS.ErrnoException }>}
  */
-export function runCapture(bin, args, { timeoutMs, cwd, input } = {}) {
+export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
   return new Promise((resolve) => {
-    const child = spawn(bin, args, { cwd, stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn(bin, args, {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: env ? { ...process.env, ...env } : undefined,
+    });
     let stdout = "";
     let stderr = "";
     let timedOut = false;

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -53,6 +53,7 @@ export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
     });
     child.on("close", (code) => {
       if (timer) clearTimeout(timer);
+      if (timedOut && process.platform !== "win32") killPosixGroup(child, "SIGKILL");
       if (escalationTimer) clearTimeout(escalationTimer);
       resolve({ code, stdout, stderr, timedOut });
     });

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -17,16 +17,26 @@ export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: env ? { ...process.env, ...env } : undefined,
+      // Give a timed command its own POSIX process group. acpx launches adapter
+      // wrappers and harnesses below itself, and killing acpx alone leaves those
+      // descendants running with our capture pipes open.
+      detached: process.platform !== "win32" && Boolean(timeoutMs),
     });
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let escalationTimer = null;
 
     const timer = timeoutMs
       ? setTimeout(() => {
           timedOut = true;
-          child.kill("SIGTERM");
-          setTimeout(() => child.kill("SIGKILL"), 5000).unref();
+          if (process.platform === "win32") {
+            killWindowsTree(child.pid);
+            return;
+          }
+          killPosixGroup(child, "SIGTERM");
+          escalationTimer = setTimeout(() => killPosixGroup(child, "SIGKILL"), 5000);
+          escalationTimer.unref();
         }, timeoutMs)
       : null;
 
@@ -38,14 +48,47 @@ export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
     });
     child.on("error", (err) => {
       if (timer) clearTimeout(timer);
+      if (escalationTimer) clearTimeout(escalationTimer);
       resolve({ code: null, stdout, stderr: `${stderr}${err.message}`, spawnError: err });
     });
     child.on("close", (code) => {
       if (timer) clearTimeout(timer);
+      if (escalationTimer) clearTimeout(escalationTimer);
       resolve({ code, stdout, stderr, timedOut });
     });
 
     if (input !== undefined) child.stdin.end(input);
     else child.stdin.end();
   });
+}
+
+function killPosixGroup(child, signal) {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    // Preserve direct-child cleanup if a platform cannot address the group.
+    try {
+      child.kill(signal);
+    } catch {
+      // The child already closed.
+    }
+  }
+}
+
+function killWindowsTree(pid) {
+  if (!pid) return;
+  const killer = spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  killer.on("error", () => {
+    // taskkill is part of Windows, but retain direct-child cleanup if it cannot start.
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The child already closed.
+    }
+  });
+  killer.unref();
 }

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -442,6 +442,6 @@ test("acpx failure classification and the per-adapter tables", () => {
   assert.equal(acpxAgentName("codex"), "codex");
   assert.equal(effortOptionKey("codex"), "reasoning_effort");
   assert.equal(effortOptionKey("claude"), "effort");
-  assert.equal(effortOptionKey("pi"), "thought_level");
+  assert.equal(effortOptionKey("pi"), null, "Pi effort is process --thinking, not ACP set");
   assert.equal(effortOptionKey("grok"), null);
 });

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawn, spawnSync } from "node:child_process";
 
 /**
@@ -49,7 +50,16 @@ fs.writeFileSync(
   fakePi,
   `#!${process.execPath}
 const fs = require("node:fs");
-fs.appendFileSync(process.env.FAKE_PI_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_PI_LOG, JSON.stringify(args) + "\\n");
+if (!args.includes("--model")) {
+  const settings = JSON.parse(fs.readFileSync(process.env.FAKE_HARNESS_SETTINGS, "utf8"));
+  process.stdout.write(JSON.stringify({
+    provider: settings.defaultProvider,
+    model: settings.defaultModel,
+    thinking: settings.defaultThinkingLevel,
+  }) + "\\n");
+}
 process.exit(0);
 `,
 );
@@ -78,7 +88,8 @@ fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify({
 }) + "\\n");
 const settings = process.env.FAKE_HARNESS_SETTINGS;
 if (argv.includes("config") && argv.includes("show")) {
-  const agents = process.env.FAKE_PI_REPLACEMENT === "1" ? { pi: { argv: ["custom-pi-adapter"] } } : {};
+  const replacement = process.env.FAKE_REPLACEMENT_AGENT;
+  const agents = replacement ? { [replacement]: { argv: ["custom-adapter"] } } : {};
   process.stdout.write(JSON.stringify({ agents }) + "\\n");
   process.exit(0);
 }
@@ -222,7 +233,7 @@ test("a Pi session with model and effort uses process --model/--thinking and lea
 test("a configured replacement Pi adapter is rejected before model or effort can be claimed", async () => {
   resetLogsAndSettings();
   const before = Buffer.from(settingsBytes());
-  process.env.FAKE_PI_REPLACEMENT = "1";
+  process.env.FAKE_REPLACEMENT_AGENT = "pi";
   try {
     await assert.rejects(
       () =>
@@ -239,7 +250,7 @@ test("a configured replacement Pi adapter is rejected before model or effort can
       },
     );
   } finally {
-    delete process.env.FAKE_PI_REPLACEMENT;
+    delete process.env.FAKE_REPLACEMENT_AGENT;
   }
   assert.equal(settingsBytes().compare(before), 0);
   assert.ok(acpxCalls().some((c) => c.argv.includes("config") && c.argv.includes("show")));
@@ -247,8 +258,33 @@ test("a configured replacement Pi adapter is rejected before model or effort can
   assert.deepEqual(jsonl(piLog), []);
 });
 
+test("a custom PI_ACP_PI_COMMAND is rejected before launch", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  process.env.PI_ACP_PI_COMMAND = fakePi;
+  try {
+    await assert.rejects(
+      () =>
+        openSession({
+          agent: "pi",
+          model: "provider/model",
+          effort: "high",
+          sessionName: "bp-pi-custom-command",
+          cwd: workDir,
+        }),
+      { name: "UserError", message: /PI_ACP_PI_COMMAND replaces the proven Pi command/ },
+    );
+  } finally {
+    delete process.env.PI_ACP_PI_COMMAND;
+  }
+  assert.equal(settingsBytes().compare(before), 0);
+  assert.deepEqual(acpxCalls(), []);
+  assert.deepEqual(jsonl(piLog), []);
+});
+
 test("the process wrapper escalates when its harness child ignores termination", async () => {
-  const signalChild = path.join(binDir, "signal-child");
+  const signalBin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-signal-bin-"));
+  const signalChild = path.join(signalBin, "pi");
   const readyPath = path.join(binDir, "signal-child.ready");
   const signalPath = path.join(binDir, "signal-child.signal");
   fs.writeFileSync(
@@ -264,16 +300,15 @@ setInterval(() => {}, 1000);
   );
   fs.chmodSync(signalChild, 0o755);
 
-  const previous = process.env.PI_ACP_PI_COMMAND;
-  process.env.PI_ACP_PI_COMMAND = signalChild;
   const invocation = prepareHarnessInvocation({ agent: "pi", model: "provider/model" });
-  if (previous === undefined) delete process.env.PI_ACP_PI_COMMAND;
-  else process.env.PI_ACP_PI_COMMAND = previous;
 
   let wrapper;
   let childPid;
   try {
-    wrapper = spawn(invocation.env.PI_ACP_PI_COMMAND, [], { stdio: "ignore" });
+    wrapper = spawn(invocation.env.PI_ACP_PI_COMMAND, [], {
+      stdio: "ignore",
+      env: { ...process.env, PATH: `${path.dirname(signalChild)}${path.delimiter}${process.env.PATH || ""}` },
+    });
     for (let attempt = 0; attempt < 100 && !fs.existsSync(readyPath); attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
@@ -411,6 +446,31 @@ test("OpenCode session passes --model at create, skips effort, and does not pers
   assert.deepEqual(setCalls(calls).map(setKey), []);
 });
 
+test("configured replacement adapters are rejected for positional built-ins", async () => {
+  for (const agent of ["claude", "codex", "opencode"]) {
+    resetLogsAndSettings();
+    const before = Buffer.from(settingsBytes());
+    process.env.FAKE_REPLACEMENT_AGENT = agent;
+    try {
+      await assert.rejects(
+        () =>
+          openSession({
+            agent,
+            model: "safe-model",
+            effort: "high",
+            sessionName: `bp-${agent}-replacement`,
+            cwd: workDir,
+          }),
+        { name: "UserError", message: new RegExp(`agents\\.${agent} replaces the proven built-in adapter`) },
+      );
+    } finally {
+      delete process.env.FAKE_REPLACEMENT_AGENT;
+    }
+    assert.equal(settingsBytes().compare(before), 0);
+    assert.ok(!acpxCalls().some((c) => c.argv.includes("new") || c.argv.includes("exec")));
+  }
+});
+
 test("Grok session forces an acpx raw-command override with process model and effort", async () => {
   resetLogsAndSettings();
   const before = Buffer.from(settingsBytes());
@@ -504,6 +564,70 @@ test("Claude and Codex stop when effort cannot be applied without a session", as
     }
     assert.ok(!acpxCalls().some((c) => c.argv.includes("exec")));
   }
+});
+
+test("the Backpass CLI applies Pi overlays without changing persistent defaults", () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-cli-repo-")));
+  const initialized = spawnSync("git", ["init", "--quiet"], { cwd: repo });
+  assert.equal(initialized.status, 0);
+  fs.writeFileSync(path.join(repo, "AGENTS.md"), "# Agent instructions\n\n- Keep changes focused.\n");
+
+  const sessionDir = path.join(fakeHome, ".pi", "agent", "sessions", "cli-e2e");
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const sessionPath = path.join(sessionDir, `${Date.now()}_cli-e2e.jsonl`);
+  const timestamp = new Date().toISOString();
+  const entries = [
+    { type: "session", version: 3, id: "cli-e2e", timestamp, cwd: repo },
+    { type: "message", message: { role: "user", content: "Please inspect the implementation." } },
+    { type: "message", message: { role: "assistant", content: "I inspected the implementation." } },
+    { type: "message", message: { role: "user", content: "Now explain the behavior." } },
+    { type: "message", message: { role: "assistant", content: "The behavior is isolated per invocation." } },
+  ];
+  fs.writeFileSync(sessionPath, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+
+  const cli = fileURLToPath(new URL("../bin/backpass.js", import.meta.url));
+  const result = spawnSync(
+    process.execPath,
+    [
+      cli,
+      "analyze",
+      "--harness",
+      "pi",
+      "--since",
+      "all",
+      "--analysis-agent",
+      "pi",
+      "--analysis-model",
+      "openai-codex/gpt-5.6-sol",
+      "--analysis-effort",
+      "high",
+      "--jobs",
+      "1",
+      "--json",
+    ],
+    { cwd: repo, env: process.env, encoding: "utf8", timeout: 15_000 },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(settingsBytes().compare(before), 0);
+  const spawned = jsonl(piLog);
+  assert.ok(spawned.length >= 1);
+  assert.deepEqual(spawned[0].slice(0, 4), [
+    "--model",
+    "openai-codex/gpt-5.6-sol",
+    "--thinking",
+    "high",
+  ]);
+  assert.deepEqual(spawned[0].slice(4), ["--mode", "rpc", "--no-themes"]);
+
+  const bare = spawnSync(fakePi, ["--mode", "rpc", "--no-themes"], {
+    env: process.env,
+    encoding: "utf8",
+  });
+  assert.equal(bare.status, 0);
+  assert.deepEqual(JSON.parse(bare.stdout), { provider: "xai", model: "grok-4.6", thinking: "high" });
+  assert.equal(settingsBytes().compare(before), 0);
 });
 
 test("an unsupported harness with a requested model stops instead of persisting", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -429,7 +429,9 @@ setInterval(() => {}, 1000);
     if (childPid) {
       try {
         process.kill(childPid, "SIGKILL");
-      } catch {}
+      } catch {
+        // The child may already have exited after the wrapper was killed.
+      }
     }
     invocation.dispose();
   }
@@ -675,12 +677,7 @@ test("the Backpass CLI applies Pi overlays without changing persistent defaults"
   assert.equal(settingsBytes().compare(before), 0);
   const spawned = jsonl(piLog);
   assert.ok(spawned.length >= 1);
-  assert.deepEqual(spawned[0].slice(0, 4), [
-    "--model",
-    "openai-codex/gpt-5.6-sol",
-    "--thinking",
-    "high",
-  ]);
+  assert.deepEqual(spawned[0].slice(0, 4), ["--model", "openai-codex/gpt-5.6-sol", "--thinking", "high"]);
   assert.deepEqual(spawned[0].slice(4), ["--mode", "rpc", "--no-themes"]);
   assertBareDefaults(before);
 });
@@ -795,7 +792,9 @@ test("the Backpass CLI keeps Pi synthesis overlays invocation-scoped", () => {
   const spawned = jsonl(piLog);
   assert.ok(spawned.some((args) => args[1] === "openai-codex/gpt-5.6-luna" && args[3] === "medium"));
   assert.ok(spawned.some((args) => args[1] === "openai-codex/gpt-5.6-sol" && args[3] === "high"));
-  assert.ok(!acpxCalls().some((call) => call.argv.includes("set") && ["model", "thought_level"].includes(setKey(call))));
+  assert.ok(
+    !acpxCalls().some((call) => call.argv.includes("set") && ["model", "thought_level"].includes(setKey(call))),
+  );
   assert.equal(settingsBytes().compare(before), 0);
   assertBareDefaults(before);
 });

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -1,0 +1,363 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Isolated harness-default mutation coverage.
+ *
+ * End-user failure: Backpass synthesis selected a Pi model via ACP `set model`,
+ * which Pi persists into `settings.json`. A later bare Pi launch then inherited
+ * that default. Isolated reproduction (temp PI_CODING_AGENT_DIR, live settings
+ * never touched): RPC `set_model` / `set_thinking_level` rewrite defaults;
+ * `pi --model` / `--thinking` at process start do not.
+ *
+ * This file drives Backpass's public acpx boundary against a fake acpx that
+ * mutates a settings fixture on `set model` / `set thought_level` (the persist
+ * path) and, when Backpass injects a process wrapper, actually spawns it the
+ * way pi-acp spawns `pi --mode rpc --no-themes`. Assertions are launched argv,
+ * wrapper-forwarded process argv, and byte-for-byte settings stability.
+ */
+
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-home-"));
+process.env.HOME = fakeHome;
+
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-bin-"));
+const fakeAcpx = path.join(binDir, "acpx");
+const fakePi = path.join(binDir, "pi");
+const fakeGrok = path.join(binDir, "grok");
+const settingsPath = path.join(fakeHome, ".pi", "agent", "settings.json");
+const acpxLog = path.join(binDir, "acpx.log");
+const piLog = path.join(binDir, "pi.log");
+const grokLog = path.join(binDir, "grok.log");
+const workDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-cwd-")));
+
+const ORIGINAL_SETTINGS = `{
+  "lastChangelogVersion": "0.84.1",
+  "defaultProvider": "xai",
+  "defaultModel": "grok-4.6",
+  "defaultThinkingLevel": "high"
+}
+`;
+
+fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+fs.writeFileSync(settingsPath, ORIGINAL_SETTINGS);
+
+fs.writeFileSync(
+  fakePi,
+  `#!${process.execPath}
+const fs = require("node:fs");
+fs.appendFileSync(process.env.FAKE_PI_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+process.exit(0);
+`,
+);
+fs.chmodSync(fakePi, 0o755);
+
+fs.writeFileSync(
+  fakeGrok,
+  `#!${process.execPath}
+const fs = require("node:fs");
+fs.appendFileSync(process.env.FAKE_GROK_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+process.exit(0);
+`,
+);
+fs.chmodSync(fakeGrok, 0o755);
+
+fs.writeFileSync(
+  fakeAcpx,
+  `#!${process.execPath}
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+const argv = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify({
+  argv,
+  cwd: process.cwd(),
+  PI_ACP_PI_COMMAND: process.env.PI_ACP_PI_COMMAND || null,
+}) + "\\n");
+const settings = process.env.FAKE_HARNESS_SETTINGS;
+const setAt = argv.indexOf("set");
+if (setAt >= 0) {
+  const key = argv[setAt + 1];
+  if (key === "model" || key === "thought_level") {
+    fs.writeFileSync(settings, JSON.stringify({ mutated: true, key }));
+  }
+  process.exit(0);
+}
+function spawnWrappedPi() {
+  const wrap = process.env.PI_ACP_PI_COMMAND;
+  if (!wrap) return;
+  spawnSync(wrap, ["--mode", "rpc", "--no-themes"], { stdio: "ignore", env: process.env });
+}
+function spawnWrappedGrok() {
+  if (process.env.FAKE_SPAWN_GROK !== "1") return;
+  spawnSync("grok", ["agent", "stdio"], { stdio: "ignore", env: process.env });
+}
+if (argv.includes("sessions") && argv.includes("new")) {
+  spawnWrappedPi();
+  spawnWrappedGrok();
+  process.exit(0);
+}
+if (argv.includes("exec")) {
+  spawnWrappedPi();
+  spawnWrappedGrok();
+  process.stdout.write('{"ok":true}\\n');
+  process.exit(0);
+}
+if (argv.includes("--file")) {
+  process.stdout.write('{"ok":true}\\n');
+  process.exit(0);
+}
+process.exit(0);
+`,
+);
+fs.chmodSync(fakeAcpx, 0o755);
+
+process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH || ""}`;
+process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+process.env.FAKE_ACPX_LOG = acpxLog;
+process.env.FAKE_PI_LOG = piLog;
+process.env.FAKE_GROK_LOG = grokLog;
+process.env.FAKE_HARNESS_SETTINGS = settingsPath;
+fs.writeFileSync(acpxLog, "");
+fs.writeFileSync(piLog, "");
+fs.writeFileSync(grokLog, "");
+
+const { execOneShot, openSession } = await import("../src/acpx.js");
+
+const promptFile = path.join(binDir, "prompt.md");
+fs.writeFileSync(promptFile, "<!-- backpass:self-session -->\nping\n");
+
+function resetLogsAndSettings() {
+  fs.writeFileSync(settingsPath, ORIGINAL_SETTINGS);
+  fs.writeFileSync(acpxLog, "");
+  fs.writeFileSync(piLog, "");
+  fs.writeFileSync(grokLog, "");
+}
+
+function settingsBytes() {
+  return fs.readFileSync(settingsPath);
+}
+
+function acpxCalls() {
+  const text = fs.readFileSync(acpxLog, "utf8").trim();
+  if (!text) return [];
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function jsonl(file) {
+  const text = fs.readFileSync(file, "utf8").trim();
+  if (!text) return [];
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function setCalls(calls) {
+  return calls.filter((c) => c.argv.includes("set"));
+}
+
+function setKey(call) {
+  const i = call.argv.indexOf("set");
+  return i >= 0 ? call.argv[i + 1] : null;
+}
+
+test("ACP set model against the isolated fixture is the persist path (pre-fix counterfactual)", () => {
+  resetLogsAndSettings();
+  const before = settingsBytes();
+  const result = spawnSync(fakeAcpx, ["pi", "-s", "x", "set", "model", "openai-codex/gpt-5.6-sol"], {
+    env: process.env,
+  });
+  assert.equal(result.status, 0);
+  assert.notEqual(settingsBytes().compare(before), 0, "set model must dirty the fixture so later tests are meaningful");
+});
+
+test("a Pi session with model and effort uses process --model/--thinking and leaves defaults unchanged", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const session = await openSession({
+    agent: "pi",
+    model: "openai-codex/gpt-5.6-sol",
+    effort: "high",
+    sessionName: "bp-pi",
+    cwd: workDir,
+  });
+  await session.close();
+
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  assert.ok(calls.some((c) => c.argv.includes("new")));
+  assert.ok(!calls.some((c) => c.argv.includes("--model")), "acpx --model is Pi's persist path");
+  assert.deepEqual(setCalls(calls).map(setKey), [], "Pi must not ACP-set model or thought_level");
+  const spawned = jsonl(piLog);
+  assert.ok(spawned.length >= 1);
+  assert.deepEqual(spawned[0].slice(0, 4), ["--model", "openai-codex/gpt-5.6-sol", "--thinking", "high"]);
+  assert.deepEqual(spawned[0].slice(4), ["--mode", "rpc", "--no-themes"]);
+
+  const bare = spawnSync(fakePi, ["--mode", "rpc", "--no-themes"], { env: process.env });
+  assert.equal(bare.status, 0);
+  assert.equal(settingsBytes().compare(before), 0);
+  const defaults = JSON.parse(settingsBytes().toString("utf8"));
+  assert.equal(defaults.defaultProvider, "xai");
+  assert.equal(defaults.defaultModel, "grok-4.6");
+  assert.equal(defaults.defaultThinkingLevel, "high");
+});
+
+test("Pi process args keep values that need literal handling, including $() and spaces", async () => {
+  resetLogsAndSettings();
+  const pwned = path.join(fakeHome, "pwned");
+  const before = Buffer.from(settingsBytes());
+  const model = 'provider/foo bar $(touch "' + pwned + '")';
+  const session = await openSession({
+    agent: "pi",
+    model,
+    effort: "medium",
+    sessionName: "bp-pi-quoted",
+    cwd: workDir,
+  });
+  await session.close();
+  assert.equal(settingsBytes().compare(before), 0);
+  assert.ok(!fs.existsSync(pwned), "model text must not be expanded by a shell");
+  const spawned = jsonl(piLog);
+  assert.equal(spawned[0][0], "--model");
+  assert.equal(spawned[0][1], model);
+  assert.equal(spawned[0][2], "--thinking");
+  assert.equal(spawned[0][3], "medium");
+});
+
+test("Pi exec one-shot with a model also uses process --model and does not persist", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  await execOneShot({
+    agent: "pi",
+    model: "openai-codex/gpt-5.6-sol:medium",
+    promptFile,
+    cwd: workDir,
+    timeoutSeconds: 5,
+  });
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  assert.ok(calls.some((c) => c.argv.includes("exec")));
+  assert.ok(!calls.some((c) => c.argv.includes("--model")));
+  assert.deepEqual(setCalls(calls).map(setKey), []);
+  const spawned = jsonl(piLog);
+  assert.deepEqual(spawned[0].slice(0, 2), ["--model", "openai-codex/gpt-5.6-sol:medium"]);
+  assert.deepEqual(spawned[0].slice(2), ["--mode", "rpc", "--no-themes"]);
+});
+
+test("Pi with no model or effort overlay does not wrap and does not persist", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const session = await openSession({ agent: "pi", sessionName: "bp-pi-default", cwd: workDir });
+  await session.close();
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  assert.ok(calls.every((c) => !c.PI_ACP_PI_COMMAND));
+  assert.ok(!calls.some((c) => c.argv.includes("--model")));
+  assert.deepEqual(setCalls(calls).map(setKey), []);
+  assert.deepEqual(jsonl(piLog), []);
+});
+
+test("Claude session passes --model at create and ACP set effort, never set model", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const session = await openSession({
+    agent: "claude",
+    model: "claude-opus-5",
+    effort: "high",
+    sessionName: "bp-claude",
+    cwd: workDir,
+  });
+  await session.close();
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  const created = calls.find((c) => c.argv.includes("new"));
+  assert.equal(created.argv[created.argv.indexOf("--model") + 1], "claude-opus-5");
+  assert.deepEqual(setCalls(calls).map(setKey), ["effort"]);
+  assert.ok(!setCalls(calls).some((c) => setKey(c) === "model"));
+});
+
+test("Codex session passes --model at create and ACP set reasoning_effort, never set model", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const session = await openSession({
+    agent: "codex",
+    model: "gpt-5.6-sol",
+    effort: "high",
+    sessionName: "bp-codex",
+    cwd: workDir,
+  });
+  await session.close();
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  const created = calls.find((c) => c.argv.includes("new"));
+  assert.equal(created.argv[created.argv.indexOf("--model") + 1], "gpt-5.6-sol");
+  assert.deepEqual(setCalls(calls).map(setKey), ["reasoning_effort"]);
+});
+
+test("OpenCode session passes --model at create, skips effort, and does not persist", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const session = await openSession({
+    agent: "opencode",
+    model: "gpt-5.6-sol",
+    effort: "high",
+    sessionName: "bp-opencode",
+    cwd: workDir,
+  });
+  assert.match(session.notes.join("\n"), /does not advertise a reasoning-effort option/);
+  await session.close();
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  const created = calls.find((c) => c.argv.includes("new"));
+  assert.equal(created.argv[created.argv.indexOf("--model") + 1], "gpt-5.6-sol");
+  assert.deepEqual(setCalls(calls).map(setKey), []);
+});
+
+test("Grok session uses process -m and --reasoning-effort and leaves defaults unchanged", async () => {
+  resetLogsAndSettings();
+  process.env.FAKE_SPAWN_GROK = "1";
+  const before = Buffer.from(settingsBytes());
+  try {
+    const session = await openSession({
+      agent: "grok",
+      model: "grok-4.6",
+      effort: "high",
+      sessionName: "bp-grok",
+      cwd: workDir,
+    });
+    await session.close();
+  } finally {
+    delete process.env.FAKE_SPAWN_GROK;
+  }
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  assert.ok(!calls.some((c) => c.argv.includes("--model")));
+  assert.deepEqual(setCalls(calls).map(setKey), []);
+  const spawned = jsonl(grokLog);
+  assert.ok(spawned.length >= 1);
+  assert.deepEqual(spawned[0].slice(0, 4), ["-m", "grok-4.6", "--reasoning-effort", "high"]);
+  assert.deepEqual(spawned[0].slice(4), ["agent", "stdio"]);
+});
+
+test("an unsupported harness with a requested model stops instead of persisting", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  await assert.rejects(
+    () =>
+      openSession({
+        agent: "cursor",
+        model: "composer-2.5",
+        sessionName: "bp-cursor",
+        cwd: workDir,
+      }),
+    { name: "UserError", message: /no proven invocation-scoped way/ },
+  );
+  assert.equal(settingsBytes().compare(before), 0);
+  assert.deepEqual(acpxCalls(), []);
+});

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -106,10 +106,44 @@ function spawnWrappedPi() {
   if (!wrap) return;
   spawnSync(wrap, ["--mode", "rpc", "--no-themes"], { stdio: "ignore", env: process.env });
 }
+function splitAgentCommand(value) {
+  const parts = [];
+  let current = "";
+  let quote = null;
+  let escaping = false;
+  let hasPart = false;
+  for (const ch of value) {
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      hasPart = true;
+    } else if (ch === "\\\\" && quote !== "'") {
+      escaping = true;
+    } else if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      hasPart = true;
+    } else if (ch === "'" || ch === '"') {
+      quote = ch;
+      hasPart = true;
+    } else if (/\\s/.test(ch)) {
+      if (hasPart) parts.push(current);
+      current = "";
+      hasPart = false;
+    } else {
+      current += ch;
+      hasPart = true;
+    }
+  }
+  if (escaping) current += "\\\\";
+  if (quote) process.exit(3);
+  if (hasPart) parts.push(current);
+  return parts;
+}
 function spawnOverriddenAgent() {
   const at = argv.indexOf("--agent");
   if (at < 0) return;
-  const parts = (argv[at + 1].match(/"(?:\\\\.|[^"\\\\])*"/g) || []).map((part) => JSON.parse(part));
+  const parts = splitAgentCommand(argv[at + 1]);
   spawnSync(parts[0], parts.slice(1), { stdio: "ignore", env: process.env });
 }
 if (argv.includes("sessions") && argv.includes("new")) {
@@ -690,7 +724,7 @@ test("the Backpass CLI applies Grok model and effort as process arguments", () =
   resetLogsAndSettings();
   const before = Buffer.from(settingsBytes());
   const repo = makeCliRepo("grok-analysis");
-  const spacedTmp = path.join(repo, "temporary files with spaces");
+  const spacedTmp = path.join(repo, "temporary 'files\\with\nspaces");
   fs.mkdirSync(spacedTmp);
   const result = runBackpass(repo, analysisArgs("grok", "grok-4.6"), { TMPDIR: spacedTmp });
   assert.equal(result.status, 0, result.stderr);

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 
 /**
  * Isolated harness-default mutation coverage.
@@ -135,6 +135,7 @@ fs.writeFileSync(piLog, "");
 fs.writeFileSync(grokLog, "");
 
 const { execOneShot, openSession, sessionPrompt } = await import("../src/acpx.js");
+const { prepareHarnessInvocation } = await import("../src/harness-invoke.js");
 
 const promptFile = path.join(binDir, "prompt.md");
 fs.writeFileSync(promptFile, "<!-- backpass:self-session -->\nping\n");
@@ -244,6 +245,58 @@ test("a configured replacement Pi adapter is rejected before model or effort can
   assert.ok(acpxCalls().some((c) => c.argv.includes("config") && c.argv.includes("show")));
   assert.ok(!acpxCalls().some((c) => c.argv.includes("new") || c.argv.includes("exec")));
   assert.deepEqual(jsonl(piLog), []);
+});
+
+test("the process wrapper forwards termination signals to its harness child", async () => {
+  const signalChild = path.join(binDir, "signal-child");
+  const readyPath = path.join(binDir, "signal-child.ready");
+  const signalPath = path.join(binDir, "signal-child.signal");
+  fs.writeFileSync(
+    signalChild,
+    `#!${process.execPath}
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(readyPath)}, String(process.pid));
+process.on("SIGTERM", () => {
+  fs.writeFileSync(${JSON.stringify(signalPath)}, "SIGTERM");
+  process.exit(0);
+});
+setInterval(() => {}, 1000);
+`,
+  );
+  fs.chmodSync(signalChild, 0o755);
+
+  const previous = process.env.PI_ACP_PI_COMMAND;
+  process.env.PI_ACP_PI_COMMAND = signalChild;
+  const invocation = prepareHarnessInvocation({ agent: "pi", model: "provider/model" });
+  if (previous === undefined) delete process.env.PI_ACP_PI_COMMAND;
+  else process.env.PI_ACP_PI_COMMAND = previous;
+
+  let wrapper;
+  let childPid;
+  try {
+    wrapper = spawn(invocation.env.PI_ACP_PI_COMMAND, [], { stdio: "ignore" });
+    for (let attempt = 0; attempt < 100 && !fs.existsSync(readyPath); attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.ok(fs.existsSync(readyPath));
+    childPid = Number(fs.readFileSync(readyPath, "utf8"));
+    const exited = new Promise((resolve) => wrapper.once("close", (code, signal) => resolve({ code, signal })));
+    wrapper.kill("SIGTERM");
+    const outcome = await Promise.race([
+      exited,
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 2000).unref()),
+    ]);
+    assert.notEqual(outcome, "timeout");
+    assert.equal(fs.readFileSync(signalPath, "utf8"), "SIGTERM");
+  } finally {
+    if (wrapper?.exitCode === null && wrapper?.signalCode === null) wrapper.kill("SIGKILL");
+    if (childPid) {
+      try {
+        process.kill(childPid, "SIGKILL");
+      } catch {}
+    }
+    invocation.dispose();
+  }
 });
 
 test("Pi process args keep values that need literal handling, including $() and spaces", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -123,11 +123,11 @@ if (argv.includes("sessions") && argv.includes("new")) {
 if (argv.includes("exec")) {
   spawnWrappedPi();
   spawnOverriddenAgent();
-  process.stdout.write('{"ok":true}\\n');
+  process.stdout.write('{"edits":[],"notes":[]}\\n');
   process.exit(0);
 }
 if (argv.includes("--file")) {
-  process.stdout.write('{"ok":true}\\n');
+  process.stdout.write('{"edits":[],"notes":[]}\\n');
   process.exit(0);
 }
 process.exit(0);
@@ -187,6 +187,71 @@ function setCalls(calls) {
 function setKey(call) {
   const i = call.argv.indexOf("set");
   return i >= 0 ? call.argv[i + 1] : null;
+}
+
+const cli = fileURLToPath(new URL("../bin/backpass.js", import.meta.url));
+let cliRun = 0;
+
+function makeCliRepo(label) {
+  cliRun += 1;
+  const repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `backpass-cli-${label}-`)));
+  const initialized = spawnSync("git", ["init", "--quiet"], { cwd: repo });
+  assert.equal(initialized.status, 0);
+  fs.writeFileSync(path.join(repo, "AGENTS.md"), "# Agent instructions\n\n- Keep changes focused.\n");
+
+  const id = `${label}-${cliRun}`;
+  const sessionDir = path.join(fakeHome, ".pi", "agent", "sessions", id);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const entries = [
+    { type: "session", version: 3, id, timestamp: new Date().toISOString(), cwd: repo },
+    { type: "message", message: { role: "user", content: "Please inspect the implementation." } },
+    { type: "message", message: { role: "assistant", content: "I inspected the implementation." } },
+    { type: "message", message: { role: "user", content: "Now explain the behavior." } },
+    { type: "message", message: { role: "assistant", content: "The behavior is isolated per invocation." } },
+  ];
+  fs.writeFileSync(
+    path.join(sessionDir, `${Date.now()}_${id}.jsonl`),
+    `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+  );
+  return repo;
+}
+
+function runBackpass(repo, args, extraEnv = {}) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: repo,
+    env: { ...process.env, ...extraEnv },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+}
+
+function analysisArgs(agent, model, effort = "high") {
+  return [
+    "analyze",
+    "--harness",
+    "pi",
+    "--since",
+    "all",
+    "--analysis-agent",
+    agent,
+    "--analysis-model",
+    model,
+    "--analysis-effort",
+    effort,
+    "--jobs",
+    "1",
+    "--json",
+  ];
+}
+
+function assertBareDefaults(before) {
+  const bare = spawnSync(fakePi, ["--mode", "rpc", "--no-themes"], {
+    env: process.env,
+    encoding: "utf8",
+  });
+  assert.equal(bare.status, 0);
+  assert.deepEqual(JSON.parse(bare.stdout), { provider: "xai", model: "grok-4.6", thinking: "high" });
+  assert.equal(settingsBytes().compare(before), 0);
 }
 
 test("ACP set model against the isolated fixture is the persist path (pre-fix counterfactual)", () => {
@@ -569,46 +634,8 @@ test("Claude and Codex stop when effort cannot be applied without a session", as
 test("the Backpass CLI applies Pi overlays without changing persistent defaults", () => {
   resetLogsAndSettings();
   const before = Buffer.from(settingsBytes());
-  const repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-cli-repo-")));
-  const initialized = spawnSync("git", ["init", "--quiet"], { cwd: repo });
-  assert.equal(initialized.status, 0);
-  fs.writeFileSync(path.join(repo, "AGENTS.md"), "# Agent instructions\n\n- Keep changes focused.\n");
-
-  const sessionDir = path.join(fakeHome, ".pi", "agent", "sessions", "cli-e2e");
-  fs.mkdirSync(sessionDir, { recursive: true });
-  const sessionPath = path.join(sessionDir, `${Date.now()}_cli-e2e.jsonl`);
-  const timestamp = new Date().toISOString();
-  const entries = [
-    { type: "session", version: 3, id: "cli-e2e", timestamp, cwd: repo },
-    { type: "message", message: { role: "user", content: "Please inspect the implementation." } },
-    { type: "message", message: { role: "assistant", content: "I inspected the implementation." } },
-    { type: "message", message: { role: "user", content: "Now explain the behavior." } },
-    { type: "message", message: { role: "assistant", content: "The behavior is isolated per invocation." } },
-  ];
-  fs.writeFileSync(sessionPath, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
-
-  const cli = fileURLToPath(new URL("../bin/backpass.js", import.meta.url));
-  const result = spawnSync(
-    process.execPath,
-    [
-      cli,
-      "analyze",
-      "--harness",
-      "pi",
-      "--since",
-      "all",
-      "--analysis-agent",
-      "pi",
-      "--analysis-model",
-      "openai-codex/gpt-5.6-sol",
-      "--analysis-effort",
-      "high",
-      "--jobs",
-      "1",
-      "--json",
-    ],
-    { cwd: repo, env: process.env, encoding: "utf8", timeout: 15_000 },
-  );
+  const repo = makeCliRepo("pi-analysis");
+  const result = runBackpass(repo, analysisArgs("pi", "openai-codex/gpt-5.6-sol"));
   assert.equal(result.status, 0, result.stderr);
   assert.equal(settingsBytes().compare(before), 0);
   const spawned = jsonl(piLog);
@@ -620,14 +647,120 @@ test("the Backpass CLI applies Pi overlays without changing persistent defaults"
     "high",
   ]);
   assert.deepEqual(spawned[0].slice(4), ["--mode", "rpc", "--no-themes"]);
+  assertBareDefaults(before);
+});
 
-  const bare = spawnSync(fakePi, ["--mode", "rpc", "--no-themes"], {
-    env: process.env,
-    encoding: "utf8",
-  });
-  assert.equal(bare.status, 0);
-  assert.deepEqual(JSON.parse(bare.stdout), { provider: "xai", model: "grok-4.6", thinking: "high" });
+test("the Backpass CLI preserves safe argument handling for Pi", () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const repo = makeCliRepo("pi-literal");
+  const pwned = path.join(repo, "pwned");
+  const model = `provider/foo bar $(touch "${pwned}")`;
+  const result = runBackpass(repo, analysisArgs("pi", model, "medium"));
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(!fs.existsSync(pwned));
+  assert.deepEqual(jsonl(piLog)[0].slice(0, 4), ["--model", model, "--thinking", "medium"]);
+  assertBareDefaults(before);
+});
+
+test("the Backpass CLI uses verified overlays for every positional harness", () => {
+  const cases = [
+    { agent: "claude", model: "claude-opus-5", effortKey: "effort" },
+    { agent: "codex", model: "gpt-5.6-sol", effortKey: "reasoning_effort" },
+    { agent: "opencode", model: "openai/gpt-5.6-sol", effortKey: null },
+  ];
+  for (const { agent, model, effortKey } of cases) {
+    resetLogsAndSettings();
+    const before = Buffer.from(settingsBytes());
+    const repo = makeCliRepo(`${agent}-analysis`);
+    const result = runBackpass(repo, analysisArgs(agent, model));
+    assert.equal(result.status, 0, result.stderr);
+    const calls = acpxCalls();
+    const created = calls.find((call) => call.argv.includes("new"));
+    assert.equal(created.argv[created.argv.indexOf("--model") + 1], model);
+    const effortCalls = setCalls(calls);
+    assert.deepEqual(effortCalls.map(setKey), effortKey ? [effortKey] : []);
+    assert.equal(settingsBytes().compare(before), 0);
+    assertBareDefaults(before);
+  }
+});
+
+test("the Backpass CLI applies Grok model and effort as process arguments", () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const repo = makeCliRepo("grok-analysis");
+  const result = runBackpass(repo, analysisArgs("grok", "grok-4.6"));
+  assert.equal(result.status, 0, result.stderr);
+  const calls = acpxCalls();
+  assert.ok(calls.every((call) => !call.argv.includes("grok-build")));
+  const spawned = jsonl(grokLog);
+  assert.deepEqual(spawned[0], ["-m", "grok-4.6", "--reasoning-effort", "high", "agent", "stdio"]);
   assert.equal(settingsBytes().compare(before), 0);
+  assertBareDefaults(before);
+});
+
+test("the Backpass CLI preserves safe process fallbacks and rejects unsafe ones", () => {
+  for (const agent of ["pi", "grok", "opencode"]) {
+    resetLogsAndSettings();
+    const before = Buffer.from(settingsBytes());
+    const repo = makeCliRepo(`${agent}-fallback`);
+    const model = agent === "grok" ? "grok-4.6" : "safe-model";
+    const result = runBackpass(repo, analysisArgs(agent, model), { FAKE_SESSIONS_UNSUPPORTED: "1" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(acpxCalls().some((call) => call.argv.includes("exec")));
+    if (agent === "pi") assert.ok(jsonl(piLog)[0].includes("--thinking"));
+    if (agent === "grok") assert.ok(jsonl(grokLog)[0].includes("--reasoning-effort"));
+    if (agent === "opencode") assert.match(result.stderr, /ran without effort=high/);
+    assert.equal(settingsBytes().compare(before), 0);
+    assertBareDefaults(before);
+  }
+
+  for (const agent of ["claude", "codex"]) {
+    resetLogsAndSettings();
+    const before = Buffer.from(settingsBytes());
+    const repo = makeCliRepo(`${agent}-unsafe-fallback`);
+    const result = runBackpass(repo, analysisArgs(agent, "safe-model"), { FAKE_SESSIONS_UNSUPPORTED: "1" });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, new RegExp(`${agent} cannot apply invocation-scoped effort=high`));
+    assert.match(result.stderr, /upgrade acpx or omit the effort override/);
+    assert.ok(!acpxCalls().some((call) => call.argv.includes("exec")));
+    assert.equal(settingsBytes().compare(before), 0);
+    assertBareDefaults(before);
+  }
+});
+
+test("the Backpass CLI keeps Pi synthesis overlays invocation-scoped", () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const repo = makeCliRepo("pi-synthesis");
+  const result = runBackpass(repo, [
+    "--harness",
+    "pi",
+    "--since",
+    "all",
+    "--analysis-agent",
+    "pi",
+    "--analysis-model",
+    "openai-codex/gpt-5.6-luna",
+    "--analysis-effort",
+    "medium",
+    "--synthesis-agent",
+    "pi",
+    "--synthesis-model",
+    "openai-codex/gpt-5.6-sol",
+    "--synthesis-effort",
+    "high",
+    "--jobs",
+    "1",
+    "--json",
+  ]);
+  assert.equal(result.status, 0, result.stderr);
+  const spawned = jsonl(piLog);
+  assert.ok(spawned.some((args) => args[1] === "openai-codex/gpt-5.6-luna" && args[3] === "medium"));
+  assert.ok(spawned.some((args) => args[1] === "openai-codex/gpt-5.6-sol" && args[3] === "high"));
+  assert.ok(!acpxCalls().some((call) => call.argv.includes("set") && ["model", "thought_level"].includes(setKey(call))));
+  assert.equal(settingsBytes().compare(before), 0);
+  assertBareDefaults(before);
 });
 
 test("an unsupported harness with a requested model stops instead of persisting", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -247,7 +247,7 @@ test("a configured replacement Pi adapter is rejected before model or effort can
   assert.deepEqual(jsonl(piLog), []);
 });
 
-test("the process wrapper forwards termination signals to its harness child", async () => {
+test("the process wrapper escalates when its harness child ignores termination", async () => {
   const signalChild = path.join(binDir, "signal-child");
   const readyPath = path.join(binDir, "signal-child.ready");
   const signalPath = path.join(binDir, "signal-child.signal");
@@ -258,7 +258,6 @@ const fs = require("node:fs");
 fs.writeFileSync(${JSON.stringify(readyPath)}, String(process.pid));
 process.on("SIGTERM", () => {
   fs.writeFileSync(${JSON.stringify(signalPath)}, "SIGTERM");
-  process.exit(0);
 });
 setInterval(() => {}, 1000);
 `,
@@ -284,10 +283,12 @@ setInterval(() => {}, 1000);
     wrapper.kill("SIGTERM");
     const outcome = await Promise.race([
       exited,
-      new Promise((resolve) => setTimeout(() => resolve("timeout"), 2000).unref()),
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 6000).unref()),
     ]);
     assert.notEqual(outcome, "timeout");
+    assert.deepEqual(outcome, { code: null, signal: "SIGKILL" });
     assert.equal(fs.readFileSync(signalPath, "utf8"), "SIGTERM");
+    assert.throws(() => process.kill(childPid, 0), { code: "ESRCH" });
   } finally {
     if (wrapper?.exitCode === null && wrapper?.signalCode === null) wrapper.kill("SIGKILL");
     if (childPid) {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -109,7 +109,8 @@ function spawnWrappedPi() {
 function spawnOverriddenAgent() {
   const at = argv.indexOf("--agent");
   if (at < 0) return;
-  spawnSync(argv[at + 1], [], { stdio: "ignore", env: process.env });
+  const parts = (argv[at + 1].match(/"(?:\\\\.|[^"\\\\])*"/g) || []).map((part) => JSON.parse(part));
+  spawnSync(parts[0], parts.slice(1), { stdio: "ignore", env: process.env });
 }
 if (argv.includes("sessions") && argv.includes("new")) {
   if (process.env.FAKE_SESSIONS_UNSUPPORTED === "1") {
@@ -365,15 +366,15 @@ setInterval(() => {}, 1000);
   );
   fs.chmodSync(signalChild, 0o755);
 
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${signalBin}${path.delimiter}${previousPath || ""}`;
   const invocation = prepareHarnessInvocation({ agent: "pi", model: "provider/model" });
+  process.env.PATH = previousPath;
 
   let wrapper;
   let childPid;
   try {
-    wrapper = spawn(invocation.env.PI_ACP_PI_COMMAND, [], {
-      stdio: "ignore",
-      env: { ...process.env, PATH: `${path.dirname(signalChild)}${path.delimiter}${process.env.PATH || ""}` },
-    });
+    wrapper = spawn(invocation.env.PI_ACP_PI_COMMAND, [], { stdio: "ignore" });
     for (let attempt = 0; attempt < 100 && !fs.existsSync(readyPath); attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
@@ -689,7 +690,9 @@ test("the Backpass CLI applies Grok model and effort as process arguments", () =
   resetLogsAndSettings();
   const before = Buffer.from(settingsBytes());
   const repo = makeCliRepo("grok-analysis");
-  const result = runBackpass(repo, analysisArgs("grok", "grok-4.6"));
+  const spacedTmp = path.join(repo, "temporary files with spaces");
+  fs.mkdirSync(spacedTmp);
+  const result = runBackpass(repo, analysisArgs("grok", "grok-4.6"), { TMPDIR: spacedTmp });
   assert.equal(result.status, 0, result.stderr);
   const calls = acpxCalls();
   assert.ok(calls.every((call) => !call.argv.includes("grok-build")));

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -77,6 +77,11 @@ fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify({
   PI_ACP_PI_COMMAND: process.env.PI_ACP_PI_COMMAND || null,
 }) + "\\n");
 const settings = process.env.FAKE_HARNESS_SETTINGS;
+if (argv.includes("config") && argv.includes("show")) {
+  const agents = process.env.FAKE_PI_REPLACEMENT === "1" ? { pi: { argv: ["custom-pi-adapter"] } } : {};
+  process.stdout.write(JSON.stringify({ agents }) + "\\n");
+  process.exit(0);
+}
 const setAt = argv.indexOf("set");
 if (setAt >= 0) {
   const key = argv[setAt + 1];
@@ -211,6 +216,34 @@ test("a Pi session with model and effort uses process --model/--thinking and lea
   assert.equal(defaults.defaultProvider, "xai");
   assert.equal(defaults.defaultModel, "grok-4.6");
   assert.equal(defaults.defaultThinkingLevel, "high");
+});
+
+test("a configured replacement Pi adapter is rejected before model or effort can be claimed", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  process.env.FAKE_PI_REPLACEMENT = "1";
+  try {
+    await assert.rejects(
+      () =>
+        openSession({
+          agent: "pi",
+          model: "provider/model",
+          effort: "high",
+          sessionName: "bp-pi-replaced",
+          cwd: workDir,
+        }),
+      {
+        name: "UserError",
+        message: /agents\.pi replaces the proven built-in adapter/,
+      },
+    );
+  } finally {
+    delete process.env.FAKE_PI_REPLACEMENT;
+  }
+  assert.equal(settingsBytes().compare(before), 0);
+  assert.ok(acpxCalls().some((c) => c.argv.includes("config") && c.argv.includes("show")));
+  assert.ok(!acpxCalls().some((c) => c.argv.includes("new") || c.argv.includes("exec")));
+  assert.deepEqual(jsonl(piLog), []);
 });
 
 test("Pi process args keep values that need literal handling, including $() and spaces", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -90,18 +90,23 @@ function spawnWrappedPi() {
   if (!wrap) return;
   spawnSync(wrap, ["--mode", "rpc", "--no-themes"], { stdio: "ignore", env: process.env });
 }
-function spawnWrappedGrok() {
-  if (process.env.FAKE_SPAWN_GROK !== "1") return;
-  spawnSync("grok", ["agent", "stdio"], { stdio: "ignore", env: process.env });
+function spawnOverriddenAgent() {
+  const at = argv.indexOf("--agent");
+  if (at < 0) return;
+  spawnSync(argv[at + 1], [], { stdio: "ignore", env: process.env });
 }
 if (argv.includes("sessions") && argv.includes("new")) {
+  if (process.env.FAKE_SESSIONS_UNSUPPORTED === "1") {
+    process.stderr.write("sessions unsupported\\n");
+    process.exit(2);
+  }
   spawnWrappedPi();
-  spawnWrappedGrok();
+  spawnOverriddenAgent();
   process.exit(0);
 }
 if (argv.includes("exec")) {
   spawnWrappedPi();
-  spawnWrappedGrok();
+  spawnOverriddenAgent();
   process.stdout.write('{"ok":true}\\n');
   process.exit(0);
 }
@@ -124,7 +129,7 @@ fs.writeFileSync(acpxLog, "");
 fs.writeFileSync(piLog, "");
 fs.writeFileSync(grokLog, "");
 
-const { execOneShot, openSession } = await import("../src/acpx.js");
+const { execOneShot, openSession, sessionPrompt } = await import("../src/acpx.js");
 
 const promptFile = path.join(binDir, "prompt.md");
 fs.writeFileSync(promptFile, "<!-- backpass:self-session -->\nping\n");
@@ -319,30 +324,99 @@ test("OpenCode session passes --model at create, skips effort, and does not pers
   assert.deepEqual(setCalls(calls).map(setKey), []);
 });
 
-test("Grok session uses process -m and --reasoning-effort and leaves defaults unchanged", async () => {
+test("Grok session forces an acpx raw-command override with process model and effort", async () => {
   resetLogsAndSettings();
-  process.env.FAKE_SPAWN_GROK = "1";
   const before = Buffer.from(settingsBytes());
-  try {
-    const session = await openSession({
-      agent: "grok",
-      model: "grok-4.6",
-      effort: "high",
-      sessionName: "bp-grok",
-      cwd: workDir,
-    });
-    await session.close();
-  } finally {
-    delete process.env.FAKE_SPAWN_GROK;
-  }
+  const session = await openSession({
+    agent: "grok",
+    model: "grok-4.6",
+    effort: "high",
+    sessionName: "bp-grok",
+    cwd: workDir,
+  });
+  await session.close();
+
   assert.equal(settingsBytes().compare(before), 0);
   const calls = acpxCalls();
+  assert.ok(calls.every((c) => c.argv.includes("--agent")));
+  assert.ok(calls.every((c) => !c.argv.includes("grok-build")));
   assert.ok(!calls.some((c) => c.argv.includes("--model")));
   assert.deepEqual(setCalls(calls).map(setKey), []);
   const spawned = jsonl(grokLog);
   assert.ok(spawned.length >= 1);
   assert.deepEqual(spawned[0].slice(0, 4), ["-m", "grok-4.6", "--reasoning-effort", "high"]);
   assert.deepEqual(spawned[0].slice(4), ["agent", "stdio"]);
+});
+
+test("Pi and Grok retain process effort when session fallback uses exec", async () => {
+  for (const agent of ["pi", "grok"]) {
+    resetLogsAndSettings();
+    process.env.FAKE_SESSIONS_UNSUPPORTED = "1";
+    try {
+      const result = await sessionPrompt({
+        agent,
+        model: agent === "pi" ? "provider/model" : "grok-4.6",
+        effort: "high",
+        sessionName: `bp-${agent}-fallback`,
+        promptFile,
+        cwd: workDir,
+        timeoutSeconds: 5,
+      });
+      assert.match(result.notes.join("\n"), /fell back to exec one-shot/);
+    } finally {
+      delete process.env.FAKE_SESSIONS_UNSUPPORTED;
+    }
+    const spawned = jsonl(agent === "pi" ? piLog : grokLog);
+    assert.ok(spawned.length >= 1);
+    assert.ok(spawned.some((args) => args.includes(agent === "pi" ? "--thinking" : "--reasoning-effort")));
+  }
+});
+
+test("OpenCode session fallback keeps its authorized effort omission visible", async () => {
+  resetLogsAndSettings();
+  process.env.FAKE_SESSIONS_UNSUPPORTED = "1";
+  let result;
+  try {
+    result = await sessionPrompt({
+      agent: "opencode",
+      model: "safe-model",
+      effort: "high",
+      sessionName: "bp-opencode-fallback",
+      promptFile,
+      cwd: workDir,
+      timeoutSeconds: 5,
+    });
+  } finally {
+    delete process.env.FAKE_SESSIONS_UNSUPPORTED;
+  }
+  assert.match(result.notes.join("\n"), /ran without effort=high/);
+  const exec = acpxCalls().find((c) => c.argv.includes("exec"));
+  assert.equal(exec.argv[exec.argv.indexOf("--model") + 1], "safe-model");
+});
+
+test("Claude and Codex stop when effort cannot be applied without a session", async () => {
+  for (const agent of ["claude", "codex"]) {
+    resetLogsAndSettings();
+    process.env.FAKE_SESSIONS_UNSUPPORTED = "1";
+    try {
+      await assert.rejects(
+        () =>
+          sessionPrompt({
+            agent,
+            model: "safe-model",
+            effort: "high",
+            sessionName: `bp-${agent}-fallback`,
+            promptFile,
+            cwd: workDir,
+            timeoutSeconds: 5,
+          }),
+        { name: "UserError", message: /cannot apply invocation-scoped effort=high/ },
+      );
+    } finally {
+      delete process.env.FAKE_SESSIONS_UNSUPPORTED;
+    }
+    assert.ok(!acpxCalls().some((c) => c.argv.includes("exec")));
+  }
 });
 
 test("an unsupported harness with a requested model stops instead of persisting", async () => {

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -58,7 +58,9 @@ setInterval(() => {}, 1000);
       if (harnessPid) {
         try {
           process.kill(harnessPid, "SIGKILL");
-        } catch {}
+        } catch {
+          // The timed process may already be gone.
+        }
       }
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -7,6 +7,65 @@ import test from "node:test";
 import { runCapture } from "../src/subprocess.js";
 
 test(
+  "a timed leader close still kills a descendant that ignores termination",
+  { skip: process.platform === "win32" && "POSIX process-group behavior" },
+  async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-timeout-leader-close-"));
+    const harnessPath = path.join(dir, "harness.cjs");
+    const acpxPath = path.join(dir, "acpx.cjs");
+    const pidPath = path.join(dir, "harness.pid");
+    const signalPath = path.join(dir, "harness.signal");
+
+    fs.writeFileSync(
+      harnessPath,
+      `const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+process.on("SIGTERM", () => {
+  fs.writeFileSync(${JSON.stringify(signalPath)}, "SIGTERM");
+});
+setInterval(() => {}, 1000);
+`,
+    );
+    fs.writeFileSync(
+      acpxPath,
+      `const { spawn } = require("node:child_process");
+spawn(process.execPath, [${JSON.stringify(harnessPath)}], { stdio: "ignore" });
+process.on("SIGTERM", () => setTimeout(() => process.exit(0), 100));
+setInterval(() => {}, 1000);
+`,
+    );
+
+    let harnessPid;
+    try {
+      const result = await runCapture(process.execPath, [acpxPath], { timeoutMs: 250 });
+      assert.equal(result.timedOut, true);
+      assert.ok(fs.existsSync(pidPath));
+      assert.equal(fs.readFileSync(signalPath, "utf8"), "SIGTERM");
+      harnessPid = Number(fs.readFileSync(pidPath, "utf8"));
+      let alive = true;
+      for (let attempt = 0; attempt < 100 && alive; attempt += 1) {
+        try {
+          process.kill(harnessPid, 0);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        } catch (err) {
+          if (err.code !== "ESRCH") throw err;
+          alive = false;
+        }
+      }
+      assert.equal(alive, false);
+    } finally {
+      if (!harnessPid && fs.existsSync(pidPath)) harnessPid = Number(fs.readFileSync(pidPath, "utf8"));
+      if (harnessPid) {
+        try {
+          process.kill(harnessPid, "SIGKILL");
+        } catch {}
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   "a timeout terminates the captured command's harness descendant",
   { skip: process.platform === "win32" && "POSIX process-group behavior" },
   async () => {

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runCapture } from "../src/subprocess.js";
+
+test(
+  "a timeout terminates the captured command's harness descendant",
+  { skip: process.platform === "win32" && "POSIX process-group behavior" },
+  async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-timeout-tree-"));
+    const harnessPath = path.join(dir, "harness.cjs");
+    const acpxPath = path.join(dir, "acpx.cjs");
+    const pidPath = path.join(dir, "harness.pid");
+    const signalPath = path.join(dir, "harness.signal");
+
+    fs.writeFileSync(
+      harnessPath,
+      `const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+process.on("SIGTERM", () => {
+  fs.writeFileSync(${JSON.stringify(signalPath)}, "SIGTERM");
+  process.exit(0);
+});
+setInterval(() => {}, 1000);
+`,
+    );
+    fs.writeFileSync(
+      acpxPath,
+      `const { spawn } = require("node:child_process");
+spawn(process.execPath, [${JSON.stringify(harnessPath)}], { stdio: "inherit" });
+setInterval(() => {}, 1000);
+`,
+    );
+
+    let harnessPid;
+    try {
+      const result = await runCapture(process.execPath, [acpxPath], { timeoutMs: 1000 });
+      assert.equal(result.timedOut, true);
+      assert.ok(fs.existsSync(pidPath), "the harness descendant started before timeout");
+      assert.equal(fs.readFileSync(signalPath, "utf8"), "SIGTERM");
+      harnessPid = Number(fs.readFileSync(pidPath, "utf8"));
+      assert.throws(() => process.kill(harnessPid, 0), { code: "ESRCH" });
+    } finally {
+      if (!harnessPid && fs.existsSync(pidPath)) harnessPid = Number(fs.readFileSync(pidPath, "utf8"));
+      if (harnessPid) {
+        try {
+          process.kill(harnessPid, "SIGKILL");
+        } catch {
+          // The timeout should already have terminated the harness.
+        }
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -192,10 +192,13 @@ test("synthesis edits the staging copy natively; measured hunks anchor to the ra
   const staged = fs.readFileSync(path.join(repo.root, ".backpass", "synthesis", "AGENTS.md"), "utf8");
   assert.ok(!staged.includes("Transcript formats drift"));
 
-  // Session lifecycle: new -> set model -> set effort -> edit turn -> annotate turn -> close,
+  // Session lifecycle: new (with --model) -> set effort -> edit turn -> annotate turn -> close,
   // every turn in the staging workspace with writes approved, never --deny-all.
   const invocations = calls();
   const workspace = path.join(repo.root, ".backpass", "synthesis");
+  const created = invocations.find((c) => c.argv.includes("new"));
+  assert.equal(created.argv[created.argv.indexOf("--model") + 1], "claude-opus-5");
+  assert.ok(!invocations.some((c) => c.argv.includes("set") && c.argv[c.argv.indexOf("set") + 1] === "model"));
   assert.deepEqual(
     invocations.map((c) =>
       c.argv
@@ -205,7 +208,6 @@ test("synthesis edits the staging copy natively; measured hunks anchor to the ra
             "new",
             "close",
             "set",
-            "model",
             "effort",
             "--file",
             "--approve-all",
@@ -215,7 +217,7 @@ test("synthesis edits the staging copy natively; measured hunks anchor to the ra
         )
         .join(" "),
     ),
-    ["sessions new", "set model", "set effort", "--approve-all --file", "--approve-all --file", "sessions close"],
+    ["sessions new", "set effort", "--approve-all --file", "--approve-all --file", "sessions close"],
   );
   for (const turn of invocations.filter((c) => c.argv.includes("--file"))) {
     assert.equal(turn.argv[turn.argv.indexOf("--cwd") + 1], workspace);

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -20,6 +20,10 @@ const fs = require("node:fs");
 const path = require("node:path");
 const argv = process.argv.slice(2);
 fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify({ argv, cwd: process.cwd() }) + "\\n");
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write('{"agents":{}}\\n');
+  process.exit(0);
+}
 const script = JSON.parse(fs.readFileSync(process.env.FAKE_ACPX_SCRIPT, "utf8"));
 const cwdAt = argv.indexOf("--cwd");
 const cwd = cwdAt >= 0 ? argv[cwdAt + 1] : process.cwd();
@@ -196,27 +200,31 @@ test("synthesis edits the staging copy natively; measured hunks anchor to the ra
   // every turn in the staging workspace with writes approved, never --deny-all.
   const invocations = calls();
   const workspace = path.join(repo.root, ".backpass", "synthesis");
+  const configured = invocations.find((c) => c.argv.includes("config") && c.argv.includes("show"));
+  assert.ok(configured);
   const created = invocations.find((c) => c.argv.includes("new"));
   assert.equal(created.argv[created.argv.indexOf("--model") + 1], "claude-opus-5");
   assert.ok(!invocations.some((c) => c.argv.includes("set") && c.argv[c.argv.indexOf("set") + 1] === "model"));
   assert.deepEqual(
-    invocations.map((c) =>
-      c.argv
-        .filter((a) =>
-          [
-            "sessions",
-            "new",
-            "close",
-            "set",
-            "effort",
-            "--file",
-            "--approve-all",
-            "--deny-all",
-            "--approve-reads",
-          ].includes(a),
-        )
-        .join(" "),
-    ),
+    invocations
+      .filter((c) => !c.argv.includes("config"))
+      .map((c) =>
+        c.argv
+          .filter((a) =>
+            [
+              "sessions",
+              "new",
+              "close",
+              "set",
+              "effort",
+              "--file",
+              "--approve-all",
+              "--deny-all",
+              "--approve-reads",
+            ].includes(a),
+          )
+          .join(" "),
+      ),
     ["sessions new", "set effort", "--approve-all --file", "--approve-all --file", "sessions close"],
   );
   for (const turn of invocations.filter((c) => c.argv.includes("--file"))) {

--- a/test/usage-output.test.js
+++ b/test/usage-output.test.js
@@ -172,7 +172,7 @@ test("across the turns of one pi session, each turn is accounted as its own incr
   const fileOut = path.join(fakeAcpxDir, "pi-session-file.txt");
   process.env.FAKE_PI_SESSION_FILE_OUT = fileOut;
   try {
-    const session = await openSession({ agent: "pi", effort: "high", sessionName: "bp-test", cwd: workDir });
+    const session = await openSession({ agent: "pi", sessionName: "bp-test", cwd: workDir });
     const first = await session.prompt({ promptFile: sessionPrompt, approveAll: true, timeoutSeconds: 5 });
     assert.deepEqual(first.usage, {
       input: 10778,

--- a/test/usage-output.test.js
+++ b/test/usage-output.test.js
@@ -33,6 +33,10 @@ fs.writeFileSync(
 const fs = require("node:fs");
 const path = require("node:path");
 const argv = process.argv.slice(2);
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write('{"agents":{}}\\n');
+  process.exit(0);
+}
 const agent = argv.find((a) => a === "codex" || a === "pi");
 // Session management calls (new / set / close) succeed silently, as acpx's do.
 if (argv.includes("sessions") || argv.includes("set")) process.exit(0);


### PR DESCRIPTION
## Intent

Fix Backpass so selecting a model or reasoning level for any agent subprocess is scoped to that single invocation and never mutates the user's persistent harness defaults.

Observed end-user failure: a normal Backpass synthesis run launched Pi with openai-codex/gpt-5.6-sol, and around that process launch Pi rewrote the shared live ~/.pi/agent/settings.json defaults from xai/grok-4.6 to openai-codex/gpt-5.6-sol. The next bare Firstmate Pi session then inherited the changed default unexpectedly. Forensic evidence is in firstmate data/dotfiles-pi-model-switch-correlation-s1/report.md; treat it as evidence, not complete causal proof: the exact historical Backpass subprocess argv is unavailable.

Requirements:
- Start with an end-user-aligned E2E reproduction in a fully isolated temporary harness home/configuration. Never touch or rewrite the captain's live Pi, Claude, Codex, Cursor, or other harness settings.
- Explicitly separate the Backpass trigger, any harness persistence behavior that exposes the defect, and the user-visible changed default.
- Compare the failing path with a proven one-off invocation path, inspect relevant implementation history, test the smallest causal counterfactual, and seek evidence that could disprove the explanation.
- Pass model and supported reasoning/effort choices through documented one-off process invocation arguments or another harness-supported session-local mechanism.
- Do not edit persistent harness configuration before launch, rely on an interactive model picker, or restore persistent settings afterward.
- Preserve current behavior when no model or effort override is requested.
- If a harness cannot provide a proven invocation-scoped override, stop safely with actionable guidance rather than silently mutating persistent defaults or pretending the requested model was used.
- Keep harness-specific argument construction explicit, testable, and maintainable.
- Turn the reproduction into behavioral regression coverage through Backpass's executable/public boundary. Tests must verify the launched command/observable subprocess behavior and that an isolated persistent settings fixture remains byte-for-byte unchanged; do not assert source text or implementation syntax. Cover Pi specifically and every other supported harness path affected by the shared fix, including values requiring safe argument handling.

Acceptance:
1. The pre-fix isolated E2E path reproduces persistent default mutation, or the exact limitation and closest faithful evidence are documented before implementation.
2. A Backpass run with explicit model/effort selection uses only one-off harness controls and leaves persistent defaults unchanged.
3. A later bare harness launch still selects its original default in the isolated reproduction.
4. No live user configuration or existing partially modified project copy is touched.
5. Relevant unit/integration/E2E tests, lint, and type checks pass.

Causal finding used in the implementation: isolated Pi reproduction showed RPC set_model / set_thinking_level rewrite settings.json, while pi --model / --thinking at process start do not. acpx --model after session/new is ACP setSessionModel, which is that persist path for Pi, so Pi must not use acpx --model or ACP set. Claude/Codex keep session-local acpx --model at sessions new plus ACP set effort. Grok uses process -m / --reasoning-effort. OpenCode uses acpx --model at create and skips effort with a report note. A harness without a proven overlay must stop rather than persist.

Do not touch live user harness configuration.

## What Changed

- Apply model and effort overrides through one-off, harness-specific controls for Pi, Grok, Claude, Codex, and OpenCode without rewriting persistent defaults.
- Verify built-in adapters, preserve unmodified launches when no override is requested, and stop safely when an invocation-scoped override cannot be proven.
- Add behavioral regression coverage for isolated settings, safe argument handling, fallback behavior, and full subprocess-tree cleanup on timeout.

## Risk Assessment

✅ Low: The invocation-scoped override paths are explicit, fail safely when unverified, preserve no-override behavior, and include behavioral coverage for supported harnesses and subprocess cleanup.

## Testing

The baseline suite completed successfully, targeted harness invocation and process-tree timeout tests passed, and an isolated public CLI E2E run showed Pi receiving one-off model and thinking arguments, no persistent ACP set calls, byte-stable settings, and the original default on a later bare Pi launch.

<details>
<summary>Evidence: Isolated Backpass-to-Pi invocation E2E evidence</summary>

Source: [Isolated Backpass-to-Pi invocation E2E evidence](https://github.com/kunchenguid/backpass/blob/195cc5b4a06fb1486278be013332279d51abe665/.no-mistakes/evidence/fm/backpass-ephemeral-harness-model-r1/pi-invocation-e2e.json)

```text
{
  "backpassExit": 0,
  "backpassOutput": "{\n  \"memoryFile\": \"AGENTS.md\",\n  \"transcripts\": 1,\n  \"summary\": {\n    \"total\": 1,\n    \"cached\": 0,\n    \"analyzed\": 1,\n    \"skipped\": 0,\n    \"failed\": 0,\n    \"usage\": [\n      {\n        \"agent\": \"pi\",\n        \"usage\": null\n      }\n    ]\n  }\n}",
  "launchedPiArgv": [
    "--model",
    "openai-codex/gpt-5.6-sol",
    "--thinking",
    "high",
    "--mode",
    "rpc",
    "--no-themes"
  ],
  "acpxPersistenceSetCalls": [],
  "settingsSha256Before": "7bce2e2b39eabb39887c5e5000eb7ef519969bfbe2285964316f878cf844a78d",
  "settingsSha256After": "7bce2e2b39eabb39887c5e5000eb7ef519969bfbe2285964316f878cf844a78d",
  "settingsByteStable": true,
  "laterBarePiDefault": {
    "provider": "xai",
    "model": "grok-4.6",
    "thinking": "high"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"040e19d92383bfc7e63fd98d4baaf49c1f5527fe","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (9) ✅</summary>

- 🚨 `src/harness-invoke.js:131` - The Grok overlay only prepends a PATH wrapper, but acpx supports replacing the built-in `grok-build` entry with an absolute/custom argv. In that supported configuration acpx bypasses this wrapper, the run succeeds using Grok&#39;s persistent default, and Backpass falsely attributes the requested model/effort. This contradicts the requirement: &#34;If a harness cannot provide a proven invocation-scoped override, stop safely ... rather than ... pretending the requested model was used.&#34; Verify the resolved acpx command or invoke a guaranteed per-call command at the acpx boundary, and fail when interception cannot be proven.
- 🚨 `src/acpx.js:423` - When named session creation is unsupported, `sessionPrompt` still falls back to `execOneShot` without effort. For Pi/Grok this drops their proven process effort flag, while Claude/Codex continue successfully despite having no available session-local effort mechanism. Normal analysis always supplies an effort, so this path returns valid-looking output at the wrong reasoning level. This contradicts the requirements to pass supported effort choices through one-off controls and to stop when no proven overlay exists. Pass effort into exec for Pi/Grok and fail actionably for unsupported Claude/Codex effort; retain only the explicitly authorized OpenCode skip.

🔧 Fix: Enforce invocation-scoped overrides across harness fallbacks
1 error still open:

- 🚨 `src/harness-invoke.js:121` - Pi still uses positional `acpx pi` while only injecting `PI_ACP_PI_COMMAND`. acpx permits `agents.pi` to replace its built-in adapter with custom argv; that adapter can ignore this pi-acp-specific environment variable, run successfully with persistent defaults, and make Backpass falsely report the requested model and effort. This contradicts: &#34;If a harness cannot provide a proven invocation-scoped override, stop safely ... rather than ... pretending the requested model was used.&#34; Force a known adapter command or detect and reject configured replacement adapters at the acpx invocation boundary.

🔧 Fix: Reject unverified replacement Pi adapters
2 issues (1 error, 1 warning) still open:

- 🚨 `src/harness-invoke.js:85` - Claude, Codex, and OpenCode leave `requiredBuiltinAgent` null, so an `acpx agents.&lt;name&gt;` replacement bypasses verification. A replacement adapter can accept session creation and config-setting calls while ignoring the requested model, using persistent defaults, or persisting effort, and Backpass will report success. This contradicts: &#34;If a harness cannot provide a proven invocation-scoped override, stop safely ... rather than ... pretending the requested model was used.&#34; Verify and reject replacement adapters for every path whose guarantees depend on the built-in adapter, not only Pi.
- ⚠️ `src/harness-invoke.js:179` - The generated wrapper waits for its child but does not forward SIGTERM, SIGINT, or SIGHUP. If acpx or an adapter terminates the wrapper during cancellation, timeout, or session shutdown, the real Pi/Grok process can remain orphaned and continue running. Relay termination signals to the child before exiting.

🔧 Fix: Forward wrapper termination signals to harness children
3 issues (2 errors, 1 warning) still open:

- 🚨 `src/harness-invoke.js:85` - Claude, Codex, and OpenCode leave requiredBuiltinAgent null, so configured acpx replacement adapters bypass verification. For example, agents.opencode can resolve to pi-acp: acpx then applies --model through Pi&#39;s persistent ACP path, the run succeeds with the authorized effort omission, and settings.json is mutated. This violates &#34;If a harness cannot provide a proven invocation-scoped override, stop safely&#34;. Verify replacement adapters for every positional built-in whose guarantees depend on adapter identity.
- 🚨 `test/harness-invoke.test.js:137` - The required regression coverage is not exercised through Backpass&#39;s executable/public boundary. These tests import internal src/acpx.js functions directly, while the pre-fix counterfactual invokes fake acpx directly, so no test demonstrates that a Backpass CLI run triggers the safe path and preserves defaults. This contradicts: &#34;Turn the reproduction into behavioral regression coverage through Backpass&#39;s executable/public boundary.&#34; Add an isolated CLI-level Backpass run using the fake harnesses and assert launched argv, byte-stable settings, and the later bare-harness default.
- ⚠️ `src/harness-invoke.js:185` - The wrapper forwards SIGTERM but does not escalate against a child that ignores it. On timeout, runCapture later SIGKILLs only the wrapper, leaving such a harness child orphaned and still running. Make timeout termination cover the child process group or have the wrapper SIGKILL the child before the parent&#39;s five-second escalation.

🔧 Fix: Escalate termination for unresponsive harness children
3 errors still open:

- 🚨 `src/harness-invoke.js:85` - Claude, Codex, and OpenCode leave requiredBuiltinAgent null, so configured acpx replacement adapters bypass verification. For example, agents.opencode can resolve to pi-acp, causing acpx --model to reach Pi&#39;s persistent model path while Backpass reports success. This contradicts the requirement: &#34;If a harness cannot provide a proven invocation-scoped override, stop safely.&#34; Reject unverified replacements for every positional built-in whose overlay depends on adapter identity.
- 🚨 `src/harness-invoke.js:125` - Pi trusts an existing PI_ACP_PI_COMMAND and wraps it without proving that command honors Pi&#39;s --model and --thinking flags. A custom command can ignore those flags, launch Pi with persistent defaults, and return successfully, so Backpass falsely claims the requested overlay. Reject an existing custom command unless its invocation-scoped controls can be positively verified.
- 🚨 `test/harness-invoke.test.js:137` - The required regression is still not exercised through Backpass&#39;s executable/public boundary. The tests import internal src/acpx.js functions, and the pre-fix counterfactual invokes fake acpx directly. This does not satisfy: &#34;Turn the reproduction into behavioral regression coverage through Backpass&#39;s executable/public boundary.&#34; Add an isolated CLI-level Backpass run that asserts launched argv, byte-stable settings, and the later bare-harness default.

🔧 Fix: Enforce verified adapters with CLI isolation coverage
1 error still open:

- 🚨 `test/harness-invoke.test.js:569` - The intent requires behavioral regression coverage &#34;through Backpass&#39;s executable/public boundary&#34; covering &#34;Pi specifically and every other supported harness path affected by the shared fix.&#34; The only CLI-level test covers Pi analysis; Claude, Codex, OpenCode, Grok, fallback behavior, and the original synthesis path are tested only by importing internal src/acpx.js functions. Add CLI-level isolated cases for those affected paths, including synthesis, and assert observable argv, unchanged settings bytes, and actionable fallback failures.

🔧 Fix: Cover all harness overlays through the CLI
2 issues (1 error, 1 warning) still open:

- 🚨 `src/harness-invoke.js:182` - The generated extensionless shebang wrapper is not executable on Windows. Pi-acp spawns a PI_ACP_PI_COMMAND override directly unless it ends in .cmd/.bat, so pinned Pi model or effort overrides fail before launch; Grok&#39;s raw command wrapper has the same portability issue. Use an explicit cross-platform Node invocation or a safely quoted platform-specific shim.
- ⚠️ `src/acpx.js:176` - Grok passes the wrapper path as an acpx --agent command string. Acpx reparses that string into command parts, so a valid TMPDIR containing spaces makes the wrapper path split into multiple tokens and the launch fails. Encode or quote the command using acpx&#39;s command-string grammar, including embedded quote and backslash handling.

🔧 Fix: Make harness wrappers portable and safely quoted
1 warning still open:

- ⚠️ `src/harness-invoke.js:242` - `renderCommandArgv` uses JSON string escaping, but acpx&#39;s raw-command parser treats backslash as a generic escape rather than decoding JSON. For example, a valid TMPDIR containing a newline makes JSON.stringify emit `\n`; acpx parses that as `n`, corrupting the Grok wrapper path and failing the launch. Encode arguments according to acpx&#39;s command-string grammar, preserving control characters as well as quotes and backslashes.

🔧 Fix: Preserve Grok command arguments through acpx parsing
✅ Re-checked - no issues remain.

✅ No issues found.

- ⚠️ `src/subprocess.js:56` - On POSIX, if a timed command spawns a descendant that ignores SIGTERM and closes or never inherits the capture pipes, the direct child can close first and this clears the scheduled process-group SIGKILL. The descendant then survives the timeout. On a timed close, kill any remaining process-group members before clearing escalation, or otherwise retain escalation independently of the leader&#39;s close event.

🔧 Fix: Kill remaining process groups after timed leader exits
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/harness-invoke.test.js`
- `node --test --test-name-pattern='the Backpass CLI keeps Pi synthesis overlays invocation-scoped' test/harness-invoke.test.js`
- `Inspected isolated acpx and Pi launch logs, compared settings bytes and SHA-256 before and after, and verified a later bare Pi launch retained the original defaults.`
- <code>`git status --short` confirmed testing left the worktree clean.</code>

✅ No issues found.
- `pnpm exec node --test test/harness-invoke.test.js`
- `acpx --version && acpx config show --format json`
- <code>Generated an evidence-only instrumented copy of the CLI E2E tests, then ran `pnpm exec node --test --test-name-pattern=&#39;the Backpass CLI (applies Pi overlays|applies Grok model|preserves safe process fallbacks|keeps Pi synthesis)&#39; .../e2e-evidence.test.mjs`</code>
- `git status --short`

✅ No issues found.
- <code>`pnpm test -- test/harness-invoke.test.js test/subprocess.test.js` (the package script expanded its existing glob and ran the full test suite)</code>
- `node --test test/harness-invoke.test.js test/subprocess.test.js`
- `node ~/.no-mistakes/evidence/01M10M04FP9JSMV2P3T7JGQKES/pi-invocation-e2e.mjs > ~/.no-mistakes/evidence/01M10M04FP9JSMV2P3T7JGQKES/pi-invocation-e2e.json`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>
