### PR TITLE
feat(discovery): add antigravity transcript adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The loop only closes when a human happens to remember a failure and edits the fi
 what happened in them, and proposes evidence-backed edits to your memory file - under a
 token budget, gated by you.
 
-- **Local-first** - Reads the transcript stores of seven agent harnesses directly from disk.
+- **Local-first** - Reads the transcript stores of eight agent harnesses directly from disk.
   No API, no upload; transcripts never leave your machine except into an agent you already
   authenticated, and obvious secrets are redacted before they do.
 - **Evidence-gated** - Every proposed edit carries verbatim quotes from real sessions, a
@@ -78,17 +78,18 @@ backpass apply     # review each edit, accept or reject, then write
 
 ### 1. Collect samples - which sessions belong to this repo
 
-backpass reads the local transcript stores of seven harnesses directly. No API, no upload.
+backpass reads the local transcript stores of eight harnesses directly. No API, no upload.
 
-| Harness        | Store                                          | Repo tie                                            |
-| -------------- | ---------------------------------------------- | --------------------------------------------------- |
-| **claude**     | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl` | per-line `cwd`                                      |
-| **codex**      | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | `cwd` + recorded `git.repository_url`               |
-| **pi**         | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`   | session-header `cwd`                                |
-| **opencode**   | `~/.local/share/opencode/opencode.db` (sqlite) | `session.directory`                                 |
-| **grok**       | `~/.grok/sessions/<encoded-cwd>/<uuid>/`       | `summary.json` `cwd` + `git_remotes`                |
-| **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                                   |
-| **hermes**     | `~/.hermes/state.db` (sqlite)                  | session cwd, with CLI prompt / ACP config fallbacks |
+| Harness         | Store                                                          | Repo tie                                            |
+| --------------- | --------------------------------------------------------------- | --------------------------------------------------- |
+| **claude**      | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl`                 | per-line `cwd`                                      |
+| **codex**       | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`                 | `cwd` + recorded `git.repository_url`               |
+| **pi**          | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`                   | session-header `cwd`                                |
+| **opencode**    | `~/.local/share/opencode/opencode.db` (sqlite)                 | `session.directory`                                 |
+| **grok**        | `~/.grok/sessions/<encoded-cwd>/<uuid>/`                       | `summary.json` `cwd` + `git_remotes`                |
+| **cursor CLI**  | `~/.cursor/chats/<md5(cwd)>/<uuid>/`                           | `meta.json` `cwd`                                   |
+| **hermes**      | `~/.hermes/state.db` (sqlite)                                  | session cwd, with CLI prompt / ACP config fallbacks |
+| **antigravity** | `~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl` | `history.jsonl` `workspace`                         |
 
 Claude collection covers `$CLAUDE_CONFIG_DIR/projects` alongside the default store, so a
 relocated config dir does not hide its sessions. The variable is read from backpass's own
@@ -424,7 +425,7 @@ CLI flags on top:
     ]
   },
   "discovery": {
-    "harnesses": ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes"],
+    "harnesses": ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes", "antigravity"],
     "since": "30d",
     "worktreeGlobs": [],
     "minUserTurns": 2

--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ backpass apply     # review each edit, accept or reject, then write
 
 backpass reads the local transcript stores of eight harnesses directly. No API, no upload.
 
-| Harness         | Store                                                          | Repo tie                                            |
-| --------------- | --------------------------------------------------------------- | --------------------------------------------------- |
-| **claude**      | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl`                 | per-line `cwd`                                      |
-| **codex**       | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`                 | `cwd` + recorded `git.repository_url`               |
-| **pi**          | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`                   | session-header `cwd`                                |
-| **opencode**    | `~/.local/share/opencode/opencode.db` (sqlite)                 | `session.directory`                                 |
-| **grok**        | `~/.grok/sessions/<encoded-cwd>/<uuid>/`                       | `summary.json` `cwd` + `git_remotes`                |
-| **cursor CLI**  | `~/.cursor/chats/<md5(cwd)>/<uuid>/`                           | `meta.json` `cwd`                                   |
-| **hermes**      | `~/.hermes/state.db` (sqlite)                                  | session cwd, with CLI prompt / ACP config fallbacks |
+| Harness         | Store                                                                                       | Repo tie                                            |
+| --------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| **claude**      | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl`                                              | per-line `cwd`                                      |
+| **codex**       | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`                                              | `cwd` + recorded `git.repository_url`               |
+| **pi**          | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`                                                | session-header `cwd`                                |
+| **opencode**    | `~/.local/share/opencode/opencode.db` (sqlite)                                              | `session.directory`                                 |
+| **grok**        | `~/.grok/sessions/<encoded-cwd>/<uuid>/`                                                    | `summary.json` `cwd` + `git_remotes`                |
+| **cursor CLI**  | `~/.cursor/chats/<md5(cwd)>/<uuid>/`                                                        | `meta.json` `cwd`                                   |
+| **hermes**      | `~/.hermes/state.db` (sqlite)                                                               | session cwd, with CLI prompt / ACP config fallbacks |
 | **antigravity** | `~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl` | `history.jsonl` `workspace`                         |
 
 Claude collection covers `$CLAUDE_CONFIG_DIR/projects` alongside the default store, so a

--- a/src/cli.js
+++ b/src/cli.js
@@ -83,7 +83,7 @@ COMMANDS
 COLLECT SAMPLES
   --since <dur>            only sessions newer than this (30d, 12h, 2w, all)  [30d]
   --harness <a,b>          limit to these harnesses
-                           (claude, codex, pi, opencode, grok, cursor, hermes)
+                           (claude, codex, pi, opencode, grok, cursor, hermes, antigravity)
   --strict                 deterministic associations only (tiers 1 and 2)
   --include-cursor-ide     also scan the Cursor IDE store (best-effort, v1.1 preview)
   --limit <n>              analyze at most N transcripts this run (newest first)

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ import { UserError, warn } from "./logger.js";
 export const CONFIG_FILENAME = ".backpassrc.json";
 export const STATE_DIRNAME = ".backpass";
 
-export const ALL_HARNESSES = ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes"];
+export const ALL_HARNESSES = ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes", "antigravity"];
 /** Cursor IDE is deferred to v1.1 and only ever runs behind --include-cursor-ide. */
 export const OPT_IN_HARNESSES = ["cursor-ide"];
 

--- a/src/discovery/adapters/antigravity.js
+++ b/src/discovery/adapters/antigravity.js
@@ -35,11 +35,13 @@ function loadHistoryMap(historyFile) {
   const entries = readJsonl(historyFile);
   for (const entry of entries) {
     if (!entry || !entry.conversationId) continue;
-    map.set(entry.conversationId, {
-      workspace: entry.workspace || null,
-      timestamp:
-        typeof entry.timestamp === "number" ? entry.timestamp : entry.timestamp ? Date.parse(entry.timestamp) : null,
-    });
+    const existing = map.get(entry.conversationId);
+    const workspace = existing?.workspace || entry.workspace || null;
+    const entryTs =
+      typeof entry.timestamp === "number" ? entry.timestamp : entry.timestamp ? Date.parse(entry.timestamp) : null;
+    const timestamp = existing?.timestamp ?? entryTs;
+
+    map.set(entry.conversationId, { workspace, timestamp });
   }
   return map;
 }

--- a/src/discovery/adapters/antigravity.js
+++ b/src/discovery/adapters/antigravity.js
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  attachToolResults,
+  contentToEvents,
+  home,
+  listDirs,
+  parseJsonLine,
+  readHeadLines,
+  readJsonl,
+  statOrNull,
+} from "./shared.js";
+
+/**
+ * Antigravity: ~/.gemini/antigravity-cli (or ANTIGRAVITY_HOME)
+ *   history.jsonl - { display, timestamp, workspace, conversationId }
+ *   brain/<conversation-id>/.system_generated/logs/transcript.jsonl - JSONL step events
+ *
+ * Each step record carries `step_index`, `type`, `source`, `status`, `created_at`, etc.
+ * `USER_INPUT` (source: USER_EXPLICIT) holds user prompt in `content`.
+ * `PLANNER_RESPONSE` (source: MODEL) holds model content, `thinking`, and `tool_calls`.
+ * `GENERIC` / `TOOL_RESULT` holds tool result content.
+ * System steps (`CONVERSATION_HISTORY`, `CHECKPOINT`) are dropped.
+ */
+
+export const name = "antigravity";
+
+export function storeRoot() {
+  return process.env.ANTIGRAVITY_HOME || home(".gemini", "antigravity-cli");
+}
+
+function loadHistoryMap(historyFile) {
+  const map = new Map();
+  const entries = readJsonl(historyFile);
+  for (const entry of entries) {
+    if (!entry || !entry.conversationId) continue;
+    if (!map.has(entry.conversationId)) {
+      map.set(entry.conversationId, {
+        workspace: entry.workspace || null,
+        timestamp:
+          typeof entry.timestamp === "number" ? entry.timestamp : entry.timestamp ? Date.parse(entry.timestamp) : null,
+      });
+    }
+  }
+  return map;
+}
+
+function conversationIdFromPath(filePath) {
+  const parts = filePath.split(path.sep);
+  const brainIdx = parts.lastIndexOf("brain");
+  if (brainIdx !== -1 && brainIdx + 1 < parts.length) {
+    return parts[brainIdx + 1];
+  }
+  return path.basename(filePath, ".jsonl");
+}
+
+function findCwdFromHistory(transcriptPath, id) {
+  try {
+    const parts = transcriptPath.split(path.sep);
+    const brainIdx = parts.lastIndexOf("brain");
+    if (brainIdx > 0) {
+      const root = parts.slice(0, brainIdx).join(path.sep);
+      const historyFile = path.join(root, "history.jsonl");
+      if (fs.existsSync(historyFile)) {
+        const historyMap = loadHistoryMap(historyFile);
+        return historyMap.get(id)?.workspace || null;
+      }
+    }
+  } catch {
+    // fail soft
+  }
+  return null;
+}
+
+/**
+ * @param {{ cutoffMs?: number }} [options]
+ */
+export function enumerate({ cutoffMs } = {}) {
+  const root = storeRoot();
+  const brainDir = path.join(root, "brain");
+  const historyMap = loadHistoryMap(path.join(root, "history.jsonl"));
+  const out = [];
+
+  for (const sessionDir of listDirs(brainDir)) {
+    const conversationId = path.basename(sessionDir);
+    let transcriptPath = path.join(sessionDir, ".system_generated", "logs", "transcript.jsonl");
+    let stat = statOrNull(transcriptPath);
+    if (!stat) {
+      transcriptPath = path.join(sessionDir, "transcript.jsonl");
+      stat = statOrNull(transcriptPath);
+    }
+    if (!stat) continue;
+    if (cutoffMs && stat.mtimeMs < cutoffMs) continue;
+
+    const historyInfo = historyMap.get(conversationId);
+    out.push({
+      key: transcriptPath,
+      path: transcriptPath,
+      mtimeMs: stat.mtimeMs,
+      bytes: stat.size,
+      extra: {
+        conversationId,
+        cwd: historyInfo?.workspace || null,
+        startedAt: historyInfo?.timestamp || null,
+      },
+    });
+  }
+  return out;
+}
+
+export function classify(candidate) {
+  let cwd = candidate.extra?.cwd || null;
+  let id = candidate.extra?.conversationId || null;
+  let startedAt = candidate.extra?.startedAt || null;
+  let model = null;
+
+  const lines = readHeadLines(candidate.path, 40);
+  for (const line of lines) {
+    const entry = parseJsonLine(line);
+    if (!entry) continue;
+    if (!cwd) {
+      cwd = entry.workspace || entry.cwd || entry.metadata?.workspace || entry.metadata?.cwd || null;
+    }
+    if (!id) {
+      id = entry.conversationId || entry.conversation_id || entry.id || entry.sessionId || null;
+    }
+    if (!startedAt) {
+      if (entry.created_at) startedAt = Date.parse(entry.created_at);
+      else if (typeof entry.timestamp === "number") startedAt = entry.timestamp;
+      else if (entry.timestamp) startedAt = Date.parse(entry.timestamp);
+    }
+    if (!model) {
+      model = entry.model || entry.model_id || entry.modelId || null;
+    }
+    if (cwd && id && startedAt && model) break;
+  }
+
+  if (!id) {
+    id = conversationIdFromPath(candidate.path);
+  }
+
+  if (!cwd) {
+    cwd = findCwdFromHistory(candidate.path, id);
+  }
+
+  if (!cwd) return null;
+
+  return {
+    id,
+    cwd,
+    gitBranch: null,
+    remotes: [],
+    startedAt: startedAt || candidate.mtimeMs,
+    model: model || null,
+  };
+}
+
+export function read(ref) {
+  const entries = readJsonl(ref.path);
+  const events = [];
+  let model = null;
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+
+    // Ignore system and checkpoint steps
+    if (
+      entry.source === "SYSTEM" ||
+      entry.type === "CONVERSATION_HISTORY" ||
+      entry.type === "CHECKPOINT" ||
+      entry.type === "SYSTEM"
+    ) {
+      continue;
+    }
+
+    if (entry.type === "USER_INPUT" || entry.source === "USER_EXPLICIT" || entry.role === "user") {
+      contentToEvents("user", entry.content ?? entry.text ?? entry.message, events);
+      continue;
+    }
+
+    if (
+      entry.type === "TOOL_RESULT" ||
+      entry.type === "tool_result" ||
+      entry.type === "GENERIC" ||
+      entry.source === "TOOL" ||
+      entry.role === "tool"
+    ) {
+      events.push({
+        kind: "tool-result",
+        id:
+          entry.tool_call_id ?? entry.call_id ?? entry.toolCallId ?? (entry.type === "GENERIC" ? entry.id : undefined),
+        result: flattenOutput(entry.result ?? entry.output ?? entry.content ?? entry.text),
+        status: entry.status === "ERROR" || entry.status === "error" || entry.is_error ? "error" : "completed",
+      });
+      continue;
+    }
+
+    if (entry.type === "PLANNER_RESPONSE" || entry.source === "MODEL" || entry.role === "assistant") {
+      model = model || entry.model || entry.model_id || entry.modelId || null;
+
+      if (Array.isArray(entry.tool_calls)) {
+        for (const call of entry.tool_calls) {
+          if (!call || typeof call !== "object") continue;
+          events.push({
+            kind: "tool",
+            name: call.name,
+            input: parseMaybeJson(call.args ?? call.input ?? call.arguments),
+            pendingId: call.id ?? call.call_id ?? call.tool_call_id ?? call.toolCallId,
+          });
+        }
+      }
+
+      contentToEvents("assistant", entry.content, events);
+      continue;
+    }
+  }
+
+  return { events: attachToolResults(events), model };
+}
+
+function parseMaybeJson(value) {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function flattenOutput(output) {
+  if (typeof output === "string") return output;
+  if (Array.isArray(output)) {
+    return output
+      .map((b) => (typeof b === "string" ? b : (b?.text ?? "")))
+      .filter(Boolean)
+      .join("\n");
+  }
+  return output ?? "";
+}

--- a/src/discovery/adapters/antigravity.js
+++ b/src/discovery/adapters/antigravity.js
@@ -36,7 +36,7 @@ function loadHistoryMap(historyFile) {
   for (const entry of entries) {
     if (!entry || !entry.conversationId) continue;
     const existing = map.get(entry.conversationId);
-    const workspace = existing?.workspace || entry.workspace || null;
+    const workspace = entry.workspace || existing?.workspace || null;
     const entryTs =
       typeof entry.timestamp === "number" ? entry.timestamp : entry.timestamp ? Date.parse(entry.timestamp) : null;
     const timestamp = existing?.timestamp ?? entryTs;

--- a/src/discovery/adapters/antigravity.js
+++ b/src/discovery/adapters/antigravity.js
@@ -35,13 +35,11 @@ function loadHistoryMap(historyFile) {
   const entries = readJsonl(historyFile);
   for (const entry of entries) {
     if (!entry || !entry.conversationId) continue;
-    if (!map.has(entry.conversationId)) {
-      map.set(entry.conversationId, {
-        workspace: entry.workspace || null,
-        timestamp:
-          typeof entry.timestamp === "number" ? entry.timestamp : entry.timestamp ? Date.parse(entry.timestamp) : null,
-      });
-    }
+    map.set(entry.conversationId, {
+      workspace: entry.workspace || null,
+      timestamp:
+        typeof entry.timestamp === "number" ? entry.timestamp : entry.timestamp ? Date.parse(entry.timestamp) : null,
+    });
   }
   return map;
 }

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -6,6 +6,7 @@ import * as opencode from "./adapters/opencode.js";
 import * as hermes from "./adapters/hermes.js";
 import * as cursorCli from "./adapters/cursor-cli.js";
 import * as cursorIde from "./adapters/cursor-ide.js";
+import * as antigravity from "./adapters/antigravity.js";
 
 import { associate, passesStrict } from "./association.js";
 import { isSelfSession } from "./self.js";
@@ -22,6 +23,7 @@ export const ADAPTERS = {
   hermes,
   cursor: cursorCli,
   "cursor-ide": cursorIde,
+  antigravity,
 };
 
 export function getAdapter(harness) {

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -642,6 +642,56 @@ test("antigravity adapter enumerates transcripts and resolves workspace from his
   });
 });
 
+test("antigravity adapter merges repeated history entries preserving earliest timestamp and non-null workspace", () => {
+  const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-antigravity-multiturn-"));
+  const brainDir = path.join(fakeRoot, "brain", "conv-multi", ".system_generated", "logs");
+  fs.mkdirSync(brainDir, { recursive: true });
+  fs.copyFileSync(path.join(FIXTURES, "antigravity-session.jsonl"), path.join(brainDir, "transcript.jsonl"));
+
+  const historyFile = path.join(fakeRoot, "history.jsonl");
+  // Turn 1: has earliest timestamp, but workspace is empty/null
+  fs.appendFileSync(
+    historyFile,
+    JSON.stringify({
+      display: "prompt 1",
+      timestamp: 1_700_000_000_000,
+      workspace: null,
+      conversationId: "conv-multi",
+    }) + "\n",
+  );
+  // Turn 2: supplies workspace, later timestamp
+  fs.appendFileSync(
+    historyFile,
+    JSON.stringify({
+      display: "prompt 2",
+      timestamp: 1_700_000_050_000,
+      workspace: "/repo/multi",
+      conversationId: "conv-multi",
+    }) + "\n",
+  );
+  // Turn 3: omits workspace again
+  fs.appendFileSync(
+    historyFile,
+    JSON.stringify({
+      display: "prompt 3",
+      timestamp: 1_700_000_100_000,
+      workspace: null,
+      conversationId: "conv-multi",
+    }) + "\n",
+  );
+
+  withAntigravityHome(fakeRoot, () => {
+    const [candidate] = antigravity.enumerate();
+    assert.ok(candidate);
+    assert.equal(candidate.extra.cwd, "/repo/multi");
+    assert.equal(candidate.extra.startedAt, 1_700_000_000_000);
+
+    const descriptor = antigravity.classify(candidate);
+    assert.equal(descriptor.cwd, "/repo/multi");
+    assert.equal(descriptor.startedAt, 1_700_000_000_000);
+  });
+});
+
 test("antigravity adapter is fail-soft on missing, empty, or unreadable store roots", () => {
   const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-antigravity-empty-"));
   withAntigravityHome(emptyDir, () => {

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -649,17 +649,17 @@ test("antigravity adapter merges repeated history entries preserving earliest ti
   fs.copyFileSync(path.join(FIXTURES, "antigravity-session.jsonl"), path.join(brainDir, "transcript.jsonl"));
 
   const historyFile = path.join(fakeRoot, "history.jsonl");
-  // Turn 1: has earliest timestamp, but workspace is empty/null
+  // Turn 1: has earliest timestamp and initial workspace
   fs.appendFileSync(
     historyFile,
     JSON.stringify({
       display: "prompt 1",
       timestamp: 1_700_000_000_000,
-      workspace: null,
+      workspace: "/repo/initial",
       conversationId: "conv-multi",
     }) + "\n",
   );
-  // Turn 2: supplies workspace, later timestamp
+  // Turn 2: updates workspace to /repo/multi with later timestamp
   fs.appendFileSync(
     historyFile,
     JSON.stringify({
@@ -669,7 +669,7 @@ test("antigravity adapter merges repeated history entries preserving earliest ti
       conversationId: "conv-multi",
     }) + "\n",
   );
-  // Turn 3: omits workspace again
+  // Turn 3: omits workspace
   fs.appendFileSync(
     historyFile,
     JSON.stringify({

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -12,6 +12,7 @@ import * as pi from "../src/discovery/adapters/pi.js";
 import * as grok from "../src/discovery/adapters/grok.js";
 import * as cursorCli from "../src/discovery/adapters/cursor-cli.js";
 import * as hermes from "../src/discovery/adapters/hermes.js";
+import * as antigravity from "../src/discovery/adapters/antigravity.js";
 import { statOrNull } from "../src/discovery/adapters/shared.js";
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
@@ -547,5 +548,108 @@ test("hermes adapter recovers v26 cli cwd from sessions.cwd when system_prompt i
     assert.equal(toolCall.name, "terminal");
     assert.equal(toolCall.input.command, "pwd");
     assert.equal(toolCall.result, "/repo/demo");
+  });
+});
+
+test("antigravity adapter classifies a session from transcript header or extra metadata", () => {
+  const file = path.join(FIXTURES, "antigravity-session.jsonl");
+  const candidate = candidateFor(file);
+  const descriptor = antigravity.classify(candidate);
+
+  assert.equal(descriptor.id, "a3dec7b4-9b79-4bc1-acb9-2c300095fa00");
+  assert.equal(descriptor.cwd, "/repo/demo");
+  assert.equal(descriptor.gitBranch, null);
+  assert.deepEqual(descriptor.remotes, []);
+  assert.equal(descriptor.startedAt, Date.parse("2026-08-01T10:00:00.000Z"));
+  assert.equal(descriptor.model, "gemini-3.7-flash");
+});
+
+test("antigravity adapter reads user/assistant turns, folds tool results, drops system/checkpoint turns", () => {
+  const file = path.join(FIXTURES, "antigravity-session.jsonl");
+  const { events, model } = antigravity.read({ path: file });
+
+  assert.equal(model, "gemini-3.7-flash");
+  assert.deepEqual(
+    messages(events).map((m) => `${m.role}: ${m.text}`),
+    ["user: Open a PR for the parser fix.", "assistant: I'll run the tests first.", "assistant: Opened PR #2731."],
+  );
+
+  const [toolCall] = tools(events);
+  assert.equal(toolCall.name, "run_command");
+  assert.deepEqual(toolCall.input, { CommandLine: "npm test" });
+  assert.equal(toolCall.result, "2 passing");
+  assert.equal(toolCall.status, "completed");
+
+  assert.ok(!JSON.stringify(events).includes("history metadata"), "history metadata must be dropped");
+  assert.ok(!JSON.stringify(events).includes("checkpoint metadata"), "checkpoint metadata must be dropped");
+  assert.ok(!JSON.stringify(events).includes("Running tests before PR"), "thinking must be dropped");
+});
+
+function withAntigravityHome(dir, fn) {
+  const prevHome = process.env.HOME;
+  const prevAgyHome = process.env.ANTIGRAVITY_HOME;
+  if (dir) process.env.ANTIGRAVITY_HOME = dir;
+  else delete process.env.ANTIGRAVITY_HOME;
+  const restore = () => {
+    process.env.HOME = prevHome;
+    if (prevAgyHome === undefined) delete process.env.ANTIGRAVITY_HOME;
+    else process.env.ANTIGRAVITY_HOME = prevAgyHome;
+  };
+  try {
+    const result = fn();
+    if (result && typeof result.then === "function") return result.finally(restore);
+    restore();
+    return result;
+  } catch (err) {
+    restore();
+    throw err;
+  }
+}
+
+function writeAntigravityStore(root, conversationId, { workspace = "/repo/demo", timestamp = 1_787_908_601_161 } = {}) {
+  const brainDir = path.join(root, "brain", conversationId, ".system_generated", "logs");
+  fs.mkdirSync(brainDir, { recursive: true });
+  fs.copyFileSync(path.join(FIXTURES, "antigravity-session.jsonl"), path.join(brainDir, "transcript.jsonl"));
+
+  const historyFile = path.join(root, "history.jsonl");
+  const historyEntry = JSON.stringify({
+    display: "Open a PR for the parser fix.",
+    timestamp,
+    workspace,
+    conversationId,
+  });
+  fs.appendFileSync(historyFile, historyEntry + "\n");
+}
+
+test("antigravity adapter enumerates transcripts and resolves workspace from history.jsonl", () => {
+  const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-antigravity-store-"));
+  writeAntigravityStore(fakeRoot, "conv-1", { workspace: "/repo/first", timestamp: 1_700_000_000_000 });
+  writeAntigravityStore(fakeRoot, "conv-2", { workspace: "/repo/second", timestamp: 1_700_100_000_000 });
+
+  withAntigravityHome(fakeRoot, () => {
+    const candidates = antigravity.enumerate();
+    assert.equal(candidates.length, 2);
+
+    const conv1 = candidates.find((c) => c.extra.conversationId === "conv-1");
+    assert.ok(conv1);
+    assert.equal(conv1.extra.cwd, "/repo/first");
+    assert.equal(conv1.extra.startedAt, 1_700_000_000_000);
+
+    const descriptor = antigravity.classify(conv1);
+    assert.equal(descriptor.id, "conv-1");
+    assert.equal(descriptor.cwd, "/repo/first");
+    assert.equal(descriptor.startedAt, 1_700_000_000_000);
+  });
+});
+
+test("antigravity adapter is fail-soft on missing, empty, or unreadable store roots", () => {
+  const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-antigravity-empty-"));
+  withAntigravityHome(emptyDir, () => {
+    assert.deepEqual(antigravity.enumerate(), []);
+  });
+
+  const missingDir = path.join(os.tmpdir(), "backpass-antigravity-nonexistent-" + Date.now());
+  withAntigravityHome(missingDir, () => {
+    assert.deepEqual(antigravity.enumerate(), []);
   });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -23,7 +23,16 @@ test("the defaults match the approved design", () => {
   assert.equal(config.minGapEvidence, 2);
   assert.equal(config.jobs, 4);
   assert.equal(config.discovery.since, "30d");
-  assert.deepEqual(config.discovery.harnesses, ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes"]);
+  assert.deepEqual(config.discovery.harnesses, [
+    "claude",
+    "codex",
+    "pi",
+    "opencode",
+    "grok",
+    "cursor",
+    "hermes",
+    "antigravity",
+  ]);
   assert.ok(!config.discovery.harnesses.includes("cursor-ide"), "Cursor IDE is deferred to v1.1");
   assert.deepEqual(config.analysis, { agent: null, model: null, effort: null }, "agents are auto-picked by default");
   assert.deepEqual(config.synthesis, { agent: null, model: null, effort: null });

--- a/test/fixtures/antigravity-session.jsonl
+++ b/test/fixtures/antigravity-session.jsonl
@@ -1,0 +1,6 @@
+{"step_index":0,"source":"SYSTEM","type":"CONVERSATION_HISTORY","created_at":"2026-08-01T10:00:00.000Z","content":"history metadata"}
+{"step_index":1,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-08-01T10:00:01.000Z","content":"Open a PR for the parser fix.","workspace":"/repo/demo","conversationId":"a3dec7b4-9b79-4bc1-acb9-2c300095fa00"}
+{"step_index":2,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-08-01T10:00:05.000Z","content":"I'll run the tests first.","thinking":"Running tests before PR","tool_calls":[{"id":"call_1","name":"run_command","args":{"CommandLine":"npm test"}}],"model":"gemini-3.7-flash"}
+{"step_index":3,"source":"MODEL","type":"GENERIC","status":"DONE","created_at":"2026-08-01T10:00:09.000Z","tool_call_id":"call_1","content":"2 passing"}
+{"step_index":4,"source":"SYSTEM","type":"CHECKPOINT","created_at":"2026-08-01T10:00:10.000Z","content":"checkpoint metadata"}
+{"step_index":5,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-08-01T10:00:20.000Z","content":"Opened PR #2731.","model":"gemini-3.7-flash"}


### PR DESCRIPTION
## Summary
Adds an Antigravity (`agy` / `antigravity-cli`) transcript discovery & parsing adapter to backpass.

### Changes
- Implemented `src/discovery/adapters/antigravity.js` supporting `storeRoot()`, `enumerate()`, `classify()`, and `read()`.
  - Recovers `cwd` and session metadata by indexing `history.jsonl` and inspecting transcript headers.
  - Normalizes `USER_INPUT` and `PLANNER_RESPONSE` steps into message events and folds tool results via `attachToolResults()`.
  - Discards internal scaffolding (`CONVERSATION_HISTORY`, `CHECKPOINT`, `SYSTEM`) and `thinking` reasoning blocks.
  - Fail-soft handling on missing or unreadable stores.
- Registered `"antigravity"` in `ADAPTERS` (`src/discovery/index.js`) and `ALL_HARNESSES` (`src/config.js`).
- Added golden session fixture `test/fixtures/antigravity-session.jsonl`.
- Added unit tests in `test/adapters.test.js` and updated discovery assertions in `test/config.test.js`.
- Verified with `pnpm run check` (ESLint, Prettier, TypeScript `checkJs`, and full 292-test suite passing).