### PR TITLE
fix: scope evidence reuse to the current memory hash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,18 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `{ agent, usage|null }` (`usageRecord` in `src/acpx.js`) and `src/commands/usage.js` is
   the one place that prints them - never `n/a`: nothing when no call ran, the harness by
   name when it stayed silent.
+- **Fold and this-run gap-ledger ingest are scoped to the current memory-set hash.**
+  `foldForRun` (`src/commands/propose.js`) filters `state.listEvidence()` by `memoryPath`
+  AND `memoryHash === current set hash`, not path alone - a transcript that fell out of
+  this run's sample (window, cap, or the transcript itself gone) can leave an evidence file
+  on disk stamped with a stale hash, and it must not count toward `analyzedSessions`,
+  per-instruction scores, or this run's gap-ledger observations (positional `AG-nnn`
+  aliases can point at a different unit once the file changes). Nothing is migrated or
+  deleted: the file stays valid and reusable once its transcript is reanalyzed, or
+  immediately if the memory bytes return to that hash. `analyzeTranscripts` separately
+  reports `summary.staleMemoryHash` and names the old/new hash on stderr, so a full
+  reanalysis without `--force` after a memory edit reads as "the file changed," not as a
+  broken cache - the cache-hit path itself (unchanged file, no `--force`) is unaffected.
 - **Gap corroboration is counted across runs through `.backpass/gap-ledger.json`**
   (`src/gap-ledger.js`, wired in `foldForRun`): one sighting per (gap, transcript id), so a
   session never counts twice and a gap seen once per run still graduates at `minGapEvidence`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,11 +118,12 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   this run's sample (window, cap, or the transcript itself gone) can leave an evidence file
   on disk stamped with a stale hash, and it must not count toward `analyzedSessions`,
   per-instruction scores, or this run's gap-ledger observations (positional `AG-nnn`
-  aliases can point at a different unit once the file changes). Nothing is migrated or
-  deleted: the file stays valid and reusable once its transcript is reanalyzed, or
-  immediately if the memory bytes return to that hash. `analyzeTranscripts` separately
-  reports `summary.staleMemoryHash` and names the old/new hash on stderr, so a full
-  reanalysis without `--force` after a memory edit reads as "the file changed," not as a
+  aliases can point at a different unit once the file changes). Folding does not migrate,
+  rewrite, or delete stale evidence; an untouched evidence file becomes eligible again if
+  the memory bytes return to its hash, while reanalysis replaces it with current evidence.
+  `analyzeTranscripts` separately reports `summary.staleMemoryHash` and names the old/new
+  hash on stderr, so a full reanalysis without `--force` after a memory edit reads as "the
+  file changed," not as a
   broken cache - the cache-hit path itself (unchanged file, no `--force`) is unaffected.
 - **Gap corroboration is counted across runs through `.backpass/gap-ledger.json`**
   (`src/gap-ledger.js`, wired in `foldForRun`): one sighting per (gap, transcript id), so a

--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ instruction covers.
 most important defence against a model confabulating influence. Negative evidence (a
 visible violation) is weighted highest.
 
-Results are cached per transcript, keyed to both the transcript's content _and_ the memory
-file's hash: edit the weights and the evidence correctly re-computes; change nothing and
-the next run is free. A memory-file edit therefore reanalyzes without `--force` - that is
+Results are cached per transcript, keyed to both the transcript's content _and_ the effective
+memory-file set hash: edit the weights and the evidence correctly re-computes; change nothing
+and the next run is free. A memory-file edit therefore reanalyzes without `--force` - that is
 not a cache miss, it is the cache doing its job - and the run says so on stderr, naming the
 old and new hash, so a "0 reused" line reads as "the file changed" rather than "reuse is
-broken." The old evidence is not lost: it stays on disk and counts again automatically,
-either once its transcript is reanalyzed against the current file or if the file's bytes
-ever go back to that hash.
+broken." Evidence files that are not refreshed remain on disk but are excluded while their
+hash is stale. They become eligible again if the memory-file set returns to that hash;
+evidence for transcripts included in the new analysis is replaced with fresh judgments.
 
 ### 4. Aggregate gradients - deterministic, no model
 
@@ -164,11 +164,12 @@ Evidence is grouped by instruction, giving each one a positive/negative count an
 gaps across sessions are clustered, and clusters seen in fewer than `minGapEvidence`
 sessions (default 2) are dropped. One bad session never rewrites the weights.
 
-Only evidence judged against the _current_ memory-file hash is folded into a proposal. A
+Only evidence judged against the _current_ memory-file set hash is folded into a proposal. A
 transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the
 transcript itself being gone - can leave an older evidence file on disk under a hash the
-memory file no longer has; that file is left untouched, but it does not count toward this
-run's session total or instruction scores until it is current again.
+memory-file set no longer has; that file is left untouched, but it does not count toward this
+run's session total or instruction scores, or add a gap observation, until it is current
+again.
 
 Those sessions are counted across runs, not per run: every gap sighting is kept in
 `.backpass/gap-ledger.json` by gap and session, so a gap seen in one session today and in
@@ -290,8 +291,8 @@ that version. If it was removed or changed since - you pulled, edited it by hand
 agent did - the edits no longer describe what is on disk, so nothing is written and you are
 told to run `backpass` again to re-propose against the current file. That rerun reanalyzes
 transcripts against the file that exists now; it does not reuse the stale judgments behind
