### PR TITLE
fix: correct synthesis orchestration and apply rollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   writes `proposal.json`, stamped with `attempt`. `ProposalViolation` carries `reason` and
   the `saved` proposal's own attempt/violations so a later empty turn is never reported as
   that proposal's author. A new synthesis clears the prior proposal before its first model
-  call, so an empty-only failure cannot leave an older proposal applicable.
+  call, so an empty-only failure cannot leave an older proposal applicable. `propose
+--resume` restores the staged tree against the versioned `synthesis.json` baseline and
+  its evidence snapshot, refuses repository drift or created-skill collisions, and starts
+  annotation in a fresh fallthrough-capable session without discovery, folding, or editing.
   `synthesisFailureHint` in `src/commands/propose.js` is
   where the advice for each terminal condition lives - never a blanket
   stronger-model/budget/max-edits line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,28 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   the proposal, which apply refuses rather than part-applies. Never pass
   `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that
   writes there fails the run loudly.
+- **An annotate turn has three outcomes, and conflating them is the 0.1.7 failure mode**
+  (`annotateLoop` in `src/synthesize.js`): the staging tree moved (re-measure and re-ask -
+  costs no `ANNOTATE_TURNS` attempt, bounded by `REMEASURE_TURNS`), the adapter returned
+  no text at all (retry once in a NEW session - the old context is the suspect), or the
+  answer was judged by the gates (the only outcome that spends an attempt and writes a
+  rejected `proposal.json`, stamped with `attempt`). `ProposalViolation` carries `reason`
+  and the `saved` proposal's own attempt/violations so a later empty turn is never reported
+  as that proposal's author, and `synthesisFailureHint` in `src/commands/propose.js` is
+  where the advice for each terminal condition lives - never a blanket
+  stronger-model/budget/max-edits line.
+- **`backpass propose --resume` re-annotates the staged tree instead of rebuilding it.**
+  `prepareWorkspace` records the baseline it measured against in `.backpass/synthesis.json`
+  (the tree itself cannot hold it - anything inside the workspace measures as a stray);
+  `restoreWorkspace` re-opens the tree only when the repo still hashes to that baseline and
+  otherwise returns a refusal. It never deletes or partially applies saved state: a failed
+  run's staging copy is the only surviving record of an expensive editing turn.
+- **An extract is one measured memory change plus the skill(s) it pays for.** `anchoredHunks`
+  merges adjacent removals, so extracting neighbouring sections yields one change and N
+  created skills - one honest accept/reject decision, since a merged change cannot be
+  half-accepted. `buildProposal` allows N skills only when they share ONE hunk; separately
+  measured skills must stay separate edits. Edits carry `skills: []`; read them through
+  `editSkills` (`src/skills.js`), which also understands the pre-0.1.8 single `skill`.
 - **Skills only count if a harness loads them.** Extractions target `.agents/skills` with
   `.claude/skills -> ../.agents/skills` as a symlink (`ensureSkillsLayout` in
   `src/skills.js`, run at write time); a bare `skills/` dir is never auto-detected and a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,15 +76,14 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   the proposal, which apply refuses rather than part-applies. Never pass
   `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that
   writes there fails the run loudly.
-- **An annotate turn has three outcomes, and conflating them is the 0.1.7 failure mode**
-  (`annotateLoop` in `src/synthesize.js`): the staging tree moved (re-measure and re-ask -
-  costs no `ANNOTATE_TURNS` attempt, bounded by `REMEASURE_TURNS`), the adapter returned
-  no text at all (retry once in a NEW session - the old context is the suspect), or the
-  answer was judged by the gates (the only outcome that spends an attempt and writes a
-  rejected `proposal.json`, stamped with `attempt`). `ProposalViolation` carries `reason`
-  and the `saved` proposal's own attempt/violations so a later empty turn is never reported
-  as that proposal's author. A new synthesis clears the prior proposal before its first
-  model call, so an empty-only failure cannot leave an older proposal applicable.
+- **Annotate-loop outcomes stay distinct** (`annotateLoop` in `src/synthesize.js`): a
+  moved staging tree is re-measured without spending an `ANNOTATE_TURNS` attempt (bounded
+  by `REMEASURE_TURNS`); no adapter text is retried once in a new session; and only a
+  non-empty answer spends an annotation attempt. Only a parseable, gate-rejected answer
+  writes `proposal.json`, stamped with `attempt`. `ProposalViolation` carries `reason` and
+  the `saved` proposal's own attempt/violations so a later empty turn is never reported as
+  that proposal's author. A new synthesis clears the prior proposal before its first model
+  call, so an empty-only failure cannot leave an older proposal applicable.
   `synthesisFailureHint` in `src/commands/propose.js` is
   where the advice for each terminal condition lives - never a blanket
   stronger-model/budget/max-edits line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,10 +83,7 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   writes `proposal.json`, stamped with `attempt`. `ProposalViolation` carries `reason` and
   the `saved` proposal's own attempt/violations so a later empty turn is never reported as
   that proposal's author. A new synthesis clears the prior proposal before its first model
-  call, so an empty-only failure cannot leave an older proposal applicable. `propose
---resume` restores the staged tree against the versioned `synthesis.json` baseline and
-  its evidence snapshot, refuses repository drift or created-skill collisions, and starts
-  annotation in a fresh fallthrough-capable session without discovery, folding, or editing.
+  call, so an empty-only failure cannot leave an older proposal applicable.
   `synthesisFailureHint` in `src/commands/propose.js` is
   where the advice for each terminal condition lives - never a blanket
   stronger-model/budget/max-edits line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,13 +58,12 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
-  For proposals carrying a memory-file hash, nothing is written until three gates pass:
+  For proposals carrying a memory-file hash, nothing is written until four gates pass:
   the memory file still exists and hashes to `proposal.memoryFile.hash` (`memoryFileSnapshot`,
   using `memoryTextHash` from `src/memory.js` so the check and the proposal cannot disagree), the
-  accepted subset clears
-  `budgetGateKind` (`src/tokens.js`), and every accepted edit for a file composes against
-  that file's one pre-write image. Any of them failing writes nothing and records no
-  rejection. A file is therefore applied whole or not at all, and a skill is written only
+  accepted subset clears `budgetGateKind` (`src/tokens.js`), every accepted edit for a file
+  composes against that file's one pre-write image, and every created skill target is still
+  absent. Any of them failing writes nothing and records no rejection. A file is therefore applied whole or not at all, and a skill is written only
   when the memory-file edit pointing at it has composed and is ready to land - skills go
   in first, so an interrupt or later write failure leaves an unreferenced skill rather
   than a memory file naming one that is missing.
@@ -84,7 +83,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   answer was judged by the gates (the only outcome that spends an attempt and writes a
   rejected `proposal.json`, stamped with `attempt`). `ProposalViolation` carries `reason`
   and the `saved` proposal's own attempt/violations so a later empty turn is never reported
-  as that proposal's author, and `synthesisFailureHint` in `src/commands/propose.js` is
+  as that proposal's author. A new synthesis clears the prior proposal before its first
+  model call, so an empty-only failure cannot leave an older proposal applicable.
+  `synthesisFailureHint` in `src/commands/propose.js` is
   where the advice for each terminal condition lives - never a blanket
   stronger-model/budget/max-edits line.
 - **An extract is one measured memory change plus the skill(s) it pays for.** `anchoredHunks`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,6 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   as that proposal's author, and `synthesisFailureHint` in `src/commands/propose.js` is
   where the advice for each terminal condition lives - never a blanket
   stronger-model/budget/max-edits line.
-- **`backpass propose --resume` re-annotates the staged tree instead of rebuilding it.**
-  `prepareWorkspace` records the baseline it measured against in `.backpass/synthesis.json`
-  (the tree itself cannot hold it - anything inside the workspace measures as a stray);
-  `restoreWorkspace` re-opens the tree only when the repo still hashes to that baseline and
-  otherwise returns a refusal. It never deletes or partially applies saved state: a failed
-  run's staging copy is the only surviving record of an expensive editing turn.
 - **An extract is one measured memory change plus the skill(s) it pays for.** `anchoredHunks`
   merges adjacent removals, so extracting neighbouring sections yields one change and N
   created skills - one honest accept/reject decision, since a merged change cannot be

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,20 +58,22 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
-  For proposals carrying a memory-file hash, nothing is written until four gates pass:
+  For proposals carrying a memory-file hash, nothing is written until five gates pass:
   the memory file still exists and hashes to `proposal.memoryFile.hash` (`memoryFileSnapshot`,
   using `memoryTextHash` from `src/memory.js` so the check and the proposal cannot disagree), the
   accepted subset clears `budgetGateKind` (`src/tokens.js`), every accepted edit for a file
   composes against that file's one pre-write image, and every created skill target is still
-  absent. Any of them failing writes nothing and records no rejection. A file is therefore applied whole or not at all, and a skill is written only
-  when the memory-file edit pointing at it has composed and is ready to land - skills go
-  in first, and a later skill failure rolls back the ones this round already wrote, so a
-  failed apply never leaves a memory file naming a skill that is missing.
+  absent. Any of them failing writes nothing and records no rejection. Accepted paths are
+  resolved before mutation, and duplicate resolved targets refuse the whole apply. Each file
+  is therefore applied whole or not at all. Skills and non-memory files land before the
+  memory file; a later failure rolls back files, skills, and loading-layout entries created
+  by the round. A rollback never overwrites a file whose identity or contents changed after
+  this round committed it - that conflict is reported and the concurrent version is kept.
 - **Synthesis edits natively, in a staging copy, never by describing text.** The agent
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,
-  `anchoredHunks`) and the agent annotates the measured changes by id in a second turn of
-  the same session. The model never supplies `find` text - every hunk is cut from the raw
+  `anchoredHunks`) and the agent annotates the measured changes by id, initially in the
+  same session. The model never supplies `find` text - every hunk is cut from the raw
   file, widened until unique, so a hunk can only go stale by the file itself changing after
   the proposal, which apply refuses rather than part-applies. Never pass
   `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,8 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   composes against that file's one pre-write image, and every created skill target is still
   absent. Any of them failing writes nothing and records no rejection. A file is therefore applied whole or not at all, and a skill is written only
   when the memory-file edit pointing at it has composed and is ready to land - skills go
-  in first, so an interrupt or later write failure leaves an unreferenced skill rather
-  than a memory file naming one that is missing.
+  in first, and a later skill failure rolls back the ones this round already wrote, so a
+  failed apply never leaves a memory file naming a skill that is missing.
 - **Synthesis edits natively, in a staging copy, never by describing text.** The agent
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,
@@ -83,10 +83,7 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   writes `proposal.json`, stamped with `attempt`. `ProposalViolation` carries `reason` and
   the `saved` proposal's own attempt/violations so a later empty turn is never reported as
   that proposal's author. A new synthesis clears the prior proposal before its first model
-  call, so an empty-only failure cannot leave an older proposal applicable. `propose
---resume` restores the staged tree against the versioned `synthesis.json` baseline and
-  its evidence snapshot, refuses repository drift or created-skill collisions, and starts
-  annotation in a fresh fallthrough-capable session without discovery, folding, or editing.
+  call, so an empty-only failure cannot leave an older proposal applicable.
   `synthesisFailureHint` in `src/commands/propose.js` is
   where the advice for each terminal condition lives - never a blanket
   stronger-model/budget/max-edits line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   moved staging tree is re-measured without spending an `ANNOTATE_TURNS` attempt (bounded
   by `REMEASURE_TURNS`); no adapter text is retried once in a new session; and only a
   non-empty answer spends an annotation attempt. Only a parseable, gate-rejected answer
-  writes `proposal.json`, stamped with `attempt`. `ProposalViolation` carries `reason` and
-  the `saved` proposal's own attempt/violations so a later empty turn is never reported as
-  that proposal's author. A new synthesis clears the prior proposal before its first model
+  writes a rejected `proposal.json` during the loop, stamped with `attempt`.
+  `ProposalViolation` carries `reason` and the `saved` proposal's own attempt/violations
+  so a later empty turn is never reported as that proposal's author. A new synthesis clears
+  the prior proposal before its first model
   call, so an empty-only failure cannot leave an older proposal applicable.
   `synthesisFailureHint` in `src/commands/propose.js` is
   where the advice for each terminal condition lives - never a blanket

--- a/README.md
+++ b/README.md
@@ -212,12 +212,8 @@ for different things:
   attempt and can trigger a re-prompt. Only a parseable, gate-rejected answer writes a
   rejected proposal, stamped with the attempt that produced it.
 
-When a run does fail, the advice it prints comes from the condition it ended on, and the
-staging copy is preserved. `backpass propose --resume` re-measures that existing tree and
-annotates it in a fresh session without discovery, analysis, or another editing turn. It
-refuses incompatible state without deleting or partially applying it, including a changed
-memory file, changed baseline skill, conflicting created skill, different checkout or
-target, or missing baseline evidence snapshot.
+When a run does fail, the advice it prints comes from the condition it ended on. Run
+`backpass propose` again to start a fresh synthesis.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -326,7 +322,6 @@ pointer-aware:
 | `backpass scan`             | collect samples only: the transcript table with a confidence column                      |
 | `backpass analyze`          | calculate loss: the tier-1 pass over pending transcripts                                 |
 | `backpass propose`          | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
-| `backpass propose --resume` | annotate the preserved staged synthesis in a fresh session, without a new edit turn      |
 | `backpass apply`            | review and write the accepted edits                                                      |
 | `backpass status`           | cache state, failed transcripts, budget bars                                             |
 | `backpass init`             | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
@@ -435,7 +430,6 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence-summary.json  aggregated gradients
   proposal.json          the latest parseable gradient-descent step (absent if none was produced)
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
-  synthesis.json         its baseline and evidence snapshot for safe `propose --resume`
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them

--- a/README.md
+++ b/README.md
@@ -279,11 +279,13 @@ that version. If it was removed or changed since - you pulled, edited it by hand
 agent did - the edits no longer describe what is on disk, so nothing is written and you are
 told to run `backpass` again to re-propose against the current file. Within a run every file
 is composed from one version: it takes every accepted edit or none of them. Apply also
-refuses the whole write if any created skill target already exists.
+refuses the whole write if any created skill target already exists or two accepted paths
+resolve to the same file.
 
-Skills are written only after every edit has composed, and before the memory file, so a
-write failure cannot leave the memory file pointing at a missing skill. If one skill write
-fails after another succeeded, apply rolls back the skills it wrote earlier in that round.
+Skills and non-memory files are written only after every edit has composed, with the memory
+file committed last. A later write failure rolls back files, skills, and loading-layout
+entries created earlier in that round. If another process changes a committed file before
+rollback reaches it, apply leaves that change untouched and reports the rollback conflict.
 
 For compatibility, proposals created by older backpass versions that do not contain a
 memory-file hash skip the freshness check. Regenerate such a proposal before applying it if

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ a sighting retires once the memory file gains an instruction that covers it, and
 sightings expire after `gapLedgerMaxAge` (default 90d). Until a gap corroborates it stays
 out of the proposal entirely.
 
-### 5. Gradient descent - one session, native edits
+### 5. Gradient descent - native edits
 
-A single high-reasoning session turns the aggregated gradients into concrete edits: ADD,
+A high-reasoning synthesis session turns the aggregated gradients into concrete edits: ADD,
 REMOVE, REWRITE, or EXTRACT→SKILL. The agent does not describe edits for backpass to
 splice in - it makes them, with its harness's own file tools, in a **staging copy** of the
 memory file under `.backpass/synthesis/` (the repo itself is read-only to it, for
@@ -195,10 +195,10 @@ accepted in halves - so when several sections leave together, their skills arriv
 extract with several skills, which is one honest accept/reject decision. Skills whose
 removals were measured separately stay separate decisions, and bundling them is refused.
 
-A violation triggers a re-prompt naming the exact breach (at most two). If those also
-fail, backpass **fails loudly** and saves the rejected proposal. It never silently
-truncates. A harness that writes past the staging copy into the repo is an error, never
-an apply.
+A malformed answer or gate violation triggers a re-prompt naming the exact breach (at
+most two). If those also fail, backpass **fails loudly** and preserves the latest parseable
+rejected proposal, if one was produced. It never silently truncates. A harness that writes
+past the staging copy into the repo is an error, never an apply.
 
 Not every annotate turn is an answer, and the three cases are kept apart because they call
 for different things:
@@ -208,8 +208,9 @@ for different things:
 - **the turn came back empty** - the harness returned success with no text at all. Nothing
   was said, so there is nothing to correct: the annotation is retried once in a **new**
   session, since the accumulated context of the old one is the likeliest cause.
-- **the answer was judged** - only this uses a re-prompt, and only this writes a rejected
-  proposal, stamped with the attempt that produced it.
+- **the turn returned text** - malformed JSON or a gate violation uses an annotation
+  attempt and can trigger a re-prompt. Only a parseable, gate-rejected answer writes a
+  rejected proposal, stamped with the attempt that produced it.
 
 When a run does fail, the advice it prints comes from the condition it ended on. Retry
 `backpass propose` to synthesize again from cached evidence, or rerun analysis first when
@@ -278,7 +279,8 @@ exact version of your memory file, so apply first checks the file still exists a
 that version. If it was removed or changed since - you pulled, edited it by hand, or another
 agent did - the edits no longer describe what is on disk, so nothing is written and you are
 told to run `backpass` again to re-propose against the current file. Within a run every file
-is composed from one version: it takes every accepted edit or none of them.
+is composed from one version: it takes every accepted edit or none of them. Apply also
+refuses the whole write if any created skill target already exists.
 
 Skills are written only after every edit has composed, and before the memory file, so a
 write failure cannot leave the memory file pointing at a missing skill. If one skill write

--- a/README.md
+++ b/README.md
@@ -212,8 +212,12 @@ for different things:
   attempt and can trigger a re-prompt. Only a parseable, gate-rejected answer writes a
   rejected proposal, stamped with the attempt that produced it.
 
-When a run does fail, the advice it prints comes from the condition it ended on. Run
-`backpass propose` again to start a fresh synthesis.
+When a run does fail, the advice it prints comes from the condition it ended on, and the
+staging copy is preserved. `backpass propose --resume` re-measures that existing tree and
+annotates it in a fresh session without discovery, analysis, or another editing turn. It
+refuses incompatible state without deleting or partially applying it, including a changed
+memory file, changed baseline skill, conflicting created skill, different checkout or
+target, or missing baseline evidence snapshot.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -283,8 +287,7 @@ refuses the whole write if any created skill target already exists.
 
 Skills are written only after every edit has composed, and before the memory file, so a
 write failure cannot leave the memory file pointing at a missing skill. If one skill write
-fails after another succeeded, apply names the unreferenced skill paths to remove before
-retrying.
+fails after another succeeded, apply rolls back the skills it wrote earlier in that round.
 
 For compatibility, proposals created by older backpass versions that do not contain a
 memory-file hash skip the freshness check. Regenerate such a proposal before applying it if
@@ -316,15 +319,16 @@ pointer-aware:
 
 ## CLI Reference
 
-| Command            | What it does                                                                             |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| `backpass`         | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
-| `backpass scan`    | collect samples only: the transcript table with a confidence column                      |
-| `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
-| `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
-| `backpass apply`   | review and write the accepted edits                                                      |
-| `backpass status`  | cache state, failed transcripts, budget bars                                             |
-| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
+| Command                     | What it does                                                                             |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `backpass`                  | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
+| `backpass scan`             | collect samples only: the transcript table with a confidence column                      |
+| `backpass analyze`          | calculate loss: the tier-1 pass over pending transcripts                                 |
+| `backpass propose`          | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
+| `backpass propose --resume` | annotate the preserved staged synthesis in a fresh session, without a new edit turn      |
+| `backpass apply`            | review and write the accepted edits                                                      |
+| `backpass status`           | cache state, failed transcripts, budget bars                                             |
+| `backpass init`             | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
 
 Run `backpass --help` for the full flag list.
 
@@ -430,6 +434,7 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence-summary.json  aggregated gradients
   proposal.json          the latest parseable gradient-descent step (absent if none was produced)
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
+  synthesis.json         its baseline and evidence snapshot for safe `propose --resume`
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them

--- a/README.md
+++ b/README.md
@@ -189,10 +189,39 @@ Then mechanical gates run, and they are not negotiable:
 - every edit carries a verbatim quote
 - the post-edit file must fit the budget, measured on the staged file
 
+An extraction is the created `SKILL.md` plus the memory-file change that pays for it.
+Neighbouring removals are merged into one measured change, and a merged change cannot be
+accepted in halves - so when several sections leave together, their skills arrive as one
+extract with several skills, which is one honest accept/reject decision. Skills whose
+removals were measured separately stay separate decisions, and bundling them is refused.
+
 A violation triggers a re-prompt naming the exact breach (at most two). If those also
 fail, backpass **fails loudly** and saves the rejected proposal. It never silently
 truncates. A harness that writes past the staging copy into the repo is an error, never
 an apply.
+
+Not every annotate turn is an answer, and the three cases are kept apart because they call
+for different things:
+
+- **the agent edited the copy again** - the ids it was given no longer describe the files.
+  It is shown the fresh measurement and answers again; this costs no re-prompt.
+- **the turn came back empty** - the harness returned success with no text at all. Nothing
+  was said, so there is nothing to correct: the annotation is retried once in a **new**
+  session, since the accumulated context of the old one is the likeliest cause.
+- **the answer was judged** - only this uses a re-prompt, and only this writes a rejected
+  proposal, stamped with the attempt that produced it.
+
+When a run does fail, the advice it prints comes from the condition it ended on, and the
+staging copy is left where it is:
+
+```
+backpass propose --resume
+```
+
+re-measures `.backpass/synthesis/` as it stands and annotates it in a fresh session -
+no discovery, no analysis, no second editing turn. It refuses, without deleting or
+half-applying anything, when the repository moved on under it: a changed memory file, a
+changed or missing skill, a different target, or another checkout.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -294,15 +323,16 @@ pointer-aware:
 
 ## CLI Reference
 
-| Command            | What it does                                                                             |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| `backpass`         | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
-| `backpass scan`    | collect samples only: the transcript table with a confidence column                      |
-| `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
-| `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
-| `backpass apply`   | review and write the accepted edits                                                      |
-| `backpass status`  | cache state, failed transcripts, budget bars                                             |
-| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
+| Command                     | What it does                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| `backpass`                  | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes.     |
+| `backpass scan`             | collect samples only: the transcript table with a confidence column                          |
+| `backpass analyze`          | calculate loss: the tier-1 pass over pending transcripts                                     |
+| `backpass propose`          | aggregate gradients + gradient descent: the tier-2 pass from cached evidence                 |
+| `backpass propose --resume` | annotate the staged synthesis again, in a fresh session, without re-running the editing turn |
+| `backpass apply`            | review and write the accepted edits                                                          |
+| `backpass status`           | cache state, failed transcripts, budget bars                                                 |
+| `backpass init`             | write `.backpassrc.json`, exclude `.backpass/` locally                                       |
 
 Run `backpass --help` for the full flag list.
 
@@ -407,6 +437,7 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence-summary.json  aggregated gradients
   proposal.json          the latest gradient-descent step
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
+  synthesis.json         what that copy was measured against, so `propose --resume` can re-open it
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them

--- a/README.md
+++ b/README.md
@@ -211,17 +211,9 @@ for different things:
 - **the answer was judged** - only this uses a re-prompt, and only this writes a rejected
   proposal, stamped with the attempt that produced it.
 
-When a run does fail, the advice it prints comes from the condition it ended on, and the
-staging copy is left where it is:
-
-```
-backpass propose --resume
-```
-
-re-measures `.backpass/synthesis/` as it stands and annotates it in a fresh session -
-no discovery, no analysis, no second editing turn. It refuses, without deleting or
-half-applying anything, when the repository moved on under it: a changed memory file, a
-changed or missing skill, a different target, or another checkout.
+When a run does fail, the advice it prints comes from the condition it ended on. Retry
+`backpass propose` to synthesize again from cached evidence, or rerun analysis first when
+the memory file changed.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -323,16 +315,15 @@ pointer-aware:
 
 ## CLI Reference
 
-| Command                     | What it does                                                                                 |
-| --------------------------- | -------------------------------------------------------------------------------------------- |
-| `backpass`                  | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes.     |
-| `backpass scan`             | collect samples only: the transcript table with a confidence column                          |
-| `backpass analyze`          | calculate loss: the tier-1 pass over pending transcripts                                     |
-| `backpass propose`          | aggregate gradients + gradient descent: the tier-2 pass from cached evidence                 |
-| `backpass propose --resume` | annotate the staged synthesis again, in a fresh session, without re-running the editing turn |
-| `backpass apply`            | review and write the accepted edits                                                          |
-| `backpass status`           | cache state, failed transcripts, budget bars                                                 |
-| `backpass init`             | write `.backpassrc.json`, exclude `.backpass/` locally                                       |
+| Command            | What it does                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| `backpass`         | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
+| `backpass scan`    | collect samples only: the transcript table with a confidence column                      |
+| `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
+| `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
+| `backpass apply`   | review and write the accepted edits                                                      |
+| `backpass status`  | cache state, failed transcripts, budget bars                                             |
+| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
 
 Run `backpass --help` for the full flag list.
 
@@ -437,7 +428,6 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence-summary.json  aggregated gradients
   proposal.json          the latest gradient-descent step
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
-  synthesis.json         what that copy was measured against, so `propose --resume` can re-open it
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   scan-cache.json        collect-samples verdicts by path + mtime + size
   evidence/<id>.json     per-transcript loss
   evidence-summary.json  aggregated gradients
-  proposal.json          the latest gradient-descent step
+  proposal.json          the latest parseable gradient-descent step (absent if none was produced)
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when

--- a/README.md
+++ b/README.md
@@ -212,9 +212,12 @@ for different things:
   attempt and can trigger a re-prompt. Only a parseable, gate-rejected answer writes a
   rejected proposal, stamped with the attempt that produced it.
 
-When a run does fail, the advice it prints comes from the condition it ended on. Retry
-`backpass propose` to synthesize again from cached evidence, or rerun analysis first when
-the memory file changed.
+When a run does fail, the advice it prints comes from the condition it ended on, and the
+staging copy is preserved. `backpass propose --resume` re-measures that existing tree and
+annotates it in a fresh session without discovery, analysis, or another editing turn. It
+refuses incompatible state without deleting or partially applying it, including a changed
+memory file, changed baseline skill, conflicting created skill, different checkout or
+target, or missing baseline evidence snapshot.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -317,15 +320,16 @@ pointer-aware:
 
 ## CLI Reference
 
-| Command            | What it does                                                                             |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| `backpass`         | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
-| `backpass scan`    | collect samples only: the transcript table with a confidence column                      |
-| `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
-| `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
-| `backpass apply`   | review and write the accepted edits                                                      |
-| `backpass status`  | cache state, failed transcripts, budget bars                                             |
-| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
+| Command                     | What it does                                                                             |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `backpass`                  | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
+| `backpass scan`             | collect samples only: the transcript table with a confidence column                      |
+| `backpass analyze`          | calculate loss: the tier-1 pass over pending transcripts                                 |
+| `backpass propose`          | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
+| `backpass propose --resume` | annotate the preserved staged synthesis in a fresh session, without a new edit turn      |
+| `backpass apply`            | review and write the accepted edits                                                      |
+| `backpass status`           | cache state, failed transcripts, budget bars                                             |
+| `backpass init`             | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
 
 Run `backpass --help` for the full flag list.
 
@@ -431,6 +435,7 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence-summary.json  aggregated gradients
   proposal.json          the latest parseable gradient-descent step (absent if none was produced)
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
+  synthesis.json         its baseline and evidence snapshot for safe `propose --resume`
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them

--- a/README.md
+++ b/README.md
@@ -316,15 +316,15 @@ pointer-aware:
 
 ## CLI Reference
 
-| Command                     | What it does                                                                             |
-| --------------------------- | ---------------------------------------------------------------------------------------- |
-| `backpass`                  | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
-| `backpass scan`             | collect samples only: the transcript table with a confidence column                      |
-| `backpass analyze`          | calculate loss: the tier-1 pass over pending transcripts                                 |
-| `backpass propose`          | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
-| `backpass apply`            | review and write the accepted edits                                                      |
-| `backpass status`           | cache state, failed transcripts, budget bars                                             |
-| `backpass init`             | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
+| Command            | What it does                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| `backpass`         | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
+| `backpass scan`    | collect samples only: the transcript table with a confidence column                      |
+| `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
+| `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
+| `backpass apply`   | review and write the accepted edits                                                      |
+| `backpass status`  | cache state, failed transcripts, budget bars                                             |
+| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
 
 Run `backpass --help` for the full flag list.
 

--- a/README.md
+++ b/README.md
@@ -212,12 +212,8 @@ for different things:
   attempt and can trigger a re-prompt. Only a parseable, gate-rejected answer writes a
   rejected proposal, stamped with the attempt that produced it.
 
-When a run does fail, the advice it prints comes from the condition it ended on, and the
-staging copy is preserved. `backpass propose --resume` re-measures that existing tree and
-annotates it in a fresh session without discovery, analysis, or another editing turn. It
-refuses incompatible state without deleting or partially applying it, including a changed
-memory file, changed baseline skill, conflicting created skill, different checkout or
-target, or missing baseline evidence snapshot.
+When a run does fail, the advice it prints comes from the condition it ended on. Run
+`backpass propose` again to start a fresh synthesis.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -319,16 +315,15 @@ pointer-aware:
 
 ## CLI Reference
 
-| Command                     | What it does                                                                             |
-| --------------------------- | ---------------------------------------------------------------------------------------- |
-| `backpass`                  | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
-| `backpass scan`             | collect samples only: the transcript table with a confidence column                      |
-| `backpass analyze`          | calculate loss: the tier-1 pass over pending transcripts                                 |
-| `backpass propose`          | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
-| `backpass propose --resume` | annotate the preserved staged synthesis in a fresh session, without a new edit turn      |
-| `backpass apply`            | review and write the accepted edits                                                      |
-| `backpass status`           | cache state, failed transcripts, budget bars                                             |
-| `backpass init`             | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
+| Command            | What it does                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| `backpass`         | collect samples → calculate loss → aggregate gradients → gradient descent. Never writes. |
+| `backpass scan`    | collect samples only: the transcript table with a confidence column                      |
+| `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
+| `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
+| `backpass apply`   | review and write the accepted edits                                                      |
+| `backpass status`  | cache state, failed transcripts, budget bars                                             |
+| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
 
 Run `backpass --help` for the full flag list.
 
@@ -434,7 +429,6 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   evidence-summary.json  aggregated gradients
   proposal.json          the latest parseable gradient-descent step (absent if none was produced)
   synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
-  synthesis.json         its baseline and evidence snapshot for safe `propose --resume`
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ out of the proposal entirely.
 
 ### 5. Gradient descent - native edits
 
-A high-reasoning synthesis session turns the aggregated gradients into concrete edits: ADD,
+A high-reasoning synthesis run turns the aggregated gradients into concrete edits: ADD,
 REMOVE, REWRITE, or EXTRACT→SKILL. The agent does not describe edits for backpass to
 splice in - it makes them, with its harness's own file tools, in a **staging copy** of the
 memory file under `.backpass/synthesis/` (the repo itself is read-only to it, for

--- a/VISION.md
+++ b/VISION.md
@@ -61,7 +61,7 @@ When coverage and accuracy are in tension, accuracy wins.
 
 ## Failure is loud and named
 
-A gate violation re-prompts with the exact breach, then fails the run and saves the rejected proposal, and never silently truncates to fit.
+A parseable proposal with gate violations is saved with its provenance before the exact breaches are re-prompted; any terminal failure is named, and the run never silently truncates to fit.
 A missing capability is named along with the command that would fix it, and `n/a` is not an acceptable thing to print at a person.
 A gap in capability is fixed or reported, never papered over with a weaker path that quietly produces worse results.
 A drifted store must never look identical to a repo with no history.

--- a/src/apply/terminal.js
+++ b/src/apply/terminal.js
@@ -2,6 +2,7 @@ import readline from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 
 import { UserError, color } from "../logger.js";
+import { editSkills } from "../skills.js";
 import { formatTokens } from "../tokens.js";
 
 /**
@@ -51,10 +52,10 @@ export function renderEdit(edit, index, total) {
   out.push("");
   out.push(renderDiff(edit));
 
-  if (edit.kind === "extract" && edit.skill) {
+  for (const skill of edit.kind === "extract" ? editSkills(edit) : []) {
     out.push("");
-    out.push(color.dim(`  new skill: ${edit.skill.path}`));
-    out.push(color.dim(`  description: ${edit.skill.description}`));
+    out.push(color.dim(`  new skill: ${skill.path}`));
+    out.push(color.dim(`  description: ${skill.description}`));
   }
 
   if (edit.evidence?.length) {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -127,7 +127,7 @@ function atomicReplace(target, text) {
       try {
         fs.closeSync(fd);
       } catch {
-        fd = undefined;
+        // Preserve the original write error.
       }
     }
     removeOwnedSkillPaths(ownership ?? []);
@@ -170,12 +170,13 @@ function removeEmptyDirectories(directories) {
  * The only place in backpass that writes to the repo.
  *
  * Everything upstream is read-only analysis; a run only changes the weights here, after
- * a human accepted specific edits. Four gates run before the first byte is written:
+ * a human accepted specific edits. Five gates run before the first byte is written:
  * the memory file must still be the file the proposal was measured against
  * (`memoryFileSnapshot`), the accepted subset must clear the same cap/shrink budget gate as
  * the full proposal (`budgetGateKind`), every accepted edit for a file must compose
- * against that file's single pre-write image, and every created skill target must still be
- * absent. Any of them failing writes nothing and records no rejection.
+ * against that file's single pre-write image, every created skill target must still be
+ * absent, and accepted paths must resolve to distinct targets. Any of them failing writes
+ * nothing and records no rejection.
  *
  * A file is therefore applied all at once or not at all. Skills are written only after
  * every accepted edit has composed, and before the files that reference them.
@@ -266,14 +267,16 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
 
   const plannedTargets = new Map();
+  const resolvedPlanned = [];
   for (const item of planned) {
+    let resolved;
     try {
-      item.resolved = fs.realpathSync(item.absolute);
+      resolved = fs.realpathSync(item.absolute);
     } catch (err) {
       results.failed.push({ file: item.relative, error: `${item.relative} could not be resolved: ${err.message}` });
       continue;
     }
-    const existing = plannedTargets.get(item.resolved);
+    const existing = plannedTargets.get(resolved);
     if (existing) {
       results.failed.push({
         file: item.relative,
@@ -281,7 +284,9 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
       });
       continue;
     }
-    plannedTargets.set(item.resolved, item);
+    const resolvedItem = { ...item, resolved };
+    plannedTargets.set(resolved, resolvedItem);
+    resolvedPlanned.push(resolvedItem);
   }
 
   if (results.failed.length) return results;
@@ -357,7 +362,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     return results;
   }
 
-  const orderedPlanned = [...planned].sort((a, b) => {
+  const orderedPlanned = [...resolvedPlanned].sort((a, b) => {
     const aMemory = a.relative === proposal.memoryFile.path;
     const bMemory = b.relative === proposal.memoryFile.path;
     return Number(aMemory) - Number(bMemory);

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -146,6 +146,26 @@ function commitStillCurrent(commit) {
   }
 }
 
+function absentParentDirectories(root, files) {
+  const directories = new Set();
+  for (const file of files) {
+    for (let current = path.dirname(file); current !== root; current = path.dirname(current)) {
+      if (!fs.existsSync(current)) directories.add(current);
+    }
+  }
+  return [...directories].sort((a, b) => b.length - a.length);
+}
+
+function removeEmptyDirectories(directories) {
+  for (const directory of directories) {
+    try {
+      fs.rmdirSync(directory);
+    } catch {
+      continue;
+    }
+  }
+}
+
 /**
  * The only place in backpass that writes to the repo.
  *
@@ -288,6 +308,13 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
   if (results.failed.length) return results;
 
+  const canonical = plannedSkills.find(
+    ({ skill }) => skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`),
+  );
+  const createdDirectoryCandidates = absentParentDirectories(repo.root, [
+    ...plannedSkills.map(({ skill }) => path.join(repo.root, skill.path)),
+    ...(canonical ? [path.join(repo.root, CLAUDE_SKILLS_LINK)] : []),
+  ]);
   const skillFailures = [];
   const writtenSkillPaths = [];
   const ownedSkillPaths = [];
@@ -307,22 +334,9 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     }
   }
 
-  const canonical = plannedSkills.find(
-    ({ skill }) => skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`),
-  );
-  if (!dryRun && !skillFailures.length && canonical) {
-    try {
-      const layout = ensureSkillsLayout(repo.root);
-      const result = results.skills.find(({ path: skillPath }) => skillPath === canonical.skill.path);
-      result.created = [...new Set([...result.created, ...layout.created])];
-      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
-    } catch (err) {
-      skillFailures.push({ file: CLAUDE_SKILLS_LINK, edit: canonical.edit.id, error: err.message });
-    }
-  }
-
   const rollbackSkills = () => {
     removeOwnedSkillPaths(ownedSkillPaths);
+    removeEmptyDirectories(createdDirectoryCandidates);
     results.skills = [];
     if (writtenSkillPaths.length) {
       results.failed.push({
@@ -349,6 +363,26 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     return Number(aMemory) - Number(bMemory);
   });
   const committed = [];
+  const rollbackCommitted = () => {
+    for (const written of [...committed].reverse()) {
+      if (!commitStillCurrent(written.commit)) {
+        results.failed.push({
+          file: written.relative,
+          error: `${written.relative} rollback conflict: the file changed after this apply wrote it; left untouched`,
+        });
+        continue;
+      }
+      try {
+        atomicReplace(written.commit.absolute, written.before);
+      } catch (rollbackError) {
+        results.failed.push({
+          file: written.relative,
+          error: `${written.relative} could not be rolled back: ${rollbackError.message}`,
+        });
+      }
+    }
+    results.written = [];
+  };
   for (const item of orderedPlanned) {
     const { relative, resolved, before, text, applied } = item;
     const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
@@ -361,24 +395,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
         file: relative,
         error: `${relative} could not be written: ${err.message}`,
       });
-      for (const written of [...committed].reverse()) {
-        if (!commitStillCurrent(written.commit)) {
-          results.failed.push({
-            file: written.relative,
-            error: `${written.relative} rollback conflict: the file changed after this apply wrote it; left untouched`,
-          });
-          continue;
-        }
-        try {
-          atomicReplace(written.commit.absolute, written.before);
-        } catch (rollbackError) {
-          results.failed.push({
-            file: written.relative,
-            error: `${written.relative} could not be rolled back: ${rollbackError.message}`,
-          });
-        }
-      }
-      results.written = [];
+      rollbackCommitted();
       rollbackSkills();
       return results;
     }
@@ -387,6 +404,20 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
     // Shrinking over several runs is the design, so this is a heading, not a failure.
     if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
+  }
+
+  if (!dryRun && canonical) {
+    try {
+      const layout = ensureSkillsLayout(repo.root);
+      const result = results.skills.find(({ path: skillPath }) => skillPath === canonical.skill.path);
+      result.created = [...new Set([...result.created, ...layout.created])];
+      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
+    } catch (err) {
+      results.failed.push({ file: CLAUDE_SKILLS_LINK, edit: canonical.edit.id, error: err.message });
+      rollbackCommitted();
+      rollbackSkills();
+      return results;
+    }
   }
 
   // Rejections are remembered so the same edit is not re-proposed without new evidence.

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -107,19 +107,22 @@ function overBudgetWarning(relative, budget) {
 }
 
 function atomicReplace(absolute, text) {
-  const temp = path.join(path.dirname(absolute), `.${path.basename(absolute)}.backpass-${randomUUID()}`);
-  const mode = fs.statSync(absolute).mode & 0o7777;
+  const target = fs.realpathSync(absolute);
+  const temp = path.join(path.dirname(target), `.${path.basename(target)}.backpass-${randomUUID()}`);
+  const mode = fs.statSync(target).mode & 0o7777;
   let fd;
   let ownership;
   try {
     fd = fs.openSync(temp, "wx");
-    ownership = [{ absolute: temp, identity: { dev: fs.fstatSync(fd).dev, ino: fs.fstatSync(fd).ino } }];
+    const stat = fs.fstatSync(fd);
+    ownership = [{ absolute: temp, identity: { dev: stat.dev, ino: stat.ino } }];
     fs.fchmodSync(fd, mode);
     fs.writeFileSync(fd, text);
     fs.fsyncSync(fd);
     fs.closeSync(fd);
     fd = undefined;
-    fs.renameSync(temp, absolute);
+    fs.renameSync(temp, target);
+    return { absolute: target, identity: ownership[0].identity, text };
   } catch (err) {
     if (fd !== undefined) {
       try {
@@ -130,6 +133,17 @@ function atomicReplace(absolute, text) {
     }
     removeOwnedSkillPaths(ownership ?? []);
     throw err;
+  }
+}
+
+function commitStillCurrent(commit) {
+  let stat;
+  try {
+    stat = fs.lstatSync(commit.absolute);
+    if (stat.dev !== commit.identity.dev || stat.ino !== commit.identity.ino) return false;
+    return fs.readFileSync(commit.absolute, "utf8") === commit.text;
+  } catch {
+    return false;
   }
 }
 
@@ -321,16 +335,24 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     const { relative, absolute, before, text, applied } = item;
     const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
 
+    let commit = null;
     try {
-      if (!dryRun) atomicReplace(absolute, text);
+      if (!dryRun) commit = atomicReplace(absolute, text);
     } catch (err) {
       results.failed.push({
         file: relative,
         error: `${relative} could not be written: ${err.message}`,
       });
       for (const written of [...committed].reverse()) {
+        if (!commitStillCurrent(written.commit)) {
+          results.failed.push({
+            file: written.relative,
+            error: `${written.relative} rollback conflict: the file changed after this apply wrote it; left untouched`,
+          });
+          continue;
+        }
         try {
-          atomicReplace(written.absolute, written.before);
+          atomicReplace(written.commit.absolute, written.before);
         } catch (rollbackError) {
           results.failed.push({
             file: written.relative,
@@ -342,7 +364,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
       rollbackSkills();
       return results;
     }
-    committed.push(item);
+    committed.push({ ...item, commit });
     results.written.push({ file: relative, edits: applied, budget, dryRun });
 
     // Shrinking over several runs is the design, so this is a heading, not a failure.

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -239,7 +239,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
       results.skills.push({ path: skill.path, dryRun, created: layout.created });
       if (!dryRun) {
         writtenSkillPaths.push(skill.path);
-        ownedSkillPaths.push(...layout.ownership);
+        ownedSkillPaths.push(...("ownership" in layout && Array.isArray(layout.ownership) ? layout.ownership : []));
       }
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -5,7 +5,7 @@ import { applyEdit, projectWithDecisions } from "../proposal.js";
 import { memoryTextHash } from "../memory.js";
 import { budgetGateKind, budgetStatus, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
-import { writeSkill } from "../skills.js";
+import { editSkills, writeSkill } from "../skills.js";
 
 function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText }) {
   if (!accepted.length) return null;
@@ -205,15 +205,19 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   const skillFailures = [];
   const writtenSkillPaths = [];
   for (const edit of accepted) {
-    if (edit.kind !== "extract" || !edit.skill) continue;
+    if (edit.kind !== "extract") continue;
     if (!landed.has(edit.id)) continue;
-    try {
-      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, edit.skill);
-      results.skills.push({ path: edit.skill.path, dryRun, created: layout.created });
-      if (!dryRun) writtenSkillPaths.push(edit.skill.path);
-      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
-    } catch (err) {
-      skillFailures.push({ file: edit.skill.path, edit: edit.id, error: err.message });
+    // One edit may create several skills when their removals were measured as one change;
+    // they land together, before the memory file that will point at all of them.
+    for (const skill of editSkills(edit)) {
+      try {
+        const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, skill);
+        results.skills.push({ path: skill.path, dryRun, created: layout.created });
+        if (!dryRun) writtenSkillPaths.push(skill.path);
+        for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
+      } catch (err) {
+        skillFailures.push({ file: skill.path, edit: edit.id, error: err.message });
+      }
     }
   }
 

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -106,8 +106,7 @@ function overBudgetWarning(relative, budget) {
   );
 }
 
-function atomicReplace(absolute, text) {
-  const target = fs.realpathSync(absolute);
+function atomicReplace(target, text) {
   const temp = path.join(path.dirname(target), `.${path.basename(target)}.backpass-${randomUUID()}`);
   const mode = fs.statSync(target).mode & 0o7777;
   let fd;
@@ -246,6 +245,25 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     for (const id of applied) landed.add(id);
   }
 
+  const plannedTargets = new Map();
+  for (const item of planned) {
+    try {
+      item.resolved = fs.realpathSync(item.absolute);
+    } catch (err) {
+      results.failed.push({ file: item.relative, error: `${item.relative} could not be resolved: ${err.message}` });
+      continue;
+    }
+    const existing = plannedTargets.get(item.resolved);
+    if (existing) {
+      results.failed.push({
+        file: item.relative,
+        error: `${item.relative} resolves to the same target as ${existing.relative}; nothing was written`,
+      });
+      continue;
+    }
+    plannedTargets.set(item.resolved, item);
+  }
+
   if (results.failed.length) return results;
 
   // Skills go in before the memory file. A skill nothing points at yet is inert, while a
@@ -332,12 +350,12 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   });
   const committed = [];
   for (const item of orderedPlanned) {
-    const { relative, absolute, before, text, applied } = item;
+    const { relative, resolved, before, text, applied } = item;
     const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
 
     let commit = null;
     try {
-      if (!dryRun) commit = atomicReplace(absolute, text);
+      if (!dryRun) commit = atomicReplace(resolved, text);
     } catch (err) {
       results.failed.push({
         file: relative,

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -5,7 +5,7 @@ import { applyEdit, projectWithDecisions } from "../proposal.js";
 import { memoryTextHash } from "../memory.js";
 import { budgetGateKind, budgetStatus, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
-import { editSkills, writeSkill } from "../skills.js";
+import { CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK, editSkills, writeSkill } from "../skills.js";
 
 function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText }) {
   if (!accepted.length) return null;
@@ -96,6 +96,55 @@ function overBudgetWarning(relative, budget) {
     `${relative} is still ${formatTokens(budget.over)} tokens over the ${formatTokens(budget.capTokens)}-token ` +
     "budget; run `backpass` again for the next shrink step"
   );
+}
+
+function pathExists(relative) {
+  try {
+    fs.lstatSync(relative);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Capture only paths this batch can create, so a failed later skill can be rolled back safely. */
+function skillWriteRollback(repoRoot, plannedSkills) {
+  const targets = plannedSkills.map(({ skill }) => path.join(repoRoot, skill.path));
+  const missingDirs = new Set();
+  for (const target of targets) {
+    for (let dir = path.dirname(target); dir !== repoRoot && !pathExists(dir); dir = path.dirname(dir)) {
+      missingDirs.add(dir);
+    }
+  }
+
+  const createsCanonicalLayout = plannedSkills.some(
+    ({ skill }) => skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`),
+  );
+  const claudeLink = path.join(repoRoot, CLAUDE_SKILLS_LINK);
+  const claudeLinkWasMissing = createsCanonicalLayout && !pathExists(claudeLink);
+  if (claudeLinkWasMissing) {
+    for (let dir = path.dirname(claudeLink); dir !== repoRoot && !pathExists(dir); dir = path.dirname(dir)) {
+      missingDirs.add(dir);
+    }
+  }
+
+  return (writtenPaths, createdLayout) => {
+    // Only remove targets whose exclusive write completed. A target that appeared in the
+    // preflight-to-write race belongs to somebody else and must never be cleaned up here.
+    for (const relative of [...writtenPaths].reverse()) {
+      fs.rmSync(path.join(repoRoot, relative), { force: true });
+    }
+    if (claudeLinkWasMissing && [...createdLayout].some((item) => item.startsWith(`${CLAUDE_SKILLS_LINK} ->`))) {
+      fs.rmSync(claudeLink, { force: true });
+    }
+    for (const dir of [...missingDirs].sort((a, b) => b.length - a.length)) {
+      try {
+        fs.rmdirSync(dir);
+      } catch {
+        // Keep non-empty directories: something outside this batch now owns their contents.
+      }
+    }
+  };
 }
 
 /**
@@ -221,13 +270,18 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
   if (results.failed.length) return results;
 
+  const rollbackSkillWrites = skillWriteRollback(repo.root, plannedSkills);
   const skillFailures = [];
   const writtenSkillPaths = [];
+  const createdSkillLayout = new Set();
   for (const { edit, skill } of plannedSkills) {
     try {
       const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, skill, { exclusive: true });
       results.skills.push({ path: skill.path, dryRun, created: layout.created });
-      if (!dryRun) writtenSkillPaths.push(skill.path);
+      if (!dryRun) {
+        writtenSkillPaths.push(skill.path);
+        for (const created of layout.created) createdSkillLayout.add(created);
+      }
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {
       skillFailures.push({ file: skill.path, edit: edit.id, error: err.message });
@@ -235,10 +289,12 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
 
   if (skillFailures.length) {
+    rollbackSkillWrites(writtenSkillPaths, createdSkillLayout);
+    results.skills = [];
     results.failed.push(...skillFailures);
     if (writtenSkillPaths.length) {
       results.failed.push({
-        error: `skill paths already written in this round: ${writtenSkillPaths.join(", ")}; remove them before retrying`,
+        error: `rolled back skill paths written earlier in this round: ${writtenSkillPaths.join(", ")}`,
       });
     }
     for (const { relative } of planned) {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -5,7 +5,7 @@ import { applyEdit, projectWithDecisions } from "../proposal.js";
 import { memoryTextHash } from "../memory.js";
 import { budgetGateKind, budgetStatus, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
-import { CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK, editSkills, writeSkill } from "../skills.js";
+import { editSkills, removeOwnedSkillPaths, writeSkill } from "../skills.js";
 
 function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText }) {
   if (!accepted.length) return null;
@@ -96,55 +96,6 @@ function overBudgetWarning(relative, budget) {
     `${relative} is still ${formatTokens(budget.over)} tokens over the ${formatTokens(budget.capTokens)}-token ` +
     "budget; run `backpass` again for the next shrink step"
   );
-}
-
-function pathExists(relative) {
-  try {
-    fs.lstatSync(relative);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/** Capture only paths this batch can create, so a failed later skill can be rolled back safely. */
-function skillWriteRollback(repoRoot, plannedSkills) {
-  const targets = plannedSkills.map(({ skill }) => path.join(repoRoot, skill.path));
-  const missingDirs = new Set();
-  for (const target of targets) {
-    for (let dir = path.dirname(target); dir !== repoRoot && !pathExists(dir); dir = path.dirname(dir)) {
-      missingDirs.add(dir);
-    }
-  }
-
-  const createsCanonicalLayout = plannedSkills.some(
-    ({ skill }) => skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`),
-  );
-  const claudeLink = path.join(repoRoot, CLAUDE_SKILLS_LINK);
-  const claudeLinkWasMissing = createsCanonicalLayout && !pathExists(claudeLink);
-  if (claudeLinkWasMissing) {
-    for (let dir = path.dirname(claudeLink); dir !== repoRoot && !pathExists(dir); dir = path.dirname(dir)) {
-      missingDirs.add(dir);
-    }
-  }
-
-  return (writtenPaths, createdLayout) => {
-    // Only remove targets whose exclusive write completed. A target that appeared in the
-    // preflight-to-write race belongs to somebody else and must never be cleaned up here.
-    for (const relative of [...writtenPaths].reverse()) {
-      fs.rmSync(path.join(repoRoot, relative), { force: true });
-    }
-    if (claudeLinkWasMissing && [...createdLayout].some((item) => item.startsWith(`${CLAUDE_SKILLS_LINK} ->`))) {
-      fs.rmSync(claudeLink, { force: true });
-    }
-    for (const dir of [...missingDirs].sort((a, b) => b.length - a.length)) {
-      try {
-        fs.rmdirSync(dir);
-      } catch {
-        // Keep non-empty directories: something outside this batch now owns their contents.
-      }
-    }
-  };
 }
 
 /**
@@ -270,17 +221,16 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
   if (results.failed.length) return results;
 
-  const rollbackSkillWrites = skillWriteRollback(repo.root, plannedSkills);
   const skillFailures = [];
   const writtenSkillPaths = [];
-  const createdSkillLayout = new Set();
+  const ownedSkillPaths = [];
   for (const { edit, skill } of plannedSkills) {
     try {
       const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, skill, { exclusive: true });
       results.skills.push({ path: skill.path, dryRun, created: layout.created });
       if (!dryRun) {
         writtenSkillPaths.push(skill.path);
-        for (const created of layout.created) createdSkillLayout.add(created);
+        ownedSkillPaths.push(...layout.ownership);
       }
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {
@@ -289,7 +239,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
 
   if (skillFailures.length) {
-    rollbackSkillWrites(writtenSkillPaths, createdSkillLayout);
+    removeOwnedSkillPaths(ownedSkillPaths);
     results.skills = [];
     results.failed.push(...skillFailures);
     if (writtenSkillPaths.length) {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -102,12 +102,12 @@ function overBudgetWarning(relative, budget) {
  * The only place in backpass that writes to the repo.
  *
  * Everything upstream is read-only analysis; a run only changes the weights here, after
- * a human accepted specific edits. Three gates run before the first byte is written:
+ * a human accepted specific edits. Four gates run before the first byte is written:
  * the memory file must still be the file the proposal was measured against
  * (`memoryFileSnapshot`), the accepted subset must clear the same cap/shrink budget gate as
- * the full proposal (`budgetGateKind`), and every accepted edit for a file must compose
- * against that file's single pre-write image. Any of them failing writes nothing and
- * records no rejection.
+ * the full proposal (`budgetGateKind`), every accepted edit for a file must compose
+ * against that file's single pre-write image, and every created skill target must still be
+ * absent. Any of them failing writes nothing and records no rejection.
  *
  * A file is therefore applied all at once or not at all. Skills are written only after
  * every accepted edit has composed, and before the files that reference them.
@@ -202,22 +202,35 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   // Skills go in before the memory file. A skill nothing points at yet is inert, while a
   // memory file pointing at a skill that is not there is actively wrong - so if a skill
   // cannot be written, the files that would reference it are left alone.
+  const plannedSkills = [];
+  const skillPaths = new Set();
+  for (const edit of accepted) {
+    if (edit.kind !== "extract" || !landed.has(edit.id)) continue;
+    for (const skill of editSkills(edit)) {
+      const absolute = path.join(repo.root, skill.path);
+      if (skillPaths.has(skill.path) || fs.existsSync(absolute)) {
+        results.failed.push({
+          file: skill.path,
+          edit: edit.id,
+          error: `${skill.path} already exists; nothing was written`,
+        });
+      }
+      skillPaths.add(skill.path);
+      plannedSkills.push({ edit, skill });
+    }
+  }
+  if (results.failed.length) return results;
+
   const skillFailures = [];
   const writtenSkillPaths = [];
-  for (const edit of accepted) {
-    if (edit.kind !== "extract") continue;
-    if (!landed.has(edit.id)) continue;
-    // One edit may create several skills when their removals were measured as one change;
-    // they land together, before the memory file that will point at all of them.
-    for (const skill of editSkills(edit)) {
-      try {
-        const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, skill);
-        results.skills.push({ path: skill.path, dryRun, created: layout.created });
-        if (!dryRun) writtenSkillPaths.push(skill.path);
-        for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
-      } catch (err) {
-        skillFailures.push({ file: skill.path, edit: edit.id, error: err.message });
-      }
+  for (const { edit, skill } of plannedSkills) {
+    try {
+      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, skill, { exclusive: true });
+      results.skills.push({ path: skill.path, dryRun, created: layout.created });
+      if (!dryRun) writtenSkillPaths.push(skill.path);
+      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
+    } catch (err) {
+      skillFailures.push({ file: skill.path, edit: edit.id, error: err.message });
     }
   }
 

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -261,15 +261,19 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     }
   }
 
-  if (skillFailures.length) {
+  const rollbackSkills = () => {
     removeOwnedSkillPaths(ownedSkillPaths);
     results.skills = [];
-    results.failed.push(...skillFailures);
     if (writtenSkillPaths.length) {
       results.failed.push({
         error: `rolled back skill paths written earlier in this round: ${writtenSkillPaths.join(", ")}`,
       });
     }
+  };
+
+  if (skillFailures.length) {
+    results.failed.push(...skillFailures);
+    rollbackSkills();
     for (const { relative } of planned) {
       results.failed.push({
         file: relative,
@@ -282,7 +286,16 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   for (const { relative, absolute, before, text, applied } of planned) {
     const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
 
-    if (!dryRun) fs.writeFileSync(absolute, text);
+    try {
+      if (!dryRun) fs.writeFileSync(absolute, text);
+    } catch (err) {
+      results.failed.push({
+        file: relative,
+        error: `${relative} could not be written: ${err.message}`,
+      });
+      rollbackSkills();
+      return results;
+    }
     results.written.push({ file: relative, edits: applied, budget, dryRun });
 
     // Shrinking over several runs is the design, so this is a heading, not a failure.

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -5,7 +5,14 @@ import { applyEdit, projectWithDecisions } from "../proposal.js";
 import { memoryTextHash } from "../memory.js";
 import { budgetGateKind, budgetStatus, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
-import { editSkills, removeOwnedSkillPaths, writeSkill } from "../skills.js";
+import {
+  CANONICAL_SKILLS_DIR,
+  CLAUDE_SKILLS_LINK,
+  editSkills,
+  ensureSkillsLayout,
+  removeOwnedSkillPaths,
+  writeSkill,
+} from "../skills.js";
 
 function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText }) {
   if (!accepted.length) return null;
@@ -226,7 +233,9 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   const ownedSkillPaths = [];
   for (const { edit, skill } of plannedSkills) {
     try {
-      const layout = dryRun ? { created: [], warnings: [] } : writeSkill(repo.root, skill, { exclusive: true });
+      const layout = dryRun
+        ? { created: [], warnings: [] }
+        : writeSkill(repo.root, skill, { exclusive: true, ensureLayout: false });
       results.skills.push({ path: skill.path, dryRun, created: layout.created });
       if (!dryRun) {
         writtenSkillPaths.push(skill.path);
@@ -235,6 +244,20 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {
       skillFailures.push({ file: skill.path, edit: edit.id, error: err.message });
+    }
+  }
+
+  const canonical = plannedSkills.find(
+    ({ skill }) => skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`),
+  );
+  if (!dryRun && !skillFailures.length && canonical) {
+    try {
+      const layout = ensureSkillsLayout(repo.root);
+      const result = results.skills.find(({ path: skillPath }) => skillPath === canonical.skill.path);
+      result.created = [...new Set([...result.created, ...layout.created])];
+      for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
+    } catch (err) {
+      skillFailures.push({ file: CLAUDE_SKILLS_LINK, edit: canonical.edit.id, error: err.message });
     }
   }
 

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 
 import { applyEdit, projectWithDecisions } from "../proposal.js";
 import { memoryTextHash } from "../memory.js";
@@ -103,6 +104,33 @@ function overBudgetWarning(relative, budget) {
     `${relative} is still ${formatTokens(budget.over)} tokens over the ${formatTokens(budget.capTokens)}-token ` +
     "budget; run `backpass` again for the next shrink step"
   );
+}
+
+function atomicReplace(absolute, text) {
+  const temp = path.join(path.dirname(absolute), `.${path.basename(absolute)}.backpass-${randomUUID()}`);
+  const mode = fs.statSync(absolute).mode & 0o7777;
+  let fd;
+  let ownership;
+  try {
+    fd = fs.openSync(temp, "wx");
+    ownership = [{ absolute: temp, identity: { dev: fs.fstatSync(fd).dev, ino: fs.fstatSync(fd).ino } }];
+    fs.fchmodSync(fd, mode);
+    fs.writeFileSync(fd, text);
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = undefined;
+    fs.renameSync(temp, absolute);
+  } catch (err) {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        fd = undefined;
+      }
+    }
+    removeOwnedSkillPaths(ownership ?? []);
+    throw err;
+  }
 }
 
 /**
@@ -283,19 +311,38 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     return results;
   }
 
-  for (const { relative, absolute, before, text, applied } of planned) {
+  const orderedPlanned = [...planned].sort((a, b) => {
+    const aMemory = a.relative === proposal.memoryFile.path;
+    const bMemory = b.relative === proposal.memoryFile.path;
+    return Number(aMemory) - Number(bMemory);
+  });
+  const committed = [];
+  for (const item of orderedPlanned) {
+    const { relative, absolute, before, text, applied } = item;
     const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
 
     try {
-      if (!dryRun) fs.writeFileSync(absolute, text);
+      if (!dryRun) atomicReplace(absolute, text);
     } catch (err) {
       results.failed.push({
         file: relative,
         error: `${relative} could not be written: ${err.message}`,
       });
+      for (const written of [...committed].reverse()) {
+        try {
+          atomicReplace(written.absolute, written.before);
+        } catch (rollbackError) {
+          results.failed.push({
+            file: written.relative,
+            error: `${written.relative} could not be rolled back: ${rollbackError.message}`,
+          });
+        }
+      }
+      results.written = [];
       rollbackSkills();
       return results;
     }
+    committed.push(item);
     results.written.push({ file: relative, edits: applied, budget, dryRun });
 
     // Shrinking over several runs is the design, so this is a heading, not a failure.

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -321,7 +321,6 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     ...(canonical ? [path.join(repo.root, CLAUDE_SKILLS_LINK)] : []),
   ]);
   const skillFailures = [];
-  const writtenSkillPaths = [];
   const ownedSkillPaths = [];
   for (const { edit, skill } of plannedSkills) {
     try {
@@ -330,7 +329,6 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
         : writeSkill(repo.root, skill, { exclusive: true, ensureLayout: false });
       results.skills.push({ path: skill.path, dryRun, created: layout.created });
       if (!dryRun) {
-        writtenSkillPaths.push(skill.path);
         ownedSkillPaths.push(...("ownership" in layout && Array.isArray(layout.ownership) ? layout.ownership : []));
       }
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
@@ -340,12 +338,19 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
 
   const rollbackSkills = () => {
-    removeOwnedSkillPaths(ownedSkillPaths);
+    const { removed, conflicts } = removeOwnedSkillPaths(ownedSkillPaths);
     removeEmptyDirectories(createdDirectoryCandidates);
     results.skills = [];
-    if (writtenSkillPaths.length) {
+    const removedPaths = removed.map((item) => item.relative).filter(Boolean);
+    if (removedPaths.length) {
       results.failed.push({
-        error: `rolled back skill paths written earlier in this round: ${writtenSkillPaths.join(", ")}`,
+        error: `rolled back skill paths written earlier in this round: ${removedPaths.join(", ")}`,
+      });
+    }
+    for (const item of conflicts) {
+      results.failed.push({
+        file: item.relative,
+        error: `${item.relative} rollback conflict: the skill changed after this apply wrote it; left untouched`,
       });
     }
   };

--- a/src/cli.js
+++ b/src/cli.js
@@ -74,7 +74,7 @@ COMMANDS
              gradient descent. Never writes.
   scan       collect samples only: which transcripts belong to this repo, and how we know
   analyze    calculate loss: one cheap model call per new transcript (tier 1)
-  propose    aggregate gradients, then gradient descent: one high-reasoning call
+  propose    aggregate gradients, then high-reasoning gradient descent
              turning the aggregated evidence into edits (tier 2)
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,6 +51,7 @@ const OPTIONS = {
   "synthesis-model": { type: "string" },
   "synthesis-effort": { type: "string" },
 
+  resume: { type: "boolean" },
   "dry-run": { type: "boolean" },
   "no-ui": { type: "boolean" },
   "no-open": { type: "boolean" },
@@ -75,7 +76,8 @@ COMMANDS
   scan       collect samples only: which transcripts belong to this repo, and how we know
   analyze    calculate loss: one cheap model call per new transcript (tier 1)
   propose    aggregate gradients, then gradient descent: one high-reasoning call
-             turning the aggregated evidence into edits (tier 2)
+             turning the aggregated evidence into edits (tier 2).
+             --resume re-annotates the synthesis this repo already has staged
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar
   init       write .backpassrc.json and exclude .backpass/ via .git/info/exclude
@@ -105,6 +107,12 @@ MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
   --synthesis-effort <e>   reasoning effort for synthesis               [high]
   --no-auto-agent          skip the ladders and pin codex / claude (the pre-0.2 defaults)
   --jobs <n>               parallel analysis calls                      [4]
+
+GRADIENT DESCENT
+  --resume                 (propose only) annotate the staged synthesis in
+                           .backpass/synthesis/ in a fresh session, instead of
+                           re-running the editing turn. Refuses, without deleting
+                           anything, if the repository moved on since it was staged.
 
 BUDGET AND SHAPE
   --budget <tokens>        always-loaded budget per memory file         [5000]
@@ -136,6 +144,7 @@ EXAMPLES
   backpass scan --since 7d --strict         what would be collected, deterministic only
   backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
+  backpass propose --resume                 re-annotate a synthesis that failed its gates
 `;
 
 /** Map CLI flags onto the config shape so one merge order covers every layer. */
@@ -227,6 +236,13 @@ export async function main(argv) {
   if (!command) {
     fail(`unknown command "${commandName}"`);
     console.error("\nRun `backpass --help` for the command list.");
+    return 2;
+  }
+  // Resuming skips discovery, analysis, and the fold, so it is a `propose` shape only.
+  // Silently ignoring it elsewhere would spend a full run the user did not ask for.
+  if (values.resume && commandName !== "propose") {
+    fail(`--resume is a \`backpass propose\` flag (got \`backpass ${commandName}\`)`);
+    console.error("  run `backpass propose --resume` to annotate the staged synthesis");
     return 2;
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,6 +51,7 @@ const OPTIONS = {
   "synthesis-model": { type: "string" },
   "synthesis-effort": { type: "string" },
 
+  resume: { type: "boolean" },
   "dry-run": { type: "boolean" },
   "no-ui": { type: "boolean" },
   "no-open": { type: "boolean" },
@@ -75,7 +76,8 @@ COMMANDS
   scan       collect samples only: which transcripts belong to this repo, and how we know
   analyze    calculate loss: one cheap model call per new transcript (tier 1)
   propose    aggregate gradients, then gradient descent: one high-reasoning call
-             turning the aggregated evidence into edits (tier 2)
+             turning the aggregated evidence into edits (tier 2).
+             --resume re-annotates the synthesis this repo already has staged
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar
   init       write .backpassrc.json and exclude .backpass/ via .git/info/exclude
@@ -105,6 +107,12 @@ MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
   --synthesis-effort <e>   one-off reasoning effort for synthesis            [high]
   --no-auto-agent          skip the ladders and pin codex / claude (the pre-0.2 defaults)
   --jobs <n>               parallel analysis calls                      [4]
+
+GRADIENT DESCENT
+  --resume                 (propose only) annotate the staged synthesis in
+                           .backpass/synthesis/ in a fresh session, instead of
+                           re-running the editing turn. Refuses, without deleting
+                           anything, if the repository moved on since it was staged.
 
 BUDGET AND SHAPE
   --budget <tokens>        always-loaded budget per memory file         [5000]
@@ -136,6 +144,7 @@ EXAMPLES
   backpass scan --since 7d --strict         what would be collected, deterministic only
   backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
+  backpass propose --resume                 re-annotate a synthesis that failed its gates
 `;
 
 /** Map CLI flags onto the config shape so one merge order covers every layer. */
@@ -227,6 +236,11 @@ export async function main(argv) {
   if (!command) {
     fail(`unknown command "${commandName}"`);
     console.error("\nRun `backpass --help` for the command list.");
+    return 2;
+  }
+  if (values.resume && commandName !== "propose") {
+    fail(`--resume is a \`backpass propose\` flag (got \`backpass ${commandName}\`)`);
+    console.error("  run `backpass propose --resume` to annotate the staged synthesis");
     return 2;
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,7 +51,6 @@ const OPTIONS = {
   "synthesis-model": { type: "string" },
   "synthesis-effort": { type: "string" },
 
-  resume: { type: "boolean" },
   "dry-run": { type: "boolean" },
   "no-ui": { type: "boolean" },
   "no-open": { type: "boolean" },
@@ -76,8 +75,7 @@ COMMANDS
   scan       collect samples only: which transcripts belong to this repo, and how we know
   analyze    calculate loss: one cheap model call per new transcript (tier 1)
   propose    aggregate gradients, then gradient descent: one high-reasoning call
-             turning the aggregated evidence into edits (tier 2).
-             --resume re-annotates the synthesis this repo already has staged
+             turning the aggregated evidence into edits (tier 2)
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar
   init       write .backpassrc.json and exclude .backpass/ via .git/info/exclude
@@ -107,12 +105,6 @@ MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
   --synthesis-effort <e>   one-off reasoning effort for synthesis            [high]
   --no-auto-agent          skip the ladders and pin codex / claude (the pre-0.2 defaults)
   --jobs <n>               parallel analysis calls                      [4]
-
-GRADIENT DESCENT
-  --resume                 (propose only) annotate the staged synthesis in
-                           .backpass/synthesis/ in a fresh session, instead of
-                           re-running the editing turn. Refuses, without deleting
-                           anything, if the repository moved on since it was staged.
 
 BUDGET AND SHAPE
   --budget <tokens>        always-loaded budget per memory file         [5000]
@@ -144,7 +136,6 @@ EXAMPLES
   backpass scan --since 7d --strict         what would be collected, deterministic only
   backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
-  backpass propose --resume                 re-annotate a synthesis that failed its gates
 `;
 
 /** Map CLI flags onto the config shape so one merge order covers every layer. */
@@ -236,11 +227,6 @@ export async function main(argv) {
   if (!command) {
     fail(`unknown command "${commandName}"`);
     console.error("\nRun `backpass --help` for the command list.");
-    return 2;
-  }
-  if (values.resume && commandName !== "propose") {
-    fail(`--resume is a \`backpass propose\` flag (got \`backpass ${commandName}\`)`);
-    console.error("  run `backpass propose --resume` to annotate the staged synthesis");
     return 2;
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,7 +51,6 @@ const OPTIONS = {
   "synthesis-model": { type: "string" },
   "synthesis-effort": { type: "string" },
 
-  resume: { type: "boolean" },
   "dry-run": { type: "boolean" },
   "no-ui": { type: "boolean" },
   "no-open": { type: "boolean" },
@@ -76,8 +75,7 @@ COMMANDS
   scan       collect samples only: which transcripts belong to this repo, and how we know
   analyze    calculate loss: one cheap model call per new transcript (tier 1)
   propose    aggregate gradients, then gradient descent: one high-reasoning call
-             turning the aggregated evidence into edits (tier 2).
-             --resume re-annotates the synthesis this repo already has staged
+             turning the aggregated evidence into edits (tier 2)
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar
   init       write .backpassrc.json and exclude .backpass/ via .git/info/exclude
@@ -107,12 +105,6 @@ MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
   --synthesis-effort <e>   reasoning effort for synthesis               [high]
   --no-auto-agent          skip the ladders and pin codex / claude (the pre-0.2 defaults)
   --jobs <n>               parallel analysis calls                      [4]
-
-GRADIENT DESCENT
-  --resume                 (propose only) annotate the staged synthesis in
-                           .backpass/synthesis/ in a fresh session, instead of
-                           re-running the editing turn. Refuses, without deleting
-                           anything, if the repository moved on since it was staged.
 
 BUDGET AND SHAPE
   --budget <tokens>        always-loaded budget per memory file         [5000]
@@ -144,7 +136,6 @@ EXAMPLES
   backpass scan --since 7d --strict         what would be collected, deterministic only
   backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
-  backpass propose --resume                 re-annotate a synthesis that failed its gates
 `;
 
 /** Map CLI flags onto the config shape so one merge order covers every layer. */
@@ -236,13 +227,6 @@ export async function main(argv) {
   if (!command) {
     fail(`unknown command "${commandName}"`);
     console.error("\nRun `backpass --help` for the command list.");
-    return 2;
-  }
-  // Resuming skips discovery, analysis, and the fold, so it is a `propose` shape only.
-  // Silently ignoring it elsewhere would spend a full run the user did not ask for.
-  if (values.resume && commandName !== "propose") {
-    fail(`--resume is a \`backpass propose\` flag (got \`backpass ${commandName}\`)`);
-    console.error("  run `backpass propose --resume` to annotate the staged synthesis");
     return 2;
   }
 

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,7 +1,9 @@
 import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
-import { synthesizeProposal } from "../synthesize.js";
+import { resumeAnnotation, synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
+import { resolveOverflowTarget } from "../skills.js";
+import { restoreWorkspace } from "../workspace.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { emitProgress } from "../progress.js";
@@ -35,6 +37,10 @@ export async function foldForRun(ctx, memoryFile) {
 
 export async function runProposal(ctx, precomputed = null) {
   const { repo, config } = ctx;
+  // Starting a new proposal run invalidates the previous result immediately. Discovery,
+  // folding, and agent resolution can all fail before synthesis starts; none of those
+  // failures may leave an older proposal available to apply as if it came from this run.
+  config.state.clearProposal();
   const { file } = precomputed || primaryMemoryFile(repo, config);
   const transcripts = precomputed?.transcripts || (await discoverForRun(ctx)).transcripts;
 
@@ -62,6 +68,48 @@ export async function runProposal(ctx, precomputed = null) {
     config,
     repo,
     transcripts,
+  });
+
+  config.state.writeProposal(proposal);
+  return { proposal, summary, memoryFile: file };
+}
+
+/**
+ * `backpass propose --resume`: annotate the staging copy that is already on disk.
+ *
+ * A failed annotation loses the annotation, not the edits - those are in
+ * `.backpass/synthesis/`, and they cost the expensive turn of the run. This skips
+ * discovery, analysis, the fold, and the editing turn, re-measures that tree as it stands,
+ * and annotates it in a new session. Nothing here rebuilds or removes the tree: saved
+ * state that cannot be resumed safely is refused with the reason, and left where it is.
+ */
+export async function resumeProposal(ctx) {
+  const { repo, config } = ctx;
+  const { file } = primaryMemoryFile(repo, config);
+  const skillsDir = resolveOverflowTarget(repo.root, config.skillsDir).dir;
+
+  const { workspace, manifest, refusal } = restoreWorkspace({
+    state: config.state,
+    repo,
+    memoryFile: file,
+    skillsDir,
+  });
+  if (refusal) throw new UserError(`cannot resume: ${refusal.message}`, refusal.hint);
+
+  const summary = manifest.summary;
+
+  info(
+    `${color.cyan("·")} resuming the synthesis staged at ${manifest.stagedAt} · ` +
+      `${file.path} · ${summary.analyzedSessions} session(s) of evidence`,
+  );
+
+  const { proposal } = await resumeAnnotation({
+    memoryFile: file,
+    summary,
+    config,
+    repo,
+    workspace,
+    harnessCounts: manifest.harnessCounts || {},
   });
 
   config.state.writeProposal(proposal);
@@ -122,17 +170,20 @@ const isEditCapViolation = (v) => /per-run cap is \d+/.test(v);
  *
  * The old advice - a stronger model, a bigger budget, a higher edit cap - was printed for
  * every failure, including the ones where the model never spoke and the ones where the
- * budget was never the constraint. Each terminal condition has a different repair.
+ * budget was never the constraint. Each terminal condition has a different repair, and
+ * three of the four are cheap, because the editing turn's work is still on disk.
  */
 export function synthesisFailureHint(err) {
+  const resume =
+    "`backpass propose --resume` re-annotates the staged edits in a fresh session, without re-running the expensive editing turn";
   if (err.reason === "empty") {
-    return "the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; run `backpass propose` again to start a fresh synthesis session";
+    return `the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; ${resume}`;
   }
   if (err.reason === "unparseable") {
-    return "the model answered but not with a JSON object; run `backpass propose` again, or pin a different harness with --synthesis-agent";
+    return `the model answered but not with a JSON object; ${resume}, or pin a different harness with --synthesis-agent`;
   }
   if (err.reason === "editing") {
-    return "the agent kept rewriting the staging copy instead of describing it; run `backpass propose` again to start fresh";
+    return `the agent kept rewriting the staging copy instead of describing it; ${resume}`;
   }
   const violations = err.violations || [];
   if (violations.some(isBudgetViolation)) {
@@ -141,7 +192,7 @@ export function synthesisFailureHint(err) {
   if (violations.some(isEditCapViolation)) {
     return "the annotation proposed more edits than the per-run learning rate allows: raise --max-edits, or re-run and let the next pass take the rest";
   }
-  return "the gates above are what the next synthesis must satisfy; run `backpass propose` again";
+  return `the gates above are what the annotation must satisfy; ${resume}`;
 }
 
 /**
@@ -169,7 +220,7 @@ export function printSynthesisFailure(err, state) {
 
 export async function cmdPropose(ctx) {
   try {
-    const { proposal } = await runProposal(ctx);
+    const { proposal } = ctx.flags.resume ? await resumeProposal(ctx) : await runProposal(ctx);
     if (ctx.flags.json) {
       json(proposal);
       return 0;

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,7 +1,9 @@
 import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
-import { synthesizeProposal } from "../synthesize.js";
+import { resumeAnnotation, synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
+import { resolveOverflowTarget } from "../skills.js";
+import { restoreWorkspace } from "../workspace.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { emitProgress } from "../progress.js";
@@ -69,6 +71,48 @@ export async function runProposal(ctx, precomputed = null) {
 }
 
 /**
+ * `backpass propose --resume`: annotate the staging copy that is already on disk.
+ *
+ * A failed annotation loses the annotation, not the edits - those are in
+ * `.backpass/synthesis/`, and they cost the expensive turn of the run. This skips
+ * discovery, analysis, the fold, and the editing turn, re-measures that tree as it stands,
+ * and annotates it in a new session. Nothing here rebuilds or removes the tree: saved
+ * state that cannot be resumed safely is refused with the reason, and left where it is.
+ */
+export async function resumeProposal(ctx) {
+  const { repo, config } = ctx;
+  const { file } = primaryMemoryFile(repo, config);
+  const skillsDir = resolveOverflowTarget(repo.root, config.skillsDir).dir;
+
+  const { workspace, manifest, refusal } = restoreWorkspace({
+    state: config.state,
+    repo,
+    memoryFile: file,
+    skillsDir,
+  });
+  if (refusal) throw new UserError(`cannot resume: ${refusal.message}`, refusal.hint);
+
+  const summary = manifest.summary;
+
+  info(
+    `${color.cyan("·")} resuming the synthesis staged at ${manifest.stagedAt} · ` +
+      `${file.path} · ${summary.analyzedSessions} session(s) of evidence`,
+  );
+
+  const { proposal } = await resumeAnnotation({
+    memoryFile: file,
+    summary,
+    config,
+    repo,
+    workspace,
+    harnessCounts: manifest.harnessCounts || {},
+  });
+
+  config.state.writeProposal(proposal);
+  return { proposal, summary, memoryFile: file };
+}
+
+/**
  * @param {object} proposal
  * @param {{ applied?: boolean, analysisUsage?: import("../acpx.js").UsageRecord[] }} [options]
  *   `analysisUsage` is the tier-1 accounting of the same run, when the caller ran it.
@@ -122,17 +166,20 @@ const isEditCapViolation = (v) => /per-run cap is \d+/.test(v);
  *
  * The old advice - a stronger model, a bigger budget, a higher edit cap - was printed for
  * every failure, including the ones where the model never spoke and the ones where the
- * budget was never the constraint. Each terminal condition has a different repair.
+ * budget was never the constraint. Each terminal condition has a different repair, and
+ * three of the four are cheap, because the editing turn's work is still on disk.
  */
 export function synthesisFailureHint(err) {
+  const resume =
+    "`backpass propose --resume` re-annotates the staged edits in a fresh session, without re-running the expensive editing turn";
   if (err.reason === "empty") {
-    return "the synthesis harness returned no text, so retry `backpass propose`; if it repeats, pin a different harness with --synthesis-agent";
+    return `the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; ${resume}`;
   }
   if (err.reason === "unparseable") {
-    return "the model answered but not with a JSON object; retry `backpass propose`, or pin a different harness with --synthesis-agent";
+    return `the model answered but not with a JSON object; ${resume}, or pin a different harness with --synthesis-agent`;
   }
   if (err.reason === "editing") {
-    return "the agent kept rewriting the staging copy instead of describing it; retry `backpass propose`, or pin a different harness with --synthesis-agent";
+    return `the agent kept rewriting the staging copy instead of describing it; ${resume}`;
   }
   const violations = err.violations || [];
   if (violations.some(isBudgetViolation)) {
@@ -141,7 +188,7 @@ export function synthesisFailureHint(err) {
   if (violations.some(isEditCapViolation)) {
     return "the annotation proposed more edits than the per-run learning rate allows: raise --max-edits, or re-run and let the next pass take the rest";
   }
-  return "the gates above are what the annotation must satisfy; retry `backpass propose`";
+  return `the gates above are what the annotation must satisfy; ${resume}`;
 }
 
 /**
@@ -169,7 +216,7 @@ export function printSynthesisFailure(err, state) {
 
 export async function cmdPropose(ctx) {
   try {
-    const { proposal } = await runProposal(ctx);
+    const { proposal } = ctx.flags.resume ? await resumeProposal(ctx) : await runProposal(ctx);
     if (ctx.flags.json) {
       json(proposal);
       return 0;

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,7 +1,9 @@
 import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
-import { synthesizeProposal } from "../synthesize.js";
+import { resumeAnnotation, synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
+import { resolveOverflowTarget } from "../skills.js";
+import { restoreWorkspace } from "../workspace.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { emitProgress } from "../progress.js";
@@ -69,6 +71,54 @@ export async function runProposal(ctx, precomputed = null) {
 }
 
 /**
+ * `backpass propose --resume`: annotate the staging copy that is already on disk.
+ *
+ * A failed annotation loses the annotation, not the edits - those are in
+ * `.backpass/synthesis/`, and they cost the expensive turn of the run. This skips
+ * discovery, analysis, the fold, and the editing turn, re-measures that tree as it stands,
+ * and annotates it in a new session. Nothing here rebuilds or removes the tree: saved
+ * state that cannot be resumed safely is refused with the reason, and left where it is.
+ */
+export async function resumeProposal(ctx) {
+  const { repo, config } = ctx;
+  const { file } = primaryMemoryFile(repo, config);
+  const skillsDir = resolveOverflowTarget(repo.root, config.skillsDir).dir;
+
+  const { workspace, manifest, refusal } = restoreWorkspace({
+    state: config.state,
+    repo,
+    memoryFile: file,
+    skillsDir,
+  });
+  if (refusal) throw new UserError(`cannot resume: ${refusal.message}`, refusal.hint);
+
+  const summary = config.state.readSummary();
+  if (!summary?.analyzedSessions) {
+    throw new UserError(
+      "cannot resume: the aggregated evidence this synthesis was built from is gone",
+      "run `backpass analyze` and then `backpass propose`; the staged copy was left untouched",
+    );
+  }
+
+  info(
+    `${color.cyan("·")} resuming the synthesis staged at ${manifest.stagedAt} · ` +
+      `${file.path} · ${summary.analyzedSessions} session(s) of evidence`,
+  );
+
+  const { proposal } = await resumeAnnotation({
+    memoryFile: file,
+    summary,
+    config,
+    repo,
+    workspace,
+    harnessCounts: manifest.harnessCounts || {},
+  });
+
+  config.state.writeProposal(proposal);
+  return { proposal, summary, memoryFile: file };
+}
+
+/**
  * @param {object} proposal
  * @param {{ applied?: boolean, analysisUsage?: import("../acpx.js").UsageRecord[] }} [options]
  *   `analysisUsage` is the tier-1 accounting of the same run, when the caller ran it.
@@ -113,9 +163,66 @@ export function printProposal(proposal, { applied = false, analysisUsage = [] } 
   out("Review and apply with `backpass apply` (nothing has been written).");
 }
 
+/** True when a violation is about the always-loaded budget rather than the annotation. */
+const isBudgetViolation = (v) => /-token budget/.test(v);
+const isEditCapViolation = (v) => /per-run cap is \d+/.test(v);
+
+/**
+ * What to actually try next, read off the condition the run ended on.
+ *
+ * The old advice - a stronger model, a bigger budget, a higher edit cap - was printed for
+ * every failure, including the ones where the model never spoke and the ones where the
+ * budget was never the constraint. Each terminal condition has a different repair, and
+ * three of the four are cheap, because the editing turn's work is still on disk.
+ */
+export function synthesisFailureHint(err) {
+  const resume =
+    "`backpass propose --resume` re-annotates the staged edits in a fresh session, without re-running the expensive editing turn";
+  if (err.reason === "empty") {
+    return `the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; ${resume}`;
+  }
+  if (err.reason === "unparseable") {
+    return `the model answered but not with a JSON object; ${resume}, or pin a different harness with --synthesis-agent`;
+  }
+  if (err.reason === "editing") {
+    return `the agent kept rewriting the staging copy instead of describing it; ${resume}`;
+  }
+  const violations = err.violations || [];
+  if (violations.some(isBudgetViolation)) {
+    return "the edit set did not clear the budget gate: raise --budget, or let the shrink continue over more runs";
+  }
+  if (violations.some(isEditCapViolation)) {
+    return "the annotation proposed more edits than the per-run learning rate allows: raise --max-edits, or re-run and let the next pass take the rest";
+  }
+  return `the gates above are what the annotation must satisfy; ${resume}`;
+}
+
+/**
+ * Report a synthesis that ended without a valid proposal: loudly, and about the turn that
+ * actually ended it (design section 6).
+ *
+ * The saved proposal and the terminal condition can be from different turns - a run whose
+ * last turn was empty leaves the rejected proposal of an earlier one on disk - so the
+ * provenance is printed rather than letting the older violations read as this turn's.
+ */
+export function printSynthesisFailure(err, state) {
+  info("");
+  for (const violation of err.violations) info(`  ${color.red("x")} ${violation}`);
+  info("");
+  if (!err.saved) {
+    info(color.dim("  no proposal was saved: no annotation turn produced one"));
+    return;
+  }
+  info(color.dim(`  the rejected proposal was saved to ${state.proposalPath}`));
+  if (err.reason !== "gates") {
+    info(color.dim(`  it is from annotation attempt ${err.saved.attempt}, not the turn above, and it lists:`));
+    for (const violation of err.saved.violations) info(color.dim(`    - ${violation}`));
+  }
+}
+
 export async function cmdPropose(ctx) {
   try {
-    const { proposal } = await runProposal(ctx);
+    const { proposal } = ctx.flags.resume ? await resumeProposal(ctx) : await runProposal(ctx);
     if (ctx.flags.json) {
       json(proposal);
       return 0;
@@ -124,12 +231,8 @@ export async function cmdPropose(ctx) {
     return 0;
   } catch (err) {
     if (err instanceof ProposalViolation) {
-      // Loud failure, never silent truncation (design section 6).
-      info("");
-      for (const violation of err.violations) info(`  ${color.red("x")} ${violation}`);
-      info("");
-      info(color.dim(`  the rejected proposal was saved to ${ctx.config.state.proposalPath}`));
-      throw new UserError(err.message, "try a stronger synthesis model, or raise --budget / --max-edits");
+      printSynthesisFailure(err, ctx.config.state);
+      throw new UserError(err.message, synthesisFailureHint(err));
     }
     throw err;
   }

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,9 +1,7 @@
 import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
-import { resumeAnnotation, synthesizeProposal } from "../synthesize.js";
+import { synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
-import { resolveOverflowTarget } from "../skills.js";
-import { restoreWorkspace } from "../workspace.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { emitProgress } from "../progress.js";
@@ -71,54 +69,6 @@ export async function runProposal(ctx, precomputed = null) {
 }
 
 /**
- * `backpass propose --resume`: annotate the staging copy that is already on disk.
- *
- * A failed annotation loses the annotation, not the edits - those are in
- * `.backpass/synthesis/`, and they cost the expensive turn of the run. This skips
- * discovery, analysis, the fold, and the editing turn, re-measures that tree as it stands,
- * and annotates it in a new session. Nothing here rebuilds or removes the tree: saved
- * state that cannot be resumed safely is refused with the reason, and left where it is.
- */
-export async function resumeProposal(ctx) {
-  const { repo, config } = ctx;
-  const { file } = primaryMemoryFile(repo, config);
-  const skillsDir = resolveOverflowTarget(repo.root, config.skillsDir).dir;
-
-  const { workspace, manifest, refusal } = restoreWorkspace({
-    state: config.state,
-    repo,
-    memoryFile: file,
-    skillsDir,
-  });
-  if (refusal) throw new UserError(`cannot resume: ${refusal.message}`, refusal.hint);
-
-  const summary = config.state.readSummary();
-  if (!summary?.analyzedSessions) {
-    throw new UserError(
-      "cannot resume: the aggregated evidence this synthesis was built from is gone",
-      "run `backpass analyze` and then `backpass propose`; the staged copy was left untouched",
-    );
-  }
-
-  info(
-    `${color.cyan("·")} resuming the synthesis staged at ${manifest.stagedAt} · ` +
-      `${file.path} · ${summary.analyzedSessions} session(s) of evidence`,
-  );
-
-  const { proposal } = await resumeAnnotation({
-    memoryFile: file,
-    summary,
-    config,
-    repo,
-    workspace,
-    harnessCounts: manifest.harnessCounts || {},
-  });
-
-  config.state.writeProposal(proposal);
-  return { proposal, summary, memoryFile: file };
-}
-
-/**
  * @param {object} proposal
  * @param {{ applied?: boolean, analysisUsage?: import("../acpx.js").UsageRecord[] }} [options]
  *   `analysisUsage` is the tier-1 accounting of the same run, when the caller ran it.
@@ -172,20 +122,17 @@ const isEditCapViolation = (v) => /per-run cap is \d+/.test(v);
  *
  * The old advice - a stronger model, a bigger budget, a higher edit cap - was printed for
  * every failure, including the ones where the model never spoke and the ones where the
- * budget was never the constraint. Each terminal condition has a different repair, and
- * three of the four are cheap, because the editing turn's work is still on disk.
+ * budget was never the constraint. Each terminal condition has a different repair.
  */
 export function synthesisFailureHint(err) {
-  const resume =
-    "`backpass propose --resume` re-annotates the staged edits in a fresh session, without re-running the expensive editing turn";
   if (err.reason === "empty") {
-    return `the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; ${resume}`;
+    return "the synthesis harness returned no text, so retry `backpass propose`; if it repeats, pin a different harness with --synthesis-agent";
   }
   if (err.reason === "unparseable") {
-    return `the model answered but not with a JSON object; ${resume}, or pin a different harness with --synthesis-agent`;
+    return "the model answered but not with a JSON object; retry `backpass propose`, or pin a different harness with --synthesis-agent";
   }
   if (err.reason === "editing") {
-    return `the agent kept rewriting the staging copy instead of describing it; ${resume}`;
+    return "the agent kept rewriting the staging copy instead of describing it; retry `backpass propose`, or pin a different harness with --synthesis-agent";
   }
   const violations = err.violations || [];
   if (violations.some(isBudgetViolation)) {
@@ -194,7 +141,7 @@ export function synthesisFailureHint(err) {
   if (violations.some(isEditCapViolation)) {
     return "the annotation proposed more edits than the per-run learning rate allows: raise --max-edits, or re-run and let the next pass take the rest";
   }
-  return `the gates above are what the annotation must satisfy; ${resume}`;
+  return "the gates above are what the annotation must satisfy; retry `backpass propose`";
 }
 
 /**
@@ -222,7 +169,7 @@ export function printSynthesisFailure(err, state) {
 
 export async function cmdPropose(ctx) {
   try {
-    const { proposal } = ctx.flags.resume ? await resumeProposal(ctx) : await runProposal(ctx);
+    const { proposal } = await runProposal(ctx);
     if (ctx.flags.json) {
       json(proposal);
       return 0;

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,9 +1,7 @@
 import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
-import { resumeAnnotation, synthesizeProposal } from "../synthesize.js";
+import { synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
-import { resolveOverflowTarget } from "../skills.js";
-import { restoreWorkspace } from "../workspace.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { emitProgress } from "../progress.js";
@@ -71,48 +69,6 @@ export async function runProposal(ctx, precomputed = null) {
 }
 
 /**
- * `backpass propose --resume`: annotate the staging copy that is already on disk.
- *
- * A failed annotation loses the annotation, not the edits - those are in
- * `.backpass/synthesis/`, and they cost the expensive turn of the run. This skips
- * discovery, analysis, the fold, and the editing turn, re-measures that tree as it stands,
- * and annotates it in a new session. Nothing here rebuilds or removes the tree: saved
- * state that cannot be resumed safely is refused with the reason, and left where it is.
- */
-export async function resumeProposal(ctx) {
-  const { repo, config } = ctx;
-  const { file } = primaryMemoryFile(repo, config);
-  const skillsDir = resolveOverflowTarget(repo.root, config.skillsDir).dir;
-
-  const { workspace, manifest, refusal } = restoreWorkspace({
-    state: config.state,
-    repo,
-    memoryFile: file,
-    skillsDir,
-  });
-  if (refusal) throw new UserError(`cannot resume: ${refusal.message}`, refusal.hint);
-
-  const summary = manifest.summary;
-
-  info(
-    `${color.cyan("·")} resuming the synthesis staged at ${manifest.stagedAt} · ` +
-      `${file.path} · ${summary.analyzedSessions} session(s) of evidence`,
-  );
-
-  const { proposal } = await resumeAnnotation({
-    memoryFile: file,
-    summary,
-    config,
-    repo,
-    workspace,
-    harnessCounts: manifest.harnessCounts || {},
-  });
-
-  config.state.writeProposal(proposal);
-  return { proposal, summary, memoryFile: file };
-}
-
-/**
  * @param {object} proposal
  * @param {{ applied?: boolean, analysisUsage?: import("../acpx.js").UsageRecord[] }} [options]
  *   `analysisUsage` is the tier-1 accounting of the same run, when the caller ran it.
@@ -166,20 +122,17 @@ const isEditCapViolation = (v) => /per-run cap is \d+/.test(v);
  *
  * The old advice - a stronger model, a bigger budget, a higher edit cap - was printed for
  * every failure, including the ones where the model never spoke and the ones where the
- * budget was never the constraint. Each terminal condition has a different repair, and
- * three of the four are cheap, because the editing turn's work is still on disk.
+ * budget was never the constraint. Each terminal condition has a different repair.
  */
 export function synthesisFailureHint(err) {
-  const resume =
-    "`backpass propose --resume` re-annotates the staged edits in a fresh session, without re-running the expensive editing turn";
   if (err.reason === "empty") {
-    return `the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; ${resume}`;
+    return "the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; run `backpass propose` again to start a fresh synthesis session";
   }
   if (err.reason === "unparseable") {
-    return `the model answered but not with a JSON object; ${resume}, or pin a different harness with --synthesis-agent`;
+    return "the model answered but not with a JSON object; run `backpass propose` again, or pin a different harness with --synthesis-agent";
   }
   if (err.reason === "editing") {
-    return `the agent kept rewriting the staging copy instead of describing it; ${resume}`;
+    return "the agent kept rewriting the staging copy instead of describing it; run `backpass propose` again to start fresh";
   }
   const violations = err.violations || [];
   if (violations.some(isBudgetViolation)) {
@@ -188,7 +141,7 @@ export function synthesisFailureHint(err) {
   if (violations.some(isEditCapViolation)) {
     return "the annotation proposed more edits than the per-run learning rate allows: raise --max-edits, or re-run and let the next pass take the rest";
   }
-  return `the gates above are what the annotation must satisfy; ${resume}`;
+  return "the gates above are what the next synthesis must satisfy; run `backpass propose` again";
 }
 
 /**
@@ -216,7 +169,7 @@ export function printSynthesisFailure(err, state) {
 
 export async function cmdPropose(ctx) {
   try {
-    const { proposal } = ctx.flags.resume ? await resumeProposal(ctx) : await runProposal(ctx);
+    const { proposal } = await runProposal(ctx);
     if (ctx.flags.json) {
       json(proposal);
       return 0;

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,9 +1,7 @@
 import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
-import { resumeAnnotation, synthesizeProposal } from "../synthesize.js";
+import { synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
-import { resolveOverflowTarget } from "../skills.js";
-import { restoreWorkspace } from "../workspace.js";
 import { UserError, color, info, json, out } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { emitProgress } from "../progress.js";
@@ -75,48 +73,6 @@ export async function runProposal(ctx, precomputed = null) {
 }
 
 /**
- * `backpass propose --resume`: annotate the staging copy that is already on disk.
- *
- * A failed annotation loses the annotation, not the edits - those are in
- * `.backpass/synthesis/`, and they cost the expensive turn of the run. This skips
- * discovery, analysis, the fold, and the editing turn, re-measures that tree as it stands,
- * and annotates it in a new session. Nothing here rebuilds or removes the tree: saved
- * state that cannot be resumed safely is refused with the reason, and left where it is.
- */
-export async function resumeProposal(ctx) {
-  const { repo, config } = ctx;
-  const { file } = primaryMemoryFile(repo, config);
-  const skillsDir = resolveOverflowTarget(repo.root, config.skillsDir).dir;
-
-  const { workspace, manifest, refusal } = restoreWorkspace({
-    state: config.state,
-    repo,
-    memoryFile: file,
-    skillsDir,
-  });
-  if (refusal) throw new UserError(`cannot resume: ${refusal.message}`, refusal.hint);
-
-  const summary = manifest.summary;
-
-  info(
-    `${color.cyan("·")} resuming the synthesis staged at ${manifest.stagedAt} · ` +
-      `${file.path} · ${summary.analyzedSessions} session(s) of evidence`,
-  );
-
-  const { proposal } = await resumeAnnotation({
-    memoryFile: file,
-    summary,
-    config,
-    repo,
-    workspace,
-    harnessCounts: manifest.harnessCounts || {},
-  });
-
-  config.state.writeProposal(proposal);
-  return { proposal, summary, memoryFile: file };
-}
-
-/**
  * @param {object} proposal
  * @param {{ applied?: boolean, analysisUsage?: import("../acpx.js").UsageRecord[] }} [options]
  *   `analysisUsage` is the tier-1 accounting of the same run, when the caller ran it.
@@ -170,20 +126,17 @@ const isEditCapViolation = (v) => /per-run cap is \d+/.test(v);
  *
  * The old advice - a stronger model, a bigger budget, a higher edit cap - was printed for
  * every failure, including the ones where the model never spoke and the ones where the
- * budget was never the constraint. Each terminal condition has a different repair, and
- * three of the four are cheap, because the editing turn's work is still on disk.
+ * budget was never the constraint. Each terminal condition has a different repair.
  */
 export function synthesisFailureHint(err) {
-  const resume =
-    "`backpass propose --resume` re-annotates the staged edits in a fresh session, without re-running the expensive editing turn";
   if (err.reason === "empty") {
-    return `the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; ${resume}`;
+    return "the synthesis harness returned no text, so nothing about the model, the budget, or the edit cap was the constraint; run `backpass propose` again to start a fresh synthesis session";
   }
   if (err.reason === "unparseable") {
-    return `the model answered but not with a JSON object; ${resume}, or pin a different harness with --synthesis-agent`;
+    return "the model answered but not with a JSON object; run `backpass propose` again, or pin a different harness with --synthesis-agent";
   }
   if (err.reason === "editing") {
-    return `the agent kept rewriting the staging copy instead of describing it; ${resume}`;
+    return "the agent kept rewriting the staging copy instead of describing it; run `backpass propose` again to start fresh";
   }
   const violations = err.violations || [];
   if (violations.some(isBudgetViolation)) {
@@ -192,7 +145,7 @@ export function synthesisFailureHint(err) {
   if (violations.some(isEditCapViolation)) {
     return "the annotation proposed more edits than the per-run learning rate allows: raise --max-edits, or re-run and let the next pass take the rest";
   }
-  return `the gates above are what the annotation must satisfy; ${resume}`;
+  return "the gates above are what the next synthesis must satisfy; run `backpass propose` again";
 }
 
 /**
@@ -220,7 +173,7 @@ export function printSynthesisFailure(err, state) {
 
 export async function cmdPropose(ctx) {
   try {
-    const { proposal } = ctx.flags.resume ? await resumeProposal(ctx) : await runProposal(ctx);
+    const { proposal } = await runProposal(ctx);
     if (ctx.flags.json) {
       json(proposal);
       return 0;

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -31,6 +31,8 @@ export async function cmdRun(ctx) {
       )}`,
     );
 
+    config.state.clearProposal();
+
     if (!resolveMemoryFiles(repo.root, config.memoryFiles).primary) {
       const result = await bootstrapRun(ctx);
       tui?.stop();
@@ -39,9 +41,6 @@ export async function cmdRun(ctx) {
       return 0;
     }
 
-    // The full pass is also a proposal run. Invalidate an older result before discovery
-    // and analysis so an early failure cannot leave it available to `backpass apply`.
-    config.state.clearProposal();
     const analysis = await runAnalysis(ctx);
 
     if (!analysis.transcripts.length) {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -2,7 +2,7 @@ import { UserError, color, info, json, out } from "../logger.js";
 import { ProposalViolation } from "../proposal.js";
 import { runAnalysis } from "./analyze.js";
 import { bootstrapJson, bootstrapRun, printBootstrap } from "./bootstrap.js";
-import { printProposal, runProposal } from "./propose.js";
+import { printProposal, printSynthesisFailure, runProposal, synthesisFailureHint } from "./propose.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { startTui } from "../tui/index.js";
 import { resolveMemoryFiles } from "../memory.js";
@@ -82,11 +82,8 @@ export async function cmdRun(ctx) {
   } catch (err) {
     tui?.stop();
     if (err instanceof ProposalViolation) {
-      info("");
-      for (const violation of err.violations) info(`  ${color.red("x")} ${violation}`);
-      info("");
-      info(color.dim(`  the rejected proposal was saved to ${config.state.proposalPath}`));
-      throw new UserError(err.message, "try a stronger synthesis model, or raise --budget / --max-edits");
+      printSynthesisFailure(err, config.state);
+      throw new UserError(err.message, synthesisFailureHint(err));
     }
     throw err;
   } finally {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -39,6 +39,9 @@ export async function cmdRun(ctx) {
       return 0;
     }
 
+    // The full pass is also a proposal run. Invalidate an older result before discovery
+    // and analysis so an early failure cannot leave it available to `backpass apply`.
+    config.state.clearProposal();
     const analysis = await runAnalysis(ctx);
 
     if (!analysis.transcripts.length) {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -10,7 +10,7 @@ import { resolveMemoryFiles } from "../memory.js";
 /**
  * The default command: one full backward pass.
  *
- *   discover -> distill -> analyze (cheap, fanned out) -> fold -> synthesize (one big call)
+ *   discover -> distill -> analyze (cheap, fanned out) -> fold -> synthesize (high-reasoning turns)
  *
  * It never writes - with one exception: a repo with no memory file at all is
  * bootstrapped (`./bootstrap.js`), which only ever creates files. Otherwise applying

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -197,9 +197,14 @@ const { spawn } = require("node:child_process");
 const { real, extra } = ${payload};
 const signals = ["SIGTERM", "SIGINT", "SIGHUP"];
 let child = null;
+let pendingSignal = null;
 let escalationTimer = null;
 const forwardSignal = (signal) => {
-  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  if (!child) {
+    pendingSignal ??= signal;
+    return;
+  }
+  if (child.exitCode !== null || child.signalCode !== null) return;
   try { child.kill(signal); } catch {}
   if (!escalationTimer) {
     escalationTimer = setTimeout(() => {
@@ -213,6 +218,7 @@ const forwardSignal = (signal) => {
 const signalHandlers = new Map(signals.map((signal) => [signal, () => forwardSignal(signal)]));
 for (const [signal, handler] of signalHandlers) process.on(signal, handler);
 child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
+if (pendingSignal) forwardSignal(pendingSignal);
 child.on("error", (err) => {
   console.error(err.message);
   process.exit(1);

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -195,11 +195,11 @@ function writeArgvWrapper({ realCommand, extraArgs, binName }) {
     `#!/usr/bin/env node
 const { spawn } = require("node:child_process");
 const { real, extra } = ${payload};
-const child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
 const signals = ["SIGTERM", "SIGINT", "SIGHUP"];
+let child = null;
 let escalationTimer = null;
 const forwardSignal = (signal) => {
-  if (child.exitCode !== null || child.signalCode !== null) return;
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
   try { child.kill(signal); } catch {}
   if (!escalationTimer) {
     escalationTimer = setTimeout(() => {
@@ -212,6 +212,7 @@ const forwardSignal = (signal) => {
 };
 const signalHandlers = new Map(signals.map((signal) => [signal, () => forwardSignal(signal)]));
 for (const [signal, handler] of signalHandlers) process.on(signal, handler);
+child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
 child.on("error", (err) => {
   console.error(err.message);
   process.exit(1);

--- a/src/prompts/annotate-preface.md
+++ b/src/prompts/annotate-preface.md
@@ -1,10 +1,10 @@
-You are joining a synthesis run that is already half done, so read this before the changes.
+You are joining a synthesis run already in progress, so read this before the changes.
 
-An earlier session edited a staging copy of `{{MEMORY_PATH}}` for the {{REPO_NAME}} repository
-and then ended without annotating what it did. **The edits below are already made.** Your job
-is only to describe them - do not redo them, do not start over, and do not revert anything you
-would have written differently. If a change genuinely cannot ship, revert that one change in
-the staging copy first and say so.
+An earlier session edited a staging copy of `{{MEMORY_PATH}}` for the {{REPO_NAME}} repository.
+**The edits below are already made.** Your fresh session did not make them and may not have seen
+prior annotation attempts. Your job is only to describe them - do not redo them, do not start
+over, and do not revert anything you would have written differently. If a change genuinely
+cannot ship, revert that one change in the staging copy first and say so.
 
 - Repository: `{{REPO_ROOT}}` (read it by absolute path when a change needs grounding)
 - Memory file under review: `{{MEMORY_PATH}}` - {{CURRENT_TOKENS}} tokens, {{BUDGET_STATE}}

--- a/src/prompts/annotate-preface.md
+++ b/src/prompts/annotate-preface.md
@@ -1,0 +1,20 @@
+You are joining a synthesis run that is already half done, so read this before the changes.
+
+An earlier session edited a staging copy of `{{MEMORY_PATH}}` for the {{REPO_NAME}} repository
+and then ended without annotating what it did. **The edits below are already made.** Your job
+is only to describe them - do not redo them, do not start over, and do not revert anything you
+would have written differently. If a change genuinely cannot ship, revert that one change in
+the staging copy first and say so.
+
+- Repository: `{{REPO_ROOT}}` (read it by absolute path when a change needs grounding)
+- Memory file under review: `{{MEMORY_PATH}}` - {{CURRENT_TOKENS}} tokens, {{BUDGET_STATE}}
+- Staging copy you are working in: `{{WORKSPACE_ROOT}}`
+
+Every edit you report needs a verbatim quote from the evidence below, so read it first.
+
+## Evidence from {{TRANSCRIPT_COUNT}} analyzed session(s)
+
+{{EVIDENCE}}
+
+---
+

--- a/src/prompts/annotate-preface.md
+++ b/src/prompts/annotate-preface.md
@@ -17,4 +17,3 @@ Every edit you report needs a verbatim quote from the evidence below, so read it
 {{EVIDENCE}}
 
 ---
-

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -1,5 +1,5 @@
-backpass measured the changes you made in the staging copy. Every change below is
-identified by an id; annotate each one so a human can review it with its evidence.
+{{PREFACE}}backpass measured the changes in the staging copy of {{MEMORY_PATH}}. Every change below
+is identified by an id; annotate each one so a human can review it with its evidence.
 
 ## Measured changes
 
@@ -39,10 +39,15 @@ Hard rules - a violation fails the whole proposal:
 4. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
    sessions.** `transcripts` is how many distinct sessions back the edit; an edit that
    only adds text is a new instruction whatever its `kind` says.
-5. `kind: "extract"` is exactly an edit whose changes include one created `SKILL.md`
-   and at least one change to `{{MEMORY_PATH}}`. Any other edit must not include a
-   created file, and an edit changes one file only.
+5. `kind: "extract"` is an edit whose changes are one or more created `SKILL.md` files
+   plus the change(s) to {{MEMORY_PATH}} that pay for them. One skill per extract is the
+   normal shape. Several skills belong in ONE extract exactly when their removals landed
+   in a **single** measured change: adjacent removals are merged into one change, and a
+   merged change cannot be accepted in halves. If each skill has its own measured change,
+   give each its own extract. Any other kind must not include a created file, and an edit
+   changes one file only.
 6. **Budget:** {{BUDGET_RULE}}
 
 If you still need to change the files, do that first and then answer; backpass
-re-measures after this reply and shows you the new ids if anything moved.
+re-measures after this reply and shows you the new ids if anything moved. Re-measuring
+does not use up an annotation attempt.

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,4 +1,5 @@
 import { renderHunkLines } from "./diff.js";
+import { editSkills } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 
 /**
@@ -14,7 +15,7 @@ import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
  *   add      only inserts text                  (gated like a new instruction)
  *   remove   only deletes text
  *   rewrite  replaces text
- *   extract  memory-file change(s) + one created SKILL.md
+ *   extract  memory-file change(s) + the created SKILL.md file(s) they pay for
  *
  * Each hunk carries a `find`/`replace` pair copied out of the original file by
  * construction; `find` occurs exactly once there. That is what the writer applies later,
@@ -44,11 +45,30 @@ export function effectiveMaxEdits(memoryFile, config) {
   return Math.min(SHRINK_MAX_EDITS, Math.max(DEFAULT_MAX_EDITS, Math.ceil(overage / SHRINK_EDIT_TOKENS)));
 }
 
+/**
+ * A synthesis run that ended without a valid proposal, carrying *why* it ended.
+ *
+ * `reason` is the terminal condition - "gates", "empty", "unparseable", "editing" - and
+ * `saved` is the last parseable-but-gated proposal written to disk, if any, with the
+ * annotation attempt that produced it. They are separate because they can disagree: a run
+ * whose last turn was empty still leaves an older rejected proposal on disk, and reporting
+ * that proposal's violations as the empty turn's result is how a run gets diagnosed wrong.
+ */
 export class ProposalViolation extends Error {
-  constructor(message, violations) {
+  /**
+   * @param {string} message
+   * @param {string[]} violations
+   * @param {{ reason?: string, attempts?: number,
+   *   saved?: { attempt: number, violations: string[] } | null, proposalPath?: string | null }} [detail]
+   */
+  constructor(message, violations, detail = {}) {
     super(message);
     this.name = "ProposalViolation";
     this.violations = violations;
+    this.reason = detail.reason || "gates";
+    this.attempts = detail.attempts ?? 0;
+    this.saved = detail.saved || null;
+    this.proposalPath = detail.proposalPath || null;
   }
 }
 
@@ -265,16 +285,27 @@ export function buildProposal(rawResult, context) {
       continue;
     }
     if (edit.kind === "extract") {
-      if (created.length !== 1 || !hunks.length || files[0] !== memoryFile.path) {
+      if (!created.length || !hunks.length || files[0] !== memoryFile.path) {
         violations.push(
-          `edit ${edit.id}: kind "extract" must group exactly one created SKILL.md with change(s) to ${memoryFile.path}`,
+          `edit ${edit.id}: kind "extract" must group created SKILL.md file(s) with change(s) to ${memoryFile.path}`,
         );
         continue;
       }
-      if (!created[0].skill) {
+      // Several skills may share one extract only when their removals were merged into a
+      // single measured change - a merged change cannot be accepted in halves, so that
+      // grouping is the measurement's, not the model's. Skills whose removals were measured
+      // separately stay separately decidable.
+      if (created.length > 1 && hunks.length > 1) {
         violations.push(
-          `edit ${edit.id}: ${created[0].file} needs YAML frontmatter with \`name:\` and \`description:\``,
+          `edit ${edit.id}: groups ${created.length} created skills against ${hunks.length} separate changes to ` +
+            `${memoryFile.path} (${hunks.map((h) => h.id).join(", ")}); give each skill its own extract, or group ` +
+            `several skills only when they share one measured change`,
         );
+        continue;
+      }
+      const unusable = created.find((c) => !c.skill);
+      if (unusable) {
+        violations.push(`edit ${edit.id}: ${unusable.file} needs YAML frontmatter with \`name:\` and \`description:\``);
         continue;
       }
     } else if (created.length) {
@@ -302,7 +333,7 @@ export function buildProposal(rawResult, context) {
       instructions: edit.instructions,
       evidence: edit.evidence,
       transcripts: edit.transcripts,
-      skill: created[0]?.skill || null,
+      skills: created.map((c) => c.skill),
       hunks: hunks.map((h) => ({
         id: h.id,
         find: h.find,
@@ -394,7 +425,7 @@ export function buildProposal(rawResult, context) {
       positive: summary?.totals?.positive ?? 0,
       negative: summary?.totals?.negative ?? 0,
       gapClusters: summary?.totals?.gapClusters ?? 0,
-      skillExtractions: accepted.filter((e) => e.kind === "extract").length,
+      skillExtractions: accepted.reduce((n, e) => n + editSkills(e).length, 0),
     },
     edits: accepted,
     verdicts: Array.isArray(rawResult?.verdicts) ? rawResult.verdicts : [],

--- a/src/skills.js
+++ b/src/skills.js
@@ -190,6 +190,22 @@ function pathIdentity(stat) {
   return { dev: stat.dev, ino: stat.ino };
 }
 
+function restoreQuarantinedPath(quarantine, destination) {
+  const stat = fs.lstatSync(quarantine);
+  if (stat.isDirectory()) {
+    fs.cpSync(quarantine, destination, { recursive: true, force: false, errorOnExist: true });
+    fs.rmSync(quarantine, { recursive: true });
+    return;
+  }
+  if (stat.isSymbolicLink()) {
+    fs.symlinkSync(fs.readlinkSync(quarantine), destination);
+    fs.unlinkSync(quarantine);
+    return;
+  }
+  fs.linkSync(quarantine, destination);
+  fs.unlinkSync(quarantine);
+}
+
 export function removeOwnedSkillPaths(paths) {
   const removed = [];
   const conflicts = [];
@@ -239,25 +255,14 @@ export function removeOwnedSkillPaths(paths) {
         continue;
       }
 
-      // The pathname was replaced after validation. Put that exact object back without
-      // overwriting anything that may have appeared at the original path meanwhile.
-      fs.linkSync(quarantine, item.absolute);
-      fs.unlinkSync(quarantine);
+      restoreQuarantinedPath(quarantine, item.absolute);
       conflicts.push(item);
     } catch {
       if (quarantined) {
         try {
-          fs.linkSync(quarantine, item.absolute);
+          restoreQuarantinedPath(quarantine, item.absolute);
         } catch {
-          // An object at the original path wins; retain the quarantined object rather
-          // than overwrite or delete either concurrent version.
-        }
-        try {
-          const moved = pathIdentity(fs.lstatSync(quarantine));
-          const restored = pathIdentity(fs.lstatSync(item.absolute));
-          if (moved.dev === restored.dev && moved.ino === restored.ino) fs.unlinkSync(quarantine);
-        } catch {
-          // Leave any object whose ownership cannot be established untouched.
+          fs.existsSync(quarantine);
         }
       }
       conflicts.push(item);

--- a/src/skills.js
+++ b/src/skills.js
@@ -190,20 +190,41 @@ function pathIdentity(stat) {
 }
 
 export function removeOwnedSkillPaths(paths) {
+  const removed = [];
+  const conflicts = [];
   for (const item of [...paths].reverse()) {
-    let observed;
+    let stat;
     try {
-      observed = pathIdentity(fs.lstatSync(item.absolute));
+      stat = fs.lstatSync(item.absolute);
     } catch {
       continue;
     }
-    if (observed.dev !== item.identity.dev || observed.ino !== item.identity.ino) continue;
+    const observed = pathIdentity(stat);
+    if (observed.dev !== item.identity.dev || observed.ino !== item.identity.ino) {
+      conflicts.push(item);
+      continue;
+    }
+    if (item.text !== undefined) {
+      let text;
+      try {
+        text = fs.readFileSync(item.absolute, "utf8");
+      } catch {
+        conflicts.push(item);
+        continue;
+      }
+      if (text !== item.text) {
+        conflicts.push(item);
+        continue;
+      }
+    }
     try {
       fs.unlinkSync(item.absolute);
+      removed.push(item);
     } catch {
-      continue;
+      conflicts.push(item);
     }
   }
+  return { removed, conflicts };
 }
 
 /**
@@ -248,13 +269,15 @@ export function writeSkill(repoRoot, skill, { exclusive = false, ensureLayout = 
   }
 
   let fd;
+  /** @type {{ absolute: string, identity: { dev: number, ino: number }, relative: string, text?: string }[] | undefined} */
   let ownership;
   try {
     fd = fs.openSync(target, "wx");
-    ownership = [{ absolute: target, identity: pathIdentity(fs.fstatSync(fd)) }];
+    ownership = [{ absolute: target, identity: pathIdentity(fs.fstatSync(fd)), relative: skill.path }];
     fs.writeFileSync(fd, text);
     fs.closeSync(fd);
     fd = undefined;
+    ownership[0].text = text;
   } catch (err) {
     if (fd !== undefined) {
       try {

--- a/src/skills.js
+++ b/src/skills.js
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 
 import { estimateTokens } from "./tokens.js";
 
@@ -217,10 +218,48 @@ export function removeOwnedSkillPaths(paths) {
         continue;
       }
     }
+
+    // Move the pathname out of the way atomically, then validate the object that was
+    // actually moved. A second pathname check followed by unlink would let a concurrent
+    // replacement slip between those operations and be deleted as if it were ours.
+    const quarantine = path.join(
+      path.dirname(item.absolute),
+      `.${path.basename(item.absolute)}.backpass-rollback-${randomUUID()}`,
+    );
+    let quarantined = false;
     try {
-      fs.unlinkSync(item.absolute);
-      removed.push(item);
+      fs.renameSync(item.absolute, quarantine);
+      quarantined = true;
+      const moved = pathIdentity(fs.lstatSync(quarantine));
+      const identityMatches = moved.dev === item.identity.dev && moved.ino === item.identity.ino;
+      const textMatches = item.text === undefined || fs.readFileSync(quarantine, "utf8") === item.text;
+      if (identityMatches && textMatches) {
+        fs.unlinkSync(quarantine);
+        removed.push(item);
+        continue;
+      }
+
+      // The pathname was replaced after validation. Put that exact object back without
+      // overwriting anything that may have appeared at the original path meanwhile.
+      fs.linkSync(quarantine, item.absolute);
+      fs.unlinkSync(quarantine);
+      conflicts.push(item);
     } catch {
+      if (quarantined) {
+        try {
+          fs.linkSync(quarantine, item.absolute);
+        } catch {
+          // An object at the original path wins; retain the quarantined object rather
+          // than overwrite or delete either concurrent version.
+        }
+        try {
+          const moved = pathIdentity(fs.lstatSync(quarantine));
+          const restored = pathIdentity(fs.lstatSync(item.absolute));
+          if (moved.dev === restored.dev && moved.ino === restored.ino) fs.unlinkSync(quarantine);
+        } catch {
+          // Leave any object whose ownership cannot be established untouched.
+        }
+      }
       conflicts.push(item);
     }
   }

--- a/src/skills.js
+++ b/src/skills.js
@@ -193,18 +193,24 @@ function ownedPath(absolute) {
   return { absolute, identity: pathIdentity(fs.lstatSync(absolute)) };
 }
 
-function missingDirectories(root, directory) {
-  const missing = [];
-  for (let current = directory; current !== root && !fs.existsSync(current); current = path.dirname(current)) {
-    missing.push(current);
-  }
-  return missing.reverse();
-}
-
 function createDirectories(root, directory) {
-  const missing = missingDirectories(root, directory);
-  fs.mkdirSync(directory, { recursive: true });
-  return missing.map(ownedPath);
+  const relative = path.relative(root, directory);
+  if (path.isAbsolute(relative) || relative === ".." || relative.startsWith(`..${path.sep}`)) {
+    throw new Error(`skill directory escapes the repository: ${directory}`);
+  }
+
+  const ownership = [];
+  let current = root;
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, component);
+    try {
+      fs.mkdirSync(current);
+      ownership.push(ownedPath(current));
+    } catch (err) {
+      if (err.code !== "EEXIST" || !fs.statSync(current).isDirectory()) throw err;
+    }
+  }
+  return ownership;
 }
 
 export function removeOwnedSkillPaths(paths) {
@@ -238,8 +244,9 @@ export function ensureSkillsLayout(repoRoot) {
   try {
     const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
     if (!fs.existsSync(canonical)) {
-      ownership.push(...createDirectories(repoRoot, canonical));
-      created.push(CANONICAL_SKILLS_DIR);
+      const canonicalOwnership = createDirectories(repoRoot, canonical);
+      ownership.push(...canonicalOwnership);
+      if (canonicalOwnership.some((item) => item.absolute === canonical)) created.push(CANONICAL_SKILLS_DIR);
     }
 
     const claude = inspectClaudeSkillsLink(repoRoot);

--- a/src/skills.js
+++ b/src/skills.js
@@ -104,19 +104,35 @@ export function renderSkillFile(skill) {
 }
 
 /**
+ * The skills one extract creates.
+ *
+ * Usually one. Several arrive together when the measurement merged their removals into a
+ * single change (`anchoredHunks`), which makes them one accept/reject decision - accepting
+ * half a merged change is not a thing a file can do. Proposals written before that was
+ * possible carry a single `skill`, so both shapes read the same way here.
+ *
+ * @returns {object[]}
+ */
+export function editSkills(edit) {
+  if (Array.isArray(edit?.skills)) return edit.skills.filter(Boolean);
+  return edit?.skill ? [edit.skill] : [];
+}
+
+/**
  * The budget arithmetic that makes extraction worth it, reported per edit:
  * "-1,900 tok always-loaded, +140 tok description".
  */
 export function extractionBudgetEffect(edit) {
-  if (edit.kind !== "extract" || !edit.skill) return null;
+  const skills = editSkills(edit);
+  if (edit.kind !== "extract" || !skills.length) return null;
   const pairs = Array.isArray(edit.hunks) ? edit.hunks : [edit];
   const removedFromMemory = pairs.reduce((sum, p) => sum + estimateTokens(p.find) - estimateTokens(p.replace), 0);
-  const descriptionCost = estimateTokens(edit.skill.description);
+  const descriptionCost = skills.reduce((sum, skill) => sum + estimateTokens(skill.description), 0);
   return {
     alwaysLoadedDelta: -removedFromMemory,
     descriptionCost,
     net: descriptionCost - removedFromMemory,
-    skillBodyTokens: estimateTokens(edit.skill.body),
+    skillBodyTokens: skills.reduce((sum, skill) => sum + estimateTokens(skill.body), 0),
   };
 }
 

--- a/src/skills.js
+++ b/src/skills.js
@@ -213,11 +213,11 @@ export function ensureSkillsLayout(repoRoot) {
 }
 
 /** Write an accepted skill extraction to disk, setting up the load layout on first use. */
-export function writeSkill(repoRoot, skill) {
+export function writeSkill(repoRoot, skill, { exclusive = false } = {}) {
   const inCanonical = skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`);
   const layout = inCanonical ? ensureSkillsLayout(repoRoot) : { created: [], warnings: [] };
   const target = path.join(repoRoot, skill.path);
   fs.mkdirSync(path.dirname(target), { recursive: true });
-  fs.writeFileSync(target, renderSkillFile(skill));
+  fs.writeFileSync(target, renderSkillFile(skill), { flag: exclusive ? "wx" : "w" });
   return { target, ...layout };
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -218,6 +218,30 @@ export function writeSkill(repoRoot, skill, { exclusive = false } = {}) {
   const layout = inCanonical ? ensureSkillsLayout(repoRoot) : { created: [], warnings: [] };
   const target = path.join(repoRoot, skill.path);
   fs.mkdirSync(path.dirname(target), { recursive: true });
-  fs.writeFileSync(target, renderSkillFile(skill), { flag: exclusive ? "wx" : "w" });
+  const text = renderSkillFile(skill);
+  if (!exclusive) {
+    fs.writeFileSync(target, text);
+    return { target, ...layout };
+  }
+
+  // Own the exclusive target from open through close. If writing fails after creation,
+  // remove only the inode this call opened; an EEXIST race never reaches that cleanup.
+  let fd;
+  try {
+    fd = fs.openSync(target, "wx");
+    fs.writeFileSync(fd, text);
+    fs.closeSync(fd);
+    fd = undefined;
+  } catch (err) {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Preserve the original write error.
+      }
+      fs.rmSync(target, { force: true });
+    }
+    throw err;
+  }
   return { target, ...layout };
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -193,8 +193,27 @@ function pathIdentity(stat) {
 function restoreQuarantinedPath(quarantine, destination) {
   const stat = fs.lstatSync(quarantine);
   if (stat.isDirectory()) {
-    fs.cpSync(quarantine, destination, { recursive: true, force: false, errorOnExist: true });
-    fs.rmSync(quarantine, { recursive: true });
+    // Restore the directory object itself. Recursively copying it can fail for valid
+    // entries such as Unix sockets and would turn restoration into a lossy clone. On
+    // POSIX, an empty directory created with mkdir is an atomic no-clobber reservation;
+    // rename may replace that reservation, but cannot replace it after another process
+    // has populated it.
+    if (process.platform === "win32") {
+      fs.renameSync(quarantine, destination);
+      return;
+    }
+
+    fs.mkdirSync(destination, { mode: stat.mode & 0o7777 });
+    try {
+      fs.renameSync(quarantine, destination);
+    } catch (err) {
+      try {
+        fs.rmdirSync(destination);
+      } catch {
+        // Another process populated the reservation. Preserve both directory trees.
+      }
+      throw err;
+    }
     return;
   }
   if (stat.isSymbolicLink()) {

--- a/src/skills.js
+++ b/src/skills.js
@@ -186,31 +186,7 @@ function inspectClaudeSkillsLink(repoRoot) {
 }
 
 function pathIdentity(stat) {
-  return { dev: stat.dev, ino: stat.ino, directory: stat.isDirectory() };
-}
-
-function ownedPath(absolute) {
-  return { absolute, identity: pathIdentity(fs.lstatSync(absolute)) };
-}
-
-function createDirectories(root, directory) {
-  const relative = path.relative(root, directory);
-  if (path.isAbsolute(relative) || relative === ".." || relative.startsWith(`..${path.sep}`)) {
-    throw new Error(`skill directory escapes the repository: ${directory}`);
-  }
-
-  const ownership = [];
-  let current = root;
-  for (const component of relative.split(path.sep).filter(Boolean)) {
-    current = path.join(current, component);
-    try {
-      fs.mkdirSync(current);
-      ownership.push(ownedPath(current));
-    } catch (err) {
-      if (err.code !== "EEXIST" || !fs.statSync(current).isDirectory()) throw err;
-    }
-  }
-  return ownership;
+  return { dev: stat.dev, ino: stat.ino };
 }
 
 export function removeOwnedSkillPaths(paths) {
@@ -223,8 +199,7 @@ export function removeOwnedSkillPaths(paths) {
     }
     if (observed.dev !== item.identity.dev || observed.ino !== item.identity.ino) continue;
     try {
-      if (item.identity.directory) fs.rmdirSync(item.absolute);
-      else fs.unlinkSync(item.absolute);
+      fs.unlinkSync(item.absolute);
     } catch {
       continue;
     }
@@ -239,52 +214,44 @@ export function removeOwnedSkillPaths(paths) {
  */
 export function ensureSkillsLayout(repoRoot) {
   const created = [];
-  const ownership = [];
   const warnings = [];
-  try {
-    const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
-    if (!fs.existsSync(canonical)) {
-      const canonicalOwnership = createDirectories(repoRoot, canonical);
-      ownership.push(...canonicalOwnership);
-      if (canonicalOwnership.some((item) => item.absolute === canonical)) created.push(CANONICAL_SKILLS_DIR);
-    }
-
-    const claude = inspectClaudeSkillsLink(repoRoot);
-    if (claude.state === "missing") {
-      const link = path.join(repoRoot, CLAUDE_SKILLS_LINK);
-      ownership.push(...createDirectories(repoRoot, path.dirname(link)));
-      fs.symlinkSync(CLAUDE_SKILLS_LINK_TARGET, link, "dir");
-      ownership.push(ownedPath(link));
-      created.push(`${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`);
-    } else if (claude.state === "dir") {
-      warnings.push(claudeSkillsDirWarning());
-    }
-    return ownership.length ? { created, warnings, ownership } : { created, warnings };
-  } catch (err) {
-    removeOwnedSkillPaths(ownership);
-    throw err;
+  const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
+  if (!fs.existsSync(canonical)) {
+    fs.mkdirSync(canonical, { recursive: true });
+    created.push(CANONICAL_SKILLS_DIR);
   }
+
+  const claude = inspectClaudeSkillsLink(repoRoot);
+  if (claude.state === "missing") {
+    const link = path.join(repoRoot, CLAUDE_SKILLS_LINK);
+    fs.mkdirSync(path.dirname(link), { recursive: true });
+    fs.symlinkSync(CLAUDE_SKILLS_LINK_TARGET, link, "dir");
+    created.push(`${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`);
+  } else if (claude.state === "dir") {
+    warnings.push(claudeSkillsDirWarning());
+  }
+  return { created, warnings };
 }
 
 /** Write an accepted skill extraction to disk, setting up the load layout on first use. */
-export function writeSkill(repoRoot, skill, { exclusive = false } = {}) {
+export function writeSkill(repoRoot, skill, { exclusive = false, ensureLayout = true } = {}) {
   const inCanonical = skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`);
-  const layout = inCanonical ? ensureSkillsLayout(repoRoot) : { created: [], warnings: [] };
-  const ownership = [...(layout.ownership ?? [])];
+  const layout = inCanonical && ensureLayout ? ensureSkillsLayout(repoRoot) : { created: [], warnings: [] };
+  const canonicalWasMissing = inCanonical && !fs.existsSync(path.join(repoRoot, CANONICAL_SKILLS_DIR));
   const target = path.join(repoRoot, skill.path);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  if (!ensureLayout && canonicalWasMissing) layout.created.push(CANONICAL_SKILLS_DIR);
   const text = renderSkillFile(skill);
   if (!exclusive) {
-    fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, text);
-    return { target, created: layout.created, warnings: layout.warnings };
+    return { target, ...layout };
   }
 
   let fd;
-  let targetOwnership;
+  let ownership;
   try {
-    ownership.push(...createDirectories(repoRoot, path.dirname(target)));
     fd = fs.openSync(target, "wx");
-    targetOwnership = { absolute: target, identity: pathIdentity(fs.fstatSync(fd)) };
+    ownership = [{ absolute: target, identity: pathIdentity(fs.fstatSync(fd)) }];
     fs.writeFileSync(fd, text);
     fs.closeSync(fd);
     fd = undefined;
@@ -296,9 +263,8 @@ export function writeSkill(repoRoot, skill, { exclusive = false } = {}) {
         // Preserve the original write error.
       }
     }
-    removeOwnedSkillPaths(targetOwnership ? [...ownership, targetOwnership] : ownership);
+    removeOwnedSkillPaths(ownership ?? []);
     throw err;
   }
-  ownership.push(targetOwnership);
-  return { target, created: layout.created, warnings: layout.warnings, ownership };
+  return { target, ...layout, ownership };
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -185,6 +185,46 @@ function inspectClaudeSkillsLink(repoRoot) {
   return { state: "other" };
 }
 
+function pathIdentity(stat) {
+  return { dev: stat.dev, ino: stat.ino, directory: stat.isDirectory() };
+}
+
+function ownedPath(absolute) {
+  return { absolute, identity: pathIdentity(fs.lstatSync(absolute)) };
+}
+
+function missingDirectories(root, directory) {
+  const missing = [];
+  for (let current = directory; current !== root && !fs.existsSync(current); current = path.dirname(current)) {
+    missing.push(current);
+  }
+  return missing.reverse();
+}
+
+function createDirectories(root, directory) {
+  const missing = missingDirectories(root, directory);
+  fs.mkdirSync(directory, { recursive: true });
+  return missing.map(ownedPath);
+}
+
+export function removeOwnedSkillPaths(paths) {
+  for (const item of [...paths].reverse()) {
+    let observed;
+    try {
+      observed = pathIdentity(fs.lstatSync(item.absolute));
+    } catch {
+      continue;
+    }
+    if (observed.dev !== item.identity.dev || observed.ino !== item.identity.ino) continue;
+    try {
+      if (item.identity.directory) fs.rmdirSync(item.absolute);
+      else fs.unlinkSync(item.absolute);
+    } catch {
+      continue;
+    }
+  }
+}
+
 /**
  * Create the canonical skills dir and the `.claude/skills -> ../.agents/skills` symlink
  * so both harness families load the same files with no duplication. An existing
@@ -193,42 +233,51 @@ function inspectClaudeSkillsLink(repoRoot) {
  */
 export function ensureSkillsLayout(repoRoot) {
   const created = [];
+  const ownership = [];
   const warnings = [];
-  const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
-  if (!fs.existsSync(canonical)) {
-    fs.mkdirSync(canonical, { recursive: true });
-    created.push(CANONICAL_SKILLS_DIR);
-  }
+  try {
+    const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
+    if (!fs.existsSync(canonical)) {
+      ownership.push(...createDirectories(repoRoot, canonical));
+      created.push(CANONICAL_SKILLS_DIR);
+    }
 
-  const claude = inspectClaudeSkillsLink(repoRoot);
-  if (claude.state === "missing") {
-    const link = path.join(repoRoot, CLAUDE_SKILLS_LINK);
-    fs.mkdirSync(path.dirname(link), { recursive: true });
-    fs.symlinkSync(CLAUDE_SKILLS_LINK_TARGET, link, "dir");
-    created.push(`${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`);
-  } else if (claude.state === "dir") {
-    warnings.push(claudeSkillsDirWarning());
+    const claude = inspectClaudeSkillsLink(repoRoot);
+    if (claude.state === "missing") {
+      const link = path.join(repoRoot, CLAUDE_SKILLS_LINK);
+      ownership.push(...createDirectories(repoRoot, path.dirname(link)));
+      fs.symlinkSync(CLAUDE_SKILLS_LINK_TARGET, link, "dir");
+      ownership.push(ownedPath(link));
+      created.push(`${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`);
+    } else if (claude.state === "dir") {
+      warnings.push(claudeSkillsDirWarning());
+    }
+    return ownership.length ? { created, warnings, ownership } : { created, warnings };
+  } catch (err) {
+    removeOwnedSkillPaths(ownership);
+    throw err;
   }
-  return { created, warnings };
 }
 
 /** Write an accepted skill extraction to disk, setting up the load layout on first use. */
 export function writeSkill(repoRoot, skill, { exclusive = false } = {}) {
   const inCanonical = skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`);
   const layout = inCanonical ? ensureSkillsLayout(repoRoot) : { created: [], warnings: [] };
+  const ownership = [...(layout.ownership ?? [])];
   const target = path.join(repoRoot, skill.path);
-  fs.mkdirSync(path.dirname(target), { recursive: true });
   const text = renderSkillFile(skill);
   if (!exclusive) {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, text);
-    return { target, ...layout };
+    return { target, created: layout.created, warnings: layout.warnings };
   }
 
-  // Own the exclusive target from open through close. If writing fails after creation,
-  // remove only the inode this call opened; an EEXIST race never reaches that cleanup.
   let fd;
+  let targetOwnership;
   try {
+    ownership.push(...createDirectories(repoRoot, path.dirname(target)));
     fd = fs.openSync(target, "wx");
+    targetOwnership = { absolute: target, identity: pathIdentity(fs.fstatSync(fd)) };
     fs.writeFileSync(fd, text);
     fs.closeSync(fd);
     fd = undefined;
@@ -239,9 +288,10 @@ export function writeSkill(repoRoot, skill, { exclusive = false } = {}) {
       } catch {
         // Preserve the original write error.
       }
-      fs.rmSync(target, { force: true });
     }
+    removeOwnedSkillPaths(targetOwnership ? [...ownership, targetOwnership] : ownership);
     throw err;
   }
-  return { target, ...layout };
+  ownership.push(targetOwnership);
+  return { target, created: layout.created, warnings: layout.warnings, ownership };
 }

--- a/src/state.js
+++ b/src/state.js
@@ -24,7 +24,6 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   prompts/               the exact prompts of the last run, one file per model turn
  *   synthesis/             the staging copy the synthesis agent edits natively (src/workspace.js)
- *   synthesis.json         the staging baseline and evidence snapshot for `propose --resume`
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -38,7 +37,6 @@ export class State {
     this.rejectionsPath = path.join(this.root, "rejections.json");
     this.gapLedgerPath = path.join(this.root, "gap-ledger.json");
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
-    this.workspaceManifestPath = path.join(this.root, "synthesis.json");
   }
 
   /**
@@ -138,14 +136,6 @@ export class State {
 
   writeGapLedger(ledger) {
     this.writeJsonFile(this.gapLedgerPath, ledger);
-  }
-
-  readWorkspaceManifest() {
-    return this.readJsonFile(this.workspaceManifestPath, null);
-  }
-
-  writeWorkspaceManifest(manifest) {
-    this.writeJsonFile(this.workspaceManifestPath, manifest);
   }
 
   readProbeCache() {

--- a/src/state.js
+++ b/src/state.js
@@ -24,6 +24,8 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   prompts/               the exact prompts of the last run, one file per model turn
  *   synthesis/             the staging copy the synthesis agent edits natively (src/workspace.js)
+ *   synthesis.json         what that copy was measured against, so `propose --resume` can
+ *                          re-open it instead of paying for another editing turn
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -37,6 +39,7 @@ export class State {
     this.rejectionsPath = path.join(this.root, "rejections.json");
     this.gapLedgerPath = path.join(this.root, "gap-ledger.json");
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
+    this.workspaceManifestPath = path.join(this.root, "synthesis.json");
   }
 
   /**
@@ -132,6 +135,15 @@ export class State {
 
   writeGapLedger(ledger) {
     this.writeJsonFile(this.gapLedgerPath, ledger);
+  }
+
+  /** The staging copy's baseline record; null when no synthesis has been staged. */
+  readWorkspaceManifest() {
+    return this.readJsonFile(this.workspaceManifestPath, null);
+  }
+
+  writeWorkspaceManifest(manifest) {
+    this.writeJsonFile(this.workspaceManifestPath, manifest);
   }
 
   readProbeCache() {

--- a/src/state.js
+++ b/src/state.js
@@ -24,6 +24,7 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   prompts/               the exact prompts of the last run, one file per model turn
  *   synthesis/             the staging copy the synthesis agent edits natively (src/workspace.js)
+ *   synthesis.json         the staging baseline and evidence snapshot for `propose --resume`
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -37,6 +38,7 @@ export class State {
     this.rejectionsPath = path.join(this.root, "rejections.json");
     this.gapLedgerPath = path.join(this.root, "gap-ledger.json");
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
+    this.workspaceManifestPath = path.join(this.root, "synthesis.json");
   }
 
   /**
@@ -136,6 +138,18 @@ export class State {
 
   writeGapLedger(ledger) {
     this.writeJsonFile(this.gapLedgerPath, ledger);
+  }
+
+  readWorkspaceManifest() {
+    return this.readJsonFile(this.workspaceManifestPath, null);
+  }
+
+  writeWorkspaceManifest(manifest) {
+    this.writeJsonFile(this.workspaceManifestPath, manifest);
+  }
+
+  clearWorkspaceManifest() {
+    fs.rmSync(this.workspaceManifestPath, { force: true });
   }
 
   readProbeCache() {

--- a/src/state.js
+++ b/src/state.js
@@ -24,6 +24,7 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   prompts/               the exact prompts of the last run, one file per model turn
  *   synthesis/             the staging copy the synthesis agent edits natively (src/workspace.js)
+ *   synthesis.json         the staging baseline and evidence snapshot for `propose --resume`
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -37,6 +38,7 @@ export class State {
     this.rejectionsPath = path.join(this.root, "rejections.json");
     this.gapLedgerPath = path.join(this.root, "gap-ledger.json");
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
+    this.workspaceManifestPath = path.join(this.root, "synthesis.json");
   }
 
   /**
@@ -136,6 +138,14 @@ export class State {
 
   writeGapLedger(ledger) {
     this.writeJsonFile(this.gapLedgerPath, ledger);
+  }
+
+  readWorkspaceManifest() {
+    return this.readJsonFile(this.workspaceManifestPath, null);
+  }
+
+  writeWorkspaceManifest(manifest) {
+    this.writeJsonFile(this.workspaceManifestPath, manifest);
   }
 
   readProbeCache() {

--- a/src/state.js
+++ b/src/state.js
@@ -24,7 +24,6 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   prompts/               the exact prompts of the last run, one file per model turn
  *   synthesis/             the staging copy the synthesis agent edits natively (src/workspace.js)
- *   synthesis.json         the staging baseline and evidence snapshot for `propose --resume`
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -38,7 +37,6 @@ export class State {
     this.rejectionsPath = path.join(this.root, "rejections.json");
     this.gapLedgerPath = path.join(this.root, "gap-ledger.json");
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
-    this.workspaceManifestPath = path.join(this.root, "synthesis.json");
   }
 
   /**
@@ -138,18 +136,6 @@ export class State {
 
   writeGapLedger(ledger) {
     this.writeJsonFile(this.gapLedgerPath, ledger);
-  }
-
-  readWorkspaceManifest() {
-    return this.readJsonFile(this.workspaceManifestPath, null);
-  }
-
-  writeWorkspaceManifest(manifest) {
-    this.writeJsonFile(this.workspaceManifestPath, manifest);
-  }
-
-  clearWorkspaceManifest() {
-    fs.rmSync(this.workspaceManifestPath, { force: true });
   }
 
   readProbeCache() {

--- a/src/state.js
+++ b/src/state.js
@@ -18,7 +18,7 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   scan-cache.json        path+mtime+size -> association verdict (design section 2.2)
  *   evidence/<id>.json     per-transcript tier-1 analysis output (design section 3)
  *   evidence-summary.json  folded evidence (stage 2)
- *   proposal.json          latest tier-2 synthesis (stage 3)
+ *   proposal.json          latest parseable tier-2 synthesis; absent if none was produced (stage 3)
  *   rejections.json        edits the human rejected, and the evidence weight behind them
  *   gap-ledger.json        gap observations by gap and session, accumulated across runs (src/gap-ledger.js)
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)

--- a/src/state.js
+++ b/src/state.js
@@ -24,8 +24,6 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   agent-probe-cache.json TTL'd availability/auth verdicts per agent|model (src/agents.js)
  *   prompts/               the exact prompts of the last run, one file per model turn
  *   synthesis/             the staging copy the synthesis agent edits natively (src/workspace.js)
- *   synthesis.json         what that copy was measured against, so `propose --resume` can
- *                          re-open it instead of paying for another editing turn
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
@@ -39,7 +37,6 @@ export class State {
     this.rejectionsPath = path.join(this.root, "rejections.json");
     this.gapLedgerPath = path.join(this.root, "gap-ledger.json");
     this.probeCachePath = path.join(this.root, "agent-probe-cache.json");
-    this.workspaceManifestPath = path.join(this.root, "synthesis.json");
   }
 
   /**
@@ -135,15 +132,6 @@ export class State {
 
   writeGapLedger(ledger) {
     this.writeJsonFile(this.gapLedgerPath, ledger);
-  }
-
-  /** The staging copy's baseline record; null when no synthesis has been staged. */
-  readWorkspaceManifest() {
-    return this.readJsonFile(this.workspaceManifestPath, null);
-  }
-
-  writeWorkspaceManifest(manifest) {
-    this.writeJsonFile(this.workspaceManifestPath, manifest);
   }
 
   readProbeCache() {

--- a/src/state.js
+++ b/src/state.js
@@ -113,6 +113,10 @@ export class State {
     this.writeJsonFile(this.proposalPath, proposal);
   }
 
+  clearProposal() {
+    fs.rmSync(this.proposalPath, { force: true });
+  }
+
   readRejections() {
     const value = this.readJsonFile(this.rejectionsPath, null);
     return value && value.version === 1 ? value : { version: 1, entries: {} };

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -120,11 +120,7 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
   );
 }
 
-/**
- * Everything both entry points need: the prompt values, the `buildProposal` context, and
- * the overflow target. `synthesizeProposal` runs an edit turn first; `resumeAnnotation`
- * starts straight at the annotation of a staging copy that is already on disk.
- */
+/** Everything synthesis needs: prompt values, proposal context, and overflow target. */
 function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const state = config.state;
   const rejections = state.readRejections();
@@ -160,8 +156,8 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
 /**
  * The header a fresh annotation session needs. An in-session annotate turn inherits the
  * repository, the budget, and the evidence from the editing turn that preceded it; a
- * session that never saw that turn - the retry after an empty reply, or `propose
- * --resume` - would otherwise be asked to quote evidence it has never been shown.
+ * session that never saw that turn - the retry after an empty reply - would otherwise
+ * be asked to quote evidence it has never been shown.
  */
 function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot }) {
   return render(loadPrompt("annotate-preface"), {
@@ -223,8 +219,8 @@ async function annotateLoop({
   noteOnce,
   overflow,
   progress,
+  ranWith,
   renderPreface,
-  startFresh = false,
 }) {
   const { memoryFile, config } = context;
   const state = config.state;
@@ -234,7 +230,7 @@ async function annotateLoop({
   let emptyTurns = 0;
   let violationsToShow = [];
   let justRemeasured = false;
-  let owePreface = startFresh;
+  let owePreface = false;
   /** @type {{ attempt: number, violations: string[] } | null} */
   let saved = null;
   /** @type {{ reason: string, violations: string[] }} */
@@ -257,13 +253,13 @@ async function annotateLoop({
     fs.writeFileSync(promptFile, prompt);
     progress("annotate", { attempt: attempts + 1, turn, changes: measured.changes.length });
 
-    const result = await holder.prompt({
+    const result = await holder.session.prompt({
       promptFile,
       approveAll: true,
       timeoutSeconds,
       promptRetries,
     });
-    usage.push(usageRecord(holder.ranWith, result));
+    usage.push(usageRecord(ranWith, result));
     for (const note of result.notes || []) noteOnce(note);
 
     // The agent may keep editing during an annotate turn; the ids it was answering about
@@ -421,23 +417,15 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   // through to the next ladder candidate; the switch is recorded in the notes so the
   // proposal's provenance is visible. Once the editing turn has run, later turns stay
   // on the same candidate - a run never silently switches models after real work.
-  /** @type {{ session: Awaited<ReturnType<typeof openSession>> | null, ranWith: string, prompt: Function }} */
-  const holder = {
-    session: null,
-    ranWith,
-    prompt(args) {
-      if (!this.session) throw new Error("synthesis session is not open");
-      return this.session.prompt(args);
-    },
-  };
+  /** @type {{ session: Awaited<ReturnType<typeof openSession>> | null }} */
+  const holder = { session: null };
   /** @type {ReturnType<typeof prepareWorkspace>} */
   let workspace = null;
   const editResult = await config.agents.withFallthrough("synthesis", async (current) => {
     ranWith = current.agent;
-    holder.ranWith = current.agent;
     chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, harnessCounts });
+    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir });
     progress("edit", { attempt: 1 });
     holder.session = await openSession({
       agent: current.agent,
@@ -489,6 +477,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       noteOnce,
       overflow,
       progress,
+      ranWith,
       renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
     });
   } finally {
@@ -496,116 +485,3 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   }
 }
 
-/**
- * `backpass propose --resume`: annotate a staging copy that is already on disk.
- *
- * The expensive half of a synthesis run is the editing turn, and its result survives a
- * failed annotation - it is sitting in `.backpass/synthesis/`. This picks that up in a new
- * session (the old one is gone, and its accumulated context is exactly what a resume is
- * escaping), re-measures the tree as it stands, and runs the same annotate loop. The
- * workspace is never rebuilt here, so nothing the previous run produced is destroyed.
- */
-export async function resumeAnnotation({ memoryFile, summary, config, repo, workspace, harnessCounts = {} }) {
-  const { rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
-    memoryFile,
-    summary,
-    config,
-    repo,
-    harnessCounts,
-  });
-
-  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
-  const sessionName = `backpass-resume-${process.pid}`;
-  const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
-  const usage = [];
-  const notes = ["resumed the staged synthesis in a fresh session; the editing turn was not re-run"];
-  const noteOnce = (note) => {
-    if (notes.includes(note)) return;
-    notes.push(note);
-    warn(note);
-  };
-
-  const pick = await config.agents.resolve("synthesis");
-  info(
-    `${color.cyan("·")} resuming the staged synthesis with ${pick.agent}` +
-      `${pick.model ? ` (${pick.model})` : ""}` +
-      `${pick.effort ? ` effort=${pick.effort}` : ""}`,
-  );
-  let chosen = pick;
-  let serial = 0;
-  const holder = {
-    session: null,
-    ranWith: pick.agent,
-    async prompt(args) {
-      if (this.session) return this.session.prompt(args);
-      return config.agents.withFallthrough("synthesis", async (current) => {
-        chosen = current;
-        this.ranWith = current.agent;
-        if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-        this.session = await openSession({
-          agent: current.agent,
-          model: current.model,
-          effort: current.effort,
-          sessionName,
-          cwd: workspace.root,
-        });
-        try {
-          return await this.session.prompt(args);
-        } catch (err) {
-          await this.session.close();
-          this.session = null;
-          throw err;
-        }
-      });
-    },
-  };
-  const progress = (phase, extra = {}) =>
-    emitProgress("synth:start", {
-      agent: holder.ranWith,
-      model: chosen.model,
-      effort: chosen.effort,
-      phase,
-      maxEdits,
-      sessionName,
-      resumed: true,
-      gapClusters: summary.totals.gapClusters,
-      instructions: summary.instructions.length,
-      suppressed: Object.keys(rejections.entries || {}).length,
-      ...extra,
-    });
-
-  const nextSession = () => {
-    serial += 1;
-    return openSession({
-      agent: chosen.agent,
-      model: chosen.model,
-      effort: chosen.effort,
-      sessionName: `${sessionName}-r${serial}`,
-      cwd: workspace.root,
-    });
-  };
-
-  try {
-    return await annotateLoop({
-      holder,
-      freshSession: nextSession,
-      workspace,
-      fingerprint,
-      repo,
-      context,
-      common,
-      promptDir,
-      timeoutSeconds,
-      promptRetries: config.promptRetries,
-      usage,
-      notes,
-      noteOnce,
-      overflow,
-      progress,
-      startFresh: true,
-      renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
-    });
-  } finally {
-    await holder.session?.close();
-  }
-}

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -121,9 +121,8 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
 }
 
 /**
- * Everything both entry points need: the prompt values, the `buildProposal` context, and
- * the overflow target. `synthesizeProposal` runs an edit turn first; `resumeAnnotation`
- * starts straight at the annotation of a staging copy that is already on disk.
+ * Everything the edit and annotation turns need: prompt values, the `buildProposal`
+ * context, and the overflow target.
  */
 function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const state = config.state;
@@ -159,9 +158,9 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
 
 /**
  * The header a fresh annotation session needs. An in-session annotate turn inherits the
- * repository, the budget, and the evidence from the editing turn that preceded it; a
- * session that never saw that turn - the retry after an empty reply, or `propose
- * --resume` - would otherwise be asked to quote evidence it has never been shown.
+ * repository, the budget, and the evidence from the editing turn that preceded it; the
+ * fresh session used after an empty reply would otherwise be asked to quote evidence it
+ * has never been shown.
  */
 function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot }) {
   return render(loadPrompt("annotate-preface"), {
@@ -438,7 +437,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     holder.ranWith = current.agent;
     chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, harnessCounts, summary });
+    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir });
     progress("edit", { attempt: 1 });
     holder.session = await openSession({
       agent: current.agent,
@@ -494,120 +493,5 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     });
   } finally {
     await holder.session.close();
-  }
-}
-
-/**
- * `backpass propose --resume`: annotate a staging copy that is already on disk.
- *
- * The expensive half of a synthesis run is the editing turn, and its result survives a
- * failed annotation - it is sitting in `.backpass/synthesis/`. This picks that up in a new
- * session (the old one is gone, and its accumulated context is exactly what a resume is
- * escaping), re-measures the tree as it stands, and runs the same annotate loop. The
- * workspace is never rebuilt here, so nothing the previous run produced is destroyed.
- */
-export async function resumeAnnotation({ memoryFile, summary, config, repo, workspace, harnessCounts = {} }) {
-  config.state.clearProposal();
-  const { rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
-    memoryFile,
-    summary,
-    config,
-    repo,
-    harnessCounts,
-  });
-
-  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
-  const sessionName = `backpass-resume-${process.pid}`;
-  const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
-  const usage = [];
-  const notes = ["resumed the staged synthesis in a fresh session; the editing turn was not re-run"];
-  const noteOnce = (note) => {
-    if (notes.includes(note)) return;
-    notes.push(note);
-    warn(note);
-  };
-
-  const pick = await config.agents.resolve("synthesis");
-  info(
-    `${color.cyan("·")} resuming the staged synthesis with ${pick.agent}` +
-      `${pick.model ? ` (${pick.model})` : ""}` +
-      `${pick.effort ? ` effort=${pick.effort}` : ""}`,
-  );
-  let chosen = pick;
-  let serial = 0;
-  const holder = {
-    session: null,
-    ranWith: pick.agent,
-    async prompt(args) {
-      if (this.session) return this.session.prompt(args);
-      return config.agents.withFallthrough("synthesis", async (current) => {
-        chosen = current;
-        this.ranWith = current.agent;
-        if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-        this.session = await openSession({
-          agent: current.agent,
-          model: current.model,
-          effort: current.effort,
-          sessionName,
-          cwd: workspace.root,
-        });
-        try {
-          return await this.session.prompt(args);
-        } catch (err) {
-          await this.session.close();
-          this.session = null;
-          throw err;
-        }
-      });
-    },
-  };
-  const progress = (phase, extra = {}) =>
-    emitProgress("synth:start", {
-      agent: holder.ranWith,
-      model: chosen.model,
-      effort: chosen.effort,
-      phase,
-      maxEdits,
-      sessionName,
-      resumed: true,
-      gapClusters: summary.totals.gapClusters,
-      instructions: summary.instructions.length,
-      suppressed: Object.keys(rejections.entries || {}).length,
-      ...extra,
-    });
-
-  const nextSession = () => {
-    serial += 1;
-    return openSession({
-      agent: chosen.agent,
-      model: chosen.model,
-      effort: chosen.effort,
-      sessionName: `${sessionName}-r${serial}`,
-      cwd: workspace.root,
-    });
-  };
-
-  try {
-    return await annotateLoop({
-      holder,
-      freshSession: nextSession,
-      workspace,
-      fingerprint,
-      repo,
-      context,
-      common,
-      promptDir,
-      timeoutSeconds,
-      promptRetries: config.promptRetries,
-      usage,
-      notes,
-      noteOnce,
-      overflow,
-      progress,
-      startFresh: true,
-      renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
-    });
-  } finally {
-    await holder.session?.close();
   }
 }

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -24,11 +24,11 @@ import { UserError, color, info, warn } from "./logger.js";
  *   annotate  backpass measures the copy against the original (`src/diff.js`) and shows
  *             the changes by id; the agent attaches kind, title, rationale, and evidence
  *
- * The annotation is what the mechanical gates validate (`buildProposal`); on a violation
- * the agent is re-prompted with the exact breaches, at most ANNOTATE_TURNS times in all,
- * then backpass fails loudly and saves the rejected proposal rather than quietly trimming
- * it (design section 6). The repo is fingerprinted before and checked after: a harness
- * that wrote past the staging copy is an error, never a silent apply.
+ * The annotation is what the mechanical gates validate (`buildProposal`); malformed or
+ * gated answers spend at most ANNOTATE_TURNS attempts and are re-prompted with the exact
+ * breaches. Backpass then fails loudly and preserves the latest parseable rejected proposal
+ * rather than quietly trimming it (design section 6). The repo is fingerprinted before and
+ * checked after: a harness that wrote past the staging copy is an error, never a silent apply.
  *
  * Three things an annotate turn can be are deliberately kept apart, because they call for
  * different responses and produce different advice at the end of a failed run:
@@ -41,8 +41,8 @@ import { UserError, color, info, warn } from "./logger.js";
  *                        spoke, so there is nothing to correct - the annotation is retried
  *                        once in a NEW session, since the accumulated context of the old
  *                        one is the likeliest reason it collapsed.
- *   the answer was judged the model spoke and the gates ruled. Only this consumes an
- *                        annotation attempt, and only this writes a rejected proposal.
+ *   the turn had text    a malformed or gated answer consumes an annotation attempt. Only
+ *                        a parseable, gate-rejected answer writes a rejected proposal.
  */
 
 /** Annotation attempts per run: the first answer plus re-prompts with the exact violations. */
@@ -155,9 +155,8 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
 
 /**
  * The header a fresh annotation session needs. An in-session annotate turn inherits the
- * repository, the budget, and the evidence from the editing turn that preceded it; a
- * session that never saw that turn - the retry after an empty reply - would otherwise
- * be asked to quote evidence it has never been shown.
+ * repository, the budget, and the evidence from its earlier turns; a session opened after
+ * an empty reply would otherwise be asked to quote evidence it has never been shown.
  */
 function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot }) {
   return render(loadPrompt("annotate-preface"), {
@@ -485,4 +484,3 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     await holder.session.close();
   }
 }
-

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -121,8 +121,9 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
 }
 
 /**
- * Everything the edit and annotation turns need: prompt values, the `buildProposal`
- * context, and the overflow target.
+ * Everything both entry points need: the prompt values, the `buildProposal` context, and
+ * the overflow target. `synthesizeProposal` runs an edit turn first; `resumeAnnotation`
+ * starts straight at the annotation of a staging copy that is already on disk.
  */
 function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const state = config.state;
@@ -158,9 +159,9 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
 
 /**
  * The header a fresh annotation session needs. An in-session annotate turn inherits the
- * repository, the budget, and the evidence from the editing turn that preceded it; the
- * fresh session used after an empty reply would otherwise be asked to quote evidence it
- * has never been shown.
+ * repository, the budget, and the evidence from the editing turn that preceded it; a
+ * session that never saw that turn - the retry after an empty reply, or `propose
+ * --resume` - would otherwise be asked to quote evidence it has never been shown.
  */
 function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot }) {
   return render(loadPrompt("annotate-preface"), {
@@ -437,7 +438,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     holder.ranWith = current.agent;
     chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir });
+    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, harnessCounts, summary });
     progress("edit", { attempt: 1 });
     holder.session = await openSession({
       agent: current.agent,
@@ -493,5 +494,120 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     });
   } finally {
     await holder.session.close();
+  }
+}
+
+/**
+ * `backpass propose --resume`: annotate a staging copy that is already on disk.
+ *
+ * The expensive half of a synthesis run is the editing turn, and its result survives a
+ * failed annotation - it is sitting in `.backpass/synthesis/`. This picks that up in a new
+ * session (the old one is gone, and its accumulated context is exactly what a resume is
+ * escaping), re-measures the tree as it stands, and runs the same annotate loop. The
+ * workspace is never rebuilt here, so nothing the previous run produced is destroyed.
+ */
+export async function resumeAnnotation({ memoryFile, summary, config, repo, workspace, harnessCounts = {} }) {
+  config.state.clearProposal();
+  const { rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
+    memoryFile,
+    summary,
+    config,
+    repo,
+    harnessCounts,
+  });
+
+  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
+  const sessionName = `backpass-resume-${process.pid}`;
+  const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
+  const usage = [];
+  const notes = ["resumed the staged synthesis in a fresh session; the editing turn was not re-run"];
+  const noteOnce = (note) => {
+    if (notes.includes(note)) return;
+    notes.push(note);
+    warn(note);
+  };
+
+  const pick = await config.agents.resolve("synthesis");
+  info(
+    `${color.cyan("·")} resuming the staged synthesis with ${pick.agent}` +
+      `${pick.model ? ` (${pick.model})` : ""}` +
+      `${pick.effort ? ` effort=${pick.effort}` : ""}`,
+  );
+  let chosen = pick;
+  let serial = 0;
+  const holder = {
+    session: null,
+    ranWith: pick.agent,
+    async prompt(args) {
+      if (this.session) return this.session.prompt(args);
+      return config.agents.withFallthrough("synthesis", async (current) => {
+        chosen = current;
+        this.ranWith = current.agent;
+        if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
+        this.session = await openSession({
+          agent: current.agent,
+          model: current.model,
+          effort: current.effort,
+          sessionName,
+          cwd: workspace.root,
+        });
+        try {
+          return await this.session.prompt(args);
+        } catch (err) {
+          await this.session.close();
+          this.session = null;
+          throw err;
+        }
+      });
+    },
+  };
+  const progress = (phase, extra = {}) =>
+    emitProgress("synth:start", {
+      agent: holder.ranWith,
+      model: chosen.model,
+      effort: chosen.effort,
+      phase,
+      maxEdits,
+      sessionName,
+      resumed: true,
+      gapClusters: summary.totals.gapClusters,
+      instructions: summary.instructions.length,
+      suppressed: Object.keys(rejections.entries || {}).length,
+      ...extra,
+    });
+
+  const nextSession = () => {
+    serial += 1;
+    return openSession({
+      agent: chosen.agent,
+      model: chosen.model,
+      effort: chosen.effort,
+      sessionName: `${sessionName}-r${serial}`,
+      cwd: workspace.root,
+    });
+  };
+
+  try {
+    return await annotateLoop({
+      holder,
+      freshSession: nextSession,
+      workspace,
+      fingerprint,
+      repo,
+      context,
+      common,
+      promptDir,
+      timeoutSeconds,
+      promptRetries: config.promptRetries,
+      usage,
+      notes,
+      noteOnce,
+      overflow,
+      progress,
+      startFresh: true,
+      renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
+    });
+  } finally {
+    await holder.session?.close();
   }
 }

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -223,7 +223,6 @@ async function annotateLoop({
   noteOnce,
   overflow,
   progress,
-  ranWith,
   renderPreface,
   startFresh = false,
 }) {
@@ -258,13 +257,13 @@ async function annotateLoop({
     fs.writeFileSync(promptFile, prompt);
     progress("annotate", { attempt: attempts + 1, turn, changes: measured.changes.length });
 
-    const result = await holder.session.prompt({
+    const result = await holder.prompt({
       promptFile,
       approveAll: true,
       timeoutSeconds,
       promptRetries,
     });
-    usage.push(usageRecord(ranWith, result));
+    usage.push(usageRecord(holder.ranWith, result));
     for (const note of result.notes || []) noteOnce(note);
 
     // The agent may keep editing during an annotate turn; the ids it was answering about
@@ -275,7 +274,7 @@ async function annotateLoop({
       remeasures += 1;
       justRemeasured = true;
       violationsToShow = [];
-      if (remeasures > REMEASURE_TURNS) {
+      if (remeasures >= REMEASURE_TURNS) {
         terminal = { reason: "editing", violations: [KEPT_EDITING_VIOLATION] };
         break;
       }
@@ -422,12 +421,20 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   // through to the next ladder candidate; the switch is recorded in the notes so the
   // proposal's provenance is visible. Once the editing turn has run, later turns stay
   // on the same candidate - a run never silently switches models after real work.
-  /** @type {{ session: Awaited<ReturnType<typeof openSession>> | null }} */
-  const holder = { session: null };
+  /** @type {{ session: Awaited<ReturnType<typeof openSession>> | null, ranWith: string, prompt: Function }} */
+  const holder = {
+    session: null,
+    ranWith,
+    prompt(args) {
+      if (!this.session) throw new Error("synthesis session is not open");
+      return this.session.prompt(args);
+    },
+  };
   /** @type {ReturnType<typeof prepareWorkspace>} */
   let workspace = null;
   const editResult = await config.agents.withFallthrough("synthesis", async (current) => {
     ranWith = current.agent;
+    holder.ranWith = current.agent;
     chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
     workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, harnessCounts });
@@ -482,7 +489,6 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       noteOnce,
       overflow,
       progress,
-      ranWith,
       renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
     });
   } finally {
@@ -525,12 +531,39 @@ export async function resumeAnnotation({ memoryFile, summary, config, repo, work
       `${pick.model ? ` (${pick.model})` : ""}` +
       `${pick.effort ? ` effort=${pick.effort}` : ""}`,
   );
-  const ranWith = pick.agent;
+  let chosen = pick;
+  let serial = 0;
+  const holder = {
+    session: null,
+    ranWith: pick.agent,
+    async prompt(args) {
+      if (this.session) return this.session.prompt(args);
+      return config.agents.withFallthrough("synthesis", async (current) => {
+        chosen = current;
+        this.ranWith = current.agent;
+        if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
+        this.session = await openSession({
+          agent: current.agent,
+          model: current.model,
+          effort: current.effort,
+          sessionName,
+          cwd: workspace.root,
+        });
+        try {
+          return await this.session.prompt(args);
+        } catch (err) {
+          await this.session.close();
+          this.session = null;
+          throw err;
+        }
+      });
+    },
+  };
   const progress = (phase, extra = {}) =>
     emitProgress("synth:start", {
-      agent: ranWith,
-      model: pick.model,
-      effort: pick.effort,
+      agent: holder.ranWith,
+      model: chosen.model,
+      effort: chosen.effort,
       phase,
       maxEdits,
       sessionName,
@@ -541,20 +574,15 @@ export async function resumeAnnotation({ memoryFile, summary, config, repo, work
       ...extra,
     });
 
-  let serial = 0;
-  const freshSession = () =>
-    openSession({
-      agent: pick.agent,
-      model: pick.model,
-      effort: pick.effort,
-      sessionName: serial === 0 ? sessionName : `${sessionName}-r${serial}`,
-      cwd: workspace.root,
-    });
-
-  const holder = { session: await freshSession() };
   const nextSession = () => {
     serial += 1;
-    return freshSession();
+    return openSession({
+      agent: chosen.agent,
+      model: chosen.model,
+      effort: chosen.effort,
+      sessionName: `${sessionName}-r${serial}`,
+      cwd: workspace.root,
+    });
   };
 
   try {
@@ -574,11 +602,10 @@ export async function resumeAnnotation({ memoryFile, summary, config, repo, work
       noteOnce,
       overflow,
       progress,
-      ranWith,
       startFresh: true,
       renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
     });
   } finally {
-    await holder.session.close();
+    await holder.session?.close();
   }
 }

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -18,17 +18,19 @@ import { UserError, color, info, warn } from "./logger.js";
  *
  * The agent never describes an edit for backpass to locate - it makes the edit, with its
  * harness's own file tools, in a staging copy of the memory file (`src/workspace.js`).
- * One session, two kinds of turn:
+ * A run starts in one session with two kinds of turn:
  *
  *   edit      the synthesis prompt; the agent edits `./AGENTS.md` in the staging copy
  *   annotate  backpass measures the copy against the original (`src/diff.js`) and shows
  *             the changes by id; the agent attaches kind, title, rationale, and evidence
  *
- * The annotation is what the mechanical gates validate (`buildProposal`); on a violation
- * the agent is re-prompted with the exact breaches, at most ANNOTATE_TURNS times in all,
- * then backpass fails loudly and saves the rejected proposal rather than quietly trimming
- * it (design section 6). The repo is fingerprinted before and checked after: a harness
- * that wrote past the staging copy is an error, never a silent apply.
+ * An empty annotation turn is retried once in a fresh session, as described below.
+ *
+ * The annotation is what the mechanical gates validate (`buildProposal`). A parseable
+ * gate-rejected answer is saved before the agent is re-prompted with the exact breaches;
+ * judged answers are bounded by ANNOTATE_TURNS, then backpass fails loudly rather than
+ * quietly trimming the result (design section 6). The repo is fingerprinted around each
+ * turn; a harness that wrote past the staging copy is an error, never a silent apply.
  *
  * Three things an annotate turn can be are deliberately kept apart, because they call for
  * different responses and produce different advice at the end of a failed run:

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -347,6 +347,7 @@ async function annotateLoop({
 }
 
 export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
+  config.state.clearProposal();
   const harnessCounts = harnessCountsOf(transcripts);
   const { state, rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
     memoryFile,

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { extractJson, openSession, usageRecord } from "./acpx.js";
 import { renderEvidenceForPrompt } from "./fold.js";
 import { renderInstructionIndex } from "./memory.js";
-import { renderPrompt } from "./prompts.js";
+import { renderPrompt, render, loadPrompt } from "./prompts.js";
 import { buildProposal, effectiveMaxEdits, ProposalViolation, renderChangesForPrompt } from "./proposal.js";
 import { loadSkills, renderSkillIndex, resolveOverflowTarget } from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
@@ -29,10 +29,37 @@ import { UserError, color, info, warn } from "./logger.js";
  * then backpass fails loudly and saves the rejected proposal rather than quietly trimming
  * it (design section 6). The repo is fingerprinted before and checked after: a harness
  * that wrote past the staging copy is an error, never a silent apply.
+ *
+ * Three things an annotate turn can be are deliberately kept apart, because they call for
+ * different responses and produce different advice at the end of a failed run:
+ *
+ *   the files moved      the ids the agent was asked about no longer exist. It is shown the
+ *                        fresh measurement and answers again; this is not a failed
+ *                        annotation and never costs an annotation attempt (REMEASURE_TURNS
+ *                        bounds it instead).
+ *   the turn was empty   the adapter returned success with no text at all. The model never
+ *                        spoke, so there is nothing to correct - the annotation is retried
+ *                        once in a NEW session, since the accumulated context of the old
+ *                        one is the likeliest reason it collapsed.
+ *   the answer was judged the model spoke and the gates ruled. Only this consumes an
+ *                        annotation attempt, and only this writes a rejected proposal.
  */
 
-/** Annotation turns per run: the first answer plus re-prompts with the exact violations. */
+/** Annotation attempts per run: the first answer plus re-prompts with the exact violations. */
 export const ANNOTATE_TURNS = 3;
+/**
+ * Turns per run the agent may spend re-editing instead of answering. Counted for the whole
+ * run, not consecutively: an agent that alternates editing and answering is still an agent
+ * that never finishes, and the loop has to end.
+ */
+export const REMEASURE_TURNS = 3;
+/** Fresh-session retries for an adapter turn that produced no text at all. */
+export const EMPTY_TURN_RETRIES = 1;
+
+const EMPTY_TURN_VIOLATION =
+  "the synthesis harness ended its turn with no output at all - no JSON, no prose, no tool call";
+const UNPARSEABLE_VIOLATION = "synthesis answered with text, but not with a JSON object";
+const KEPT_EDITING_VIOLATION = "synthesis kept editing the staging copy instead of annotating the measured changes";
 
 function budgetRule(memoryFile, config, maxEdits) {
   const remaining = config.budgetTokens - memoryFile.tokens;
@@ -93,13 +120,17 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
   );
 }
 
-export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
+/**
+ * Everything both entry points need: the prompt values, the `buildProposal` context, and
+ * the overflow target. `synthesizeProposal` runs an edit turn first; `resumeAnnotation`
+ * starts straight at the annotation of a staging copy that is already on disk.
+ */
+function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const state = config.state;
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
   for (const w of overflow.warnings) warn(w);
   const skillFiles = loadSkills(repo.root, overflow.dir);
-  const harnessCounts = harnessCountsOf(transcripts);
   const maxEdits = effectiveMaxEdits(memoryFile, config);
 
   const common = {
@@ -108,6 +139,228 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     MAX_EDITS: String(maxEdits),
     MIN_GAP_EVIDENCE: String(config.minGapEvidence),
   };
+
+  const context = {
+    memoryFile,
+    config: { ...config, skillsDir: overflow.dir },
+    repo,
+    summary,
+    harnessCounts,
+    rejections,
+    isSuppressed: isSuppressedByRejection,
+    skillFiles,
+  };
+
+  const promptDir = path.join(state.root, "prompts");
+  fs.mkdirSync(promptDir, { recursive: true });
+
+  return { state, rejections, overflow, skillFiles, maxEdits, common, context, promptDir };
+}
+
+/**
+ * The header a fresh annotation session needs. An in-session annotate turn inherits the
+ * repository, the budget, and the evidence from the editing turn that preceded it; a
+ * session that never saw that turn - the retry after an empty reply, or `propose
+ * --resume` - would otherwise be asked to quote evidence it has never been shown.
+ */
+function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot }) {
+  return render(loadPrompt("annotate-preface"), {
+    MEMORY_PATH: memoryFile.path,
+    REPO_NAME: repo.name,
+    REPO_ROOT: repo.root,
+    WORKSPACE_ROOT: workspaceRoot,
+    CURRENT_TOKENS: String(memoryFile.tokens),
+    BUDGET_STATE: budgetState(memoryFile, config),
+    TRANSCRIPT_COUNT: String(summary.analyzedSessions),
+    EVIDENCE: renderEvidenceForPrompt(summary),
+  });
+}
+
+const REMEASURE_NOTICE =
+  `\n\n## The files moved after they were measured\n\nYou changed the files again during your last turn, so the ids you were given no longer ` +
+  `describe them. Nothing is wrong with the shape of your answer - annotate the re-measured ` +
+  `changes above instead. This did not use up an annotation attempt.\n`;
+
+const rejectionBlock = (violations) =>
+  `\n\n## Your previous answer was rejected\n\nIt violated these hard rules. Fix every one of them ` +
+  `(edit the files first if a change must go or move) and return the corrected JSON object only.\n\n` +
+  `${violations.map((v) => `- ${v}`).join("\n")}\n`;
+
+/** The headline of a failed run, named after the condition it actually ended on. */
+function terminalMessage(reason, attempts, violations) {
+  if (reason === "empty") {
+    return "synthesis ended its turn with no output, in the run's session and again in a fresh one";
+  }
+  if (reason === "editing") {
+    return `synthesis kept editing the staging copy instead of annotating it (${REMEASURE_TURNS} re-measurements)`;
+  }
+  return (
+    `synthesis could not produce a valid proposal after ${Math.max(attempts - 1, 0)} re-prompt(s) ` +
+    `(${violations.length} violation(s))`
+  );
+}
+
+/**
+ * Drive the annotate turns to a valid proposal, or throw a `ProposalViolation` describing
+ * the condition the run actually ended on.
+ *
+ * `holder.session` is the live session; the loop replaces it when it needs a fresh one and
+ * the caller closes whatever is in the holder at the end.
+ */
+async function annotateLoop({
+  holder,
+  freshSession,
+  workspace,
+  fingerprint,
+  repo,
+  context,
+  common,
+  promptDir,
+  timeoutSeconds,
+  promptRetries,
+  usage,
+  notes,
+  noteOnce,
+  overflow,
+  progress,
+  ranWith,
+  renderPreface,
+  startFresh = false,
+}) {
+  const { memoryFile, config } = context;
+  const state = config.state;
+
+  let attempts = 0;
+  let remeasures = 0;
+  let emptyTurns = 0;
+  let violationsToShow = [];
+  let justRemeasured = false;
+  let owePreface = startFresh;
+  /** @type {{ attempt: number, violations: string[] } | null} */
+  let saved = null;
+  /** @type {{ reason: string, violations: string[] }} */
+  let terminal;
+
+  for (let turn = 1; ; turn += 1) {
+    assertRepoUntouched(repo, fingerprint, workspace.root);
+    const measured = measureWorkspace(workspace);
+
+    let prompt = renderPrompt("annotate", {
+      ...common,
+      PREFACE: owePreface ? renderPreface() : "",
+      CHANGES: renderChangesForPrompt(measured, memoryFile),
+    });
+    owePreface = false;
+    if (justRemeasured) prompt += REMEASURE_NOTICE;
+    else if (violationsToShow.length) prompt += rejectionBlock(violationsToShow);
+
+    const promptFile = path.join(promptDir, `synthesis-annotate-${turn}.md`);
+    fs.writeFileSync(promptFile, prompt);
+    progress("annotate", { attempt: attempts + 1, turn, changes: measured.changes.length });
+
+    const result = await holder.session.prompt({
+      promptFile,
+      approveAll: true,
+      timeoutSeconds,
+      promptRetries,
+    });
+    usage.push(usageRecord(ranWith, result));
+    for (const note of result.notes || []) noteOnce(note);
+
+    // The agent may keep editing during an annotate turn; the ids it was answering about
+    // are then stale, so the answer is dropped and the fresh measurement shown instead.
+    // That is a measurement problem, not a failed annotation: it costs no attempt.
+    assertRepoUntouched(repo, fingerprint, workspace.root);
+    if (measureWorkspace(workspace).signature !== measured.signature) {
+      remeasures += 1;
+      justRemeasured = true;
+      violationsToShow = [];
+      if (remeasures > REMEASURE_TURNS) {
+        terminal = { reason: "editing", violations: [KEPT_EDITING_VIOLATION] };
+        break;
+      }
+      warn(
+        `synthesis edited the staging copy again; re-measuring and re-annotating ` +
+          `(annotation attempt ${attempts + 1} of ${ANNOTATE_TURNS} is still unspent)`,
+      );
+      emitProgress("synth:remeasure", { turn, attempt: attempts + 1, remeasures });
+      continue;
+    }
+    justRemeasured = false;
+
+    // An empty turn is not a bad answer; it is no answer. Retry it once in a new session,
+    // because the accumulated context of this one is the likeliest reason it collapsed.
+    if (!(result.text || "").trim()) {
+      emptyTurns += 1;
+      if (emptyTurns > EMPTY_TURN_RETRIES) {
+        terminal = { reason: "empty", violations: [EMPTY_TURN_VIOLATION] };
+        break;
+      }
+      warn("synthesis ended its turn with no output; retrying the annotation once in a fresh session");
+      emitProgress("synth:empty", { turn, attempt: attempts + 1, emptyTurns });
+      await holder.session.close();
+      holder.session = await freshSession();
+      // The new session knows nothing, so it is given the preface; `violationsToShow` is
+      // kept because those gates are still what the run's annotation has to satisfy.
+      owePreface = true;
+      continue;
+    }
+
+    attempts += 1;
+    const parsed = extractJson(result.text);
+    if (!parsed) {
+      violationsToShow = [UNPARSEABLE_VIOLATION];
+      if (attempts >= ANNOTATE_TURNS) {
+        terminal = { reason: "unparseable", violations: violationsToShow };
+        break;
+      }
+      warn(`synthesis violated 1 gate(s); re-prompting with the exact violations`);
+      emitProgress("synth:violations", { attempt: attempts, violations: violationsToShow });
+      continue;
+    }
+
+    const { proposal, violations } = buildProposal(parsed, { ...context, measured });
+    proposal.notes = [...proposal.notes, ...notes];
+    proposal.usage = usage;
+    proposal.overflowTarget = overflow;
+    proposal.attempt = attempts;
+    if (!violations.length) {
+      emitProgress("synth:done", { edits: proposal.edits.length, attempt: attempts });
+      return { proposal, violations: [] };
+    }
+
+    violationsToShow = violations;
+    proposal.violations = violations;
+    // Keep the rejected proposal so a loud failure is still inspectable. It records which
+    // attempt produced it, so a later empty turn cannot be reported as its author.
+    state.writeProposal(proposal);
+    saved = { attempt: attempts, violations };
+    if (attempts >= ANNOTATE_TURNS) {
+      terminal = { reason: "gates", violations };
+      break;
+    }
+    warn(`synthesis violated ${violations.length} gate(s); re-prompting with the exact violations`);
+    emitProgress("synth:violations", { attempt: attempts, violations });
+  }
+
+  throw new ProposalViolation(terminalMessage(terminal.reason, attempts, terminal.violations), terminal.violations, {
+    reason: terminal.reason,
+    attempts,
+    saved,
+    proposalPath: saved ? state.proposalPath : null,
+  });
+}
+
+export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
+  const harnessCounts = harnessCountsOf(transcripts);
+  const { state, rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
+    memoryFile,
+    summary,
+    config,
+    repo,
+    harnessCounts,
+  });
+
   const editValues = {
     ...common,
     REPO_NAME: repo.name,
@@ -128,19 +381,6 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     REJECTIONS: renderRejections(rejections),
   };
 
-  const context = {
-    memoryFile,
-    config: { ...config, skillsDir: overflow.dir },
-    repo,
-    summary,
-    harnessCounts,
-    rejections,
-    isSuppressed: isSuppressedByRejection,
-    skillFiles,
-  };
-
-  const promptDir = path.join(state.root, "prompts");
-  fs.mkdirSync(promptDir, { recursive: true });
   const editPromptFile = path.join(promptDir, "synthesis-edit.md");
   fs.writeFileSync(editPromptFile, renderPrompt("synthesis", editValues));
 
@@ -163,6 +403,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       `${pick.effort ? ` effort=${pick.effort}` : ""}`,
   );
   let ranWith = pick.agent;
+  let chosen = pick;
   const progress = (phase, extra = {}) =>
     emitProgress("synth:start", {
       agent: ranWith,
@@ -181,16 +422,17 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   // through to the next ladder candidate; the switch is recorded in the notes so the
   // proposal's provenance is visible. Once the editing turn has run, later turns stay
   // on the same candidate - a run never silently switches models after real work.
-  /** @type {Awaited<ReturnType<typeof openSession>> | null} */
-  let session = null;
+  /** @type {{ session: Awaited<ReturnType<typeof openSession>> | null }} */
+  const holder = { session: null };
   /** @type {ReturnType<typeof prepareWorkspace>} */
   let workspace = null;
   const editResult = await config.agents.withFallthrough("synthesis", async (current) => {
     ranWith = current.agent;
+    chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir });
+    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, harnessCounts });
     progress("edit", { attempt: 1 });
-    session = await openSession({
+    holder.session = await openSession({
       agent: current.agent,
       model: current.model,
       effort: current.effort,
@@ -198,90 +440,145 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       cwd: workspace.root,
     });
     try {
-      return await session.prompt({
+      return await holder.session.prompt({
         promptFile: editPromptFile,
         approveAll: true,
         timeoutSeconds,
         promptRetries: config.promptRetries,
       });
     } catch (err) {
-      await session.close();
-      session = null;
+      await holder.session.close();
+      holder.session = null;
       throw err;
     }
   });
   usage.push(usageRecord(ranWith, editResult));
   for (const note of editResult.notes || []) noteOnce(note);
 
-  const turn = session;
+  let serial = 1;
+  const freshSession = () =>
+    openSession({
+      agent: chosen.agent,
+      model: chosen.model,
+      effort: chosen.effort,
+      sessionName: `${sessionName}-r${(serial += 1)}`,
+      cwd: workspace.root,
+    });
+
   try {
-    let lastViolations = [];
-    for (let attempt = 1; attempt <= ANNOTATE_TURNS; attempt += 1) {
-      assertRepoUntouched(repo, fingerprint, workspace.root);
-      const measured = measureWorkspace(workspace);
-
-      let prompt = renderPrompt("annotate", {
-        ...common,
-        CHANGES: renderChangesForPrompt(measured, memoryFile),
-      });
-      if (lastViolations.length) {
-        prompt +=
-          `\n\n## Your previous answer was rejected\n\nIt violated these hard rules. Fix every one of them ` +
-          `(edit the files first if a change must go or move) and return the corrected JSON object only.\n\n` +
-          `${lastViolations.map((v) => `- ${v}`).join("\n")}\n`;
-      }
-      const promptFile = path.join(promptDir, `synthesis-annotate-${attempt}.md`);
-      fs.writeFileSync(promptFile, prompt);
-      progress("annotate", { attempt, changes: measured.changes.length });
-
-      const result = await turn.prompt({
-        promptFile,
-        approveAll: true,
-        timeoutSeconds,
-        promptRetries: config.promptRetries,
-      });
-      usage.push(usageRecord(ranWith, result));
-      for (const note of result.notes || []) noteOnce(note);
-
-      // The agent may keep editing during an annotate turn; ids are then stale, so the
-      // answer is discarded and the fresh measurement is shown instead.
-      assertRepoUntouched(repo, fingerprint, workspace.root);
-      const remeasured = measureWorkspace(workspace);
-      if (remeasured.signature !== measured.signature) {
-        lastViolations = [
-          "the files changed after the changes were measured; annotate the re-measured changes shown above",
-        ];
-      } else {
-        const parsed = extractJson(result.text);
-        if (!parsed) {
-          lastViolations = ["synthesis returned no parseable JSON object"];
-        } else {
-          const { proposal, violations } = buildProposal(parsed, { ...context, measured });
-          proposal.notes = [...proposal.notes, ...notes];
-          proposal.usage = usage;
-          proposal.overflowTarget = overflow;
-          if (!violations.length) {
-            emitProgress("synth:done", { edits: proposal.edits.length, attempt });
-            return { proposal, violations: [] };
-          }
-          lastViolations = violations;
-          proposal.violations = violations;
-          // Keep the rejected proposal so a loud failure is still inspectable.
-          state.writeProposal(proposal);
-        }
-      }
-
-      if (attempt < ANNOTATE_TURNS) {
-        warn(`synthesis violated ${lastViolations.length} gate(s); re-prompting with the exact violations`);
-        emitProgress("synth:violations", { attempt, violations: lastViolations });
-      }
-    }
-
-    throw new ProposalViolation(
-      `synthesis could not produce a valid proposal after ${ANNOTATE_TURNS - 1} re-prompt(s) (${lastViolations.length} violation(s))`,
-      lastViolations,
-    );
+    return await annotateLoop({
+      holder,
+      freshSession,
+      workspace,
+      fingerprint,
+      repo,
+      context,
+      common,
+      promptDir,
+      timeoutSeconds,
+      promptRetries: config.promptRetries,
+      usage,
+      notes,
+      noteOnce,
+      overflow,
+      progress,
+      ranWith,
+      renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
+    });
   } finally {
-    await turn.close();
+    await holder.session.close();
+  }
+}
+
+/**
+ * `backpass propose --resume`: annotate a staging copy that is already on disk.
+ *
+ * The expensive half of a synthesis run is the editing turn, and its result survives a
+ * failed annotation - it is sitting in `.backpass/synthesis/`. This picks that up in a new
+ * session (the old one is gone, and its accumulated context is exactly what a resume is
+ * escaping), re-measures the tree as it stands, and runs the same annotate loop. The
+ * workspace is never rebuilt here, so nothing the previous run produced is destroyed.
+ */
+export async function resumeAnnotation({ memoryFile, summary, config, repo, workspace, harnessCounts = {} }) {
+  const { rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
+    memoryFile,
+    summary,
+    config,
+    repo,
+    harnessCounts,
+  });
+
+  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
+  const sessionName = `backpass-resume-${process.pid}`;
+  const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
+  const usage = [];
+  const notes = ["resumed the staged synthesis in a fresh session; the editing turn was not re-run"];
+  const noteOnce = (note) => {
+    if (notes.includes(note)) return;
+    notes.push(note);
+    warn(note);
+  };
+
+  const pick = await config.agents.resolve("synthesis");
+  info(
+    `${color.cyan("·")} resuming the staged synthesis with ${pick.agent}` +
+      `${pick.model ? ` (${pick.model})` : ""}` +
+      `${pick.effort ? ` effort=${pick.effort}` : ""}`,
+  );
+  const ranWith = pick.agent;
+  const progress = (phase, extra = {}) =>
+    emitProgress("synth:start", {
+      agent: ranWith,
+      model: pick.model,
+      effort: pick.effort,
+      phase,
+      maxEdits,
+      sessionName,
+      resumed: true,
+      gapClusters: summary.totals.gapClusters,
+      instructions: summary.instructions.length,
+      suppressed: Object.keys(rejections.entries || {}).length,
+      ...extra,
+    });
+
+  let serial = 0;
+  const freshSession = () =>
+    openSession({
+      agent: pick.agent,
+      model: pick.model,
+      effort: pick.effort,
+      sessionName: serial === 0 ? sessionName : `${sessionName}-r${serial}`,
+      cwd: workspace.root,
+    });
+
+  const holder = { session: await freshSession() };
+  const nextSession = () => {
+    serial += 1;
+    return freshSession();
+  };
+
+  try {
+    return await annotateLoop({
+      holder,
+      freshSession: nextSession,
+      workspace,
+      fingerprint,
+      repo,
+      context,
+      common,
+      promptDir,
+      timeoutSeconds,
+      promptRetries: config.promptRetries,
+      usage,
+      notes,
+      noteOnce,
+      overflow,
+      progress,
+      ranWith,
+      startFresh: true,
+      renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
+    });
+  } finally {
+    await holder.session.close();
   }
 }

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -13,8 +13,8 @@ import { measureWorkspace, prepareWorkspace, repoFingerprint } from "./workspace
 import { UserError, color, info, warn } from "./logger.js";
 
 /**
- * Stage 3 of the pipeline (design section 3): one high-reasoning session that turns
- * folded evidence into concrete edits.
+ * Stage 3 of the pipeline (design section 3): high-reasoning synthesis that turns folded
+ * evidence into concrete edits.
  *
  * The agent never describes an edit for backpass to locate - it makes the edit, with its
  * harness's own file tools, in a staging copy of the memory file (`src/workspace.js`).

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -24,11 +24,11 @@ import { UserError, color, info, warn } from "./logger.js";
  *   annotate  backpass measures the copy against the original (`src/diff.js`) and shows
  *             the changes by id; the agent attaches kind, title, rationale, and evidence
  *
- * The annotation is what the mechanical gates validate (`buildProposal`); malformed or
- * gated answers spend at most ANNOTATE_TURNS attempts and are re-prompted with the exact
- * breaches. Backpass then fails loudly and preserves the latest parseable rejected proposal
- * rather than quietly trimming it (design section 6). The repo is fingerprinted before and
- * checked after: a harness that wrote past the staging copy is an error, never a silent apply.
+ * The annotation is what the mechanical gates validate (`buildProposal`); on a violation
+ * the agent is re-prompted with the exact breaches, at most ANNOTATE_TURNS times in all,
+ * then backpass fails loudly and saves the rejected proposal rather than quietly trimming
+ * it (design section 6). The repo is fingerprinted before and checked after: a harness
+ * that wrote past the staging copy is an error, never a silent apply.
  *
  * Three things an annotate turn can be are deliberately kept apart, because they call for
  * different responses and produce different advice at the end of a failed run:
@@ -41,8 +41,8 @@ import { UserError, color, info, warn } from "./logger.js";
  *                        spoke, so there is nothing to correct - the annotation is retried
  *                        once in a NEW session, since the accumulated context of the old
  *                        one is the likeliest reason it collapsed.
- *   the turn had text    a malformed or gated answer consumes an annotation attempt. Only
- *                        a parseable, gate-rejected answer writes a rejected proposal.
+ *   the answer was judged the model spoke and the gates ruled. Only this consumes an
+ *                        annotation attempt, and only this writes a rejected proposal.
  */
 
 /** Annotation attempts per run: the first answer plus re-prompts with the exact violations. */
@@ -120,7 +120,11 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
   );
 }
 
-/** Everything synthesis needs: prompt values, proposal context, and overflow target. */
+/**
+ * Everything both entry points need: the prompt values, the `buildProposal` context, and
+ * the overflow target. `synthesizeProposal` runs an edit turn first; `resumeAnnotation`
+ * starts straight at the annotation of a staging copy that is already on disk.
+ */
 function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const state = config.state;
   const rejections = state.readRejections();
@@ -155,8 +159,9 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
 
 /**
  * The header a fresh annotation session needs. An in-session annotate turn inherits the
- * repository, the budget, and the evidence from its earlier turns; a session opened after
- * an empty reply would otherwise be asked to quote evidence it has never been shown.
+ * repository, the budget, and the evidence from the editing turn that preceded it; a
+ * session that never saw that turn - the retry after an empty reply, or `propose
+ * --resume` - would otherwise be asked to quote evidence it has never been shown.
  */
 function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot }) {
   return render(loadPrompt("annotate-preface"), {
@@ -218,8 +223,8 @@ async function annotateLoop({
   noteOnce,
   overflow,
   progress,
-  ranWith,
   renderPreface,
+  startFresh = false,
 }) {
   const { memoryFile, config } = context;
   const state = config.state;
@@ -229,7 +234,7 @@ async function annotateLoop({
   let emptyTurns = 0;
   let violationsToShow = [];
   let justRemeasured = false;
-  let owePreface = false;
+  let owePreface = startFresh;
   /** @type {{ attempt: number, violations: string[] } | null} */
   let saved = null;
   /** @type {{ reason: string, violations: string[] }} */
@@ -252,13 +257,13 @@ async function annotateLoop({
     fs.writeFileSync(promptFile, prompt);
     progress("annotate", { attempt: attempts + 1, turn, changes: measured.changes.length });
 
-    const result = await holder.session.prompt({
+    const result = await holder.prompt({
       promptFile,
       approveAll: true,
       timeoutSeconds,
       promptRetries,
     });
-    usage.push(usageRecord(ranWith, result));
+    usage.push(usageRecord(holder.ranWith, result));
     for (const note of result.notes || []) noteOnce(note);
 
     // The agent may keep editing during an annotate turn; the ids it was answering about
@@ -417,15 +422,23 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
   // through to the next ladder candidate; the switch is recorded in the notes so the
   // proposal's provenance is visible. Once the editing turn has run, later turns stay
   // on the same candidate - a run never silently switches models after real work.
-  /** @type {{ session: Awaited<ReturnType<typeof openSession>> | null }} */
-  const holder = { session: null };
+  /** @type {{ session: Awaited<ReturnType<typeof openSession>> | null, ranWith: string, prompt: Function }} */
+  const holder = {
+    session: null,
+    ranWith,
+    prompt(args) {
+      if (!this.session) throw new Error("synthesis session is not open");
+      return this.session.prompt(args);
+    },
+  };
   /** @type {ReturnType<typeof prepareWorkspace>} */
   let workspace = null;
   const editResult = await config.agents.withFallthrough("synthesis", async (current) => {
     ranWith = current.agent;
+    holder.ranWith = current.agent;
     chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir });
+    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, harnessCounts, summary });
     progress("edit", { attempt: 1 });
     holder.session = await openSession({
       agent: current.agent,
@@ -477,10 +490,124 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       noteOnce,
       overflow,
       progress,
-      ranWith,
       renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
     });
   } finally {
     await holder.session.close();
+  }
+}
+
+/**
+ * `backpass propose --resume`: annotate a staging copy that is already on disk.
+ *
+ * The expensive half of a synthesis run is the editing turn, and its result survives a
+ * failed annotation - it is sitting in `.backpass/synthesis/`. This picks that up in a new
+ * session (the old one is gone, and its accumulated context is exactly what a resume is
+ * escaping), re-measures the tree as it stands, and runs the same annotate loop. The
+ * workspace is never rebuilt here, so nothing the previous run produced is destroyed.
+ */
+export async function resumeAnnotation({ memoryFile, summary, config, repo, workspace, harnessCounts = {} }) {
+  config.state.clearProposal();
+  const { rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
+    memoryFile,
+    summary,
+    config,
+    repo,
+    harnessCounts,
+  });
+
+  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
+  const sessionName = `backpass-resume-${process.pid}`;
+  const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
+  const usage = [];
+  const notes = ["resumed the staged synthesis in a fresh session; the editing turn was not re-run"];
+  const noteOnce = (note) => {
+    if (notes.includes(note)) return;
+    notes.push(note);
+    warn(note);
+  };
+
+  const pick = await config.agents.resolve("synthesis");
+  info(
+    `${color.cyan("·")} resuming the staged synthesis with ${pick.agent}` +
+      `${pick.model ? ` (${pick.model})` : ""}` +
+      `${pick.effort ? ` effort=${pick.effort}` : ""}`,
+  );
+  let chosen = pick;
+  let serial = 0;
+  const holder = {
+    session: null,
+    ranWith: pick.agent,
+    async prompt(args) {
+      if (this.session) return this.session.prompt(args);
+      return config.agents.withFallthrough("synthesis", async (current) => {
+        chosen = current;
+        this.ranWith = current.agent;
+        if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
+        this.session = await openSession({
+          agent: current.agent,
+          model: current.model,
+          effort: current.effort,
+          sessionName,
+          cwd: workspace.root,
+        });
+        try {
+          return await this.session.prompt(args);
+        } catch (err) {
+          await this.session.close();
+          this.session = null;
+          throw err;
+        }
+      });
+    },
+  };
+  const progress = (phase, extra = {}) =>
+    emitProgress("synth:start", {
+      agent: holder.ranWith,
+      model: chosen.model,
+      effort: chosen.effort,
+      phase,
+      maxEdits,
+      sessionName,
+      resumed: true,
+      gapClusters: summary.totals.gapClusters,
+      instructions: summary.instructions.length,
+      suppressed: Object.keys(rejections.entries || {}).length,
+      ...extra,
+    });
+
+  const nextSession = () => {
+    serial += 1;
+    return openSession({
+      agent: chosen.agent,
+      model: chosen.model,
+      effort: chosen.effort,
+      sessionName: `${sessionName}-r${serial}`,
+      cwd: workspace.root,
+    });
+  };
+
+  try {
+    return await annotateLoop({
+      holder,
+      freshSession: nextSession,
+      workspace,
+      fingerprint,
+      repo,
+      context,
+      common,
+      promptDir,
+      timeoutSeconds,
+      promptRetries: config.promptRetries,
+      usage,
+      notes,
+      noteOnce,
+      overflow,
+      progress,
+      startFresh: true,
+      renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
+    });
+  } finally {
+    await holder.session?.close();
   }
 }

--- a/src/tui/index.js
+++ b/src/tui/index.js
@@ -103,8 +103,7 @@ export function initialState(meta) {
       instructions: 0,
       suppressed: 0,
       violations: [],
-      remeasures: 0,
-      emptyTurns: 0,
+      annotateCondition: null,
       edits: 0,
     },
   };
@@ -235,15 +234,16 @@ export function reduceEvent(state, event, data, now = Date.now()) {
       break;
     case "synth:violations":
       s.violations = data.violations || [];
+      s.annotateCondition = null;
       break;
     // Neither of these is a rejected answer, so neither clears into the violations list:
     // the files moved under the ids, or the harness said nothing at all.
     case "synth:remeasure":
-      s.remeasures = data.remeasures ?? s.remeasures + 1;
+      s.annotateCondition = "remeasure";
       s.violations = [];
       break;
     case "synth:empty":
-      s.emptyTurns = data.emptyTurns ?? s.emptyTurns + 1;
+      s.annotateCondition = "empty";
       s.violations = [];
       break;
     case "synth:done":

--- a/src/tui/index.js
+++ b/src/tui/index.js
@@ -103,6 +103,8 @@ export function initialState(meta) {
       instructions: 0,
       suppressed: 0,
       violations: [],
+      remeasures: 0,
+      emptyTurns: 0,
       edits: 0,
     },
   };
@@ -233,6 +235,16 @@ export function reduceEvent(state, event, data, now = Date.now()) {
       break;
     case "synth:violations":
       s.violations = data.violations || [];
+      break;
+    // Neither of these is a rejected answer, so neither clears into the violations list:
+    // the files moved under the ids, or the harness said nothing at all.
+    case "synth:remeasure":
+      s.remeasures = data.remeasures ?? s.remeasures + 1;
+      s.violations = [];
+      break;
+    case "synth:empty":
+      s.emptyTurns = data.emptyTurns ?? s.emptyTurns + 1;
+      s.violations = [];
       break;
     case "synth:done":
       s.status = "done";

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -247,6 +247,9 @@ function synthSummary(theme, s) {
   const model = [s.agent, s.model].filter(Boolean).join(" · ");
   const effort = s.effort ? ` · effort ${s.effort}` : "";
   if (s.status === "done") return theme.paint(`${s.edits} edit(s) · passed validation`, "dim");
+  if (s.phase === "annotate" && s.emptyTurns) {
+    return theme.paint("fresh session after an empty turn · ", "dim") + theme.paint(`${model}${effort}`, "dim");
+  }
   if (s.phase === "annotate" && s.attempt > 1) {
     return (
       theme.paint("re-prompt ", "dim") +
@@ -384,6 +387,19 @@ function synthesizeDetail(state, theme, width, spin) {
     sectionRule(theme, STAGE_LABELS.synthesize, `aggregated gradients → at most ${state.meta.maxEdits} edits`, width),
   ];
 
+  // A re-measurement and an empty turn are named for what they are: neither spent one of
+  // the annotation attempts, and saying "violated 1 gate(s)" for either is how a run gets
+  // read as almost-passing when nothing was judged at all.
+  if (s.phase === "annotate" && s.remeasures) {
+    lines.push(
+      ` ${theme.paint("~", "yellow")} ${theme.paint("the files moved; re-annotating the new ids", "text")} ${theme.paint("· no annotation attempt spent", "dim")}`,
+    );
+  }
+  if (s.phase === "annotate" && s.emptyTurns) {
+    lines.push(
+      ` ${theme.paint("~", "yellow")} ${theme.paint("the harness returned an empty turn", "text")} ${theme.paint("· retrying in a fresh session", "dim")}`,
+    );
+  }
   if (s.phase === "annotate" && s.attempt > 1 && s.violations.length) {
     lines.push(
       ` ${theme.paint("!", "yellow")} ${theme.paint(`synthesis violated ${s.violations.length} gate(s)`, "text")} ${theme.paint("· re-prompting with the exact breaches", "dim")}`,

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -247,7 +247,7 @@ function synthSummary(theme, s) {
   const model = [s.agent, s.model].filter(Boolean).join(" · ");
   const effort = s.effort ? ` · effort ${s.effort}` : "";
   if (s.status === "done") return theme.paint(`${s.edits} edit(s) · passed validation`, "dim");
-  if (s.phase === "annotate" && s.emptyTurns) {
+  if (s.phase === "annotate" && s.annotateCondition === "empty") {
     return theme.paint("fresh session after an empty turn · ", "dim") + theme.paint(`${model}${effort}`, "dim");
   }
   if (s.phase === "annotate" && s.attempt > 1) {
@@ -390,12 +390,12 @@ function synthesizeDetail(state, theme, width, spin) {
   // A re-measurement and an empty turn are named for what they are: neither spent one of
   // the annotation attempts, and saying "violated 1 gate(s)" for either is how a run gets
   // read as almost-passing when nothing was judged at all.
-  if (s.phase === "annotate" && s.remeasures) {
+  if (s.phase === "annotate" && s.annotateCondition === "remeasure") {
     lines.push(
       ` ${theme.paint("~", "yellow")} ${theme.paint("the files moved; re-annotating the new ids", "text")} ${theme.paint("· no annotation attempt spent", "dim")}`,
     );
   }
-  if (s.phase === "annotate" && s.emptyTurns) {
+  if (s.phase === "annotate" && s.annotateCondition === "empty") {
     lines.push(
       ` ${theme.paint("~", "yellow")} ${theme.paint("the harness returned an empty turn", "text")} ${theme.paint("· retrying in a fresh session", "dim")}`,
     );

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -15,14 +15,10 @@ import { sha256 } from "./state.js";
  * under `.backpass/synthesis/` holding only the memory file and the skills directory.
  * The agent reads the real repository by absolute path for grounding; what it changes in
  * the copy is measured here (`measureWorkspace`) and becomes the proposal the human
- * reviews. The copy is wiped and rebuilt on every synthesis - with one exception:
- * `backpass propose --resume` re-opens the copy an earlier run left behind
- * (`restoreWorkspace`), which is what the `synthesis.json` manifest written here is for.
+ * reviews. The copy is wiped and rebuilt on every synthesis.
  */
 
 export const WORKSPACE_DIRNAME = "synthesis";
-/** The manifest's shape. A tree written by a different shape is refused, never rebuilt over. */
-export const WORKSPACE_MANIFEST_VERSION = 2;
 
 export function workspaceRoot(state) {
   return path.join(state.root, WORKSPACE_DIRNAME);
@@ -31,14 +27,8 @@ export function workspaceRoot(state) {
 /**
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
- *
- * The same record is written next to the copy as `synthesis.json`, because `originals`
- * is what the measurement is *against*: without it a later process looking at the tree
- * could not tell an edit from the file it started as. That manifest is what makes
- * `backpass propose --resume` possible, and what lets it refuse a tree whose repo has
- * moved on rather than measure against the wrong baseline.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCounts = {}, summary = null }) {
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
   const root = workspaceRoot(state);
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
@@ -49,7 +39,6 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCo
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
 
-  const skills = [];
   const skillsSource = path.join(repo.root, skillsDir);
   if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
     for (const relative of walkFiles(skillsSource)) {
@@ -57,144 +46,12 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCo
       const to = path.join(root, skillsDir, relative);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      const text = fs.readFileSync(from, "utf8");
-      const staged = path.posix.join(skillsDir, relative);
-      originals.set(staged, text);
-      skills.push({ path: staged, hash: sha256(text) });
+      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
     }
   }
   fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
 
-  state.writeWorkspaceManifest({
-    version: WORKSPACE_MANIFEST_VERSION,
-    stagedAt: new Date().toISOString(),
-    repoRoot: repo.root,
-    repoName: repo.name,
-    memoryPath: memoryFile.path,
-    memoryHash: memoryFile.hash,
-    skillsDir,
-    skills,
-    harnessCounts,
-    summary,
-  });
-
   return { root, memoryPath: memoryFile.path, skillsDir, originals };
-}
-
-/**
- * Re-open the staging copy a previous run left behind, without touching a byte of it.
- *
- * Returns `{ workspace, manifest }`, or `{ refusal }` naming what is incompatible. Every
- * check is a read: a tree that cannot be resumed is left exactly as it is, because it is
- * the only copy of an expensive editing turn and the human may still want it.
- */
-export function restoreWorkspace({ state, repo, memoryFile, skillsDir }) {
-  const root = workspaceRoot(state);
-  const manifest = state.readWorkspaceManifest();
-
-  if (!fs.existsSync(root)) {
-    return { refusal: { message: "there is no staged synthesis to resume", hint: "run `backpass propose` first" } };
-  }
-  if (!manifest) {
-    // A tree staged before the manifest existed. What it was measured against is not
-    // recoverable, and guessing the baseline is how a hunk lands on text it never saw.
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} has no record of what it was measured against`,
-        hint: "it was staged before backpass kept one; run `backpass propose` and a failure of that run will be resumable - nothing was deleted",
-      },
-    };
-  }
-  if (manifest.version !== WORKSPACE_MANIFEST_VERSION) {
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} was written by a different version of backpass (manifest v${manifest.version})`,
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-  if (manifest.repoRoot !== repo.root) {
-    return {
-      refusal: {
-        message: `the staged synthesis belongs to ${manifest.repoRoot}, not ${repo.root}`,
-        hint: "resume it from that checkout; nothing was deleted",
-      },
-    };
-  }
-  if (manifest.memoryPath !== memoryFile.path || manifest.skillsDir !== skillsDir) {
-    return {
-      refusal: {
-        message:
-          `the staged synthesis targets ${manifest.memoryPath} with skills in ${manifest.skillsDir}, ` +
-          `but this run targets ${memoryFile.path} with skills in ${skillsDir}`,
-        hint: "re-run without the differing flags, or run `backpass propose` for a fresh synthesis",
-      },
-    };
-  }
-  if (manifest.memoryHash !== memoryFile.hash) {
-    return {
-      refusal: {
-        message:
-          `${memoryFile.path} changed after the staged synthesis was measured ` +
-          `(${manifest.memoryHash} -> ${memoryFile.hash}), so its edits no longer describe the file on disk`,
-        hint: "run `backpass propose` to re-synthesize against the current file; the staged copy was left untouched",
-      },
-    };
-  }
-  if (!manifest.summary?.analyzedSessions) {
-    return {
-      refusal: {
-        message: "the staged synthesis has no usable snapshot of the evidence it was built from",
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-
-  const originals = new Map([[memoryFile.path, memoryFile.text]]);
-  for (const entry of manifest.skills || []) {
-    const source = path.join(repo.root, entry.path);
-    if (!fs.existsSync(source)) {
-      return {
-        refusal: {
-          message: `${entry.path} was in the repository when the synthesis was staged and is gone now`,
-          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
-        },
-      };
-    }
-    const text = fs.readFileSync(source, "utf8");
-    if (sha256(text) !== entry.hash) {
-      return {
-        refusal: {
-          message: `${entry.path} changed after the staged synthesis was measured`,
-          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
-        },
-      };
-    }
-    originals.set(entry.path, text);
-  }
-
-  if (!fs.existsSync(path.join(root, memoryFile.path))) {
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} is incomplete: ${memoryFile.path} is missing from it`,
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-
-  for (const relative of walkFiles(path.join(root, skillsDir))) {
-    const staged = path.posix.join(skillsDir, relative);
-    if (!originals.has(staged) && fs.existsSync(path.join(repo.root, staged))) {
-      return {
-        refusal: {
-          message: `${staged} was created in the repository after this synthesis was staged`,
-          hint: "move or remove the conflicting file, or run `backpass propose` for a fresh synthesis; nothing was deleted",
-        },
-      };
-    }
-  }
-
-  return { workspace: { root, memoryPath: memoryFile.path, skillsDir, originals }, manifest };
 }
 
 function walkFiles(dir, prefix = "") {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -15,10 +15,14 @@ import { sha256 } from "./state.js";
  * under `.backpass/synthesis/` holding only the memory file and the skills directory.
  * The agent reads the real repository by absolute path for grounding; what it changes in
  * the copy is measured here (`measureWorkspace`) and becomes the proposal the human
- * reviews. The copy is wiped and rebuilt on every synthesis.
+ * reviews. The copy is wiped and rebuilt on every synthesis - with one exception:
+ * `backpass propose --resume` re-opens the copy an earlier run left behind
+ * (`restoreWorkspace`), which is what the `synthesis.json` manifest written here is for.
  */
 
 export const WORKSPACE_DIRNAME = "synthesis";
+/** The manifest's shape. A tree written by a different shape is refused, never rebuilt over. */
+export const WORKSPACE_MANIFEST_VERSION = 2;
 
 export function workspaceRoot(state) {
   return path.join(state.root, WORKSPACE_DIRNAME);
@@ -27,9 +31,19 @@ export function workspaceRoot(state) {
 /**
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
+ *
+ * The same record is written next to the copy as `synthesis.json`, because `originals`
+ * is what the measurement is *against*: without it a later process looking at the tree
+ * could not tell an edit from the file it started as. That manifest is what makes
+ * `backpass propose --resume` possible, and what lets it refuse a tree whose repo has
+ * moved on rather than measure against the wrong baseline.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCounts = {}, summary = null }) {
   const root = workspaceRoot(state);
+  // The old manifest describes the old tree. Invalidate it before touching that tree so
+  // an interruption can only leave an unresumable workspace, never a partial new tree
+  // that restoreWorkspace accepts against the previous run's baseline.
+  state.clearWorkspaceManifest();
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
 
@@ -39,6 +53,7 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
 
+  const skills = [];
   const skillsSource = path.join(repo.root, skillsDir);
   if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
     for (const relative of walkFiles(skillsSource)) {
@@ -46,12 +61,144 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
       const to = path.join(root, skillsDir, relative);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
+      const text = fs.readFileSync(from, "utf8");
+      const staged = path.posix.join(skillsDir, relative);
+      originals.set(staged, text);
+      skills.push({ path: staged, hash: sha256(text) });
     }
   }
   fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
 
+  state.writeWorkspaceManifest({
+    version: WORKSPACE_MANIFEST_VERSION,
+    stagedAt: new Date().toISOString(),
+    repoRoot: repo.root,
+    repoName: repo.name,
+    memoryPath: memoryFile.path,
+    memoryHash: memoryFile.hash,
+    skillsDir,
+    skills,
+    harnessCounts,
+    summary,
+  });
+
   return { root, memoryPath: memoryFile.path, skillsDir, originals };
+}
+
+/**
+ * Re-open the staging copy a previous run left behind, without touching a byte of it.
+ *
+ * Returns `{ workspace, manifest }`, or `{ refusal }` naming what is incompatible. Every
+ * check is a read: a tree that cannot be resumed is left exactly as it is, because it is
+ * the only copy of an expensive editing turn and the human may still want it.
+ */
+export function restoreWorkspace({ state, repo, memoryFile, skillsDir }) {
+  const root = workspaceRoot(state);
+  const manifest = state.readWorkspaceManifest();
+
+  if (!fs.existsSync(root)) {
+    return { refusal: { message: "there is no staged synthesis to resume", hint: "run `backpass propose` first" } };
+  }
+  if (!manifest) {
+    // A tree staged before the manifest existed. What it was measured against is not
+    // recoverable, and guessing the baseline is how a hunk lands on text it never saw.
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} has no record of what it was measured against`,
+        hint: "it was staged before backpass kept one; run `backpass propose` and a failure of that run will be resumable - nothing was deleted",
+      },
+    };
+  }
+  if (manifest.version !== WORKSPACE_MANIFEST_VERSION) {
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} was written by a different version of backpass (manifest v${manifest.version})`,
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+  if (manifest.repoRoot !== repo.root) {
+    return {
+      refusal: {
+        message: `the staged synthesis belongs to ${manifest.repoRoot}, not ${repo.root}`,
+        hint: "resume it from that checkout; nothing was deleted",
+      },
+    };
+  }
+  if (manifest.memoryPath !== memoryFile.path || manifest.skillsDir !== skillsDir) {
+    return {
+      refusal: {
+        message:
+          `the staged synthesis targets ${manifest.memoryPath} with skills in ${manifest.skillsDir}, ` +
+          `but this run targets ${memoryFile.path} with skills in ${skillsDir}`,
+        hint: "re-run without the differing flags, or run `backpass propose` for a fresh synthesis",
+      },
+    };
+  }
+  if (manifest.memoryHash !== memoryFile.hash) {
+    return {
+      refusal: {
+        message:
+          `${memoryFile.path} changed after the staged synthesis was measured ` +
+          `(${manifest.memoryHash} -> ${memoryFile.hash}), so its edits no longer describe the file on disk`,
+        hint: "run `backpass propose` to re-synthesize against the current file; the staged copy was left untouched",
+      },
+    };
+  }
+  if (!manifest.summary?.analyzedSessions) {
+    return {
+      refusal: {
+        message: "the staged synthesis has no usable snapshot of the evidence it was built from",
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+
+  const originals = new Map([[memoryFile.path, memoryFile.text]]);
+  for (const entry of manifest.skills || []) {
+    const source = path.join(repo.root, entry.path);
+    if (!fs.existsSync(source)) {
+      return {
+        refusal: {
+          message: `${entry.path} was in the repository when the synthesis was staged and is gone now`,
+          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
+        },
+      };
+    }
+    const text = fs.readFileSync(source, "utf8");
+    if (sha256(text) !== entry.hash) {
+      return {
+        refusal: {
+          message: `${entry.path} changed after the staged synthesis was measured`,
+          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
+        },
+      };
+    }
+    originals.set(entry.path, text);
+  }
+
+  if (!fs.existsSync(path.join(root, memoryFile.path))) {
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} is incomplete: ${memoryFile.path} is missing from it`,
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+
+  for (const relative of walkFiles(path.join(root, skillsDir))) {
+    const staged = path.posix.join(skillsDir, relative);
+    if (!originals.has(staged) && fs.existsSync(path.join(repo.root, staged))) {
+      return {
+        refusal: {
+          message: `${staged} was created in the repository after this synthesis was staged`,
+          hint: "move or remove the conflicting file, or run `backpass propose` for a fresh synthesis; nothing was deleted",
+        },
+      };
+    }
+  }
+
+  return { workspace: { root, memoryPath: memoryFile.path, skillsDir, originals }, manifest };
 }
 
 function walkFiles(dir, prefix = "") {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -15,14 +15,10 @@ import { sha256 } from "./state.js";
  * under `.backpass/synthesis/` holding only the memory file and the skills directory.
  * The agent reads the real repository by absolute path for grounding; what it changes in
  * the copy is measured here (`measureWorkspace`) and becomes the proposal the human
- * reviews. The copy is wiped and rebuilt on every synthesis - with one exception:
- * `backpass propose --resume` re-opens the copy an earlier run left behind
- * (`restoreWorkspace`), which is what the `synthesis.json` manifest written here is for.
+ * reviews. The copy is wiped and rebuilt on every synthesis.
  */
 
 export const WORKSPACE_DIRNAME = "synthesis";
-/** The manifest's shape. A tree written by a different shape is refused, never rebuilt over. */
-export const WORKSPACE_MANIFEST_VERSION = 2;
 
 export function workspaceRoot(state) {
   return path.join(state.root, WORKSPACE_DIRNAME);
@@ -31,19 +27,9 @@ export function workspaceRoot(state) {
 /**
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
- *
- * The same record is written next to the copy as `synthesis.json`, because `originals`
- * is what the measurement is *against*: without it a later process looking at the tree
- * could not tell an edit from the file it started as. That manifest is what makes
- * `backpass propose --resume` possible, and what lets it refuse a tree whose repo has
- * moved on rather than measure against the wrong baseline.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCounts = {}, summary = null }) {
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
   const root = workspaceRoot(state);
-  // The old manifest describes the old tree. Invalidate it before touching that tree so
-  // an interruption can only leave an unresumable workspace, never a partial new tree
-  // that restoreWorkspace accepts against the previous run's baseline.
-  state.clearWorkspaceManifest();
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
 
@@ -53,7 +39,6 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCo
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
 
-  const skills = [];
   const skillsSource = path.join(repo.root, skillsDir);
   if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
     for (const relative of walkFiles(skillsSource)) {
@@ -61,144 +46,12 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCo
       const to = path.join(root, skillsDir, relative);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      const text = fs.readFileSync(from, "utf8");
-      const staged = path.posix.join(skillsDir, relative);
-      originals.set(staged, text);
-      skills.push({ path: staged, hash: sha256(text) });
+      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
     }
   }
   fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
 
-  state.writeWorkspaceManifest({
-    version: WORKSPACE_MANIFEST_VERSION,
-    stagedAt: new Date().toISOString(),
-    repoRoot: repo.root,
-    repoName: repo.name,
-    memoryPath: memoryFile.path,
-    memoryHash: memoryFile.hash,
-    skillsDir,
-    skills,
-    harnessCounts,
-    summary,
-  });
-
   return { root, memoryPath: memoryFile.path, skillsDir, originals };
-}
-
-/**
- * Re-open the staging copy a previous run left behind, without touching a byte of it.
- *
- * Returns `{ workspace, manifest }`, or `{ refusal }` naming what is incompatible. Every
- * check is a read: a tree that cannot be resumed is left exactly as it is, because it is
- * the only copy of an expensive editing turn and the human may still want it.
- */
-export function restoreWorkspace({ state, repo, memoryFile, skillsDir }) {
-  const root = workspaceRoot(state);
-  const manifest = state.readWorkspaceManifest();
-
-  if (!fs.existsSync(root)) {
-    return { refusal: { message: "there is no staged synthesis to resume", hint: "run `backpass propose` first" } };
-  }
-  if (!manifest) {
-    // A tree staged before the manifest existed. What it was measured against is not
-    // recoverable, and guessing the baseline is how a hunk lands on text it never saw.
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} has no record of what it was measured against`,
-        hint: "it was staged before backpass kept one; run `backpass propose` and a failure of that run will be resumable - nothing was deleted",
-      },
-    };
-  }
-  if (manifest.version !== WORKSPACE_MANIFEST_VERSION) {
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} was written by a different version of backpass (manifest v${manifest.version})`,
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-  if (manifest.repoRoot !== repo.root) {
-    return {
-      refusal: {
-        message: `the staged synthesis belongs to ${manifest.repoRoot}, not ${repo.root}`,
-        hint: "resume it from that checkout; nothing was deleted",
-      },
-    };
-  }
-  if (manifest.memoryPath !== memoryFile.path || manifest.skillsDir !== skillsDir) {
-    return {
-      refusal: {
-        message:
-          `the staged synthesis targets ${manifest.memoryPath} with skills in ${manifest.skillsDir}, ` +
-          `but this run targets ${memoryFile.path} with skills in ${skillsDir}`,
-        hint: "re-run without the differing flags, or run `backpass propose` for a fresh synthesis",
-      },
-    };
-  }
-  if (manifest.memoryHash !== memoryFile.hash) {
-    return {
-      refusal: {
-        message:
-          `${memoryFile.path} changed after the staged synthesis was measured ` +
-          `(${manifest.memoryHash} -> ${memoryFile.hash}), so its edits no longer describe the file on disk`,
-        hint: "run `backpass propose` to re-synthesize against the current file; the staged copy was left untouched",
-      },
-    };
-  }
-  if (!manifest.summary?.analyzedSessions) {
-    return {
-      refusal: {
-        message: "the staged synthesis has no usable snapshot of the evidence it was built from",
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-
-  const originals = new Map([[memoryFile.path, memoryFile.text]]);
-  for (const entry of manifest.skills || []) {
-    const source = path.join(repo.root, entry.path);
-    if (!fs.existsSync(source)) {
-      return {
-        refusal: {
-          message: `${entry.path} was in the repository when the synthesis was staged and is gone now`,
-          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
-        },
-      };
-    }
-    const text = fs.readFileSync(source, "utf8");
-    if (sha256(text) !== entry.hash) {
-      return {
-        refusal: {
-          message: `${entry.path} changed after the staged synthesis was measured`,
-          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
-        },
-      };
-    }
-    originals.set(entry.path, text);
-  }
-
-  if (!fs.existsSync(path.join(root, memoryFile.path))) {
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} is incomplete: ${memoryFile.path} is missing from it`,
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-
-  for (const relative of walkFiles(path.join(root, skillsDir))) {
-    const staged = path.posix.join(skillsDir, relative);
-    if (!originals.has(staged) && fs.existsSync(path.join(repo.root, staged))) {
-      return {
-        refusal: {
-          message: `${staged} was created in the repository after this synthesis was staged`,
-          hint: "move or remove the conflicting file, or run `backpass propose` for a fresh synthesis; nothing was deleted",
-        },
-      };
-    }
-  }
-
-  return { workspace: { root, memoryPath: memoryFile.path, skillsDir, originals }, manifest };
 }
 
 function walkFiles(dir, prefix = "") {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -15,14 +15,10 @@ import { sha256 } from "./state.js";
  * under `.backpass/synthesis/` holding only the memory file and the skills directory.
  * The agent reads the real repository by absolute path for grounding; what it changes in
  * the copy is measured here (`measureWorkspace`) and becomes the proposal the human
- * reviews. The copy is wiped and rebuilt on every synthesis - with one exception:
- * `backpass propose --resume` re-opens the copy an earlier run left behind
- * (`restoreWorkspace`), which is what the `synthesis.json` manifest written here is for.
+ * reviews. The copy is wiped and rebuilt on every synthesis.
  */
 
 export const WORKSPACE_DIRNAME = "synthesis";
-/** The manifest's shape. A tree written by a different shape is refused, never rebuilt over. */
-export const WORKSPACE_MANIFEST_VERSION = 1;
 
 export function workspaceRoot(state) {
   return path.join(state.root, WORKSPACE_DIRNAME);
@@ -31,14 +27,8 @@ export function workspaceRoot(state) {
 /**
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
- *
- * The same record is written next to the copy as `synthesis.json`, because `originals`
- * is what the measurement is *against*: without it a later process looking at the tree
- * could not tell an edit from the file it started as. That manifest is what makes
- * `backpass propose --resume` possible, and what lets it refuse a tree whose repo has
- * moved on rather than measure against the wrong baseline.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCounts = {} }) {
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
   const root = workspaceRoot(state);
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
@@ -49,7 +39,6 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCo
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
 
-  const skills = [];
   const skillsSource = path.join(repo.root, skillsDir);
   if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
     for (const relative of walkFiles(skillsSource)) {
@@ -57,123 +46,12 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCo
       const to = path.join(root, skillsDir, relative);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      const text = fs.readFileSync(from, "utf8");
-      const staged = path.posix.join(skillsDir, relative);
-      originals.set(staged, text);
-      skills.push({ path: staged, hash: sha256(text) });
+      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
     }
   }
   fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
 
-  state.writeWorkspaceManifest({
-    version: WORKSPACE_MANIFEST_VERSION,
-    stagedAt: new Date().toISOString(),
-    repoRoot: repo.root,
-    repoName: repo.name,
-    memoryPath: memoryFile.path,
-    memoryHash: memoryFile.hash,
-    skillsDir,
-    skills,
-    harnessCounts,
-  });
-
   return { root, memoryPath: memoryFile.path, skillsDir, originals };
-}
-
-/**
- * Re-open the staging copy a previous run left behind, without touching a byte of it.
- *
- * Returns `{ workspace, manifest }`, or `{ refusal }` naming what is incompatible. Every
- * check is a read: a tree that cannot be resumed is left exactly as it is, because it is
- * the only copy of an expensive editing turn and the human may still want it.
- */
-export function restoreWorkspace({ state, repo, memoryFile, skillsDir }) {
-  const root = workspaceRoot(state);
-  const manifest = state.readWorkspaceManifest();
-
-  if (!fs.existsSync(root)) {
-    return { refusal: { message: "there is no staged synthesis to resume", hint: "run `backpass propose` first" } };
-  }
-  if (!manifest) {
-    // A tree staged before the manifest existed. What it was measured against is not
-    // recoverable, and guessing the baseline is how a hunk lands on text it never saw.
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} has no record of what it was measured against`,
-        hint: "it was staged before backpass kept one; run `backpass propose` and a failure of that run will be resumable - nothing was deleted",
-      },
-    };
-  }
-  if (manifest.version !== WORKSPACE_MANIFEST_VERSION) {
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} was written by a different version of backpass (manifest v${manifest.version})`,
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-  if (manifest.repoRoot !== repo.root) {
-    return {
-      refusal: {
-        message: `the staged synthesis belongs to ${manifest.repoRoot}, not ${repo.root}`,
-        hint: "resume it from that checkout; nothing was deleted",
-      },
-    };
-  }
-  if (manifest.memoryPath !== memoryFile.path || manifest.skillsDir !== skillsDir) {
-    return {
-      refusal: {
-        message:
-          `the staged synthesis targets ${manifest.memoryPath} with skills in ${manifest.skillsDir}, ` +
-          `but this run targets ${memoryFile.path} with skills in ${skillsDir}`,
-        hint: "re-run without the differing flags, or run `backpass propose` for a fresh synthesis",
-      },
-    };
-  }
-  if (manifest.memoryHash !== memoryFile.hash) {
-    return {
-      refusal: {
-        message:
-          `${memoryFile.path} changed after the staged synthesis was measured ` +
-          `(${manifest.memoryHash} -> ${memoryFile.hash}), so its edits no longer describe the file on disk`,
-        hint: "run `backpass propose` to re-synthesize against the current file; the staged copy was left untouched",
-      },
-    };
-  }
-
-  const originals = new Map([[memoryFile.path, memoryFile.text]]);
-  for (const entry of manifest.skills || []) {
-    const source = path.join(repo.root, entry.path);
-    if (!fs.existsSync(source)) {
-      return {
-        refusal: {
-          message: `${entry.path} was in the repository when the synthesis was staged and is gone now`,
-          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
-        },
-      };
-    }
-    const text = fs.readFileSync(source, "utf8");
-    if (sha256(text) !== entry.hash) {
-      return {
-        refusal: {
-          message: `${entry.path} changed after the staged synthesis was measured`,
-          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
-        },
-      };
-    }
-    originals.set(entry.path, text);
-  }
-
-  if (!fs.existsSync(path.join(root, memoryFile.path))) {
-    return {
-      refusal: {
-        message: `the staged synthesis in ${root} is incomplete: ${memoryFile.path} is missing from it`,
-        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
-      },
-    };
-  }
-
-  return { workspace: { root, memoryPath: memoryFile.path, skillsDir, originals }, manifest };
 }
 
 function walkFiles(dir, prefix = "") {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -15,10 +15,14 @@ import { sha256 } from "./state.js";
  * under `.backpass/synthesis/` holding only the memory file and the skills directory.
  * The agent reads the real repository by absolute path for grounding; what it changes in
  * the copy is measured here (`measureWorkspace`) and becomes the proposal the human
- * reviews. The copy is wiped and rebuilt on every synthesis.
+ * reviews. The copy is wiped and rebuilt on every synthesis - with one exception:
+ * `backpass propose --resume` re-opens the copy an earlier run left behind
+ * (`restoreWorkspace`), which is what the `synthesis.json` manifest written here is for.
  */
 
 export const WORKSPACE_DIRNAME = "synthesis";
+/** The manifest's shape. A tree written by a different shape is refused, never rebuilt over. */
+export const WORKSPACE_MANIFEST_VERSION = 2;
 
 export function workspaceRoot(state) {
   return path.join(state.root, WORKSPACE_DIRNAME);
@@ -27,8 +31,14 @@ export function workspaceRoot(state) {
 /**
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
+ *
+ * The same record is written next to the copy as `synthesis.json`, because `originals`
+ * is what the measurement is *against*: without it a later process looking at the tree
+ * could not tell an edit from the file it started as. That manifest is what makes
+ * `backpass propose --resume` possible, and what lets it refuse a tree whose repo has
+ * moved on rather than measure against the wrong baseline.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCounts = {}, summary = null }) {
   const root = workspaceRoot(state);
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
@@ -39,6 +49,7 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
 
+  const skills = [];
   const skillsSource = path.join(repo.root, skillsDir);
   if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
     for (const relative of walkFiles(skillsSource)) {
@@ -46,12 +57,144 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
       const to = path.join(root, skillsDir, relative);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
+      const text = fs.readFileSync(from, "utf8");
+      const staged = path.posix.join(skillsDir, relative);
+      originals.set(staged, text);
+      skills.push({ path: staged, hash: sha256(text) });
     }
   }
   fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
 
+  state.writeWorkspaceManifest({
+    version: WORKSPACE_MANIFEST_VERSION,
+    stagedAt: new Date().toISOString(),
+    repoRoot: repo.root,
+    repoName: repo.name,
+    memoryPath: memoryFile.path,
+    memoryHash: memoryFile.hash,
+    skillsDir,
+    skills,
+    harnessCounts,
+    summary,
+  });
+
   return { root, memoryPath: memoryFile.path, skillsDir, originals };
+}
+
+/**
+ * Re-open the staging copy a previous run left behind, without touching a byte of it.
+ *
+ * Returns `{ workspace, manifest }`, or `{ refusal }` naming what is incompatible. Every
+ * check is a read: a tree that cannot be resumed is left exactly as it is, because it is
+ * the only copy of an expensive editing turn and the human may still want it.
+ */
+export function restoreWorkspace({ state, repo, memoryFile, skillsDir }) {
+  const root = workspaceRoot(state);
+  const manifest = state.readWorkspaceManifest();
+
+  if (!fs.existsSync(root)) {
+    return { refusal: { message: "there is no staged synthesis to resume", hint: "run `backpass propose` first" } };
+  }
+  if (!manifest) {
+    // A tree staged before the manifest existed. What it was measured against is not
+    // recoverable, and guessing the baseline is how a hunk lands on text it never saw.
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} has no record of what it was measured against`,
+        hint: "it was staged before backpass kept one; run `backpass propose` and a failure of that run will be resumable - nothing was deleted",
+      },
+    };
+  }
+  if (manifest.version !== WORKSPACE_MANIFEST_VERSION) {
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} was written by a different version of backpass (manifest v${manifest.version})`,
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+  if (manifest.repoRoot !== repo.root) {
+    return {
+      refusal: {
+        message: `the staged synthesis belongs to ${manifest.repoRoot}, not ${repo.root}`,
+        hint: "resume it from that checkout; nothing was deleted",
+      },
+    };
+  }
+  if (manifest.memoryPath !== memoryFile.path || manifest.skillsDir !== skillsDir) {
+    return {
+      refusal: {
+        message:
+          `the staged synthesis targets ${manifest.memoryPath} with skills in ${manifest.skillsDir}, ` +
+          `but this run targets ${memoryFile.path} with skills in ${skillsDir}`,
+        hint: "re-run without the differing flags, or run `backpass propose` for a fresh synthesis",
+      },
+    };
+  }
+  if (manifest.memoryHash !== memoryFile.hash) {
+    return {
+      refusal: {
+        message:
+          `${memoryFile.path} changed after the staged synthesis was measured ` +
+          `(${manifest.memoryHash} -> ${memoryFile.hash}), so its edits no longer describe the file on disk`,
+        hint: "run `backpass propose` to re-synthesize against the current file; the staged copy was left untouched",
+      },
+    };
+  }
+  if (!manifest.summary?.analyzedSessions) {
+    return {
+      refusal: {
+        message: "the staged synthesis has no usable snapshot of the evidence it was built from",
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+
+  const originals = new Map([[memoryFile.path, memoryFile.text]]);
+  for (const entry of manifest.skills || []) {
+    const source = path.join(repo.root, entry.path);
+    if (!fs.existsSync(source)) {
+      return {
+        refusal: {
+          message: `${entry.path} was in the repository when the synthesis was staged and is gone now`,
+          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
+        },
+      };
+    }
+    const text = fs.readFileSync(source, "utf8");
+    if (sha256(text) !== entry.hash) {
+      return {
+        refusal: {
+          message: `${entry.path} changed after the staged synthesis was measured`,
+          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
+        },
+      };
+    }
+    originals.set(entry.path, text);
+  }
+
+  if (!fs.existsSync(path.join(root, memoryFile.path))) {
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} is incomplete: ${memoryFile.path} is missing from it`,
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+
+  for (const relative of walkFiles(path.join(root, skillsDir))) {
+    const staged = path.posix.join(skillsDir, relative);
+    if (!originals.has(staged) && fs.existsSync(path.join(repo.root, staged))) {
+      return {
+        refusal: {
+          message: `${staged} was created in the repository after this synthesis was staged`,
+          hint: "move or remove the conflicting file, or run `backpass propose` for a fresh synthesis; nothing was deleted",
+        },
+      };
+    }
+  }
+
+  return { workspace: { root, memoryPath: memoryFile.path, skillsDir, originals }, manifest };
 }
 
 function walkFiles(dir, prefix = "") {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -15,10 +15,14 @@ import { sha256 } from "./state.js";
  * under `.backpass/synthesis/` holding only the memory file and the skills directory.
  * The agent reads the real repository by absolute path for grounding; what it changes in
  * the copy is measured here (`measureWorkspace`) and becomes the proposal the human
- * reviews. The copy is wiped and rebuilt on every synthesis.
+ * reviews. The copy is wiped and rebuilt on every synthesis - with one exception:
+ * `backpass propose --resume` re-opens the copy an earlier run left behind
+ * (`restoreWorkspace`), which is what the `synthesis.json` manifest written here is for.
  */
 
 export const WORKSPACE_DIRNAME = "synthesis";
+/** The manifest's shape. A tree written by a different shape is refused, never rebuilt over. */
+export const WORKSPACE_MANIFEST_VERSION = 1;
 
 export function workspaceRoot(state) {
   return path.join(state.root, WORKSPACE_DIRNAME);
@@ -27,8 +31,14 @@ export function workspaceRoot(state) {
 /**
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
+ *
+ * The same record is written next to the copy as `synthesis.json`, because `originals`
+ * is what the measurement is *against*: without it a later process looking at the tree
+ * could not tell an edit from the file it started as. That manifest is what makes
+ * `backpass propose --resume` possible, and what lets it refuse a tree whose repo has
+ * moved on rather than measure against the wrong baseline.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir, harnessCounts = {} }) {
   const root = workspaceRoot(state);
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
@@ -39,6 +49,7 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
 
+  const skills = [];
   const skillsSource = path.join(repo.root, skillsDir);
   if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
     for (const relative of walkFiles(skillsSource)) {
@@ -46,12 +57,123 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
       const to = path.join(root, skillsDir, relative);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
+      const text = fs.readFileSync(from, "utf8");
+      const staged = path.posix.join(skillsDir, relative);
+      originals.set(staged, text);
+      skills.push({ path: staged, hash: sha256(text) });
     }
   }
   fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
 
+  state.writeWorkspaceManifest({
+    version: WORKSPACE_MANIFEST_VERSION,
+    stagedAt: new Date().toISOString(),
+    repoRoot: repo.root,
+    repoName: repo.name,
+    memoryPath: memoryFile.path,
+    memoryHash: memoryFile.hash,
+    skillsDir,
+    skills,
+    harnessCounts,
+  });
+
   return { root, memoryPath: memoryFile.path, skillsDir, originals };
+}
+
+/**
+ * Re-open the staging copy a previous run left behind, without touching a byte of it.
+ *
+ * Returns `{ workspace, manifest }`, or `{ refusal }` naming what is incompatible. Every
+ * check is a read: a tree that cannot be resumed is left exactly as it is, because it is
+ * the only copy of an expensive editing turn and the human may still want it.
+ */
+export function restoreWorkspace({ state, repo, memoryFile, skillsDir }) {
+  const root = workspaceRoot(state);
+  const manifest = state.readWorkspaceManifest();
+
+  if (!fs.existsSync(root)) {
+    return { refusal: { message: "there is no staged synthesis to resume", hint: "run `backpass propose` first" } };
+  }
+  if (!manifest) {
+    // A tree staged before the manifest existed. What it was measured against is not
+    // recoverable, and guessing the baseline is how a hunk lands on text it never saw.
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} has no record of what it was measured against`,
+        hint: "it was staged before backpass kept one; run `backpass propose` and a failure of that run will be resumable - nothing was deleted",
+      },
+    };
+  }
+  if (manifest.version !== WORKSPACE_MANIFEST_VERSION) {
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} was written by a different version of backpass (manifest v${manifest.version})`,
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+  if (manifest.repoRoot !== repo.root) {
+    return {
+      refusal: {
+        message: `the staged synthesis belongs to ${manifest.repoRoot}, not ${repo.root}`,
+        hint: "resume it from that checkout; nothing was deleted",
+      },
+    };
+  }
+  if (manifest.memoryPath !== memoryFile.path || manifest.skillsDir !== skillsDir) {
+    return {
+      refusal: {
+        message:
+          `the staged synthesis targets ${manifest.memoryPath} with skills in ${manifest.skillsDir}, ` +
+          `but this run targets ${memoryFile.path} with skills in ${skillsDir}`,
+        hint: "re-run without the differing flags, or run `backpass propose` for a fresh synthesis",
+      },
+    };
+  }
+  if (manifest.memoryHash !== memoryFile.hash) {
+    return {
+      refusal: {
+        message:
+          `${memoryFile.path} changed after the staged synthesis was measured ` +
+          `(${manifest.memoryHash} -> ${memoryFile.hash}), so its edits no longer describe the file on disk`,
+        hint: "run `backpass propose` to re-synthesize against the current file; the staged copy was left untouched",
+      },
+    };
+  }
+
+  const originals = new Map([[memoryFile.path, memoryFile.text]]);
+  for (const entry of manifest.skills || []) {
+    const source = path.join(repo.root, entry.path);
+    if (!fs.existsSync(source)) {
+      return {
+        refusal: {
+          message: `${entry.path} was in the repository when the synthesis was staged and is gone now`,
+          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
+        },
+      };
+    }
+    const text = fs.readFileSync(source, "utf8");
+    if (sha256(text) !== entry.hash) {
+      return {
+        refusal: {
+          message: `${entry.path} changed after the staged synthesis was measured`,
+          hint: "run `backpass propose` to re-synthesize against the current repository; the staged copy was left untouched",
+        },
+      };
+    }
+    originals.set(entry.path, text);
+  }
+
+  if (!fs.existsSync(path.join(root, memoryFile.path))) {
+    return {
+      refusal: {
+        message: `the staged synthesis in ${root} is incomplete: ${memoryFile.path} is missing from it`,
+        hint: "run `backpass propose` for a fresh synthesis; nothing was deleted",
+      },
+    };
+  }
+
+  return { workspace: { root, memoryPath: memoryFile.path, skillsDir, originals }, manifest };
 }
 
 function walkFiles(dir, prefix = "") {

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -730,22 +730,21 @@
           if (!edit.targetsMemoryFile) body.appendChild(el("div", "target", "target: " + edit.file));
           if (edit.rationale) body.appendChild(el("p", "rationale", edit.rationale));
 
-          if (edit.kind === "extract" && edit.skill) {
-            var prev = el("div", "skillprev");
-            prev.appendChild(
-              el(
-                "span",
-                "fm",
-                "--- " +
-                  edit.skill.path +
-                  " (new) ---\nname: " +
-                  edit.skill.name +
-                  "\ndescription: " +
-                  edit.skill.description,
-              ),
-            );
-            prev.appendChild(document.createTextNode("\n\n" + (edit.skill.body || "").slice(0, 900)));
-            body.appendChild(prev);
+          // An extract creates one skill, or several when their removals were measured as
+          // one change - then they are one decision, so they are previewed on one card.
+          if (edit.kind === "extract") {
+            editSkills(edit).forEach(function (skill) {
+              var prev = el("div", "skillprev");
+              prev.appendChild(
+                el(
+                  "span",
+                  "fm",
+                  "--- " + skill.path + " (new) ---\nname: " + skill.name + "\ndescription: " + skill.description,
+                ),
+              );
+              prev.appendChild(document.createTextNode("\n\n" + (skill.body || "").slice(0, 900)));
+              body.appendChild(prev);
+            });
           }
 
           var diff = el("div", "diff");
@@ -807,6 +806,17 @@
 
         function nonEmpty(line) {
           return line.length > 0;
+        }
+
+        // The skills one extract creates. A proposal saved before an extract could carry
+        // several (merged removals) has a single `skill`; both shapes read the same way.
+        function editSkills(edit) {
+          if (Array.isArray(edit.skills)) {
+            return edit.skills.filter(function (skill) {
+              return skill;
+            });
+          }
+          return edit.skill ? [edit.skill] : [];
         }
 
         // Measured edits carry display lines per hunk (ctx/del/ins); a legacy

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -255,6 +255,31 @@ test("a concurrently created skill refuses the whole apply before any write", ()
   assert.equal(fs.existsSync(path.join(dir, ".claude")), false);
 });
 
+test("a later skill write failure rolls back skills written earlier in the same apply", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const memory = path.join(dir, "AGENTS.md");
+  const before = fs.readFileSync(memory, "utf8");
+
+  // The exact skill target is absent at preflight, but its parent is a file. The first
+  // skill therefore writes successfully and the second fails while creating its parent.
+  const obstruction = path.join(dir, ".agents/skills/release-details");
+  fs.mkdirSync(path.dirname(obstruction), { recursive: true });
+  fs.writeFileSync(obstruction, "concurrent parent\n");
+
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+
+  assert.equal(applied.status, 1, `apply should report the write failure:\n${applied.output}`);
+  assert.match(applied.output, /rolled back skill paths written earlier in this round/);
+  assert.equal(fs.readFileSync(memory, "utf8"), before, "the memory pointers were not written");
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/ci-details/SKILL.md")), false);
+  assert.equal(fs.readFileSync(obstruction, "utf8"), "concurrent parent\n");
+  assert.equal(fs.existsSync(path.join(dir, ".claude")), false, "the new loading layout was rolled back too");
+});
+
 test("apply names a memory file left over budget without refusing the shrink", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -233,6 +233,25 @@ test("an unchanged memory file applies every accepted edit and its skills", () =
   assert.equal(porcelain(dir).includes(".backpass"), false, "run state stays out of the working tree");
 });
 
+test("a symlinked memory file updates its target without replacing the link", () => {
+  const dir = initRepo();
+  const memory = path.join(dir, "AGENTS.md");
+  const target = path.join(dir, "MEMORY.md");
+  fs.renameSync(memory, target);
+  fs.symlinkSync("MEMORY.md", memory);
+  const proposal = proposeExtractions(dir);
+
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+
+  assert.equal(applied.status, 0, `apply should succeed:\n${applied.output}`);
+  assert.equal(fs.lstatSync(memory).isSymbolicLink(), true);
+  assert.equal(fs.readlinkSync(memory), "MEMORY.md");
+  assert.match(fs.readFileSync(target, "utf8"), /- Load `ci-details` for this topic\./);
+});
+
 test("a concurrently created skill refuses the whole apply before any write", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);
@@ -331,6 +350,58 @@ test("a later file failure rolls back earlier files and leaves memory untouched"
     fs.readdirSync(dir).some((name) => name.includes(".backpass-")),
     false,
   );
+});
+
+test("rollback reports a conflict instead of overwriting a replaced file", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const existing = path.join(dir, "existing.md");
+  const alias = path.join(dir, "alias.md");
+  const lockedDir = path.join(dir, "locked");
+  fs.writeFileSync(existing, "before\n");
+  fs.symlinkSync("existing.md", alias);
+  fs.mkdirSync(lockedDir);
+  fs.writeFileSync(path.join(lockedDir, "existing.md"), "locked before\n");
+  proposal.edits.push(
+    {
+      id: "e3",
+      kind: "rewrite",
+      file: "existing.md",
+      find: "before\n",
+      replace: "first write\n",
+    },
+    {
+      id: "e4",
+      kind: "rewrite",
+      file: "alias.md",
+      find: "before\n",
+      replace: "replacement write\n",
+    },
+    {
+      id: "e5",
+      kind: "rewrite",
+      file: "locked/existing.md",
+      find: "locked before\n",
+      replace: "locked after\n",
+    },
+  );
+  fs.writeFileSync(path.join(dir, ".backpass/proposal.json"), JSON.stringify(proposal));
+  fs.chmodSync(lockedDir, 0o555);
+
+  let applied;
+  try {
+    applied = runApply(
+      dir,
+      proposal.edits.map((e) => e.id),
+    );
+  } finally {
+    fs.chmodSync(lockedDir, 0o755);
+  }
+
+  assert.equal(applied.status, 1, `apply should fail:\n${applied.output}`);
+  assert.match(applied.output, /existing\.md rollback conflict/);
+  assert.equal(fs.lstatSync(alias).isSymbolicLink(), true);
+  assert.equal(fs.readFileSync(existing, "utf8"), "before\n");
 });
 
 test("a memory write failure rolls back skills without truncating memory", () => {

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -233,6 +233,28 @@ test("an unchanged memory file applies every accepted edit and its skills", () =
   assert.equal(porcelain(dir).includes(".backpass"), false, "run state stays out of the working tree");
 });
 
+test("a concurrently created skill refuses the whole apply before any write", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const memory = path.join(dir, "AGENTS.md");
+  const before = fs.readFileSync(memory, "utf8");
+  const concurrent = path.join(dir, ".agents/skills/release-details/SKILL.md");
+  fs.mkdirSync(path.dirname(concurrent), { recursive: true });
+  fs.writeFileSync(concurrent, "concurrent skill\n");
+
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+
+  assert.equal(applied.status, 1, `apply should refuse the collision:\n${applied.output}`);
+  assert.match(applied.output, /release-details\/SKILL\.md already exists; nothing was written/);
+  assert.equal(fs.readFileSync(memory, "utf8"), before);
+  assert.equal(fs.readFileSync(concurrent, "utf8"), "concurrent skill\n");
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/ci-details/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".claude")), false);
+});
+
 test("apply names a memory file left over budget without refusing the shrink", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -280,6 +280,26 @@ test("a later skill write failure rolls back skills written earlier in the same 
   assert.equal(fs.existsSync(path.join(dir, ".claude")), false, "the new loading layout was rolled back too");
 });
 
+test("a memory write failure rolls back skills written earlier in the same apply", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const memory = path.join(dir, "AGENTS.md");
+  const before = fs.readFileSync(memory, "utf8");
+  fs.chmodSync(memory, 0o444);
+
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+
+  assert.equal(applied.status, 1, `apply should report the memory write failure:\n${applied.output}`);
+  assert.match(applied.output, /AGENTS\.md could not be written/);
+  assert.match(applied.output, /rolled back skill paths written earlier in this round/);
+  assert.equal(fs.readFileSync(memory, "utf8"), before, "the memory file stayed byte-identical");
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/ci-details/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")), false);
+});
+
 test("apply names a memory file left over budget without refusing the shrink", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -280,17 +280,78 @@ test("a later skill write failure rolls back skills written earlier in the same 
   assert.equal(fs.existsSync(path.join(dir, ".claude")), false, "the new loading layout was rolled back too");
 });
 
-test("a memory write failure rolls back skills written earlier in the same apply", () => {
+test("a later file failure rolls back earlier files and leaves memory untouched", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);
   const memory = path.join(dir, "AGENTS.md");
   const before = fs.readFileSync(memory, "utf8");
-  fs.chmodSync(memory, 0o444);
-
-  const applied = runApply(
-    dir,
-    proposal.edits.map((e) => e.id),
+  const existing = path.join(dir, "existing.md");
+  const lockedDir = path.join(dir, "locked");
+  const locked = path.join(lockedDir, "existing.md");
+  fs.writeFileSync(existing, "before\n");
+  fs.mkdirSync(lockedDir);
+  fs.writeFileSync(locked, "locked before\n");
+  proposal.edits.push(
+    {
+      id: "e3",
+      kind: "rewrite",
+      file: "existing.md",
+      find: "before\n",
+      replace: "after\n",
+    },
+    {
+      id: "e4",
+      kind: "rewrite",
+      file: "locked/existing.md",
+      find: "locked before\n",
+      replace: "locked after\n",
+    },
   );
+  fs.writeFileSync(path.join(dir, ".backpass/proposal.json"), JSON.stringify(proposal));
+  fs.chmodSync(lockedDir, 0o555);
+
+  let applied;
+  try {
+    applied = runApply(
+      dir,
+      proposal.edits.map((e) => e.id),
+    );
+  } finally {
+    fs.chmodSync(lockedDir, 0o755);
+  }
+
+  assert.equal(applied.status, 1, `apply should report the later write failure:\n${applied.output}`);
+  assert.match(applied.output, /locked\/existing\.md could not be written/);
+  assert.equal(fs.readFileSync(existing, "utf8"), "before\n", "the earlier file write was rolled back");
+  assert.equal(fs.readFileSync(locked, "utf8"), "locked before\n");
+  assert.equal(fs.readFileSync(memory, "utf8"), before, "the memory file stayed byte-identical");
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/ci-details/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")), false);
+  assert.equal(
+    fs.readdirSync(dir).some((name) => name.includes(".backpass-")),
+    false,
+  );
+});
+
+test("a memory write failure rolls back skills without truncating memory", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const memory = path.join(dir, "AGENTS.md");
+  const before = fs.readFileSync(memory, "utf8");
+  fs.mkdirSync(path.join(dir, ".agents/skills"), { recursive: true });
+  fs.mkdirSync(path.join(dir, ".claude"));
+  fs.symlinkSync("../.agents/skills", path.join(dir, ".claude/skills"), "dir");
+  fs.chmodSync(dir, 0o555);
+
+  let applied;
+  try {
+    applied = runApply(
+      dir,
+      proposal.edits.map((e) => e.id),
+    );
+  } finally {
+    fs.chmodSync(dir, 0o755);
+  }
 
   assert.equal(applied.status, 1, `apply should report the memory write failure:\n${applied.output}`);
   assert.match(applied.output, /AGENTS\.md could not be written/);
@@ -298,6 +359,10 @@ test("a memory write failure rolls back skills written earlier in the same apply
   assert.equal(fs.readFileSync(memory, "utf8"), before, "the memory file stayed byte-identical");
   assert.equal(fs.existsSync(path.join(dir, ".agents/skills/ci-details/SKILL.md")), false);
   assert.equal(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")), false);
+  assert.equal(
+    fs.readdirSync(dir).some((name) => name.includes(".backpass-")),
+    false,
+  );
 });
 
 test("apply names a memory file left over budget without refusing the shrink", () => {

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -413,10 +413,11 @@ test("apply refuses accepted paths that resolve to the same target", () => {
   assert.equal(fs.existsSync(path.join(dir, ".agents")), false);
 });
 
-test("rollback leaves a concurrently changed file untouched", { timeout: 15000 }, async () => {
+test("rollback leaves concurrently changed files and skills untouched", { timeout: 15000 }, async () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);
   const existing = path.join(dir, "existing.md");
+  const concurrentSkill = path.join(dir, ".agents/skills/ci-details/SKILL.md");
   const slow = path.join(dir, "slow.md");
   const lockedDir = path.join(dir, "locked");
   const slowBefore = "a".repeat(8 * 1024 * 1024);
@@ -460,6 +461,7 @@ test("rollback leaves a concurrently changed file untouched", { timeout: 15000 }
   while (Date.now() < deadline) {
     if (fs.readFileSync(existing, "utf8") === "first write\n") {
       fs.writeFileSync(existing, "concurrent write\n");
+      fs.writeFileSync(concurrentSkill, "concurrent skill write\n");
       changed = true;
       break;
     }
@@ -471,7 +473,10 @@ test("rollback leaves a concurrently changed file untouched", { timeout: 15000 }
   assert.equal(changed, true, `the apply never exposed its first committed file:\n${applied.output}`);
   assert.equal(applied.status, 1, `apply should fail:\n${applied.output}`);
   assert.match(applied.output, /existing\.md rollback conflict/);
+  assert.match(applied.output, /ci-details\/SKILL\.md rollback conflict/);
   assert.equal(fs.readFileSync(existing, "utf8"), "concurrent write\n");
+  assert.equal(fs.readFileSync(concurrentSkill, "utf8"), "concurrent skill write\n");
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")), false);
   assert.equal(fs.readFileSync(slow, "utf8"), slowBefore);
 });
 

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -518,7 +518,7 @@ test("skill rollback preserves a replacement made immediately before removal", (
   assert.equal(fs.readFileSync(memory, "utf8"), before);
 });
 
-test("skill rollback restores a concurrent directory replacement", () => {
+test("skill rollback restores an exact concurrent directory without recursively copying it", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);
   const concurrentSkill = path.join(dir, ".agents/skills/ci-details/SKILL.md");
@@ -537,6 +537,7 @@ test("skill rollback restores a concurrent directory replacement", () => {
     BACKPASS_TEST_REPLACE_ON_ROLLBACK: concurrentSkill,
     BACKPASS_TEST_REPLACEMENT_TEXT: "directory replacement\n",
     BACKPASS_TEST_REPLACEMENT_DIRECTORY: "1",
+    BACKPASS_TEST_REJECT_DIRECTORY_COPY: "1",
   };
 
   let applied;

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -143,7 +143,7 @@ function proposeExtractions(dir) {
   assert.deepEqual(violations, [], "the fixture proposal must clear the gates");
   assert.equal(proposal.edits.length, 2);
   staged.state.writeProposal(proposal);
-  return proposal;
+  return /** @type {any} */ (proposal);
 }
 
 /** Run `backpass apply` for real, with the fake review surface accepting every edit. */
@@ -164,7 +164,7 @@ function applyInvocation(dir, editIds) {
     args: [CLI, "apply", "--no-open"],
     options: {
       cwd: dir,
-      encoding: "utf8",
+      encoding: /** @type {BufferEncoding} */ ("utf8"),
       env: {
         ...process.env,
         NO_COLOR: "1",

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -165,12 +165,12 @@ function applyInvocation(dir, editIds) {
     options: {
       cwd: dir,
       encoding: /** @type {BufferEncoding} */ ("utf8"),
-      env: {
+      env: /** @type {NodeJS.ProcessEnv} */ ({
         ...process.env,
         NO_COLOR: "1",
         BACKPASS_LAVISH_BIN: FAKE_LAVISH,
         FAKE_LAVISH_SCENARIO: scenario,
-      },
+      }),
     },
   };
 }
@@ -478,6 +478,44 @@ test("rollback leaves concurrently changed files and skills untouched", { timeou
   assert.equal(fs.readFileSync(concurrentSkill, "utf8"), "concurrent skill write\n");
   assert.equal(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")), false);
   assert.equal(fs.readFileSync(slow, "utf8"), slowBefore);
+});
+
+test("skill rollback preserves a replacement made immediately before removal", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const memory = path.join(dir, "AGENTS.md");
+  const before = fs.readFileSync(memory, "utf8");
+  const concurrentSkill = path.join(dir, ".agents/skills/ci-details/SKILL.md");
+  const replacement = "concurrent replacement\n";
+  fs.mkdirSync(path.join(dir, ".agents/skills"), { recursive: true });
+  fs.mkdirSync(path.join(dir, ".claude"));
+  fs.symlinkSync("../.agents/skills", path.join(dir, ".claude/skills"), "dir");
+  fs.chmodSync(dir, 0o555);
+
+  const invocation = applyInvocation(
+    dir,
+    proposal.edits.map((edit) => edit.id),
+  );
+  invocation.args.unshift("--import", path.join(ROOT, "test/fixtures/replace-before-skill-rollback.js"));
+  invocation.options.env = {
+    ...invocation.options.env,
+    BACKPASS_TEST_REPLACE_ON_ROLLBACK: concurrentSkill,
+    BACKPASS_TEST_REPLACEMENT_TEXT: replacement,
+  };
+
+  let applied;
+  try {
+    const result = spawnSync(process.execPath, invocation.args, invocation.options);
+    applied = { ...result, output: `${result.stdout}${result.stderr}` };
+  } finally {
+    fs.chmodSync(dir, 0o755);
+  }
+
+  assert.equal(applied.status, 1, `apply should report the write failure:\n${applied.output}`);
+  assert.match(applied.output, /ci-details\/SKILL\.md rollback conflict/);
+  assert.equal(fs.readFileSync(concurrentSkill, "utf8"), replacement);
+  assert.equal(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")), false);
+  assert.equal(fs.readFileSync(memory, "utf8"), before);
 });
 
 test("a memory write failure rolls back skills without truncating memory", () => {

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -518,6 +518,45 @@ test("skill rollback preserves a replacement made immediately before removal", (
   assert.equal(fs.readFileSync(memory, "utf8"), before);
 });
 
+test("skill rollback restores a concurrent directory replacement", () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const concurrentSkill = path.join(dir, ".agents/skills/ci-details/SKILL.md");
+  fs.mkdirSync(path.join(dir, ".agents/skills"), { recursive: true });
+  fs.mkdirSync(path.join(dir, ".claude"));
+  fs.symlinkSync("../.agents/skills", path.join(dir, ".claude/skills"), "dir");
+  fs.chmodSync(dir, 0o555);
+
+  const invocation = applyInvocation(
+    dir,
+    proposal.edits.map((edit) => edit.id),
+  );
+  invocation.args.unshift("--import", path.join(ROOT, "test/fixtures/replace-before-skill-rollback.js"));
+  invocation.options.env = {
+    ...invocation.options.env,
+    BACKPASS_TEST_REPLACE_ON_ROLLBACK: concurrentSkill,
+    BACKPASS_TEST_REPLACEMENT_TEXT: "directory replacement\n",
+    BACKPASS_TEST_REPLACEMENT_DIRECTORY: "1",
+  };
+
+  let applied;
+  try {
+    const result = spawnSync(process.execPath, invocation.args, invocation.options);
+    applied = { ...result, output: `${result.stdout}${result.stderr}` };
+  } finally {
+    fs.chmodSync(dir, 0o755);
+  }
+
+  assert.equal(applied.status, 1, `apply should report the write failure:\n${applied.output}`);
+  assert.match(applied.output, /ci-details\/SKILL\.md rollback conflict/);
+  assert.equal(fs.lstatSync(concurrentSkill).isDirectory(), true);
+  assert.equal(fs.readFileSync(path.join(concurrentSkill, "marker.txt"), "utf8"), "directory replacement\n");
+  assert.equal(
+    fs.readdirSync(path.dirname(concurrentSkill)).some((name) => name.includes(".backpass-rollback-")),
+    false,
+  );
+});
+
 test("a memory write failure rolls back skills without truncating memory", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { buildProposal } from "../src/proposal.js";
@@ -147,7 +147,7 @@ function proposeExtractions(dir) {
 }
 
 /** Run `backpass apply` for real, with the fake review surface accepting every edit. */
-function runApply(dir, editIds) {
+function applyInvocation(dir, editIds) {
   const decisions = editIds.map((id) => `${id}=accepted`).join(" ");
   // Outside the repo: the assertions below read `git status`, so the harness must not
   // leave a file there itself.
@@ -160,18 +160,38 @@ function runApply(dir, editIds) {
       ],
     }),
   );
-
-  const result = spawnSync(process.execPath, [CLI, "apply", "--no-open"], {
-    cwd: dir,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      NO_COLOR: "1",
-      BACKPASS_LAVISH_BIN: FAKE_LAVISH,
-      FAKE_LAVISH_SCENARIO: scenario,
+  return {
+    args: [CLI, "apply", "--no-open"],
+    options: {
+      cwd: dir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        BACKPASS_LAVISH_BIN: FAKE_LAVISH,
+        FAKE_LAVISH_SCENARIO: scenario,
+      },
     },
-  });
+  };
+}
+
+function runApply(dir, editIds) {
+  const { args, options } = applyInvocation(dir, editIds);
+  const result = spawnSync(process.execPath, args, options);
   return { ...result, output: `${result.stdout}${result.stderr}` };
+}
+
+function runApplyAsync(dir, editIds) {
+  const { args, options } = applyInvocation(dir, editIds);
+  const child = spawn(process.execPath, args, options);
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => (stdout += chunk));
+  child.stderr.on("data", (chunk) => (stderr += chunk));
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status, signal) => resolve({ status, signal, stdout, stderr, output: `${stdout}${stderr}` }));
+  });
 }
 
 const porcelain = (dir) => execFileSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8" }).trim();
@@ -346,6 +366,8 @@ test("a later file failure rolls back earlier files and leaves memory untouched"
   assert.equal(fs.readFileSync(memory, "utf8"), before, "the memory file stayed byte-identical");
   assert.equal(fs.existsSync(path.join(dir, ".agents/skills/ci-details/SKILL.md")), false);
   assert.equal(fs.existsSync(path.join(dir, ".agents/skills/release-details/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".agents")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".claude")), false);
   assert.equal(
     fs.readdirSync(dir).some((name) => name.includes(".backpass-")),
     false,
@@ -389,6 +411,68 @@ test("apply refuses accepted paths that resolve to the same target", () => {
   assert.equal(fs.readFileSync(existing, "utf8"), "before\n");
   assert.equal(fs.readFileSync(memory, "utf8"), memoryBefore);
   assert.equal(fs.existsSync(path.join(dir, ".agents")), false);
+});
+
+test("rollback leaves a concurrently changed file untouched", { timeout: 15000 }, async () => {
+  const dir = initRepo();
+  const proposal = proposeExtractions(dir);
+  const existing = path.join(dir, "existing.md");
+  const slow = path.join(dir, "slow.md");
+  const lockedDir = path.join(dir, "locked");
+  const slowBefore = "a".repeat(8 * 1024 * 1024);
+  const slowAfter = "b".repeat(8 * 1024 * 1024);
+  fs.writeFileSync(existing, "before\n");
+  fs.writeFileSync(slow, slowBefore);
+  fs.mkdirSync(lockedDir);
+  fs.writeFileSync(path.join(lockedDir, "existing.md"), "locked before\n");
+  proposal.edits.push(
+    {
+      id: "e3",
+      kind: "rewrite",
+      file: "existing.md",
+      find: "before\n",
+      replace: "first write\n",
+    },
+    {
+      id: "e4",
+      kind: "rewrite",
+      file: "slow.md",
+      find: slowBefore,
+      replace: slowAfter,
+    },
+    {
+      id: "e5",
+      kind: "rewrite",
+      file: "locked/existing.md",
+      find: "locked before\n",
+      replace: "locked after\n",
+    },
+  );
+  fs.writeFileSync(path.join(dir, ".backpass/proposal.json"), JSON.stringify(proposal));
+  fs.chmodSync(lockedDir, 0o555);
+
+  const applying = runApplyAsync(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
+  let changed = false;
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (fs.readFileSync(existing, "utf8") === "first write\n") {
+      fs.writeFileSync(existing, "concurrent write\n");
+      changed = true;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+
+  const applied = await applying;
+  fs.chmodSync(lockedDir, 0o755);
+  assert.equal(changed, true, `the apply never exposed its first committed file:\n${applied.output}`);
+  assert.equal(applied.status, 1, `apply should fail:\n${applied.output}`);
+  assert.match(applied.output, /existing\.md rollback conflict/);
+  assert.equal(fs.readFileSync(existing, "utf8"), "concurrent write\n");
+  assert.equal(fs.readFileSync(slow, "utf8"), slowBefore);
 });
 
 test("a memory write failure rolls back skills without truncating memory", () => {

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -352,16 +352,15 @@ test("a later file failure rolls back earlier files and leaves memory untouched"
   );
 });
 
-test("rollback reports a conflict instead of overwriting a replaced file", () => {
+test("apply refuses accepted paths that resolve to the same target", () => {
   const dir = initRepo();
   const proposal = proposeExtractions(dir);
+  const memory = path.join(dir, "AGENTS.md");
+  const memoryBefore = fs.readFileSync(memory, "utf8");
   const existing = path.join(dir, "existing.md");
   const alias = path.join(dir, "alias.md");
-  const lockedDir = path.join(dir, "locked");
   fs.writeFileSync(existing, "before\n");
   fs.symlinkSync("existing.md", alias);
-  fs.mkdirSync(lockedDir);
-  fs.writeFileSync(path.join(lockedDir, "existing.md"), "locked before\n");
   proposal.edits.push(
     {
       id: "e3",
@@ -375,33 +374,21 @@ test("rollback reports a conflict instead of overwriting a replaced file", () =>
       kind: "rewrite",
       file: "alias.md",
       find: "before\n",
-      replace: "replacement write\n",
-    },
-    {
-      id: "e5",
-      kind: "rewrite",
-      file: "locked/existing.md",
-      find: "locked before\n",
-      replace: "locked after\n",
+      replace: "second write\n",
     },
   );
   fs.writeFileSync(path.join(dir, ".backpass/proposal.json"), JSON.stringify(proposal));
-  fs.chmodSync(lockedDir, 0o555);
 
-  let applied;
-  try {
-    applied = runApply(
-      dir,
-      proposal.edits.map((e) => e.id),
-    );
-  } finally {
-    fs.chmodSync(lockedDir, 0o755);
-  }
+  const applied = runApply(
+    dir,
+    proposal.edits.map((e) => e.id),
+  );
 
-  assert.equal(applied.status, 1, `apply should fail:\n${applied.output}`);
-  assert.match(applied.output, /existing\.md rollback conflict/);
-  assert.equal(fs.lstatSync(alias).isSymbolicLink(), true);
+  assert.equal(applied.status, 1, `apply should refuse the collision:\n${applied.output}`);
+  assert.match(applied.output, /alias\.md resolves to the same target as existing\.md; nothing was written/);
   assert.equal(fs.readFileSync(existing, "utf8"), "before\n");
+  assert.equal(fs.readFileSync(memory, "utf8"), memoryBefore);
+  assert.equal(fs.existsSync(path.join(dir, ".agents")), false);
 });
 
 test("a memory write failure rolls back skills without truncating memory", () => {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import { bootstrapRun } from "../src/commands/bootstrap.js";
 import { renderPointer, renderStarterMemory } from "../src/bootstrap.js";
@@ -10,6 +12,8 @@ import { loadConfig } from "../src/config.js";
 import { setLoggerSink } from "../src/logger.js";
 import { isPointerTo, parseMemoryUnits } from "../src/memory.js";
 import { State } from "../src/state.js";
+
+const CLI = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../bin/backpass");
 
 function makeRepo(files = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-bootstrap-"));
@@ -131,6 +135,24 @@ test("starter memory is the minimal skeleton: purpose, an empty Learnings sectio
 
   // Deterministic: the checkout's contents no longer change the starter.
   assert.equal(renderStarterMemory({ repo: makeRepo() }), text);
+});
+
+test("a bootstrap run invalidates an older proposal", () => {
+  const repo = makeRepo();
+  execFileSync("git", ["init", "-q"], { cwd: repo.root });
+  const state = new State(repo.root).ensure();
+  state.writeProposal({ generatedAt: "earlier", edits: [{ id: "stale" }] });
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-bootstrap-home-"));
+
+  const result = spawnSync(process.execPath, [CLI, "--since", "1m"], {
+    cwd: repo.root,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, NO_COLOR: "1" },
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  assert.equal(fs.existsSync(path.join(repo.root, "AGENTS.md")), true);
+  assert.equal(state.readProposal(), null);
 });
 
 test("no memory file and no transcripts: seeds AGENTS.md from defaults plus a CLAUDE.md pointer", async () => {

--- a/test/fixtures/replace-before-skill-rollback.js
+++ b/test/fixtures/replace-before-skill-rollback.js
@@ -14,7 +14,12 @@ fs.renameSync = function replaceBeforeSkillRollback(source, destination) {
   ) {
     replaced = true;
     fs.unlinkSync(source);
-    fs.writeFileSync(source, replacement ?? "concurrent replacement\n");
+    if (process.env.BACKPASS_TEST_REPLACEMENT_DIRECTORY === "1") {
+      fs.mkdirSync(source);
+      fs.writeFileSync(`${source}/marker.txt`, replacement ?? "concurrent replacement\n");
+    } else {
+      fs.writeFileSync(source, replacement ?? "concurrent replacement\n");
+    }
   }
   return renameSync.call(this, source, destination);
 };

--- a/test/fixtures/replace-before-skill-rollback.js
+++ b/test/fixtures/replace-before-skill-rollback.js
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+
+const target = process.env.BACKPASS_TEST_REPLACE_ON_ROLLBACK;
+const replacement = process.env.BACKPASS_TEST_REPLACEMENT_TEXT;
+const renameSync = fs.renameSync;
+let replaced = false;
+
+fs.renameSync = function replaceBeforeSkillRollback(source, destination) {
+  if (
+    !replaced &&
+    target &&
+    source === target &&
+    pathLooksLikeSkillRollback(destination)
+  ) {
+    replaced = true;
+    fs.unlinkSync(source);
+    fs.writeFileSync(source, replacement ?? "concurrent replacement\n");
+  }
+  return renameSync.call(this, source, destination);
+};
+
+function pathLooksLikeSkillRollback(file) {
+  return file.includes(".backpass-rollback-");
+}

--- a/test/fixtures/replace-before-skill-rollback.js
+++ b/test/fixtures/replace-before-skill-rollback.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 const target = process.env.BACKPASS_TEST_REPLACE_ON_ROLLBACK;
 const replacement = process.env.BACKPASS_TEST_REPLACEMENT_TEXT;
 const renameSync = fs.renameSync;
+const cpSync = fs.cpSync;
 let replaced = false;
 
 fs.renameSync = function replaceBeforeSkillRollback(source, destination) {
@@ -22,6 +23,13 @@ fs.renameSync = function replaceBeforeSkillRollback(source, destination) {
     }
   }
   return renameSync.call(this, source, destination);
+};
+
+fs.cpSync = function rejectUnsupportedDirectoryCopy(source, destination, options) {
+  if (process.env.BACKPASS_TEST_REJECT_DIRECTORY_COPY === "1" && pathLooksLikeSkillRollback(source)) {
+    throw Object.assign(new Error("recursive copy cannot preserve a Unix socket"), { code: "EINVAL" });
+  }
+  return cpSync.call(this, source, destination, options);
 };
 
 function pathLooksLikeSkillRollback(file) {

--- a/test/fixtures/signal-during-spawn.cjs
+++ b/test/fixtures/signal-during-spawn.cjs
@@ -1,4 +1,5 @@
 const childProcess = require("node:child_process");
+const process = require("node:process");
 
 const spawn = childProcess.spawn;
 childProcess.spawn = function signalDuringSpawn(...args) {

--- a/test/fixtures/signal-during-spawn.cjs
+++ b/test/fixtures/signal-during-spawn.cjs
@@ -1,0 +1,11 @@
+const childProcess = require("node:child_process");
+
+const spawn = childProcess.spawn;
+childProcess.spawn = function signalDuringSpawn(...args) {
+  const child = spawn.apply(this, args);
+  if (process.env.BACKPASS_TEST_SIGNAL_DURING_SPAWN === "1") {
+    delete process.env.BACKPASS_TEST_SIGNAL_DURING_SPAWN;
+    process.emit("SIGTERM");
+  }
+  return child;
+};

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -382,6 +382,39 @@ test("a custom PI_ACP_PI_COMMAND is rejected before launch", async () => {
   assert.deepEqual(jsonl(piLog), []);
 });
 
+test("the process wrapper forwards a signal received while spawning", async () => {
+  const signalBin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-early-signal-bin-"));
+  const signalChild = path.join(signalBin, "pi");
+  fs.writeFileSync(signalChild, `#!${process.execPath}\nsetInterval(() => {}, 1000);\n`);
+  fs.chmodSync(signalChild, 0o755);
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${signalBin}${path.delimiter}${previousPath || ""}`;
+  const invocation = prepareHarnessInvocation({ agent: "pi", model: "provider/model" });
+  process.env.PATH = previousPath;
+
+  let wrapper;
+  try {
+    wrapper = spawn(invocation.env.PI_ACP_PI_COMMAND, [], {
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--require=${path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures/signal-during-spawn.cjs")}`,
+        BACKPASS_TEST_SIGNAL_DURING_SPAWN: "1",
+      },
+    });
+    const exited = new Promise((resolve) => wrapper.once("close", (code, signal) => resolve({ code, signal })));
+    const outcome = await Promise.race([
+      exited,
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 2000).unref()),
+    ]);
+    assert.notEqual(outcome, "timeout");
+  } finally {
+    if (wrapper?.exitCode === null && wrapper?.signalCode === null) wrapper.kill("SIGKILL");
+    invocation.dispose();
+  }
+});
+
 test("the process wrapper escalates when its harness child ignores termination", async () => {
   const signalBin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-signal-bin-"));
   const signalChild = path.join(signalBin, "pi");

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -1,0 +1,237 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The synthesis pass driven through the real CLI, against a stand-in acpx.
+ *
+ * `test/synthesize.test.js` calls `synthesizeProposal` directly; this helper stays one
+ * level out, where a user is: a git repo with a memory file and analysis evidence already
+ * on disk, `backpass propose` as its own process, and a fake `acpx` that behaves the way a
+ * harness with native file tools does - it edits `<cwd>/AGENTS.md`, answers annotate turns
+ * with scripted JSON, and can end a turn saying nothing at all, which is what the failure
+ * this scaffolding was written for actually did.
+ *
+ * Every acpx invocation is logged, so a test can assert what the CLI spent: how many
+ * sessions were opened, which prompts each turn carried, and whether an edit turn ran.
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+export const CLI = path.join(ROOT, "bin", "backpass.js");
+
+const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fake-cli-"));
+
+/**
+ * The stand-in harness. Driven by a JSON script:
+ *
+ *   {
+ *     edit: { "<file>": "<text>" | { replace: [[from, to]] } | null },
+ *     annotations: [ { editFirst?: <edits>, reply?: <json|string>, empty?: true } ]
+ *   }
+ *
+ * The last annotation step repeats once the script runs out, so "and then it kept
+ * answering the same way" needs no padding.
+ */
+const FAKE_ACPX = path.join(fakeDir, "acpx");
+fs.writeFileSync(
+  FAKE_ACPX,
+  `#!${process.execPath}
+const fs = require("node:fs");
+const path = require("node:path");
+const argv = process.argv.slice(2);
+const at = (flag) => (argv.indexOf(flag) >= 0 ? argv[argv.indexOf(flag) + 1] : null);
+const cwd = at("--cwd") || process.cwd();
+const promptFile = at("--file");
+const entry = { argv, cwd, session: at("-s"), promptFile, prompt: null };
+const script = JSON.parse(fs.readFileSync(process.env.FAKE_ACPX_SCRIPT, "utf8"));
+const statePath = process.env.FAKE_ACPX_STATE;
+const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : { annotate: 0, edit: 0 };
+
+function applyEdits(edits) {
+  for (const [file, change] of Object.entries(edits || {})) {
+    const target = path.isAbsolute(file) ? file : path.join(cwd, file);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    if (change === null) { fs.rmSync(target, { recursive: true, force: true }); continue; }
+    if (typeof change === "string") { fs.writeFileSync(target, change); continue; }
+    let text = fs.readFileSync(target, "utf8");
+    for (const [from, to] of change.replace) {
+      if (!text.includes(from)) throw new Error("fake harness: cannot find " + JSON.stringify(from));
+      text = text.replace(from, to);
+    }
+    fs.writeFileSync(target, text);
+  }
+}
+
+function log() {
+  fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify(entry) + "\\n");
+}
+
+if (argv.includes("sessions") || argv.includes("set")) {
+  if (argv.includes("new")) process.stdout.write("fake-session-id\\n");
+  log();
+  process.exit(0);
+}
+if (!promptFile) { log(); process.exit(2); }
+
+const prompt = fs.readFileSync(promptFile, "utf8");
+entry.prompt = prompt;
+entry.turn = prompt.includes("## Measured changes") ? "annotate" : "edit";
+log();
+
+if (entry.turn === "edit") {
+  state.edit += 1;
+  if (!argv.includes("--approve-all")) {
+    process.stdout.write("I could not edit the file: write permission was denied.\\n");
+    process.exit(0);
+  }
+  applyEdits(script.edit);
+  process.stdout.write("Edited the staging copy.\\n");
+  process.stderr.write("[acpx] tokens: input=1000 output=20 total=1020\\n");
+} else {
+  const step = script.annotations[Math.min(state.annotate, script.annotations.length - 1)];
+  state.annotate += 1;
+  if (step.editFirst) applyEdits(step.editFirst);
+  if (!step.empty) {
+    process.stdout.write(typeof step.reply === "string" ? step.reply : JSON.stringify(step.reply) + "\\n");
+  }
+  process.stderr.write("[acpx] tokens: input=500 output=30 total=530\\n");
+}
+fs.writeFileSync(statePath, JSON.stringify(state));
+`,
+);
+fs.chmodSync(FAKE_ACPX, 0o755);
+
+function git(args, cwd) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+/**
+ * A repo `backpass propose` will run in: a git checkout with the memory file committed,
+ * and tier-1 evidence already recorded, so the run starts at the fold.
+ */
+export function makeCliRepo({ memory, sessions = 3, files = {} }) {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-cli-")));
+  fs.writeFileSync(path.join(dir, "AGENTS.md"), memory);
+  for (const [name, text] of Object.entries(files)) {
+    const absolute = path.join(dir, name);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, text);
+  }
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "-m", "memory"], dir);
+
+  const evidenceDir = path.join(dir, ".backpass", "evidence");
+  fs.mkdirSync(evidenceDir, { recursive: true });
+  for (let i = 1; i <= sessions; i += 1) {
+    fs.writeFileSync(
+      path.join(evidenceDir, `claude_s${i}.json`),
+      JSON.stringify({
+        status: "ok",
+        memoryPath: "AGENTS.md",
+        transcript: { harness: "claude", id: `claude:s${i}`, path: `/dev/null/s${i}`, mtimeMs: 1, bytes: 10 },
+        positive: [],
+        negative: [
+          {
+            instruction: "AG-001",
+            quote: `session ${i} re-derived the release steps by hand`,
+            effect: "wasted a turn",
+            moment: "turn 4",
+          },
+        ],
+        gaps: [],
+      }),
+    );
+  }
+  return dir;
+}
+
+/** An isolated HOME, so discovery finds no real transcript store on this machine. */
+const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-cli-home-"));
+
+/**
+ * Run the CLI for real. `script` is the fake harness's scenario for this invocation;
+ * omitting it reuses whatever the previous call in this repo left on disk.
+ *
+ * @returns {{ status: number|null, stdout: string, stderr: string, output: string,
+ *   calls: () => any[], sessionsOpened: () => number, editTurns: () => number,
+ *   annotateTurns: () => number }}
+ */
+export function runCli(dir, args, { script = null, env = {} } = {}) {
+  const scriptPath = path.join(dir, ".backpass", "fake-script.json");
+  const statePath = path.join(dir, ".backpass", "fake-state.json");
+  const logPath = path.join(dir, ".backpass", `fake-log-${Date.now()}-${Math.random().toString(16).slice(2)}.jsonl`);
+  fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+  if (script) {
+    fs.writeFileSync(scriptPath, JSON.stringify(script));
+    fs.rmSync(statePath, { force: true });
+  }
+  fs.writeFileSync(logPath, "");
+
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    cwd: dir,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: emptyHome,
+      USERPROFILE: emptyHome,
+      NO_COLOR: "1",
+      CI: "1",
+      BACKPASS_ACPX_BIN: FAKE_ACPX,
+      FAKE_ACPX_SCRIPT: scriptPath,
+      FAKE_ACPX_STATE: statePath,
+      FAKE_ACPX_LOG: logPath,
+      ...env,
+    },
+  });
+
+  const calls = () =>
+    fs
+      .readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+
+  return {
+    ...result,
+    output: `${result.stdout}${result.stderr}`,
+    calls,
+    sessionsOpened: () => calls().filter((c) => c.argv.includes("sessions") && c.argv.includes("new")).length,
+    editTurns: () => calls().filter((c) => c.turn === "edit").length,
+    annotateTurns: () => calls().filter((c) => c.turn === "annotate").length,
+  };
+}
+
+/** The prompts a run wrote, in turn order. */
+export function annotatePrompts(dir) {
+  const promptDir = path.join(dir, ".backpass", "prompts");
+  if (!fs.existsSync(promptDir)) return [];
+  return fs
+    .readdirSync(promptDir)
+    .filter((f) => /^synthesis-annotate-\d+\.md$/.test(f))
+    .sort((a, b) => Number(/\d+/.exec(a)[0]) - Number(/\d+/.exec(b)[0]))
+    .map((f) => fs.readFileSync(path.join(promptDir, f), "utf8"));
+}
+
+export function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+/** Every file under a directory as `relative path -> contents`, for byte-level preservation checks. */
+export function snapshotTree(root) {
+  const out = {};
+  const walk = (dir, prefix) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(path.join(dir, entry.name), relative);
+      else if (entry.isFile()) out[relative] = fs.readFileSync(path.join(dir, entry.name), "utf8");
+    }
+  };
+  if (fs.existsSync(root)) walk(root, "");
+  return out;
+}

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -68,6 +68,11 @@ function log() {
   fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify(entry) + "\\n");
 }
 
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write(JSON.stringify({ agents: {} }) + "\\n");
+  log();
+  process.exit(0);
+}
 if (argv.includes("sessions") || argv.includes("set")) {
   if (argv.includes("new")) process.stdout.write("fake-session-id\\n");
   log();

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -68,6 +68,11 @@ function log() {
   fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify(entry) + "\\n");
 }
 
+if (argv.includes("status")) {
+  process.stdout.write(JSON.stringify({ availableModels: script.availableModels || [] }) + "\\n");
+  log();
+  process.exit(0);
+}
 if (argv.includes("sessions") || argv.includes("set")) {
   if (argv.includes("new")) process.stdout.write("fake-session-id\\n");
   log();
@@ -90,6 +95,10 @@ if (entry.turn === "edit") {
   process.stdout.write("Edited the staging copy.\\n");
   process.stderr.write("[acpx] tokens: input=1000 output=20 total=1020\\n");
 } else {
+  if (script.failAgent && argv.includes(script.failAgent)) {
+    process.stderr.write("[acpx] error: RUNTIME AUTH_REQUIRED fake authentication failure\\n");
+    process.exit(1);
+  }
   const step = script.annotations[Math.min(state.annotate, script.annotations.length - 1)];
   state.annotate += 1;
   if (step.editFirst) applyEdits(step.editFirst);

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -226,3 +226,17 @@ export function annotatePrompts(dir) {
 export function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
+
+/** Every file under a directory as `relative path -> contents`, for preservation checks. */
+export function snapshotTree(root) {
+  const out = {};
+  const walk = (dir, prefix) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(path.join(dir, entry.name), relative);
+      else if (entry.isFile()) out[relative] = fs.readFileSync(path.join(dir, entry.name), "utf8");
+    }
+  };
+  if (fs.existsSync(root)) walk(root, "");
+  return out;
+}

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -68,11 +68,6 @@ function log() {
   fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify(entry) + "\\n");
 }
 
-if (argv.includes("status")) {
-  process.stdout.write(JSON.stringify({ availableModels: script.availableModels || [] }) + "\\n");
-  log();
-  process.exit(0);
-}
 if (argv.includes("sessions") || argv.includes("set")) {
   if (argv.includes("new")) process.stdout.write("fake-session-id\\n");
   log();
@@ -95,10 +90,6 @@ if (entry.turn === "edit") {
   process.stdout.write("Edited the staging copy.\\n");
   process.stderr.write("[acpx] tokens: input=1000 output=20 total=1020\\n");
 } else {
-  if (script.failAgent && argv.includes(script.failAgent)) {
-    process.stderr.write("[acpx] error: RUNTIME AUTH_REQUIRED fake authentication failure\\n");
-    process.exit(1);
-  }
   const step = script.annotations[Math.min(state.annotate, script.annotations.length - 1)];
   state.annotate += 1;
   if (step.editFirst) applyEdits(step.editFirst);
@@ -229,18 +220,4 @@ export function annotatePrompts(dir) {
 
 export function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
-}
-
-/** Every file under a directory as `relative path -> contents`, for byte-level preservation checks. */
-export function snapshotTree(root) {
-  const out = {};
-  const walk = (dir, prefix) => {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
-      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
-      if (entry.isDirectory()) walk(path.join(dir, entry.name), relative);
-      else if (entry.isFile()) out[relative] = fs.readFileSync(path.join(dir, entry.name), "utf8");
-    }
-  };
-  if (fs.existsSync(root)) walk(root, "");
-  return out;
 }

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -769,7 +769,7 @@ test("a skill is written only when the memory-file edit that points at it lands"
   assert.equal(fs.existsSync(path.join(repo.root, ".claude/skills")), false, "and no layout side effects");
 });
 
-test("a failed later skill write names skill paths already written", () => {
+test("a failed later skill write rolls back skill paths written earlier", () => {
   const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
   const { proposal, repo, state } = gate({
     edit: (root) => {
@@ -804,11 +804,10 @@ test("a failed later skill write names skill paths already written", () => {
 
   assert.deepEqual(results.written, []);
   assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), MEMORY_TEXT);
-  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), true);
+  assert.equal(fs.existsSync(path.join(repo.root, ".agents/skills/node-setup/SKILL.md")), false);
   assert.ok(
     results.failed.some(
-      (failure) =>
-        /already written/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
+      (failure) => /rolled back/.test(failure.error) && failure.error.includes(".agents/skills/node-setup/SKILL.md"),
     ),
   );
 });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -274,14 +274,14 @@ test("a proposal that would exceed the budget fails the gate", () => {
   assert.ok(violations.some((v) => /over the 100-token budget/.test(v)));
 });
 
-test("an extract is one created SKILL.md grouped with the memory change that pays for it", () => {
-  const skillText =
-    "---\nname: release-signing\ndescription: Load before tagging a release.\n---\n\n## Steps\n\n1. sign\n";
+const skillFile = (name) => `---\nname: ${name}\ndescription: Load before ${name}.\n---\n\n## Steps\n\n1. do it\n`;
+
+test("an extract is the created SKILL.md file(s) grouped with the memory change that pays for them", () => {
   const extractEdit = (root) => {
     writeIn(root, "AGENTS.md", (t) =>
       t.replace("- Use Node 18 via nvm before running any script.", "- See the release-signing skill."),
     );
-    writeIn(root, ".agents/skills/release-signing/SKILL.md", skillText);
+    writeIn(root, ".agents/skills/release-signing/SKILL.md", skillFile("release-signing"));
   };
 
   const good = gate({
@@ -289,16 +289,17 @@ test("an extract is one created SKILL.md grouped with the memory change that pay
     annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "x" })] },
   });
   assert.deepEqual(good.violations, []);
-  assert.equal(good.proposal.edits[0].skill.path, ".agents/skills/release-signing/SKILL.md");
-  assert.equal(good.proposal.edits[0].skill.name, "release-signing");
-  assert.equal(good.proposal.edits[0].skill.body, "## Steps\n\n1. sign");
+  assert.deepEqual(
+    good.proposal.edits[0].skills.map((s) => [s.path, s.name, s.body]),
+    [[".agents/skills/release-signing/SKILL.md", "release-signing", "## Steps\n\n1. do it"]],
+  );
   assert.equal(good.proposal.stats.skillExtractions, 1);
 
   const split = gate({
     edit: extractEdit,
     annotation: { edits: [claim(["H1"], { kind: "extract", title: "x" }), claim(["H2"], { kind: "add", title: "y" })] },
   });
-  assert.ok(split.violations.some((v) => /kind "extract" must group exactly one created SKILL\.md/.test(v)));
+  assert.ok(split.violations.some((v) => /kind "extract" must group created SKILL\.md file\(s\)/.test(v)));
   assert.ok(split.violations.some((v) => /only kind "extract" may include a created file \(H2\)/.test(v)));
 
   const headless = gate({
@@ -309,6 +310,49 @@ test("an extract is one created SKILL.md grouped with the memory change that pay
     annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "x" })] },
   });
   assert.ok(headless.violations.some((v) => /needs YAML frontmatter/.test(v)));
+});
+
+test("skills whose removals were measured as one change may share an extract; separately measured ones may not", () => {
+  // Two neighbouring rules leave together, so the measurement merges their removal into a
+  // single hunk. Their two skills then cannot be accepted apart from each other.
+  const coalesced = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) =>
+        t.replace(
+          "- Prefer small commits.\n- Use Node 18 via nvm before running any script.\n",
+          "- See the commit-style and node-setup skills.\n",
+        ),
+      );
+      writeIn(root, ".agents/skills/commit-style/SKILL.md", skillFile("commit-style"));
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillFile("node-setup"));
+    },
+    annotation: { edits: [claim(["H1", "H2", "H3"], { kind: "extract", title: "extract two playbooks" })] },
+  });
+  assert.deepEqual(coalesced.violations, [], "one measured change plus two skills is one honest decision");
+  assert.equal(coalesced.proposal.edits.length, 1);
+  assert.deepEqual(coalesced.proposal.edits[0].skills.map((s) => s.name).sort(), ["commit-style", "node-setup"]);
+  assert.equal(coalesced.proposal.edits[0].hunks.length, 1);
+  assert.equal(coalesced.proposal.stats.skillExtractions, 2, "the stat counts skills, not cards");
+
+  // Two rules with an untouched line between them stay two measured changes, so they stay
+  // two decisions: bundling them would take away the reviewer's ability to split them.
+  const separate = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) =>
+        t
+          .replace("- Whenever a PR is mentioned, include its URL.", "- See the url-policy skill.")
+          .replace("- Use Node 18 via nvm before running any script.", "- See the node-setup skill."),
+      );
+      writeIn(root, ".agents/skills/url-policy/SKILL.md", skillFile("url-policy"));
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillFile("node-setup"));
+    },
+    annotation: { edits: [claim(["H1", "H2", "H3", "H4"], { kind: "extract", title: "extract both" })] },
+  });
+  assert.ok(
+    separate.violations.some((v) => /groups 2 created skills against 2 separate changes/.test(v)),
+    `expected a split demand, got ${JSON.stringify(separate.violations)}`,
+  );
+  assert.ok(separate.violations.some((v) => /give each skill its own extract/.test(v)));
 });
 
 test("a skill's description can be rewritten in place; deletions and stray files are refused or ignored", () => {
@@ -745,12 +789,9 @@ test("a failed later skill write names skill paths already written", () => {
       replace: "- See the url-policy skill.",
     },
   ];
-  second.skill = {
-    ...second.skill,
-    name: "url-policy",
-    path: ".agents/skills",
-    body: "Always include the full URL.",
-  };
+  second.skills = [
+    { ...second.skills[0], name: "url-policy", path: ".agents/skills", body: "Always include the full URL." },
+  ];
   proposal.edits.push(second);
 
   const results = applyDecisions({

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -103,7 +103,17 @@ setInterval(() => {}, 1000);
       assert.ok(fs.existsSync(pidPath), "the harness descendant started before timeout");
       assert.equal(fs.readFileSync(signalPath, "utf8"), "SIGTERM");
       harnessPid = Number(fs.readFileSync(pidPath, "utf8"));
-      assert.throws(() => process.kill(harnessPid, 0), { code: "ESRCH" });
+      let alive = true;
+      for (let attempt = 0; attempt < 100 && alive; attempt += 1) {
+        try {
+          process.kill(harnessPid, 0);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        } catch (err) {
+          if (err.code !== "ESRCH") throw err;
+          alive = false;
+        }
+      }
+      assert.equal(alive, false, "the harness descendant was reaped after termination");
     } finally {
       if (!harnessPid && fs.existsSync(pidPath)) harnessPid = Number(fs.readFileSync(pidPath, "utf8"));
       if (harnessPid) {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -240,7 +240,7 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.match(run.stderr, /carries no verbatim evidence quote/);
 
   // The advice is about the condition the run actually ended on.
-  assert.match(run.stderr, /run `backpass propose` again to start a fresh synthesis session/);
+  assert.match(run.stderr, /backpass propose --resume/);
   assert.doesNotMatch(run.stderr, /stronger synthesis model/);
   assert.doesNotMatch(run.stderr, /--budget/);
   assert.doesNotMatch(run.stderr, /--max-edits/);
@@ -259,7 +259,74 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.ok(staged[".agents/skills/incident-response/SKILL.md"]);
 });
 
-test("a failed synthesis invalidates an older applicable proposal", () => {
+test("propose --resume annotates the preserved tree from its own evidence snapshot", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
+        SPLIT_THE_COPY,
+        { empty: true },
+        { empty: true },
+      ],
+    },
+  });
+  assert.equal(failed.status, 1);
+  const before = stagedTree(dir);
+
+  // A later run may replace the general summary file. Resume must use the evidence saved
+  // with this staging baseline rather than silently annotating old edits with new evidence.
+  fs.writeFileSync(
+    path.join(dir, ".backpass", "evidence-summary.json"),
+    JSON.stringify({ analyzedSessions: 99, instructions: [], totals: { gapClusters: 0 } }),
+  );
+  const resumed = runCli(dir, ["propose", "--resume", ...PIN], {
+    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
+  });
+
+  assert.equal(resumed.status, 0, `the resume should succeed:\n${resumed.output}`);
+  assert.equal(resumed.editTurns(), 0, "the staged edits are not regenerated");
+  assert.equal(resumed.annotateTurns(), 1);
+  assert.deepEqual(stagedTree(dir), before, "annotation preserves the staged tree byte for byte");
+  assert.match(resumed.stdout, /2 edit\(s\) from 3 session\(s\)/);
+  const [prompt] = annotatePrompts(dir);
+  assert.ok(prompt.includes("joining a synthesis run already in progress"));
+  assert.ok(prompt.includes("session 1 re-derived the release steps by hand"));
+  assert.ok(proposalOf(dir).notes.some((note) => /resumed the staged synthesis/.test(note)));
+});
+
+test("propose --resume refuses incompatible state without deleting it or opening a session", () => {
+  const empty = makeCliRepo({ memory: MEMORY });
+  const wrongCommand = runCli(empty, ["--resume", ...PIN], { script: { edit: {}, annotations: [] } });
+  assert.equal(wrongCommand.status, 2);
+  assert.match(wrongCommand.stderr, /--resume is a `backpass propose` flag/);
+  assert.equal(wrongCommand.calls().length, 0);
+
+  const missing = runCli(empty, ["propose", "--resume", ...PIN], { script: { edit: {}, annotations: [] } });
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /cannot resume: there is no staged synthesis to resume/);
+  assert.equal(missing.calls().length, 0);
+
+  const dir = makeCliRepo({ memory: MEMORY });
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: { edit: EDIT_TURN, annotations: [{ reply: "not json" }] },
+  });
+  assert.equal(failed.status, 1);
+  const staged = stagedTree(dir);
+  fs.appendFileSync(path.join(dir, "AGENTS.md"), "\n- A concurrent rule.\n");
+
+  const refused = runCli(dir, ["propose", "--resume", ...PIN], {
+    script: { edit: {}, annotations: [{ reply: COALESCED_ANSWER }] },
+  });
+  assert.equal(refused.status, 1);
+  assert.match(refused.stderr, /cannot resume: AGENTS\.md changed after the staged synthesis was measured/);
+  assert.match(refused.stderr, /staged copy was left untouched/);
+  assert.equal(refused.calls().length, 0);
+  assert.deepEqual(stagedTree(dir), staged);
+});
+
+test("a proposal run invalidates an older applicable proposal before folding", () => {
   const dir = makeCliRepo({ memory: MEMORY });
   const succeeded = runCli(dir, ["propose", ...PIN], {
     script: { edit: EDIT_TURN, annotations: [{ reply: COALESCED_ANSWER }] },
@@ -267,10 +334,15 @@ test("a failed synthesis invalidates an older applicable proposal", () => {
   assert.equal(succeeded.status, 0, `the first proposal should succeed:\n${succeeded.output}`);
   assert.equal(fs.existsSync(path.join(dir, ".backpass", "proposal.json")), true);
 
+  // Fail before synthesis starts. An earlier applicable proposal must not survive merely
+  // because this run never reached the model boundary.
+  fs.rmSync(path.join(dir, ".backpass", "evidence"), { recursive: true, force: true });
   const failed = runCli(dir, ["propose", ...PIN], {
     script: { edit: EDIT_TURN, annotations: [{ reply: "not json" }] },
   });
-  assert.equal(failed.status, 1, `the second synthesis should fail:\n${failed.output}`);
+  assert.equal(failed.status, 1, `the second proposal run should fail during folding:\n${failed.output}`);
+  assert.match(failed.stderr, /no loss calculated yet/);
+  assert.equal(failed.calls().filter((call) => call.turn).length, 0, "no synthesis turn ran");
   assert.equal(fs.existsSync(path.join(dir, ".backpass", "proposal.json")), false);
 
   const applied = runCli(dir, ["apply", "--no-open"]);

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -161,6 +161,25 @@ test("a remeasurement is not a failed annotation: it costs no attempt, and the n
   assert.ok(prompts[3].includes("is not part of any edit"));
 });
 
+test("the remeasurement limit stops on the declared third file-moving turn", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        SPLIT_THE_COPY,
+        { editFirst: { "AGENTS.md": { replace: [[SPLIT, POINTERS]] } }, reply: { edits: [] } },
+        SPLIT_THE_COPY,
+        { reply: SPLIT_ANSWER },
+      ],
+    },
+  });
+
+  assert.equal(run.status, 1, `the run should stop at the limit:\n${run.output}`);
+  assert.equal(run.annotateTurns(), 3);
+  assert.match(run.stderr, /kept editing the staging copy instead of annotating it \(3 re-measurements\)/);
+});
+
 test("an empty turn is retried once in a fresh session, with the evidence it would otherwise have lost", () => {
   const dir = makeCliRepo({ memory: MEMORY });
   const run = runCli(dir, ["propose", ...PIN], {
@@ -280,6 +299,34 @@ test("propose --resume annotates the staged synthesis in a fresh session, withou
   );
   assert.ok(proposal.notes.some((n) => /resumed the staged synthesis/.test(n)));
   assert.match(resumed.stdout, /2 edit\(s\) from 3 session\(s\)/);
+});
+
+test("propose --resume falls through when the first candidate fails its real annotation call", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: { edit: EDIT_TURN, annotations: [{ empty: true }, { empty: true }] },
+  });
+  assert.equal(failed.status, 1);
+  fs.writeFileSync(
+    path.join(dir, ".backpassrc.json"),
+    JSON.stringify({ ladders: { synthesis: [{ model: "fake-model", agents: ["pi", "codex"] }] } }),
+  );
+
+  const resumed = runCli(dir, ["propose", "--resume"], {
+    script: {
+      edit: {},
+      annotations: [{ reply: COALESCED_ANSWER }],
+      availableModels: ["fake-model"],
+      failAgent: "pi",
+    },
+  });
+
+  assert.equal(resumed.status, 0, `the fallback candidate should complete the resume:\n${resumed.output}`);
+  const annotationCalls = resumed.calls().filter((call) => call.turn === "annotate");
+  assert.equal(annotationCalls.length, 2);
+  assert.ok(annotationCalls[0].argv.includes("pi"));
+  assert.ok(annotationCalls[1].argv.includes("codex"));
+  assert.ok(proposalOf(dir).notes.some((note) => /fell through to codex/.test(note)));
 });
 
 test("propose --resume refuses saved state it cannot annotate safely, and destroys none of it", () => {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { annotatePrompts, makeCliRepo, readJson, runCli, snapshotTree } from "./helpers/synthesis-cli.js";
+import { annotatePrompts, makeCliRepo, readJson, runCli } from "./helpers/synthesis-cli.js";
 
 /**
  * The synthesis orchestration, through `backpass propose` as a user runs it.
@@ -118,7 +118,6 @@ const SPLIT_ANSWER = {
 const SPLIT_THE_COPY = { editFirst: { "AGENTS.md": { replace: [[POINTERS, SPLIT]] } }, reply: { edits: [] } };
 
 const proposalOf = (dir) => readJson(path.join(dir, ".backpass", "proposal.json"));
-const stagedTree = (dir) => snapshotTree(path.join(dir, ".backpass", "synthesis"));
 
 test("a remeasurement is not a failed annotation: it costs no attempt, and the new ids get a real one", () => {
   const dir = makeCliRepo({ memory: MEMORY });
@@ -240,7 +239,7 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.match(run.stderr, /carries no verbatim evidence quote/);
 
   // The advice is about the condition the run actually ended on.
-  assert.match(run.stderr, /backpass propose --resume/);
+  assert.match(run.stderr, /retry `backpass propose`/);
   assert.doesNotMatch(run.stderr, /stronger synthesis model/);
   assert.doesNotMatch(run.stderr, /--budget/);
   assert.doesNotMatch(run.stderr, /--max-edits/);
@@ -254,128 +253,6 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
     "the empty turn wrote nothing into the rejected proposal",
   );
 
-  // The expensive half of the run survives the failure: this is what --resume picks up.
-  const staged = stagedTree(dir);
-  assert.ok(staged["AGENTS.md"].includes("## Incident response"), "the staged copy is the split layout");
-  assert.ok(staged[".agents/skills/release-checklist/SKILL.md"]);
-  assert.ok(staged[".agents/skills/incident-response/SKILL.md"]);
-});
-
-test("propose --resume annotates the staged synthesis in a fresh session, without re-running the editing turn", () => {
-  const dir = makeCliRepo({ memory: MEMORY });
-  const failed = runCli(dir, ["propose", ...PIN], {
-    script: {
-      edit: EDIT_TURN,
-      annotations: [
-        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
-        SPLIT_THE_COPY,
-        { empty: true },
-        { empty: true },
-      ],
-    },
-  });
-  assert.equal(failed.status, 1);
-  const before = stagedTree(dir);
-
-  const resumed = runCli(dir, ["propose", "--resume", ...PIN], {
-    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
-  });
-
-  assert.equal(resumed.status, 0, `the resume should succeed:\n${resumed.output}`);
-  assert.equal(resumed.editTurns(), 0, "no editing turn: the edits were already on disk");
-  assert.equal(resumed.annotateTurns(), 1);
-  assert.deepEqual(stagedTree(dir), before, "the staged copy is annotated in place, byte for byte");
-
-  const [prompt] = annotatePrompts(dir);
-  assert.ok(prompt.includes("You are joining a synthesis run that is already half done"));
-  assert.ok(prompt.includes("session 1 re-derived the release steps by hand"));
-
-  const proposal = proposalOf(dir);
-  assert.deepEqual(proposal.violations ?? [], []);
-  assert.equal(proposal.edits.length, 2, "the layout the failed run was one annotation away from");
-  assert.deepEqual(
-    proposal.edits.map((e) => e.kind),
-    ["extract", "extract"],
-  );
-  assert.ok(proposal.notes.some((n) => /resumed the staged synthesis/.test(n)));
-  assert.match(resumed.stdout, /2 edit\(s\) from 3 session\(s\)/);
-});
-
-test("propose --resume falls through when the first candidate fails its real annotation call", () => {
-  const dir = makeCliRepo({ memory: MEMORY });
-  const failed = runCli(dir, ["propose", ...PIN], {
-    script: { edit: EDIT_TURN, annotations: [{ empty: true }, { empty: true }] },
-  });
-  assert.equal(failed.status, 1);
-  fs.writeFileSync(
-    path.join(dir, ".backpassrc.json"),
-    JSON.stringify({ ladders: { synthesis: [{ model: "fake-model", agents: ["pi", "codex"] }] } }),
-  );
-
-  const resumed = runCli(dir, ["propose", "--resume"], {
-    script: {
-      edit: {},
-      annotations: [{ reply: COALESCED_ANSWER }],
-      availableModels: ["fake-model"],
-      failAgent: "pi",
-    },
-  });
-
-  assert.equal(resumed.status, 0, `the fallback candidate should complete the resume:\n${resumed.output}`);
-  const annotationCalls = resumed.calls().filter((call) => call.turn === "annotate");
-  assert.equal(annotationCalls.length, 2);
-  assert.ok(annotationCalls[0].argv.includes("pi"));
-  assert.ok(annotationCalls[1].argv.includes("codex"));
-  assert.ok(proposalOf(dir).notes.some((note) => /fell through to codex/.test(note)));
-});
-
-test("propose --resume refuses saved state it cannot annotate safely, and destroys none of it", () => {
-  const fresh = makeCliRepo({ memory: MEMORY });
-  const nothingStaged = runCli(fresh, ["propose", "--resume", ...PIN], { script: { edit: {}, annotations: [] } });
-  assert.equal(nothingStaged.status, 1);
-  assert.match(nothingStaged.stderr, /cannot resume: there is no staged synthesis to resume/);
-  assert.equal(nothingStaged.calls().length, 0, "nothing was spent on a model");
-
-  const dir = makeCliRepo({ memory: MEMORY });
-  const failed = runCli(dir, ["propose", ...PIN], {
-    script: {
-      edit: EDIT_TURN,
-      annotations: [
-        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
-        { empty: true },
-        { empty: true },
-      ],
-    },
-  });
-  assert.equal(failed.status, 1);
-  const staged = stagedTree(dir);
-  const rejected = proposalOf(dir);
-
-  // Someone edits the memory file the staged synthesis was measured against. Every hunk in
-  // that copy is anchored to text that may no longer exist, so resuming would measure
-  // against the wrong baseline.
-  fs.appendFileSync(path.join(dir, "AGENTS.md"), "\n- A rule that landed while the run was failing.\n");
-  const drifted = runCli(dir, ["propose", "--resume", ...PIN], {
-    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
-  });
-
-  assert.equal(drifted.status, 1, `the resume should be refused:\n${drifted.output}`);
-  assert.match(drifted.stderr, /cannot resume: AGENTS\.md changed after the staged synthesis was measured/);
-  assert.match(drifted.stderr, /the staged copy was left untouched/);
-  assert.equal(drifted.calls().length, 0, "no session was opened for a resume that cannot be trusted");
-  assert.deepEqual(stagedTree(dir), staged, "the staged copy is exactly as the failed run left it");
-  assert.deepEqual(proposalOf(dir), rejected, "and the rejected proposal is neither applied nor rewritten");
-  assert.equal(fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8").includes("## Playbooks"), false, "nothing applied");
-
-  // A tree staged by a version that kept no baseline record. Guessing one is how a hunk
-  // lands on text it was never measured against, so it is refused too - and still kept.
-  fs.rmSync(path.join(dir, ".backpass", "synthesis.json"));
-  const unrecorded = runCli(dir, ["propose", "--resume", ...PIN], {
-    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
-  });
-  assert.equal(unrecorded.status, 1);
-  assert.match(unrecorded.stderr, /has no record of what it was measured against/);
-  assert.deepEqual(stagedTree(dir), staged);
 });
 
 test("skills whose removals merged into one change ship as one decision, and apply writes them together", () => {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -1,0 +1,409 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { annotatePrompts, makeCliRepo, readJson, runCli, snapshotTree } from "./helpers/synthesis-cli.js";
+
+/**
+ * The synthesis orchestration, through `backpass propose` as a user runs it.
+ *
+ * These cover the run that produced the 0.1.7 "synthesis returned no parseable JSON
+ * object": a shrink that extracted two neighbouring sections (whose removals the
+ * measurement merges into ONE change), a turn that re-edited the staging copy so the ids
+ * moved, and a final turn where the harness returned success with no text at all. Each of
+ * those three is a separate condition with a separate right answer, and the assertions
+ * here are what a user can see: the exit code, what was printed, what is in
+ * `.backpass/proposal.json`, and what is left in `.backpass/synthesis/`.
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const FAKE_LAVISH = path.join(ROOT, "test", "fixtures", "fake-lavish", "lavish-axi");
+const PIN = ["--synthesis-agent", "claude", "--synthesis-model", "fake-model"];
+
+const MEMORY = [
+  "# Demo agent memory",
+  "",
+  "## Build",
+  "",
+  "- Run `make build` before every push.",
+  "",
+  "## Release checklist",
+  "",
+  "- Tag the release commit with the version.",
+  "- Push the tag before the artifacts.",
+  "- Never hand-edit CHANGELOG.md.",
+  "",
+  "## Incident response",
+  "",
+  "- Page the on-call before rolling back.",
+  "- Write the postmortem within two days.",
+  "- Link the postmortem from the incident channel.",
+  "",
+  "## Style",
+  "",
+  "- Never use the em dash.",
+  "",
+].join("\n");
+
+/** The two sections the editing turn lifts out, as one contiguous span of the file. */
+const BOTH_SECTIONS = [
+  "## Release checklist",
+  "",
+  "- Tag the release commit with the version.",
+  "- Push the tag before the artifacts.",
+  "- Never hand-edit CHANGELOG.md.",
+  "",
+  "## Incident response",
+  "",
+  "- Page the on-call before rolling back.",
+  "- Write the postmortem within two days.",
+  "- Link the postmortem from the incident channel.",
+  "",
+].join("\n");
+
+/** What the editing turn leaves: one pointer block, so the removals measure as ONE change. */
+const POINTERS = [
+  "## Playbooks",
+  "- Release steps: .agents/skills/release-checklist/SKILL.md",
+  "- Incidents: .agents/skills/incident-response/SKILL.md",
+  "",
+].join("\n");
+
+/** What an agent rewrites the copy into when it wants the two extractions measured apart. */
+const SPLIT = [
+  "## Release checklist",
+  "",
+  "- Release steps: .agents/skills/release-checklist/SKILL.md",
+  "",
+  "## Incident response",
+  "",
+  "- Incidents: .agents/skills/incident-response/SKILL.md",
+  "",
+].join("\n");
+
+const skill = (name) => `---\nname: ${name}\ndescription: Load before ${name} work.\n---\n\n## Steps\n\n1. do it\n`;
+
+const EDIT_TURN = {
+  "AGENTS.md": { replace: [[BOTH_SECTIONS, POINTERS]] },
+  ".agents/skills/release-checklist/SKILL.md": skill("release-checklist"),
+  ".agents/skills/incident-response/SKILL.md": skill("incident-response"),
+};
+
+const QUOTE = {
+  polarity: "negative",
+  text: "session 1 re-derived the release steps by hand",
+  source: "claude · s1 · turn 4",
+};
+
+const extract = (changes, title, extra = {}) => ({
+  changes,
+  kind: "extract",
+  title,
+  rationale: "the evidence shows these steps are looked up, not remembered",
+  evidence: [QUOTE],
+  transcripts: 3,
+  ...extra,
+});
+
+/** The coalesced layout: one merged memory change (H1) plus the two created skills. */
+const COALESCED_ANSWER = { edits: [extract(["H1", "H2", "H3"], "extract two playbooks")] };
+/** The layout after the copy is split: each skill with its own measured change. */
+const SPLIT_ANSWER = {
+  edits: [extract(["H1", "H4"], "extract the release checklist"), extract(["H2", "H3"], "extract incident response")],
+};
+/** A turn that edits the copy so the ids the agent was given no longer describe it. */
+const SPLIT_THE_COPY = { editFirst: { "AGENTS.md": { replace: [[POINTERS, SPLIT]] } }, reply: { edits: [] } };
+
+const proposalOf = (dir) => readJson(path.join(dir, ".backpass", "proposal.json"));
+const stagedTree = (dir) => snapshotTree(path.join(dir, ".backpass", "synthesis"));
+
+test("a remeasurement is not a failed annotation: it costs no attempt, and the new ids get a real one", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        // 1: judged and rejected - the one edit carries no evidence quote.
+        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
+        // 2: the agent splits the copy instead of answering. The ids move.
+        SPLIT_THE_COPY,
+        // 3: judged and rejected again - H4 is left out of every edit.
+        { reply: { edits: [extract(["H1", "H4"], "extract the release checklist")] } },
+        // 4: the third and last annotation attempt, and it passes.
+        { reply: SPLIT_ANSWER },
+      ],
+    },
+  });
+
+  assert.equal(run.status, 0, `the run should succeed:\n${run.output}`);
+  assert.equal(run.annotateTurns(), 4, "four turns, because one of them only moved the files");
+  const proposal = proposalOf(dir);
+  assert.equal(proposal.attempt, 3, "three annotation attempts were judged, not four");
+  assert.deepEqual(proposal.violations ?? [], []);
+  assert.equal(proposal.edits.length, 2);
+
+  // turn 1 plain · turn 2 corrects turn 1 · turn 3 re-annotates the moved ids · turn 4 corrects turn 3
+  const prompts = annotatePrompts(dir);
+  assert.equal(prompts.length, 4);
+  assert.ok(prompts[1].includes("Your previous answer was rejected"));
+  assert.ok(prompts[1].includes("carries no verbatim evidence quote"));
+  assert.ok(prompts[2].includes("The files moved after they were measured"));
+  assert.ok(
+    !prompts[2].includes("Your previous answer was rejected"),
+    "the turn after a remeasurement asks for an annotation, not a correction",
+  );
+  assert.ok(prompts[2].includes("did not use up an annotation attempt"));
+  assert.ok(prompts[2].includes("[H4: new file"), "and it asks about the re-measured ids");
+  assert.ok(prompts[3].includes("Your previous answer was rejected"));
+  assert.ok(prompts[3].includes("is not part of any edit"));
+});
+
+test("an empty turn is retried once in a fresh session, with the evidence it would otherwise have lost", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: { edit: EDIT_TURN, annotations: [{ empty: true }, { reply: COALESCED_ANSWER }] },
+  });
+
+  assert.equal(run.status, 0, `the run should succeed:\n${run.output}`);
+  assert.match(run.stderr, /ended its turn with no output; retrying the annotation once in a fresh session/);
+  assert.equal(run.editTurns(), 1, "the expensive editing turn is not repeated");
+  assert.equal(run.sessionsOpened(), 2, "the retry runs in a new session, not the one that went quiet");
+
+  const sessions = run.calls().filter((c) => c.session);
+  assert.equal(new Set(sessions.map((c) => c.session)).size, 2);
+  assert.notEqual(
+    run.calls().find((c) => c.turn === "annotate" && c.prompt.includes("joining a synthesis run")).session,
+    run.calls().find((c) => c.turn === "edit").session,
+  );
+
+  // The fresh session never saw the editing turn, so the annotate prompt has to carry the
+  // repository, the file, and the evidence every edit must quote.
+  const [, retry] = annotatePrompts(dir);
+  assert.ok(retry.includes("You are joining a synthesis run that is already half done"));
+  assert.ok(retry.includes("The edits below are already made."));
+  assert.ok(retry.includes("session 1 re-derived the release steps by hand"), "the evidence travels with it");
+  assert.ok(retry.includes("## Measured changes"));
+
+  const proposal = proposalOf(dir);
+  assert.deepEqual(proposal.violations ?? [], []);
+  assert.equal(proposal.attempt, 1, "the empty turn was never an annotation attempt");
+  assert.equal(proposal.edits.length, 1);
+});
+
+test("a run that ends on an empty turn says so, and never reads an older proposal as that turn's answer", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
+        SPLIT_THE_COPY,
+        { empty: true },
+        { empty: true },
+      ],
+    },
+  });
+
+  assert.equal(run.status, 1, `the run should fail:\n${run.output}`);
+  assert.equal(run.sessionsOpened(), 2, "the empty turn was retried in a fresh session before giving up");
+
+  // The failure is named after the turn that ended the run.
+  assert.match(run.stderr, /ended its turn with no output at all/);
+  assert.match(run.stderr, /no output, in the run's session and again in a fresh one/);
+  assert.doesNotMatch(run.stderr, /no parseable JSON/);
+
+  // The proposal on disk is from an earlier attempt, and is reported as such rather than
+  // as what the empty turn produced.
+  assert.match(run.stderr, /it is from annotation attempt 1, not the turn above/);
+  assert.match(run.stderr, /carries no verbatim evidence quote/);
+
+  // The advice is about the condition the run actually ended on.
+  assert.match(run.stderr, /backpass propose --resume/);
+  assert.doesNotMatch(run.stderr, /stronger synthesis model/);
+  assert.doesNotMatch(run.stderr, /--budget/);
+  assert.doesNotMatch(run.stderr, /--max-edits/);
+
+  const proposal = proposalOf(dir);
+  assert.equal(proposal.attempt, 1);
+  assert.equal(proposal.edits.length, 0);
+  assert.ok(proposal.violations.some((v) => /carries no verbatim evidence quote/.test(v)));
+  assert.ok(
+    !proposal.violations.some((v) => /no output|parseable JSON/.test(v)),
+    "the empty turn wrote nothing into the rejected proposal",
+  );
+
+  // The expensive half of the run survives the failure: this is what --resume picks up.
+  const staged = stagedTree(dir);
+  assert.ok(staged["AGENTS.md"].includes("## Incident response"), "the staged copy is the split layout");
+  assert.ok(staged[".agents/skills/release-checklist/SKILL.md"]);
+  assert.ok(staged[".agents/skills/incident-response/SKILL.md"]);
+});
+
+test("propose --resume annotates the staged synthesis in a fresh session, without re-running the editing turn", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
+        SPLIT_THE_COPY,
+        { empty: true },
+        { empty: true },
+      ],
+    },
+  });
+  assert.equal(failed.status, 1);
+  const before = stagedTree(dir);
+
+  const resumed = runCli(dir, ["propose", "--resume", ...PIN], {
+    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
+  });
+
+  assert.equal(resumed.status, 0, `the resume should succeed:\n${resumed.output}`);
+  assert.equal(resumed.editTurns(), 0, "no editing turn: the edits were already on disk");
+  assert.equal(resumed.annotateTurns(), 1);
+  assert.deepEqual(stagedTree(dir), before, "the staged copy is annotated in place, byte for byte");
+
+  const [prompt] = annotatePrompts(dir);
+  assert.ok(prompt.includes("You are joining a synthesis run that is already half done"));
+  assert.ok(prompt.includes("session 1 re-derived the release steps by hand"));
+
+  const proposal = proposalOf(dir);
+  assert.deepEqual(proposal.violations ?? [], []);
+  assert.equal(proposal.edits.length, 2, "the layout the failed run was one annotation away from");
+  assert.deepEqual(
+    proposal.edits.map((e) => e.kind),
+    ["extract", "extract"],
+  );
+  assert.ok(proposal.notes.some((n) => /resumed the staged synthesis/.test(n)));
+  assert.match(resumed.stdout, /2 edit\(s\) from 3 session\(s\)/);
+});
+
+test("propose --resume refuses saved state it cannot annotate safely, and destroys none of it", () => {
+  const fresh = makeCliRepo({ memory: MEMORY });
+  const nothingStaged = runCli(fresh, ["propose", "--resume", ...PIN], { script: { edit: {}, annotations: [] } });
+  assert.equal(nothingStaged.status, 1);
+  assert.match(nothingStaged.stderr, /cannot resume: there is no staged synthesis to resume/);
+  assert.equal(nothingStaged.calls().length, 0, "nothing was spent on a model");
+
+  const dir = makeCliRepo({ memory: MEMORY });
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
+        { empty: true },
+        { empty: true },
+      ],
+    },
+  });
+  assert.equal(failed.status, 1);
+  const staged = stagedTree(dir);
+  const rejected = proposalOf(dir);
+
+  // Someone edits the memory file the staged synthesis was measured against. Every hunk in
+  // that copy is anchored to text that may no longer exist, so resuming would measure
+  // against the wrong baseline.
+  fs.appendFileSync(path.join(dir, "AGENTS.md"), "\n- A rule that landed while the run was failing.\n");
+  const drifted = runCli(dir, ["propose", "--resume", ...PIN], {
+    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
+  });
+
+  assert.equal(drifted.status, 1, `the resume should be refused:\n${drifted.output}`);
+  assert.match(drifted.stderr, /cannot resume: AGENTS\.md changed after the staged synthesis was measured/);
+  assert.match(drifted.stderr, /the staged copy was left untouched/);
+  assert.equal(drifted.calls().length, 0, "no session was opened for a resume that cannot be trusted");
+  assert.deepEqual(stagedTree(dir), staged, "the staged copy is exactly as the failed run left it");
+  assert.deepEqual(proposalOf(dir), rejected, "and the rejected proposal is neither applied nor rewritten");
+  assert.equal(fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8").includes("## Playbooks"), false, "nothing applied");
+
+  // A tree staged by a version that kept no baseline record. Guessing one is how a hunk
+  // lands on text it was never measured against, so it is refused too - and still kept.
+  fs.rmSync(path.join(dir, ".backpass", "synthesis.json"));
+  const unrecorded = runCli(dir, ["propose", "--resume", ...PIN], {
+    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
+  });
+  assert.equal(unrecorded.status, 1);
+  assert.match(unrecorded.stderr, /has no record of what it was measured against/);
+  assert.deepEqual(stagedTree(dir), staged);
+});
+
+test("skills whose removals merged into one change ship as one decision, and apply writes them together", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: { edit: EDIT_TURN, annotations: [{ reply: COALESCED_ANSWER }] },
+  });
+
+  assert.equal(run.status, 0, `two skills against one merged change is a legal extract:\n${run.output}`);
+  const proposal = proposalOf(dir);
+  assert.equal(proposal.edits.length, 1, "one merged change cannot be accepted in halves, so it is one decision");
+  assert.equal(proposal.edits[0].hunks.length, 1);
+  assert.deepEqual(proposal.edits[0].skills.map((s) => s.name).sort(), ["incident-response", "release-checklist"]);
+  assert.equal(proposal.stats.skillExtractions, 2, "two skills, on one card");
+
+  const applied = runCli(dir, ["apply", "--no-open"], { env: applyEnv("e1=accepted") });
+  assert.equal(applied.status, 0, `apply should write both skills:\n${applied.output}`);
+
+  const memory = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8");
+  assert.ok(memory.includes("- Release steps: .agents/skills/release-checklist/SKILL.md"));
+  assert.ok(memory.includes("- Incidents: .agents/skills/incident-response/SKILL.md"));
+  assert.ok(!memory.includes("- Page the on-call before rolling back."));
+  for (const name of ["release-checklist", "incident-response"]) {
+    const written = fs.readFileSync(path.join(dir, ".agents", "skills", name, "SKILL.md"), "utf8");
+    assert.ok(written.includes(`name: ${name}`), `${name} was written, so the pointer is not dangling`);
+  }
+});
+
+test("skills measured as separate changes stay separate decisions: bundling them is refused with the fix", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: { ...EDIT_TURN, "AGENTS.md": { replace: [[BOTH_SECTIONS, SPLIT]] } },
+      // One extract for two skills whose removals were measured apart: taking that as one
+      // decision would deny the reviewer a choice the file can actually honour.
+      annotations: [
+        { reply: { edits: [extract(["H1", "H2", "H3", "H4"], "extract both playbooks")] } },
+        { reply: SPLIT_ANSWER },
+      ],
+    },
+  });
+
+  assert.equal(run.status, 0, `the corrected answer should pass:\n${run.output}`);
+  const second = annotatePrompts(dir)[1];
+  assert.ok(second.includes("groups 2 created skills against 2 separate changes"));
+  assert.ok(second.includes("give each skill its own extract"));
+
+  const proposal = proposalOf(dir);
+  assert.equal(proposal.edits.length, 2);
+  assert.deepEqual(
+    proposal.edits.map((e) => e.skills.length),
+    [1, 1],
+  );
+
+  // Both cards are decidable on their own: one accepted, one rejected, and the file takes
+  // exactly the accepted half.
+  const applied = runCli(dir, ["apply", "--no-open"], { env: applyEnv("e1=accepted e2=rejected") });
+  assert.equal(applied.status, 0, `apply should honour the split decision:\n${applied.output}`);
+  const memory = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8");
+  assert.ok(memory.includes("- Release steps: .agents/skills/release-checklist/SKILL.md"));
+  assert.ok(memory.includes("- Page the on-call before rolling back."), "the rejected extraction stayed in the file");
+  assert.equal(fs.existsSync(path.join(dir, ".agents", "skills", "release-checklist", "SKILL.md")), true);
+  assert.equal(fs.existsSync(path.join(dir, ".agents", "skills", "incident-response", "SKILL.md")), false);
+});
+
+/** The fake review surface, answering with one decision vector. */
+function applyEnv(decisions) {
+  const scenario = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-lavish-")), "scenario.json");
+  fs.writeFileSync(
+    scenario,
+    JSON.stringify({
+      polls: [
+        `prompts[1]{uid,prompt,selector,tag,text}:\n  "1","BACKPASS_DECISIONS ${decisions}",button#btn-apply,choice,${decisions}`,
+      ],
+    }),
+  );
+  return { BACKPASS_LAVISH_BIN: FAKE_LAVISH, FAKE_LAVISH_SCENARIO: scenario };
+}

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { annotatePrompts, makeCliRepo, readJson, runCli } from "./helpers/synthesis-cli.js";
+import { annotatePrompts, makeCliRepo, readJson, runCli, snapshotTree } from "./helpers/synthesis-cli.js";
 
 /**
  * The synthesis orchestration, through `backpass propose` as a user runs it.
@@ -118,6 +118,7 @@ const SPLIT_ANSWER = {
 const SPLIT_THE_COPY = { editFirst: { "AGENTS.md": { replace: [[POINTERS, SPLIT]] } }, reply: { edits: [] } };
 
 const proposalOf = (dir) => readJson(path.join(dir, ".backpass", "proposal.json"));
+const stagedTree = (dir) => snapshotTree(path.join(dir, ".backpass", "synthesis"));
 
 test("a remeasurement is not a failed annotation: it costs no attempt, and the new ids get a real one", () => {
   const dir = makeCliRepo({ memory: MEMORY });
@@ -239,7 +240,7 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.match(run.stderr, /carries no verbatim evidence quote/);
 
   // The advice is about the condition the run actually ended on.
-  assert.match(run.stderr, /retry `backpass propose`/);
+  assert.match(run.stderr, /backpass propose --resume/);
   assert.doesNotMatch(run.stderr, /stronger synthesis model/);
   assert.doesNotMatch(run.stderr, /--budget/);
   assert.doesNotMatch(run.stderr, /--max-edits/);
@@ -252,6 +253,77 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
     !proposal.violations.some((v) => /no output|parseable JSON/.test(v)),
     "the empty turn wrote nothing into the rejected proposal",
   );
+  const staged = stagedTree(dir);
+  assert.ok(staged["AGENTS.md"].includes("## Incident response"));
+  assert.ok(staged[".agents/skills/release-checklist/SKILL.md"]);
+  assert.ok(staged[".agents/skills/incident-response/SKILL.md"]);
+});
+
+test("propose --resume annotates the preserved tree from its own evidence snapshot", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
+        SPLIT_THE_COPY,
+        { empty: true },
+        { empty: true },
+      ],
+    },
+  });
+  assert.equal(failed.status, 1);
+  const before = stagedTree(dir);
+
+  // A later run may replace the general summary file. Resume must use the evidence saved
+  // with this staging baseline rather than silently annotating old edits with new evidence.
+  fs.writeFileSync(
+    path.join(dir, ".backpass", "evidence-summary.json"),
+    JSON.stringify({ analyzedSessions: 99, instructions: [], totals: { gapClusters: 0 } }),
+  );
+  const resumed = runCli(dir, ["propose", "--resume", ...PIN], {
+    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
+  });
+
+  assert.equal(resumed.status, 0, `the resume should succeed:\n${resumed.output}`);
+  assert.equal(resumed.editTurns(), 0, "the staged edits are not regenerated");
+  assert.equal(resumed.annotateTurns(), 1);
+  assert.deepEqual(stagedTree(dir), before, "annotation preserves the staged tree byte for byte");
+  assert.match(resumed.stdout, /2 edit\(s\) from 3 session\(s\)/);
+  const [prompt] = annotatePrompts(dir);
+  assert.ok(prompt.includes("joining a synthesis run already in progress"));
+  assert.ok(prompt.includes("session 1 re-derived the release steps by hand"));
+  assert.ok(proposalOf(dir).notes.some((note) => /resumed the staged synthesis/.test(note)));
+});
+
+test("propose --resume refuses incompatible state without deleting it or opening a session", () => {
+  const empty = makeCliRepo({ memory: MEMORY });
+  const wrongCommand = runCli(empty, ["--resume", ...PIN], { script: { edit: {}, annotations: [] } });
+  assert.equal(wrongCommand.status, 2);
+  assert.match(wrongCommand.stderr, /--resume is a `backpass propose` flag/);
+  assert.equal(wrongCommand.calls().length, 0);
+
+  const missing = runCli(empty, ["propose", "--resume", ...PIN], { script: { edit: {}, annotations: [] } });
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /cannot resume: there is no staged synthesis to resume/);
+  assert.equal(missing.calls().length, 0);
+
+  const dir = makeCliRepo({ memory: MEMORY });
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: { edit: EDIT_TURN, annotations: [{ reply: "not json" }] },
+  });
+  assert.equal(failed.status, 1);
+  const staged = stagedTree(dir);
+  fs.appendFileSync(path.join(dir, "AGENTS.md"), "\n- A concurrent rule.\n");
+
+  const refused = runCli(dir, ["propose", "--resume", ...PIN], {
+    script: { edit: {}, annotations: [{ reply: COALESCED_ANSWER }] },
+  });
+  assert.equal(refused.status, 1);
+  assert.match(refused.stderr, /cannot resume: AGENTS\.md changed after the staged synthesis was measured/);
+  assert.match(refused.stderr, /staged copy was left untouched/);
+  assert.equal(refused.calls().length, 0);
+  assert.deepEqual(stagedTree(dir), staged);
 });
 
 test("a failed synthesis invalidates an older applicable proposal", () => {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -240,7 +240,7 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.match(run.stderr, /carries no verbatim evidence quote/);
 
   // The advice is about the condition the run actually ended on.
-  assert.match(run.stderr, /backpass propose --resume/);
+  assert.match(run.stderr, /run `backpass propose` again to start a fresh synthesis session/);
   assert.doesNotMatch(run.stderr, /stronger synthesis model/);
   assert.doesNotMatch(run.stderr, /--budget/);
   assert.doesNotMatch(run.stderr, /--max-edits/);
@@ -257,73 +257,6 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.ok(staged["AGENTS.md"].includes("## Incident response"));
   assert.ok(staged[".agents/skills/release-checklist/SKILL.md"]);
   assert.ok(staged[".agents/skills/incident-response/SKILL.md"]);
-});
-
-test("propose --resume annotates the preserved tree from its own evidence snapshot", () => {
-  const dir = makeCliRepo({ memory: MEMORY });
-  const failed = runCli(dir, ["propose", ...PIN], {
-    script: {
-      edit: EDIT_TURN,
-      annotations: [
-        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
-        SPLIT_THE_COPY,
-        { empty: true },
-        { empty: true },
-      ],
-    },
-  });
-  assert.equal(failed.status, 1);
-  const before = stagedTree(dir);
-
-  // A later run may replace the general summary file. Resume must use the evidence saved
-  // with this staging baseline rather than silently annotating old edits with new evidence.
-  fs.writeFileSync(
-    path.join(dir, ".backpass", "evidence-summary.json"),
-    JSON.stringify({ analyzedSessions: 99, instructions: [], totals: { gapClusters: 0 } }),
-  );
-  const resumed = runCli(dir, ["propose", "--resume", ...PIN], {
-    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
-  });
-
-  assert.equal(resumed.status, 0, `the resume should succeed:\n${resumed.output}`);
-  assert.equal(resumed.editTurns(), 0, "the staged edits are not regenerated");
-  assert.equal(resumed.annotateTurns(), 1);
-  assert.deepEqual(stagedTree(dir), before, "annotation preserves the staged tree byte for byte");
-  assert.match(resumed.stdout, /2 edit\(s\) from 3 session\(s\)/);
-  const [prompt] = annotatePrompts(dir);
-  assert.ok(prompt.includes("joining a synthesis run already in progress"));
-  assert.ok(prompt.includes("session 1 re-derived the release steps by hand"));
-  assert.ok(proposalOf(dir).notes.some((note) => /resumed the staged synthesis/.test(note)));
-});
-
-test("propose --resume refuses incompatible state without deleting it or opening a session", () => {
-  const empty = makeCliRepo({ memory: MEMORY });
-  const wrongCommand = runCli(empty, ["--resume", ...PIN], { script: { edit: {}, annotations: [] } });
-  assert.equal(wrongCommand.status, 2);
-  assert.match(wrongCommand.stderr, /--resume is a `backpass propose` flag/);
-  assert.equal(wrongCommand.calls().length, 0);
-
-  const missing = runCli(empty, ["propose", "--resume", ...PIN], { script: { edit: {}, annotations: [] } });
-  assert.equal(missing.status, 1);
-  assert.match(missing.stderr, /cannot resume: there is no staged synthesis to resume/);
-  assert.equal(missing.calls().length, 0);
-
-  const dir = makeCliRepo({ memory: MEMORY });
-  const failed = runCli(dir, ["propose", ...PIN], {
-    script: { edit: EDIT_TURN, annotations: [{ reply: "not json" }] },
-  });
-  assert.equal(failed.status, 1);
-  const staged = stagedTree(dir);
-  fs.appendFileSync(path.join(dir, "AGENTS.md"), "\n- A concurrent rule.\n");
-
-  const refused = runCli(dir, ["propose", "--resume", ...PIN], {
-    script: { edit: {}, annotations: [{ reply: COALESCED_ANSWER }] },
-  });
-  assert.equal(refused.status, 1);
-  assert.match(refused.stderr, /cannot resume: AGENTS\.md changed after the staged synthesis was measured/);
-  assert.match(refused.stderr, /staged copy was left untouched/);
-  assert.equal(refused.calls().length, 0);
-  assert.deepEqual(stagedTree(dir), staged);
 });
 
 test("a failed synthesis invalidates an older applicable proposal", () => {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -252,7 +252,26 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
     !proposal.violations.some((v) => /no output|parseable JSON/.test(v)),
     "the empty turn wrote nothing into the rejected proposal",
   );
+});
 
+test("a failed synthesis invalidates an older applicable proposal", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const succeeded = runCli(dir, ["propose", ...PIN], {
+    script: { edit: EDIT_TURN, annotations: [{ reply: COALESCED_ANSWER }] },
+  });
+  assert.equal(succeeded.status, 0, `the first proposal should succeed:\n${succeeded.output}`);
+  assert.equal(fs.existsSync(path.join(dir, ".backpass", "proposal.json")), true);
+
+  const failed = runCli(dir, ["propose", ...PIN], {
+    script: { edit: EDIT_TURN, annotations: [{ reply: "not json" }] },
+  });
+  assert.equal(failed.status, 1, `the second synthesis should fail:\n${failed.output}`);
+  assert.equal(fs.existsSync(path.join(dir, ".backpass", "proposal.json")), false);
+
+  const applied = runCli(dir, ["apply", "--no-open"]);
+  assert.equal(applied.status, 1);
+  assert.match(applied.stderr, /no proposal to apply/);
+  assert.equal(fs.readFileSync(path.join(dir, "AGENTS.md"), "utf8"), MEMORY);
 });
 
 test("skills whose removals merged into one change ship as one decision, and apply writes them together", () => {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -200,7 +200,7 @@ test("an empty turn is retried once in a fresh session, with the evidence it wou
   // The fresh session never saw the editing turn, so the annotate prompt has to carry the
   // repository, the file, and the evidence every edit must quote.
   const [, retry] = annotatePrompts(dir);
-  assert.ok(retry.includes("You are joining a synthesis run that is already half done"));
+  assert.ok(retry.includes("You are joining a synthesis run already in progress"));
   assert.ok(retry.includes("The edits below are already made."));
   assert.ok(retry.includes("session 1 re-derived the release steps by hand"), "the evidence travels with it");
   assert.ok(retry.includes("## Measured changes"));

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -240,7 +240,7 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.match(run.stderr, /carries no verbatim evidence quote/);
 
   // The advice is about the condition the run actually ended on.
-  assert.match(run.stderr, /backpass propose --resume/);
+  assert.match(run.stderr, /run `backpass propose` again to start a fresh synthesis session/);
   assert.doesNotMatch(run.stderr, /stronger synthesis model/);
   assert.doesNotMatch(run.stderr, /--budget/);
   assert.doesNotMatch(run.stderr, /--max-edits/);
@@ -259,74 +259,7 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.ok(staged[".agents/skills/incident-response/SKILL.md"]);
 });
 
-test("propose --resume annotates the preserved tree from its own evidence snapshot", () => {
-  const dir = makeCliRepo({ memory: MEMORY });
-  const failed = runCli(dir, ["propose", ...PIN], {
-    script: {
-      edit: EDIT_TURN,
-      annotations: [
-        { reply: { edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })] } },
-        SPLIT_THE_COPY,
-        { empty: true },
-        { empty: true },
-      ],
-    },
-  });
-  assert.equal(failed.status, 1);
-  const before = stagedTree(dir);
-
-  // A later run may replace the general summary file. Resume must use the evidence saved
-  // with this staging baseline rather than silently annotating old edits with new evidence.
-  fs.writeFileSync(
-    path.join(dir, ".backpass", "evidence-summary.json"),
-    JSON.stringify({ analyzedSessions: 99, instructions: [], totals: { gapClusters: 0 } }),
-  );
-  const resumed = runCli(dir, ["propose", "--resume", ...PIN], {
-    script: { edit: {}, annotations: [{ reply: SPLIT_ANSWER }] },
-  });
-
-  assert.equal(resumed.status, 0, `the resume should succeed:\n${resumed.output}`);
-  assert.equal(resumed.editTurns(), 0, "the staged edits are not regenerated");
-  assert.equal(resumed.annotateTurns(), 1);
-  assert.deepEqual(stagedTree(dir), before, "annotation preserves the staged tree byte for byte");
-  assert.match(resumed.stdout, /2 edit\(s\) from 3 session\(s\)/);
-  const [prompt] = annotatePrompts(dir);
-  assert.ok(prompt.includes("joining a synthesis run already in progress"));
-  assert.ok(prompt.includes("session 1 re-derived the release steps by hand"));
-  assert.ok(proposalOf(dir).notes.some((note) => /resumed the staged synthesis/.test(note)));
-});
-
-test("propose --resume refuses incompatible state without deleting it or opening a session", () => {
-  const empty = makeCliRepo({ memory: MEMORY });
-  const wrongCommand = runCli(empty, ["--resume", ...PIN], { script: { edit: {}, annotations: [] } });
-  assert.equal(wrongCommand.status, 2);
-  assert.match(wrongCommand.stderr, /--resume is a `backpass propose` flag/);
-  assert.equal(wrongCommand.calls().length, 0);
-
-  const missing = runCli(empty, ["propose", "--resume", ...PIN], { script: { edit: {}, annotations: [] } });
-  assert.equal(missing.status, 1);
-  assert.match(missing.stderr, /cannot resume: there is no staged synthesis to resume/);
-  assert.equal(missing.calls().length, 0);
-
-  const dir = makeCliRepo({ memory: MEMORY });
-  const failed = runCli(dir, ["propose", ...PIN], {
-    script: { edit: EDIT_TURN, annotations: [{ reply: "not json" }] },
-  });
-  assert.equal(failed.status, 1);
-  const staged = stagedTree(dir);
-  fs.appendFileSync(path.join(dir, "AGENTS.md"), "\n- A concurrent rule.\n");
-
-  const refused = runCli(dir, ["propose", "--resume", ...PIN], {
-    script: { edit: {}, annotations: [{ reply: COALESCED_ANSWER }] },
-  });
-  assert.equal(refused.status, 1);
-  assert.match(refused.stderr, /cannot resume: AGENTS\.md changed after the staged synthesis was measured/);
-  assert.match(refused.stderr, /staged copy was left untouched/);
-  assert.equal(refused.calls().length, 0);
-  assert.deepEqual(stagedTree(dir), staged);
-});
-
-test("a proposal run invalidates an older applicable proposal before folding", () => {
+test("a failed synthesis invalidates an older applicable proposal", () => {
   const dir = makeCliRepo({ memory: MEMORY });
   const succeeded = runCli(dir, ["propose", ...PIN], {
     script: { edit: EDIT_TURN, annotations: [{ reply: COALESCED_ANSWER }] },
@@ -334,15 +267,10 @@ test("a proposal run invalidates an older applicable proposal before folding", (
   assert.equal(succeeded.status, 0, `the first proposal should succeed:\n${succeeded.output}`);
   assert.equal(fs.existsSync(path.join(dir, ".backpass", "proposal.json")), true);
 
-  // Fail before synthesis starts. An earlier applicable proposal must not survive merely
-  // because this run never reached the model boundary.
-  fs.rmSync(path.join(dir, ".backpass", "evidence"), { recursive: true, force: true });
   const failed = runCli(dir, ["propose", ...PIN], {
     script: { edit: EDIT_TURN, annotations: [{ reply: "not json" }] },
   });
-  assert.equal(failed.status, 1, `the second proposal run should fail during folding:\n${failed.output}`);
-  assert.match(failed.stderr, /no loss calculated yet/);
-  assert.equal(failed.calls().filter((call) => call.turn).length, 0, "no synthesis turn ran");
+  assert.equal(failed.status, 1, `the second synthesis should fail:\n${failed.output}`);
   assert.equal(fs.existsSync(path.join(dir, ".backpass", "proposal.json")), false);
 
   const applied = runCli(dir, ["apply", "--no-open"]);

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -281,7 +281,8 @@ test("an agent that keeps editing during an annotate turn is shown the re-measur
   assert.deepEqual(violations, []);
   assert.equal(proposal.edits.length, 2);
   const second = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-2.md"), "utf8");
-  assert.ok(second.includes("the files changed after the changes were measured"));
+  assert.ok(second.includes("The files moved after they were measured"));
+  assert.ok(!second.includes("Your previous answer was rejected"), "a re-measurement is not a rejected answer");
   assert.ok(second.includes("[H2: AGENTS.md line 12 (-1/+1)"));
 });
 

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -371,20 +371,11 @@ test("a gate violation renders the exact breaches and the re-prompt marker", () 
 test("synthesis progress shows only the active annotation condition", () => {
   const afterViolation = stateAfter([
     ...SYNTH_SCRIPT,
-    [
-      "synth:start",
-      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
-    ],
+    ["synth:start", { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 }],
     ["synth:empty", { emptyTurns: 1 }],
-    [
-      "synth:start",
-      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
-    ],
+    ["synth:start", { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 }],
     ["synth:violations", { attempt: 1, violations: ["answer was not JSON"] }],
-    [
-      "synth:start",
-      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 2, changes: 3 },
-    ],
+    ["synth:start", { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 2, changes: 3 }],
   ]);
   const violationText = render(afterViolation).join("\n");
   assert.ok(violationText.includes("synthesis violated 1 gate(s)"));
@@ -393,16 +384,10 @@ test("synthesis progress shows only the active annotation condition", () => {
 
   const afterEmpty = stateAfter([
     ...SYNTH_SCRIPT,
-    [
-      "synth:start",
-      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
-    ],
+    ["synth:start", { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 }],
     ["synth:remeasure", { remeasures: 1 }],
     ["synth:empty", { emptyTurns: 1 }],
-    [
-      "synth:start",
-      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
-    ],
+    ["synth:start", { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 }],
   ]);
   const emptyText = render(afterEmpty).join("\n");
   assert.ok(emptyText.includes("retrying in a fresh session"));

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -368,6 +368,47 @@ test("a gate violation renders the exact breaches and the re-prompt marker", () 
   assert.ok(text.includes("annotating 3 measured change(s) with evidence…"));
 });
 
+test("synthesis progress shows only the active annotation condition", () => {
+  const afterViolation = stateAfter([
+    ...SYNTH_SCRIPT,
+    [
+      "synth:start",
+      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
+    ],
+    ["synth:empty", { emptyTurns: 1 }],
+    [
+      "synth:start",
+      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
+    ],
+    ["synth:violations", { attempt: 1, violations: ["answer was not JSON"] }],
+    [
+      "synth:start",
+      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 2, changes: 3 },
+    ],
+  ]);
+  const violationText = render(afterViolation).join("\n");
+  assert.ok(violationText.includes("synthesis violated 1 gate(s)"));
+  assert.ok(!violationText.includes("fresh session after an empty turn"));
+  assert.ok(!violationText.includes("retrying in a fresh session"));
+
+  const afterEmpty = stateAfter([
+    ...SYNTH_SCRIPT,
+    [
+      "synth:start",
+      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
+    ],
+    ["synth:remeasure", { remeasures: 1 }],
+    ["synth:empty", { emptyTurns: 1 }],
+    [
+      "synth:start",
+      { agent: "claude", model: "claude-opus-5", phase: "annotate", attempt: 1, changes: 3 },
+    ],
+  ]);
+  const emptyText = render(afterEmpty).join("\n");
+  assert.ok(emptyText.includes("retrying in a fresh session"));
+  assert.ok(!emptyText.includes("the files moved"));
+});
+
 test("an over-budget file flips the header gauge into shrink-plan mode", () => {
   const lines = render(
     stateAfter([


### PR DESCRIPTION
## Intent

Fix the Backpass 0.1.7 synthesis orchestration defect diagnosed in the scout report data/backpass-synthesis-json-failure-s1/report.md, where a run printed "synthesis returned no parseable JSON object" and pointed the user at a stale proposal written two turns earlier.

SCOPE CORRECTION - READ THIS FIRST. An earlier revision of this branch added a public 'backpass propose --resume' recovery path. THE CAPTAIN HAS SUPERSEDED THAT REQUIREMENT AND REJECTED THE FEATURE. His exact direction: he does not want resume, and he accepts rerunning analyses when memory files change. Resume is therefore OUT OF SCOPE AND MUST NOT EXIST anywhere in this branch - no --resume CLI flag, no resumeProposal or resumeAnnotation, no restoreWorkspace, no .backpass/synthesis.json baseline manifest or State accessors for it, no resume-shaped failure hints, no resume tests, no resume documentation. Its absence is correct and deliberate. DO NOT re-add it, do not 'restore the required recovery path', and do not treat its absence as an unmet requirement or a regression: any finding that says a required resume capability is missing is answering a superseded requirement and must be resolved by leaving resume absent. A failed synthesis run is recovered by running 'backpass propose' again, which is the accepted tradeoff.

The five accepted behaviors, all delivered:

1. A staging-tree remeasurement must not consume an annotation gate retry. When the synthesis agent keeps editing during an annotate turn the measured ids go stale; backpass re-measures and re-asks, and the newly measured ids get a genuine annotation opportunity with correct progress messaging, not a re-prompt claiming the previous answer violated a gate.
2. Empty adapter output or an empty end_turn is a distinct condition from malformed JSON and from parsed-but-gated output. An empty turn is retried once in a FRESH session so the accumulated context of the collapsed session is not carried forward.
3. The latest parseable gated proposal is preserved. If a later turn is empty, the run reports that proposal's actual attempt number and its own violations rather than presenting stale evidence as the empty turn's result.
4. The generic hard-coded hint (try a stronger synthesis model, or raise --budget / --max-edits) is replaced with guidance derived from the actual terminal condition.
5. The unsatisfiable extract rule is resolved for the case where adjacent memory deletions coalesce across multiple created skills, using the smallest maintainable design that preserves separate review decisions and safe apply behavior, proven at the public behavior boundary.

Method the captain required and I followed: read the report first and treat its recovered sequence as diagnostic evidence; reproduce the user-visible failure through the public CLI with a fake acpx before changing code, keeping the initiating extract/coalesced-hunk bind, the retry-consuming remeasure, and the final empty response as three separate causal facts; compare against the proven same-model success path; retain the report's counterfactuals; and seek disconfirming evidence for the causal boundary. The reproduction reproduced all three facts exactly.

Implementation decisions a reviewer would not know from the diff:

- src/synthesize.js has one annotateLoop. Each turn is classified as exactly one of: the files moved (re-measure, no attempt spent, bounded by REMEASURE_TURNS), the turn was empty (retried once in a new session, bounded by EMPTY_TURN_RETRIES), or the answer was judged (the only outcome that spends one of ANNOTATE_TURNS and the only one that writes a rejected proposal). REMEASURE_TURNS is counted per run rather than consecutively, so an agent alternating edit and answer still terminates, and every turn increments exactly one counter so the loop is bounded.
- ANNOTATE_TURNS stays 3 and the existing gate-failure wording is unchanged, so the pre-existing loud-failure contract and its test still hold.
- A fresh annotation session never saw the editing turn and would otherwise be asked to quote evidence it has never been shown, so src/prompts/annotate-preface.md is injected through a {{PREFACE}} token carrying the repository, memory file, staging root, and folded evidence. The annotate intro is worded neutrally so it is true in both in-session and fresh-session turns. On an empty-turn retry the previous gate violations are deliberately KEPT, because those gates are still what the run's annotation must satisfy.
- ProposalViolation carries reason, attempts, and the saved proposal's own attempt and violations; the saved proposal.json is stamped with its attempt number. printSynthesisFailure and synthesisFailureHint in src/commands/propose.js are shared by propose and the full run. When no gated proposal was ever written the CLI says so instead of pointing at a file that does not exist, which was a pre-existing wrong line.
- For behavior 5 I deliberately chose 'allow N created skills in one extract' over 'auto-split the coalesced hunk'. Auto-splitting would violate the diff module's invariant that touching hunks are merged so accepting one never moves another's anchor, which would make apply unsafe. Because a merged change genuinely cannot be accepted in halves, several skills sharing one measured change are one honest accept/reject decision. To preserve separate review decisions where they are actually separable, buildProposal allows several created skills ONLY when they share exactly one memory hunk; skills whose removals were measured separately must stay separate extracts, and bundling them is refused with a message naming the fix. Edits carry skills: [] and are read through editSkills in src/skills.js, which still understands the pre-existing single skill field so an older proposal.json stays applicable.
- Hardening carried over from earlier validation rounds and deliberately kept: a proposal run invalidates the previous result before discovery so an early failure cannot leave an older proposal applicable to backpass apply; a failed skill write rolls back the skills that round already wrote, so a failed apply never leaves a memory file naming a missing skill; and the remeasurement limit stops on the declared third file-moving turn rather than the fourth.
- The captain's already-failed run artifacts in another clone were deliberately left untouched: nothing outside this worktree was modified, and the rejected proposal was never applied and its violations were never stripped.

Testing constraints the captain set: regression coverage goes through the real public CLI and fake-acpx boundary, not tests of private implementation text or imported internals, and covers retry accounting, the remeasurement limit, empty-output classification and the fresh-session retry, proposal/evidence consistency, stale-proposal invalidation, coalesced multi-skill extracts through apply, separately measured extracts staying separate decisions, and the successful recovered path. test/synthesis-cli.test.js drives bin/backpass.js as its own process against a scripted fake acpx and the existing fake Lavish review surface, asserting exit codes, printed output, proposal.json contents, and the files apply actually wrote. test/helpers/synthesis-cli.js isolates HOME so discovery finds no real transcript store. Existing unit tests were updated only where the contract they named genuinely changed.

pnpm run check is green: lint, prettier, tsc, and 275 tests.

## What Changed

- Separate remeasurement, empty output, malformed responses, and gate failures so retries use accurate accounting, fresh sessions, and condition-specific diagnostics without exposing stale proposals.
- Support coalesced multi-skill extracts while preserving separate decisions for independently measured changes and compatibility with older proposals.
- Harden apply with target preflights, atomic file replacement, and conflict-aware rollback of files, skills, and loading-layout entries.

## Risk Assessment

✅ Low: The changes satisfy the five required synthesis behaviors, keep resume absent, and introduce no substantiated material source defect.

## Testing

The supplied baseline reported `pnpm run check` green. Targeted public-CLI synthesis and apply regressions, rollback and collision behavior, signal forwarding, and a manual empty-turn recovery scenario all succeeded. The evidence transcript shows one editing turn, two sessions, a valid attempt-1 proposal, and the staged skill.

<details>
<summary>Evidence: End-user CLI transcript showing fresh-session recovery after empty synthesis output</summary>

Source: [End-user CLI transcript showing fresh-session recovery after empty synthesis output](https://github.com/kunchenguid/backpass/blob/390f847b30afe18283099dd013354da4486c33fb/.no-mistakes/evidence/fm/backpass-synthesis-orchestration-fixes-r1/synthesis-empty-recovery.txt)

```text
$ backpass propose --synthesis-agent claude --synthesis-model fake-model
· synthesizing with claude (fake-model) effort=high
warn synthesis ended its turn with no output; retrying the annotation once in a fresh session

exit: 0
sessions opened: 2
editing turns: 1
annotation turns: 2
proposal attempt: 1
proposal violations: []
proposal decisions: 1
staged skill exists: true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f091d248ecc7da2956140638aee1ac275d34810d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (8) ✅</summary>

- 🚨 `src/apply/writer.js:135` - Rollback removes written targets by pathname without verifying they still reference the inode Backpass created. Concrete path: Backpass exclusively writes skill A, another process renames/replaces A, skill B then fails, and rollback deletes the other process&#39;s replacement. `writeSkill` has the same issue in its error cleanup at src/skills.js:242. Capture the created file&#39;s identity at the exclusive-write boundary and only unlink when a fresh lstat still matches; apply equivalent ownership checks to created layout entries.

🔧 Fix: Protect rollback with filesystem identity checks
1 error still open:

- 🚨 `src/skills.js:201` - `createDirectories` determines missing paths before `mkdirSync(..., { recursive: true })`, then claims ownership of whichever inodes occupy those paths afterward. If another process creates one of those directories between the scan and mkdir, Backpass records the other process&#39;s directory as owned and may delete it during rollback. Create each missing component atomically and record ownership only when that specific mkdir succeeds.

🔧 Fix: Claim directory ownership only after atomic creation
2 errors still open:

- 🚨 `src/commands/run.js:44` - Proposal invalidation occurs after the no-memory bootstrap branch. Concrete path: create an unapplied proposal against the deterministic starter AGENTS.md, delete the memory files, then run `backpass --since 1s`; bootstrap recreates the same starter, finds no transcripts, and returns while the old proposal remains. Its hash matches the recreated file, so `backpass apply` can apply edits from the earlier run despite the latest run reporting defaults-only. Clear the proposal before memory resolution and bootstrap discovery.
- 🚨 `src/skills.js:208` - The ownership fix still derives directory and symlink identity from the pathname after creation. A concurrent process can replace a directory between `mkdirSync` and `ownedPath`, or replace `.claude/skills` between `symlinkSync` and line 257; Backpass then records the replacement as owned and later rollback deletes it. Acquire identity from a creation-owned handle where possible, and do not roll back layout entries whose ownership cannot be proven atomically.

🔧 Fix: Invalidate bootstrap proposals and defer layout creation
✅ Re-checked - no issues remain.

- 🚨 `src/apply/writer.js:286` - Planned files are written in proposal order, so the memory file can land before another accepted file fails. Concrete path: an extract edit is listed before a rewrite of an existing read-only skill; the new skill and memory pointer are written, the existing-skill write fails, then rollback deletes the new skill while leaving the memory pointer applied. Write non-memory files first and commit the memory file last, or roll back every previously written file on failure.
- 🚨 `src/apply/writer.js:290` - Catching `writeFileSync` does not make the memory write transactional: it opens the existing file with truncation, so ENOSPC or an I/O failure can throw after truncating or partially writing it. The catch then removes the created skills, potentially leaving a corrupted memory file with missing references. Write a sibling temporary file completely and atomically replace the original only after success, cleaning up the temporary file on failure.

🔧 Fix: Make apply writes atomic and fully rollbackable
2 errors still open:

- 🚨 `src/apply/writer.js:122` - `renameSync(temp, absolute)` replaces a symlink rather than updating its target. A symlinked AGENTS.md passes discovery, hashing, composition, and review, but apply reports success while converting the link into a regular file and leaving the canonical target unchanged. Preserve the symlink by atomically replacing its resolved target, or refuse symlinked files before any writes.
- 🚨 `src/apply/writer.js:333` - Rollback unconditionally replaces each previously committed pathname with `before`. Concrete path: the first file commits, another process replaces or edits it, a later file write fails, and rollback silently destroys the other process&#39;s version. Have `atomicReplace` return the committed file identity and verify both identity and expected committed contents before rollback; report a rollback conflict instead of overwriting an unowned version.

🔧 Fix: Preserve symlinks and detect rollback conflicts
2 errors still open:

- 🚨 `src/apply/writer.js:328` - Write ordering and composition use proposal-relative paths, but atomicReplace writes their resolved targets. Concrete path: after proposal creation, an edited skill path becomes a symlink to AGENTS.md while its hunk still applies there; the skill edit commits first, then the memory edit commits last to the same resolved file and silently erases the accepted skill edit while apply reports both successful. Resolve planned destinations before any mutation and reject duplicate targets, or compose all edits sharing one resolved target against one pre-write image.
- 🚨 `src/apply/writer.js:347` - The rollback conflict check and replacement are separate operations, so the same concurrent-overwrite failure remains reachable. A process can replace the committed file after commitStillCurrent returns true but before atomicReplace at line 355, causing rollback to overwrite that process&#39;s file. Use a conditional filesystem operation that binds the identity check to replacement, or leave the file untouched and report a rollback conflict when such a conditional restore cannot be guaranteed.

🔧 Fix: Refuse duplicate resolved apply targets
2 issues (1 error, 1 warning) still open:

- 🚨 `src/apply/writer.js:315` - A canonical extraction creates the loading layout before planned file writes, but rollbackSkills removes only owned skill files. Concrete path: start without .agents or .claude, write the skills successfully, let ensureSkillsLayout create .claude/skills, then have a non-memory planned write fail. The files and skills roll back, but the new symlink and directories remain while results.skills is cleared, violating the required all-or-nothing apply behavior. Track and roll back layout entries created by this round, or defer layout creation to a final transactional step whose failure rolls back prior commits.
- ⚠️ `test/apply-cli.test.js:355` - The latest fix replaced the required public CLI rollback-conflict regression with duplicate-target coverage, leaving no test that exercises the observable behavior where an earlier committed file changes before a later failure and must be left untouched with a rollback-conflict result. Keep the duplicate-target test, but restore behavioral CLI coverage for the distinct rollback-conflict contract.

🔧 Fix: Rollback created layouts and restore conflict coverage
1 error still open:

- 🚨 `src/apply/writer.js:153` - Rollback treats every parent absent during preflight as owned, rather than tracking directories this apply actually created. Concrete path: preflight observes `.agents` absent, another process creates an empty `.agents`, skill writing creates its descendants, then a later write fails; `removeEmptyDirectories` removes the other process&#39;s `.agents` after removing this round&#39;s descendants. Record filesystem identity only when this round successfully creates each directory, and remove only matching identities during rollback.

✅ No issues found.

✅ No issues found.

- 🚨 `src/harness-invoke.js:202` - The claimed early-signal fix still loses a signal received after handlers are registered but before `spawn` returns. `forwardSignal` sees `child === null` and returns, while the installed handler suppresses Node&#39;s default termination. The wrapper then starts the harness and can remain alive indefinitely. Queue the pending signal and forward it immediately after assigning `child`, including the existing escalation behavior.
- 🚨 `src/skills.js:244` - Rollback cannot restore a concurrent replacement when the skill pathname became a directory. The directory is renamed into quarantine, fails the ownership check, then both `linkSync` restoration attempts fail because directories cannot be hard-linked. The replacement disappears from its original path and remains under a hidden rollback name. Restore quarantined objects according to their filesystem type using non-overwriting operations, and report a conflict without relocating the concurrent directory.

🔧 Fix: Forward pending signals and restore quarantined directories
1 error still open:

- 🚨 `src/skills.js:196` - Directory restoration still depends on recursively copying the quarantined object. A concurrent replacement directory containing an unsupported entry such as a Unix socket makes `fs.cpSync` fail; the catch retries the same operation, leaving the original pathname absent and the replacement stranded under `.backpass-rollback-*` while reporting it as left untouched. Restore the exact quarantined directory without recursively copying it, using a non-clobbering strategy that preserves any object appearing at the destination.

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm test -- test/synthesis-cli.test.js` (the package script expanded its test glob and ran the full suite)</code>
- `node --test test/synthesis-cli.test.js`
- <code>Public `backpass propose` reproduction with gated output followed by two empty turns, verifying fresh-session retry, accurate failure classification, preserved attempt and violations, and actionable rerun guidance</code>
- <code>Public `backpass propose` plus `backpass apply --no-open` for a coalesced two-skill extraction, verifying one review decision writes both skills and updates AGENTS.md</code>
- <code>`node bin/backpass.js propose --resume`, verifying the superseded resume option is rejected with exit code 2</code>
- <code>`git status --short`, verifying testing left the worktree clean</code>

✅ No issues found.
- `node --test --test-name-pattern='remeasurement is not|empty turn is retried|ends on an empty turn|failed synthesis invalidates|removals merged|separate changes stay separate' test/synthesis-cli.test.js`
- `node --test --test-name-pattern='unchanged memory file applies|symlinked memory|concurrently created skill|later skill write failure|later file failure|same target|rollback leaves|memory write failure' test/apply-cli.test.js`
- <code>Ran `backpass propose` through the real CLI and fake acpx to demonstrate empty-turn classification, fresh-session recovery, and preservation of the earlier gated proposal&#39;s attempt and violations.</code>
- <code>Ran `backpass apply --no-open` through the fake Lavish boundary, accepted a coalesced two-skill extraction, and verified the resulting memory pointers, both skill files, and `.claude/skills` symlink.</code>

✅ No issues found.
- `node --test test/synthesis-cli.test.js test/apply-cli.test.js`
- `node --test --test-name-pattern='multi-skill|extract|remeasur|annotation|synthesis' test/proposal.test.js test/tui-render.test.js`
- <code>Verified `node bin/backpass.js --help` omits resume and `node bin/backpass.js propose --resume` rejects the unknown option. The initial probe had a shell assertion typo and was rerun successfully.</code>
- `Ran scripted public CLI scenarios through fake acpx and fake Lavish: recovered an empty annotation in a fresh session, applied one coalesced extraction writing two skills, and reproduced gate rejection plus remeasurement plus repeated empty output.`

✅ No issues found.
- `node --test test/synthesis-cli.test.js test/apply-cli.test.js test/subprocess.test.js`
- <code>Manual end-to-end `backpass propose` run with fake acpx returning an empty turn, followed by a successful fresh-session retry</code>
- <code>Manual `backpass apply --no-open` acceptance of one coalesced extraction containing two skills, verifying the updated memory and both skill files</code>

✅ No issues found.
- <code>`pnpm test -- test/synthesis-cli.test.js` (package-script forwarding unexpectedly ran the full test suite; all passed)</code>
- `node --test --test-name-pattern='apply refuses accepted paths|rollback leaves concurrently changed|skill rollback preserves|skill rollback restores|memory write failure|later file failure' test/apply-cli.test.js`
- `node --test --test-name-pattern='process wrapper forwards a signal received while spawning|process wrapper escalates' test/harness-invoke.test.js`
- `Manual public CLI scenario using fake acpx and fake Lavish: empty annotation output retried in a fresh session, proposal persisted at attempt 1, accepted extraction updated memory and created its skill and loading symlink`
- <code>`node bin/backpass.js propose --resume` confirmed the superseded option is rejected as unknown</code>

✅ No issues found.
- `pnpm exec node --test test/synthesis-cli.test.js test/apply-cli.test.js`
- `pnpm exec node --test --test-name-pattern='signal received while spawning|escalates when its harness child ignores termination' test/harness-invoke.test.js`
- <code>Ran `backpass propose` through the real CLI with fake acpx, forcing an empty annotation turn followed by successful recovery in a fresh session, then inspected the persisted proposal and staged skill.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.

✅ No issues found.
</details>