-the refused proposal. Within a run every file
-is composed from one version: it takes every accepted edit or none of them. Apply also
+the refused proposal. Within a run every file is composed from one version: it takes every
+accepted edit or none of them. Apply also
 refuses the whole write if any created skill target already exists or two accepted paths
 resolve to the same file.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,12 @@ visible violation) is weighted highest.
 
 Results are cached per transcript, keyed to both the transcript's content _and_ the memory
 file's hash: edit the weights and the evidence correctly re-computes; change nothing and
-the next run is free.
+the next run is free. A memory-file edit therefore reanalyzes without `--force` - that is
+not a cache miss, it is the cache doing its job - and the run says so on stderr, naming the
+old and new hash, so a "0 reused" line reads as "the file changed" rather than "reuse is
+broken." The old evidence is not lost: it stays on disk and counts again automatically,
+either once its transcript is reanalyzed against the current file or if the file's bytes
+ever go back to that hash.
 
 ### 4. Aggregate gradients - deterministic, no model
 
@@ -158,6 +163,12 @@ Evidence is grouped by instruction, giving each one a positive/negative count an
 **relevance** figure: the share of analyzed sessions in which it mattered at all. Duplicate
 gaps across sessions are clustered, and clusters seen in fewer than `minGapEvidence`
 sessions (default 2) are dropped. One bad session never rewrites the weights.
+
+Only evidence judged against the _current_ memory-file hash is folded into a proposal. A
+transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the
+transcript itself being gone - can leave an older evidence file on disk under a hash the
+memory file no longer has; that file is left untouched, but it does not count toward this
+run's session total or instruction scores until it is current again.
 
 Those sessions are counted across runs, not per run: every gap sighting is kept in
 `.backpass/gap-ledger.json` by gap and session, so a gap seen in one session today and in
@@ -277,7 +288,9 @@ Apply preflights every accepted edit before writing. The proposal was measured a
 exact version of your memory file, so apply first checks the file still exists and is still
 that version. If it was removed or changed since - you pulled, edited it by hand, or another
 agent did - the edits no longer describe what is on disk, so nothing is written and you are
-told to run `backpass` again to re-propose against the current file. Within a run every file
+told to run `backpass` again to re-propose against the current file. That rerun reanalyzes
+transcripts against the file that exists now; it does not reuse the stale judgments behind
+the refused proposal. Within a run every file
 is composed from one version: it takes every accepted edit or none of them. Apply also
 refuses the whole write if any created skill target already exists or two accepted paths
 resolve to the same file.

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -185,7 +185,16 @@ async function pool(items, limit, worker) {
 export async function analyzeTranscripts({ transcripts, memoryFile, config, repo, memoryHash, force = false }) {
   const state = config.state;
   const pending = [];
-  const summary = { total: transcripts.length, cached: 0, analyzed: 0, skipped: 0, failed: 0, usage: [] };
+  const summary = {
+    total: transcripts.length,
+    cached: 0,
+    analyzed: 0,
+    skipped: 0,
+    failed: 0,
+    usage: [],
+    staleMemoryHash: 0,
+  };
+  const priorHashes = new Set();
 
   for (const transcript of transcripts) {
     const existing = state.readEvidence(transcript.id);
@@ -193,7 +202,21 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
       summary.cached += 1;
       continue;
     }
+    // Distinguish "no prior evidence" from "prior evidence exists, but it was judged
+    // against a memory file that no longer matches" - a re-analysis here, not a miss.
+    if (existing?.status === "ok" && existing.memoryHash && existing.memoryHash !== memoryHash) {
+      summary.staleMemoryHash += 1;
+      priorHashes.add(existing.memoryHash);
+    }
     pending.push(transcript);
+  }
+
+  if (summary.staleMemoryHash) {
+    info(
+      `${color.yellow("·")} ${summary.staleMemoryHash} transcript(s) have evidence from a previous ` +
+        `${memoryFile.path} (${[...priorHashes].join(", ")} -> ${memoryHash}); that evidence is stale, not ` +
+        `missing, and reuse resumes once this pass re-judges it against the current file`,
+    );
   }
 
   if (!pending.length) {

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -203,7 +203,7 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
       continue;
     }
     // Distinguish "no prior evidence" from "prior evidence exists, but it was judged
-    // against a memory file that no longer matches" - a re-analysis here, not a miss.
+    // against a memory-file set that no longer matches" - a re-analysis here, not a miss.
     if (existing?.status === "ok" && existing.memoryHash && existing.memoryHash !== memoryHash) {
       summary.staleMemoryHash += 1;
       priorHashes.add(existing.memoryHash);
@@ -214,8 +214,8 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
   if (summary.staleMemoryHash) {
     info(
       `${color.yellow("·")} ${summary.staleMemoryHash} transcript(s) have evidence from a previous ` +
-        `${memoryFile.path} (${[...priorHashes].join(", ")} -> ${memoryHash}); that evidence is stale, not ` +
-        `missing, and reuse resumes once this pass re-judges it against the current file`,
+        `memory-file set (${[...priorHashes].join(", ")} -> ${memoryHash}); that evidence is stale, not ` +
+        `missing, and reuse resumes once this pass re-judges it against the current memory-file set`,
     );
   }
 

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -76,7 +76,8 @@ function memoryFileSnapshot(proposal, repo) {
         file: relative,
         error:
           `${relative} no longer exists, so its edits no longer describe the file on disk; nothing was written. ` +
-          `Run \`backpass\` to re-propose against the current repository.`,
+          `Run \`backpass\` to re-propose against the current repository - that pass reanalyzes transcripts ` +
+          `against the file that exists now, it does not reuse the judgments behind this proposal.`,
       },
     };
   }
@@ -94,7 +95,8 @@ function memoryFileSnapshot(proposal, repo) {
       error:
         `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
         `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
-        `against the current ${relative}.`,
+        `against the current ${relative} - that pass reanalyzes transcripts against the new file, it does ` +
+        `not reuse the stale judgments behind this proposal.`,
     },
   };
 }

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -1,7 +1,7 @@
 import { analyzeTranscripts } from "../analyze.js";
 import { applyDecisions, writeBootstrapFiles } from "../apply/writer.js";
 import { bootstrapTargets, renderPointer, starterMemoryFile } from "../bootstrap.js";
-import { color, info, json, out, warn } from "../logger.js";
+import { UserError, color, info, json, out, warn } from "../logger.js";
 import { resolveMemoryFiles } from "../memory.js";
 import { emitProgress } from "../progress.js";
 import { ProposalViolation } from "../proposal.js";
@@ -53,15 +53,25 @@ export async function bootstrapRun(ctx, deps = {}) {
   const seed = [{ path: canonical, text: starter.text }];
   if (pointer) seed.push({ path: pointer, text: renderPointer(canonical) });
   const seeded = writeBootstrapFiles(repo.root, seed);
-  const memoryHash = resolveMemoryFiles(repo.root, config.memoryFiles).hash;
+  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles);
   for (const w of seeded.written) info(`${color.green("·")} wrote ${w.file}`);
   for (const s of seeded.skipped) warn(`${s.file} ${s.reason} - left untouched`);
 
+  const canonicalSkipped = seeded.skipped.some((entry) => entry.file === canonical);
+  if (canonicalSkipped || resolved.primary?.path !== starter.path || resolved.primary?.text !== starter.text) {
+    throw new UserError(
+      `${canonical} changed while backpass was bootstrapping it`,
+      "run `backpass` again to analyze the memory file that now exists",
+    );
+  }
+  const memoryFile = resolved.primary;
+  const memoryHash = resolved.hash;
+
   emitProgress("memory", {
-    path: starter.path,
-    tokens: starter.tokens,
+    path: memoryFile.path,
+    tokens: memoryFile.tokens,
     budget: config.budgetTokens,
-    units: starter.units.length,
+    units: memoryFile.units.length,
   });
 
   const result = {
@@ -80,7 +90,7 @@ export async function bootstrapRun(ctx, deps = {}) {
 
   result.summary = await analyze({
     transcripts,
-    memoryFile: starter,
+    memoryFile,
     config,
     repo,
     memoryHash,
@@ -91,7 +101,7 @@ export async function bootstrapRun(ctx, deps = {}) {
       `${result.summary.skipped} too short · ${result.summary.failed} failed`,
   );
 
-  const folded = await foldForRun(ctx, starter, memoryHash);
+  const folded = await foldForRun(ctx, memoryFile, memoryHash);
   config.state.writeSummary(folded);
   emitProgress("fold:done", {
     instructions: folded.instructions.length,
@@ -104,7 +114,7 @@ export async function bootstrapRun(ctx, deps = {}) {
 
   try {
     const { proposal } = await synthesize({
-      memoryFile: starter,
+      memoryFile,
       summary: folded,
       config,
       repo,

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -89,7 +89,7 @@ export async function bootstrapRun(ctx, deps = {}) {
       `${result.summary.skipped} too short · ${result.summary.failed} failed`,
   );
 
-  const folded = await foldForRun(ctx, starter);
+  const folded = await foldForRun(ctx, starter, starter.hash);
   config.state.writeSummary(folded);
   emitProgress("fold:done", {
     instructions: folded.instructions.length,

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -2,6 +2,7 @@ import { analyzeTranscripts } from "../analyze.js";
 import { applyDecisions, writeBootstrapFiles } from "../apply/writer.js";
 import { bootstrapTargets, renderPointer, starterMemoryFile } from "../bootstrap.js";
 import { color, info, json, out, warn } from "../logger.js";
+import { resolveMemoryFiles } from "../memory.js";
 import { emitProgress } from "../progress.js";
 import { ProposalViolation } from "../proposal.js";
 import { synthesizeProposal } from "../synthesize.js";
@@ -52,6 +53,7 @@ export async function bootstrapRun(ctx, deps = {}) {
   const seed = [{ path: canonical, text: starter.text }];
   if (pointer) seed.push({ path: pointer, text: renderPointer(canonical) });
   const seeded = writeBootstrapFiles(repo.root, seed);
+  const memoryHash = resolveMemoryFiles(repo.root, config.memoryFiles).hash;
   for (const w of seeded.written) info(`${color.green("·")} wrote ${w.file}`);
   for (const s of seeded.skipped) warn(`${s.file} ${s.reason} - left untouched`);
 
@@ -81,7 +83,7 @@ export async function bootstrapRun(ctx, deps = {}) {
     memoryFile: starter,
     config,
     repo,
-    memoryHash: starter.hash,
+    memoryHash,
     force: Boolean(ctx.flags.force),
   });
   info(
@@ -89,7 +91,7 @@ export async function bootstrapRun(ctx, deps = {}) {
       `${result.summary.skipped} too short · ${result.summary.failed} failed`,
   );
 
-  const folded = await foldForRun(ctx, starter, starter.hash);
+  const folded = await foldForRun(ctx, starter, memoryHash);
   config.state.writeSummary(folded);
   emitProgress("fold:done", {
     instructions: folded.instructions.length,

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -15,11 +15,21 @@ import { discoverForRun } from "./scan.js";
  * prune what the current file now covers or what aged out (after recording, because the
  * evidence files that fed an expired sighting are still on disk and would re-add it),
  * then cluster from the ledger.
+ *
+ * Evidence is also filtered to `memoryHash`: a transcript's evidence file is rewritten
+ * every time it is re-analyzed against a changed memory file, but a transcript that fell
+ * out of this run's sample (window, cap, or discovery drift) leaves its last evidence file
+ * on disk under whatever hash it was last judged against. That leftover file is real and
+ * reusable the moment its transcript is re-analyzed - or immediately, if the memory file's
+ * bytes return to that hash - but folding it into *this* proposal would score it against
+ * an instruction index it was never judged against (aliases are positional) and inflate
+ * `analyzedSessions` with a session this run never touched. Nothing is migrated, rewritten,
+ * or deleted here - only excluded from this run's fold.
  */
-export async function foldForRun(ctx, memoryFile) {
+export async function foldForRun(ctx, memoryFile, memoryHash) {
   const { state, minGapEvidence, gapLedgerMaxAge } = ctx.config;
   const evidence = state.listEvidence();
-  const relevant = evidence.filter((e) => e.memoryPath === memoryFile.path);
+  const relevant = evidence.filter((e) => e.memoryPath === memoryFile.path && e.memoryHash === memoryHash);
 
   const ledger = state.readGapLedger();
   recordGapObservations(ledger, relevant);
@@ -39,11 +49,11 @@ export async function runProposal(ctx, precomputed = null) {
   // folding, and agent resolution can all fail before synthesis starts; none of those
   // failures may leave an older proposal available to apply as if it came from this run.
   config.state.clearProposal();
-  const { file } = precomputed || primaryMemoryFile(repo, config);
+  const { file, hash } = precomputed || primaryMemoryFile(repo, config);
   const transcripts = precomputed?.transcripts || (await discoverForRun(ctx)).transcripts;
 
   const foldStarted = Date.now();
-  const summary = await foldForRun(ctx, file);
+  const summary = await foldForRun(ctx, file, hash);
   config.state.writeSummary(summary);
   emitProgress("fold:done", {
     instructions: summary.instructions.length,

--- a/test/analyze-reuse.test.js
+++ b/test/analyze-reuse.test.js
@@ -217,5 +217,16 @@ test("old-hash leftover evidence cannot change the current fold's session count,
       ["pi-session-a"],
       "only the current-hash session is recorded into the ledger this run",
     );
+
+    fs.writeFileSync(path.join(dir, "AGENTS.md"), MEMORY);
+    const reverted = resolveMemoryFiles(dir, ["AGENTS.md", "CLAUDE.md"]);
+    return foldForRun(ctx, reverted.primary, reverted.hash).then((revertedSummary) => {
+      assert.equal(
+        revertedSummary.analyzedSessions,
+        1,
+        "the untouched session B evidence becomes reusable when its original memory bytes are current again",
+      );
+      assert.equal(revertedSummary.instructions.find((i) => i.instruction === "AG-001").positive, 1);
+    });
   });
 });

--- a/test/analyze-reuse.test.js
+++ b/test/analyze-reuse.test.js
@@ -1,0 +1,221 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { State } from "../src/state.js";
+import { resolveMemoryFiles } from "../src/memory.js";
+import { foldForRun } from "../src/commands/propose.js";
+
+/**
+ * The reuse-miss incident, through the public CLI (design section on evidence keys,
+ * `src/state.js` `evidenceKey`/`isEvidenceFresh`, `src/commands/propose.js` `foldForRun`).
+ *
+ * A memory-hash change is supposed to invalidate cached evidence - that part always
+ * worked. Two things did not: the CLI gave no reason a full reanalysis happened without
+ * `--force` (silent invalidation), and `foldForRun` picked up every evidence file for the
+ * memory path regardless of which memory-file hash it was judged against, so a session
+ * that fell out of the current sample (window, cap, or a since-removed transcript) still
+ * counted in the fold under a stale hash (fold contamination). This file drives the real
+ * CLI against a fake acpx, then reads the same `.backpass/` state files a user or `backpass
+ * status` would.
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CLI = path.join(ROOT, "bin", "backpass.js");
+
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-bin-"));
+const fakePi = path.join(binDir, "pi");
+const fakeAcpx = path.join(binDir, "acpx");
+
+fs.writeFileSync(fakePi, `#!${process.execPath}\nprocess.exit(0);\n`);
+fs.chmodSync(fakePi, 0o755);
+
+// One canned analysis answer for every `--file` call: a positive hit on AG-001 and one
+// gap proposal, regardless of which transcript or memory hash asked for it. Good enough
+// to see whether fold and the gap ledger scope evidence to the current hash.
+fs.writeFileSync(
+  fakeAcpx,
+  `#!${process.execPath}
+const argv = process.argv.slice(2);
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write(JSON.stringify({ agents: {} }) + "\\n");
+  process.exit(0);
+}
+if (argv.includes("--file")) {
+  process.stdout.write(JSON.stringify({
+    positive: [{ instruction: "AG-001", moment: "start", effect: "followed it", quote: "followed the build rule exactly as written" }],
+    negative: [],
+    gaps: [{ mistake: "skipped lint", proposedInstruction: "Always run lint before pushing.", recurrenceRisk: "high", quote: "skipped lint entirely this time" }],
+  }) + "\\n");
+  process.exit(0);
+}
+process.exit(0);
+`,
+);
+fs.chmodSync(fakeAcpx, 0o755);
+
+function git(args, cwd) {
+  spawnSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function initRepo(memory) {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-repo-")));
+  git(["init", "--quiet", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  fs.writeFileSync(path.join(dir, "AGENTS.md"), memory);
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "-m", "memory"], dir);
+  return dir;
+}
+
+/** A minimal Pi session, non-trivial enough to clear the triviality filter. */
+function writeSession(home, id, cwd) {
+  const dir = path.join(home, ".pi", "agent", "sessions", id);
+  fs.mkdirSync(dir, { recursive: true });
+  const entries = [
+    { type: "session", version: 3, id, timestamp: new Date().toISOString(), cwd },
+    { type: "message", message: { role: "user", content: "Please build the project." } },
+    { type: "message", message: { role: "assistant", content: "Ran make build as instructed." } },
+    { type: "message", message: { role: "user", content: "Now run the tests too." } },
+    { type: "message", message: { role: "assistant", content: "Tests pass." } },
+  ];
+  const file = path.join(dir, `${Date.now()}_${id}.jsonl`);
+  fs.writeFileSync(file, `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`);
+  return file;
+}
+
+const ANALYZE_ARGS = [
+  "analyze",
+  "--harness",
+  "pi",
+  "--since",
+  "all",
+  "--analysis-agent",
+  "pi",
+  "--jobs",
+  "1",
+  "--json",
+];
+
+function runAnalyze(dir, home, extraArgs = []) {
+  const result = spawnSync(process.execPath, [CLI, ...ANALYZE_ARGS, ...extraArgs], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      BACKPASS_ACPX_BIN: fakeAcpx,
+      NO_COLOR: "1",
+    },
+    encoding: "utf8",
+    timeout: 20000,
+  });
+  return { ...result, output: `${result.stdout}${result.stderr}`, summary: JSON.parse(result.stdout).summary };
+}
+
+const MEMORY = "# Agent instructions\n\n- Run `make build` before every push.\n";
+const MEMORY_EDITED = "# Agent instructions\n\n- Run `make build` before every push.\n- Never skip the changelog.\n";
+
+test("the first analysis performs work, an unchanged second reuses it, and --force reanalyzes anyway", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-home-"));
+  const dir = initRepo(MEMORY);
+  writeSession(home, "session-a", dir);
+
+  const first = runAnalyze(dir, home);
+  assert.equal(first.status, 0, first.output);
+  assert.deepEqual([first.summary.analyzed, first.summary.cached], [1, 0], "the first pass has no cache to hit");
+
+  const second = runAnalyze(dir, home);
+  assert.equal(second.status, 0, second.output);
+  assert.deepEqual(
+    [second.summary.analyzed, second.summary.cached],
+    [0, 1],
+    "an unchanged memory file is a free rerun",
+  );
+  assert.equal(second.summary.staleMemoryHash, 0, "nothing is stale when the memory file did not change");
+
+  const forced = runAnalyze(dir, home, ["--force"]);
+  assert.equal(forced.status, 0, forced.output);
+  assert.deepEqual(
+    [forced.summary.analyzed, forced.summary.cached],
+    [1, 0],
+    "--force reanalyzes even evidence that would otherwise still be fresh",
+  );
+});
+
+test("editing AGENTS.md without --force reanalyzes and explains that prior evidence is stale, not missing", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-home-"));
+  const dir = initRepo(MEMORY);
+  writeSession(home, "session-a", dir);
+
+  runAnalyze(dir, home); // seed one fresh evidence file
+
+  fs.writeFileSync(path.join(dir, "AGENTS.md"), MEMORY_EDITED);
+  const third = runAnalyze(dir, home);
+  assert.equal(third.status, 0, third.output);
+  assert.deepEqual(
+    [third.summary.analyzed, third.summary.cached],
+    [1, 0],
+    "a memory-file edit invalidates the cache, exactly as documented",
+  );
+  assert.equal(third.summary.staleMemoryHash, 1, "the invalidation is attributed to the hash change, not a plain miss");
+  assert.match(third.stderr, /evidence from a previous AGENTS\.md/);
+  assert.match(third.stderr, /stale, not missing/);
+  assert.match(third.stderr, /sha256:\w+ -> sha256:\w+/, "names the old and new hash");
+});
+
+test("old-hash leftover evidence cannot change the current fold's session count, instruction scores, or gap observations", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-home-"));
+  const dir = initRepo(MEMORY);
+  const fileA = writeSession(home, "session-a", dir);
+  const fileB = writeSession(home, "session-b", dir);
+
+  const both = runAnalyze(dir, home);
+  assert.equal(both.status, 0, both.output);
+  assert.equal(both.summary.analyzed, 2, "both sessions are analyzed under the first hash");
+  void fileA;
+
+  // Session B falls out of this run's sample (window, cap, or - as here - the transcript
+  // itself is gone) while its evidence file, still stamped with the old hash, stays on
+  // disk. The memory file also changes, so session A's evidence goes stale too.
+  fs.renameSync(fileB, `${fileB}.bak`);
+  fs.writeFileSync(path.join(dir, "AGENTS.md"), MEMORY_EDITED);
+
+  const onlyA = runAnalyze(dir, home);
+  assert.equal(onlyA.status, 0, onlyA.output);
+  assert.equal(onlyA.summary.total, 1, "session B is no longer discovered at all");
+  assert.deepEqual([onlyA.summary.analyzed, onlyA.summary.cached], [1, 0]);
+
+  // Fold this run's evidence the way `backpass propose` does - same exported function,
+  // reading the same evidence directory the CLI run above just wrote to.
+  const state = new State(dir).ensure();
+  const resolved = resolveMemoryFiles(dir, ["AGENTS.md", "CLAUDE.md"]);
+  const ctx = { config: { state, minGapEvidence: 2, gapLedgerMaxAge: "90d" } };
+
+  return foldForRun(ctx, resolved.primary, resolved.hash).then((summary) => {
+    assert.equal(summary.analyzedSessions, 1, "session B's leftover evidence must not inflate the session count");
+
+    const ag001 = summary.instructions.find((i) => i.instruction === "AG-001");
+    assert.equal(ag001.positive, 1, "only session A's positive evidence is scored");
+    assert.equal(ag001.sessions, 1);
+
+    assert.equal(
+      summary.gaps.length,
+      0,
+      "the gap needs 2 corroborating sessions; B's stale-hash sighting must not count toward that bar",
+    );
+    const ledger = state.readGapLedger();
+    const sessionsSeen = Object.values(ledger.entries).flatMap((e) => Object.keys(e.sessions));
+    assert.deepEqual(
+      sessionsSeen,
+      ["pi-session-a"],
+      "only the current-hash session is recorded into the ledger this run",
+    );
+  });
+});

--- a/test/analyze-reuse.test.js
+++ b/test/analyze-reuse.test.js
@@ -165,7 +165,7 @@ test("editing AGENTS.md without --force reanalyzes and explains that prior evide
     "a memory-file edit invalidates the cache, exactly as documented",
   );
   assert.equal(third.summary.staleMemoryHash, 1, "the invalidation is attributed to the hash change, not a plain miss");
-  assert.match(third.stderr, /evidence from a previous AGENTS\.md/);
+  assert.match(third.stderr, /evidence from a previous memory-file set/);
   assert.match(third.stderr, /stale, not missing/);
   assert.match(third.stderr, /sha256:\w+ -> sha256:\w+/, "names the old and new hash");
 });

--- a/test/apply-cli.test.js
+++ b/test/apply-cli.test.js
@@ -224,6 +224,11 @@ test("a memory file that changed after the proposal is left untouched by apply",
   assert.match(applied.output, new RegExp(proposal.memoryFile.hash), "names the image the edits were measured on");
   assert.match(applied.output, /nothing was written/);
   assert.match(applied.output, /Run `backpass`/, "names the command that regenerates against the current file");
+  assert.match(
+    applied.output,
+    /reanalyzes transcripts against the new file, it does not reuse the stale judgments/,
+    "explains that recovery does not reuse the proposal's stale analysis",
+  );
 });
 
 test("an unchanged memory file applies every accepted edit and its skills", () => {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -251,7 +251,10 @@ test("bootstrap aborts analysis when the canonical memory file appears during di
   );
 
   assert.equal(analyzed, false);
-  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), "# Concurrent instructions\n\n- Keep this file.\n");
+  assert.equal(
+    fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"),
+    "# Concurrent instructions\n\n- Keep this file.\n",
+  );
   assert.deepEqual(ctx.config.state.listEvidence(), []);
 });
 

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 import { bootstrapRun } from "../src/commands/bootstrap.js";
 import { renderPointer, renderStarterMemory } from "../src/bootstrap.js";
 import { loadConfig } from "../src/config.js";
-import { setLoggerSink } from "../src/logger.js";
+import { UserError, setLoggerSink } from "../src/logger.js";
 import { isPointerTo, memorySetHash, memoryTextHash, parseMemoryUnits } from "../src/memory.js";
 import { State } from "../src/state.js";
 
@@ -223,6 +223,36 @@ test("with transcripts: analysis gaps become the first evidence-backed instructi
   const saved = ctx.config.state.readProposal();
   assert.equal(saved.appliedBy, "bootstrap");
   assert.ok(saved.appliedAt);
+});
+
+test("bootstrap aborts analysis when the canonical memory file appears during discovery", async () => {
+  const repo = makeRepo();
+  const ctx = makeCtx(repo);
+  let analyzed = false;
+  const discoverWithConcurrentMemory = async () => {
+    fs.writeFileSync(path.join(repo.root, "AGENTS.md"), "# Concurrent instructions\n\n- Keep this file.\n");
+    return discoverTwo();
+  };
+
+  await assert.rejects(
+    () =>
+      withSink(() =>
+        bootstrapRun(ctx, {
+          discover: discoverWithConcurrentMemory,
+          analyze: async () => {
+            analyzed = true;
+          },
+        }),
+      ),
+    (error) =>
+      error instanceof UserError &&
+      /changed while backpass was bootstrapping/.test(error.message) &&
+      /run `backpass` again/.test(error.hint),
+  );
+
+  assert.equal(analyzed, false);
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), "# Concurrent instructions\n\n- Keep this file.\n");
+  assert.deepEqual(ctx.config.state.listEvidence(), []);
 });
 
 test("bootstrap never overwrites: a CLAUDE.md that appears is kept, only the missing file is created", async () => {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -10,7 +10,7 @@ import { bootstrapRun } from "../src/commands/bootstrap.js";
 import { renderPointer, renderStarterMemory } from "../src/bootstrap.js";
 import { loadConfig } from "../src/config.js";
 import { setLoggerSink } from "../src/logger.js";
-import { isPointerTo, parseMemoryUnits } from "../src/memory.js";
+import { isPointerTo, memorySetHash, memoryTextHash, parseMemoryUnits } from "../src/memory.js";
 import { State } from "../src/state.js";
 
 const CLI = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../bin/backpass");
@@ -208,6 +208,16 @@ test("with transcripts: analysis gaps become the first evidence-backed instructi
     ["## Learnings", "## Maintaining this file"],
   );
   assert.equal(fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8"), renderPointer("AGENTS.md"));
+
+  const bootstrapHash = memorySetHash([
+    { path: "AGENTS.md", hash: memoryTextHash(renderStarterMemory({ repo })) },
+    { path: "CLAUDE.md", hash: memoryTextHash(renderPointer("AGENTS.md")) },
+  ]);
+  assert.deepEqual(
+    ctx.config.state.listEvidence().map((e) => e.memoryHash),
+    [bootstrapHash, bootstrapHash],
+    "bootstrap evidence uses the effective memory-set hash that a later proposal fold expects",
+  );
 
   // The applied proposal is marked so `backpass apply` cannot replay it onto the new file.
   const saved = ctx.config.state.readProposal();

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -42,9 +42,9 @@ function harness(overrides = {}) {
 }
 
 /** One backpass run: the evidence files on disk at the time, then the fold. */
-async function run(h, records, file = memoryFile()) {
+async function run(h, records, file = memoryFile(), memoryHash = "h1") {
   for (const r of records) h.state.writeEvidence(r.transcript.id, r);
-  return foldForRun(h.ctx, file);
+  return foldForRun(h.ctx, file, memoryHash);
 }
 
 const GAP = "Read docs/db.md before writing queries.";
@@ -57,8 +57,14 @@ test("a gap seen once now and once on a later run accumulates to two sessions an
   assert.equal(first.totals.droppedGapSingletons, 1);
 
   // Later run: s1's evidence was rewritten against a changed memory file and the model
-  // no longer mentions the gap; a new session s2 reports it in different words.
-  const second = await run(h, [record("claude-s1", [], { memoryHash: "h2" }), record("claude-s2", [GAP_REPHRASED])]);
+  // no longer mentions the gap; a new session s2 reports it in different words, both
+  // analyzed against the new hash.
+  const second = await run(
+    h,
+    [record("claude-s1", [], { memoryHash: "h2" }), record("claude-s2", [GAP_REPHRASED], { memoryHash: "h2" })],
+    memoryFile(),
+    "h2",
+  );
   assert.equal(second.gaps.length, 1, "the gap graduates once two distinct sessions have reported it");
   assert.equal(second.gaps[0].sessions, 2);
   assert.equal(second.gaps[0].proposedInstruction, GAP, "the shortest phrasing is canonical");
@@ -129,7 +135,12 @@ test("re-analysis of a session does not restart its expiry clock", async () => {
   const h = harness({ gapLedgerMaxAge: "90d" });
   await run(h, [record("claude-s1", [GAP])]);
   age(h, 120);
-  const summary = await run(h, [record("claude-s1", [GAP], { memoryHash: "h2" }), record("claude-s2", [GAP])]);
+  const summary = await run(
+    h,
+    [record("claude-s1", [GAP], { memoryHash: "h2" }), record("claude-s2", [GAP], { memoryHash: "h2" })],
+    memoryFile(),
+    "h2",
+  );
   assert.equal(summary.gaps.length, 0, "the re-seen old sighting keeps its original first-seen time");
 });
 

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -4,6 +4,8 @@ import path from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { memorySetHash, memoryTextHash } from "../../src/memory.js";
+
 /**
  * The synthesis pass driven through the real CLI, against a stand-in acpx.
  *
@@ -132,12 +134,16 @@ export function makeCliRepo({ memory, sessions = 3, files = {} }) {
 
   const evidenceDir = path.join(dir, ".backpass", "evidence");
   fs.mkdirSync(evidenceDir, { recursive: true });
+  // Real evidence always carries the set hash it was judged against (`foldForRun` filters
+  // on it); match what the CLI computes for this repo's memory files so fold picks it up.
+  const memoryHash = memorySetHash([{ path: "AGENTS.md", hash: memoryTextHash(memory) }]);
   for (let i = 1; i <= sessions; i += 1) {
     fs.writeFileSync(
       path.join(evidenceDir, `claude_s${i}.json`),
       JSON.stringify({
         status: "ok",
         memoryPath: "AGENTS.md",
+        memoryHash,
         transcript: { harness: "claude", id: `claude:s${i}`, path: `/dev/null/s${i}`, mtimeMs: 1, bytes: 10 },
         positive: [],
         negative: [


### PR DESCRIPTION
## Intent

Fix Backpass's measured stale-memory-hash folding defect without implementing session-start memory cohorts. Reports read first: firstmate/data/backpass-analysis-reuse-miss-s1/report.md and firstmate/data/backpass-memory-cohort-necessity-assessment-s1/report.md. Reproduce the defect through Backpass's public executable path before implementing the fix. Separate the initiating memory-file hash change, the silent cache-invalidation explanation gap, and the visible proposal-fold contamination. Use a proven unchanged-memory cache-hit path as the counterexample and seek disconfirming evidence against the proposed scope.

Implement the smallest robust correction supported by those reports:
1. Preserve transcript evidence invalidation when the effective memory-file set hash changes.
2. When building a proposal, fold only evidence whose memoryHash matches the current memory-set hash as well as the current memory path.
3. Restrict this run's gap-ledger observations to that same current-hash evidence so unsampled stale rows cannot influence the current proposal.
4. Keep old evidence files intact and reusable if their memory bytes become current again. Do not migrate, rewrite, or delete old evidence.
5. Make hash-driven invalidation understandable in normal CLI output when prior successful evidence exists under another memory hash. Distinguish stale evidence from missing evidence, explain that the memory changed, and state that a completed analysis against the new file restores reuse.
6. Improve the existing stale-proposal apply recovery copy so users know rerunning will reanalyze against the current memory rather than reuse stale judgments.
7. Add public or executable behavioral regression coverage proving: the first analysis performs work; an unchanged second analysis reuses it without --force; editing AGENTS.md without --force reanalyzes and explains why; --force still reanalyzes fresh evidence; old-hash leftover evidence cannot alter the current folded session count, instruction scores, or this-run gap observations. Assert observable behavior and normalized output, never implementation source text.
8. Update user documentation only where the visible cache or proposal semantics need clarification.

Explicitly out of scope: session-start memory attribution or cohorts, timestamp inference of historical memory, instruction-level cache invalidation, evidence-schema migration, weakening memory-hash invalidation, broad synthesis or sampling redesign.

Implementation is complete on branch fm/backpass-current-hash-fold-fix-r1 (2 commits): foldForRun now filters evidence by memoryPath AND current memory-set hash; analyzeTranscripts tracks and announces stale-hash evidence separately from missing evidence; apply's stale-proposal recovery copy clarifies reanalysis vs stale-judgment reuse; README.md and AGENTS.md updated; test/analyze-reuse.test.js added with 3 regression tests verified to fail pre-fix and pass post-fix. Full pnpm run check (lint, format, typecheck, 287 tests) is green.

## What Changed

- Filter proposal folding and gap-ledger observations to evidence matching the current effective memory-set hash, while preserving stale evidence for future reuse.
- Explain hash-driven reanalysis and stale-proposal recovery in CLI output and documentation, and ensure bootstrap uses the resolved memory snapshot consistently.
- Add executable regression coverage for cache reuse, forced and hash-triggered reanalysis, stale-evidence exclusion, bootstrap consistency, and apply recovery messaging.

## Risk Assessment

✅ Low: The change consistently scopes folding and new ledger ingestion to the current memory-set hash, preserves stale evidence, and correctly guards bootstrap snapshot consistency without introducing a substantiated reachable defect.

## Testing

The author-reported full check was already green; this phase ran focused cache, folding, gap-ledger, stale-apply, and bootstrap tests, then captured a public CLI transcript demonstrating first-run work, unchanged reuse, explicit stale-memory explanation after editing AGENTS.md, and forced reanalysis. All targeted checks passed and the worktree remained clean.

<details>
<summary>Evidence: Public CLI cache reuse and stale-memory invalidation transcript</summary>

Source: [Public CLI cache reuse and stale-memory invalidation transcript](https://github.com/kunchenguid/backpass/blob/c2748abee6c2b97a3c2f4cc038f90747b125b735/.no-mistakes/evidence/fm/backpass-current-hash-fold-fix-r1/cache-reuse-cli-transcript.txt)

```text

## First analysis
· analyzing 1 transcript(s) with pi effort=medium at jobs=1
  1/1 analyzed
{"total":1,"analyzed":1,"reused":0,"staleMemoryHash":0}

## Unchanged second analysis
{"total":1,"analyzed":0,"reused":1,"staleMemoryHash":0}

## After editing AGENTS.md without --force
· 1 transcript(s) have evidence from a previous memory-file set (sha256:3f8e98e4730414f6 -> sha256:3e7b5ebf1e53a00c); that evidence is stale, not missing, and reuse resumes once this pass re-judges it against the current memory-file set
· analyzing 1 transcript(s) with pi effort=medium at jobs=1
  1/1 analyzed
{"total":1,"analyzed":1,"reused":0,"staleMemoryHash":1}

## Explicit --force
· analyzing 1 transcript(s) with pi effort=medium at jobs=1
  1/1 analyzed
{"total":1,"analyzed":1,"reused":0,"staleMemoryHash":0}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b7ab6632fa1fa7f5fabeedb0e688840f05f9b730","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 0 issues</summary>

✅ No issues found.

- 🚨 `src/commands/bootstrap.js:56` - After bootstrap writes, the effective hash is read from disk but analysis still uses the in-memory starter. If the canonical file appears concurrently and `writeBootstrapFiles` skips it, evidence judged against the starter is stamped with the unrelated on-disk file&#39;s hash, then accepted by this fold and future proposal folds. Resolve the memory file and hash as one snapshot after seeding, and abort bootstrap analysis if the canonical file was skipped or differs from the starter.
- ⚠️ `src/analyze.js:216` - The stale-evidence message attributes the old hash to the current primary path, but `memoryHash` covers the entire configured memory-file set. Changing only a secondary file, or changing the configured primary path, therefore reports evidence from a previous current-path file even when that file was not the changed source. Describe this as a previous memory-file set, or retain and report the prior evidence paths.

🔧 Fix: Guard bootstrap snapshots and clarify stale-set output
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/analyze-reuse.test.js test/gap-ledger.test.js`
- <code>Public CLI sequence using `bin/backpass.js analyze`: first analysis, unchanged cache hit, AGENTS.md edit without `--force`, post-refresh cache hit, and forced reanalysis</code>
- <code>`node --test test/analyze-reuse.test.js` after adding old-hash reversion coverage</code>
- `node --test --test-name-pattern='a memory file that changed after the proposal is left untouched by apply' test/apply-cli.test.js`

✅ No issues found.
- `node --test test/analyze-reuse.test.js test/gap-ledger.test.js test/apply-cli.test.js test/bootstrap.test.js`
- <code>`node ~/.no-mistakes/evidence/01M13G2AQ5YYP383ADQH1M5WM5/cache-reuse-e2e.mjs &gt; ~/.no-mistakes/evidence/01M13G2AQ5YYP383ADQH1M5WM5/cache-reuse-cli-transcript.txt` - exercised the public CLI with first-run analysis, unchanged reuse, memory-edit invalidation messaging, and `--force` reanalysis</code>
- <code>`git status --short` - confirmed testing left no transient worktree changes</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
