### PR TITLE
fix(discovery): discover BB-managed Pi sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ backpass reads the local transcript stores of seven harnesses directly. No API, 
 | -------------- | ---------------------------------------------- | --------------------------------------------------- |
 | **claude**     | `~/.claude/projects/<munged-cwd>/<uuid>.jsonl` | per-line `cwd`                                      |
 | **codex**      | `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` | `cwd` + recorded `git.repository_url`               |
-| **pi**         | `~/.pi/agent/sessions/<escaped-cwd>/*.jsonl`   | session-header `cwd`                                |
+| **pi**         | standalone and BB-managed Pi JSONL stores      | session-header `cwd`                                |
 | **opencode**   | `~/.local/share/opencode/opencode.db` (sqlite) | `session.directory`                                 |
 | **grok**       | `~/.grok/sessions/<encoded-cwd>/<uuid>/`       | `summary.json` `cwd` + `git_remotes`                |
 | **cursor CLI** | `~/.cursor/chats/<md5(cwd)>/<uuid>/`           | `meta.json` `cwd`                                   |
@@ -94,6 +94,11 @@ Claude collection covers `$CLAUDE_CONFIG_DIR/projects` alongside the default sto
 relocated config dir does not hide its sessions. The variable is read from backpass's own
 environment: if you reach that profile through an alias that only prefixes `claude`, set it
 for the backpass run too (`CLAUDE_CONFIG_DIR=~/.claude-work backpass`, or export it).
+
+Pi collection covers standalone sessions under `~/.pi/agent/sessions/` and BB-managed Pi
+sessions under `~/.bb/pi-bridge-sessions/`. It also honors `PI_CODING_AGENT_DIR`,
+`PI_CODING_AGENT_SESSION_DIR`, `BB_DATA_DIR`, and `BB_PI_BRIDGE_SESSION_DIR` when they are
+set in backpass's environment. Roots that resolve to the same directory are scanned once.
 
 Hermes collection includes CLI and ACP sessions only. Gateway, cron, and WhatsApp sessions
 are excluded because their recorded cwd belongs to the shared gateway process, not a project.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ for the backpass run too (`CLAUDE_CONFIG_DIR=~/.claude-work backpass`, or export
 Pi collection covers standalone sessions under `~/.pi/agent/sessions/` and BB-managed Pi
 sessions under `~/.bb/pi-bridge-sessions/`. It also honors `PI_CODING_AGENT_DIR`,
 `PI_CODING_AGENT_SESSION_DIR`, `BB_DATA_DIR`, and `BB_PI_BRIDGE_SESSION_DIR` when they are
-set in backpass's environment. Roots that resolve to the same directory are scanned once.
+set in backpass's environment. When roots overlap, backpass scans every applicable layout
+and reads each JSONL file once.
 
 Hermes collection includes CLI and ACP sessions only. Gateway, cron, and WhatsApp sessions
 are excluded because their recorded cwd belongs to the shared gateway process, not a project.

--- a/src/discovery/adapters/pi.js
+++ b/src/discovery/adapters/pi.js
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 
 import {
@@ -13,7 +14,9 @@ import {
 } from "./shared.js";
 
 /**
- * pi: ~/.pi/agent/sessions/<escaped-cwd>/<ISO-ts>_<uuid>.jsonl
+ * Pi writes standalone sessions under
+ * `~/.pi/agent/sessions/<escaped-cwd>/<ISO-ts>_<uuid>.jsonl`. BB's Pi bridge writes the
+ * same JSONL shape directly under `<bb-data-dir>/pi-bridge-sessions/`.
  *
  * Line 1 is `{type:"session", cwd, id}`. Entries form a parent/child tree but arrive in
  * order, so a linear read is faithful. `model_change` / `thinking_level_change` records
@@ -26,13 +29,62 @@ export function storeRoot() {
   return home(".pi", "agent", "sessions");
 }
 
+function expandEnvPath(value) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (trimmed === "~") return home();
+  if (trimmed.startsWith("~/")) return path.join(home(), trimmed.slice(2));
+  return path.resolve(trimmed);
+}
+
+function realpathOrResolve(value) {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+function storeSpecs() {
+  const specs = [
+    { path: storeRoot(), nested: true },
+    { path: home(".bb", "pi-bridge-sessions"), nested: false },
+  ];
+  const piAgentDir = expandEnvPath(process.env.PI_CODING_AGENT_DIR);
+  if (piAgentDir) specs.push({ path: path.join(piAgentDir, "sessions"), nested: true });
+  const piSessionDir = expandEnvPath(process.env.PI_CODING_AGENT_SESSION_DIR);
+  if (piSessionDir) specs.push({ path: piSessionDir, nested: false });
+  const bbDataDir = expandEnvPath(process.env.BB_DATA_DIR);
+  if (bbDataDir) specs.push({ path: path.join(bbDataDir, "pi-bridge-sessions"), nested: false });
+  const bridgeDir = expandEnvPath(process.env.BB_PI_BRIDGE_SESSION_DIR);
+  if (bridgeDir) specs.push({ path: bridgeDir, nested: false });
+
+  const unique = new Map();
+  for (const spec of specs) {
+    const key = realpathOrResolve(spec.path);
+    if (!unique.has(key)) unique.set(key, spec);
+  }
+  return [...unique.values()];
+}
+
+export function storeRoots() {
+  return storeSpecs().map((spec) => spec.path);
+}
+
 export function enumerate() {
   const out = [];
-  for (const dir of listDirs(storeRoot())) {
-    for (const file of listFiles(dir, ".jsonl")) {
+  const seen = new Set();
+  for (const spec of storeSpecs()) {
+    const files = spec.nested
+      ? listDirs(spec.path).flatMap((dir) => listFiles(dir, ".jsonl"))
+      : listFiles(spec.path, ".jsonl");
+    for (const file of files) {
+      const key = realpathOrResolve(file);
+      if (seen.has(key)) continue;
+      seen.add(key);
       const stat = statOrNull(file);
       if (!stat) continue;
-      out.push({ key: file, path: file, mtimeMs: stat.mtimeMs, bytes: stat.size });
+      out.push({ key, path: file, mtimeMs: stat.mtimeMs, bytes: stat.size });
     }
   }
   return out;

--- a/src/discovery/adapters/pi.js
+++ b/src/discovery/adapters/pi.js
@@ -47,22 +47,28 @@ function realpathOrResolve(value) {
 
 function storeSpecs() {
   const specs = [
-    { path: storeRoot(), nested: true },
-    { path: home(".bb", "pi-bridge-sessions"), nested: false },
+    { path: storeRoot(), direct: false, nested: true },
+    { path: home(".bb", "pi-bridge-sessions"), direct: true, nested: false },
   ];
   const piAgentDir = expandEnvPath(process.env.PI_CODING_AGENT_DIR);
-  if (piAgentDir) specs.push({ path: path.join(piAgentDir, "sessions"), nested: true });
+  if (piAgentDir) specs.push({ path: path.join(piAgentDir, "sessions"), direct: false, nested: true });
   const piSessionDir = expandEnvPath(process.env.PI_CODING_AGENT_SESSION_DIR);
-  if (piSessionDir) specs.push({ path: piSessionDir, nested: false });
+  if (piSessionDir) specs.push({ path: piSessionDir, direct: true, nested: false });
   const bbDataDir = expandEnvPath(process.env.BB_DATA_DIR);
-  if (bbDataDir) specs.push({ path: path.join(bbDataDir, "pi-bridge-sessions"), nested: false });
+  if (bbDataDir) specs.push({ path: path.join(bbDataDir, "pi-bridge-sessions"), direct: true, nested: false });
   const bridgeDir = expandEnvPath(process.env.BB_PI_BRIDGE_SESSION_DIR);
-  if (bridgeDir) specs.push({ path: bridgeDir, nested: false });
+  if (bridgeDir) specs.push({ path: bridgeDir, direct: true, nested: false });
 
   const unique = new Map();
   for (const spec of specs) {
     const key = realpathOrResolve(spec.path);
-    if (!unique.has(key)) unique.set(key, spec);
+    const existing = unique.get(key);
+    if (existing) {
+      existing.direct ||= spec.direct;
+      existing.nested ||= spec.nested;
+    } else {
+      unique.set(key, spec);
+    }
   }
   return [...unique.values()];
 }
@@ -75,9 +81,10 @@ export function enumerate() {
   const out = [];
   const seen = new Set();
   for (const spec of storeSpecs()) {
-    const files = spec.nested
-      ? listDirs(spec.path).flatMap((dir) => listFiles(dir, ".jsonl"))
-      : listFiles(spec.path, ".jsonl");
+    const files = [
+      ...(spec.direct ? listFiles(spec.path, ".jsonl") : []),
+      ...(spec.nested ? listDirs(spec.path).flatMap((dir) => listFiles(dir, ".jsonl")) : []),
+    ];
     for (const file of files) {
       const key = realpathOrResolve(file);
       if (seen.has(key)) continue;

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -13,6 +13,7 @@ import * as grok from "../src/discovery/adapters/grok.js";
 import * as cursorCli from "../src/discovery/adapters/cursor-cli.js";
 import * as hermes from "../src/discovery/adapters/hermes.js";
 import { statOrNull } from "../src/discovery/adapters/shared.js";
+import { associate } from "../src/discovery/association.js";
 
 const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
 
@@ -131,6 +132,142 @@ test("pi adapter reads the session header and drops thinking blocks", () => {
   const [toolCall] = tools(events);
   assert.equal(toolCall.name, "bash");
   assert.equal(toolCall.result, "nothing to commit");
+});
+
+function writePiSession(file, { id, cwd }) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    `${JSON.stringify({ type: "session", version: 3, id, timestamp: "2026-08-27T00:00:00.000Z", cwd })}\n`,
+  );
+}
+
+function withPiStoreEnv(
+  { homeDir, piAgentDir = undefined, piSessionDir = undefined, bbDataDir = undefined, bridgeDir = undefined },
+  fn,
+) {
+  const previous = {
+    HOME: process.env.HOME,
+    PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+    PI_CODING_AGENT_SESSION_DIR: process.env.PI_CODING_AGENT_SESSION_DIR,
+    BB_DATA_DIR: process.env.BB_DATA_DIR,
+    BB_PI_BRIDGE_SESSION_DIR: process.env.BB_PI_BRIDGE_SESSION_DIR,
+  };
+  process.env.HOME = homeDir;
+  for (const [key, value] of Object.entries({
+    PI_CODING_AGENT_DIR: piAgentDir,
+    PI_CODING_AGENT_SESSION_DIR: piSessionDir,
+    BB_DATA_DIR: bbDataDir,
+    BB_PI_BRIDGE_SESSION_DIR: bridgeDir,
+  })) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test("pi adapter enumerates standalone and BB-managed session roots without duplicates", () => {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-pi-home-"));
+  const piAgentDir = path.join(fakeHome, "pi-agent");
+  const piSessionDir = path.join(fakeHome, "pi-session-override");
+  const bbDataDir = path.join(fakeHome, "bb-data");
+  const bridgeDir = path.join(fakeHome, "bridge-override");
+  writePiSession(path.join(fakeHome, ".pi", "agent", "sessions", "-repo-demo", "standalone.jsonl"), {
+    id: "standalone",
+    cwd: "/repo/demo",
+  });
+  writePiSession(path.join(piAgentDir, "sessions", "-repo-demo", "custom-agent.jsonl"), {
+    id: "custom-agent",
+    cwd: "/repo/demo",
+  });
+  writePiSession(path.join(piSessionDir, "custom-session.jsonl"), {
+    id: "custom-session",
+    cwd: "/repo/demo",
+  });
+  writePiSession(path.join(fakeHome, ".bb", "pi-bridge-sessions", "default-bb.jsonl"), {
+    id: "default-bb",
+    cwd: "/repo/demo",
+  });
+  writePiSession(path.join(bbDataDir, "pi-bridge-sessions", "custom-data.jsonl"), {
+    id: "custom-data",
+    cwd: "/repo/demo",
+  });
+  writePiSession(path.join(bridgeDir, "direct-override.jsonl"), {
+    id: "direct-override",
+    cwd: "/repo/demo",
+  });
+
+  withPiStoreEnv({ homeDir: fakeHome, piAgentDir, piSessionDir, bbDataDir, bridgeDir }, () => {
+    assert.deepEqual(
+      pi
+        .enumerate()
+        .map((candidate) => path.basename(candidate.path))
+        .sort(),
+      [
+        "custom-agent.jsonl",
+        "custom-data.jsonl",
+        "custom-session.jsonl",
+        "default-bb.jsonl",
+        "direct-override.jsonl",
+        "standalone.jsonl",
+      ],
+    );
+  });
+
+  const defaultBridgeDir = path.join(fakeHome, ".bb", "pi-bridge-sessions");
+  withPiStoreEnv(
+    {
+      homeDir: fakeHome,
+      piAgentDir: path.join(fakeHome, ".pi", "agent"),
+      bbDataDir: path.join(fakeHome, ".bb"),
+      bridgeDir: defaultBridgeDir,
+    },
+    () => {
+      assert.equal(
+        pi.enumerate().filter((candidate) => path.basename(candidate.path) === "default-bb.jsonl").length,
+        1,
+        "the same BB root exposed by defaults and environment is scanned once",
+      );
+    },
+  );
+});
+
+test("BB-managed Pi cwd values use the existing live and deleted worktree association", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-pi-association-"));
+  const live = path.join(root, "live", "hexdeck");
+  const deleted = path.join(root, "deleted", "hexdeck");
+  const bridgeDir = path.join(root, "bb", "pi-bridge-sessions");
+  fs.mkdirSync(live, { recursive: true });
+  writePiSession(path.join(bridgeDir, "live.jsonl"), { id: "live", cwd: live });
+  writePiSession(path.join(bridgeDir, "deleted.jsonl"), { id: "deleted", cwd: deleted });
+
+  withPiStoreEnv({ homeDir: path.join(root, "home"), bridgeDir }, () => {
+    const descriptors = new Map(
+      pi.enumerate().map((candidate) => [path.basename(candidate.path), pi.classify(candidate)]),
+    );
+    const liveRealpath = fs.realpathSync(live);
+    const repo = { name: "hexdeck", worktrees: [liveRealpath], remotes: [] };
+    assert.deepEqual(associate(descriptors.get("live.jsonl"), repo), {
+      tier: 1,
+      confidence: "exact",
+      reason: `cwd is worktree ${liveRealpath}`,
+    });
+    assert.deepEqual(
+      associate(descriptors.get("deleted.jsonl"), repo, { worktreeGlobs: [path.join(root, "deleted", "**")] }),
+      {
+        tier: 3,
+        confidence: "path",
+        reason: "dead path ending in /hexdeck",
+      },
+    );
+  });
 });
 
 test("grok adapter reads remotes from summary.json and tool calls off the assistant record", () => {

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -239,6 +239,30 @@ test("pi adapter enumerates standalone and BB-managed session roots without dupl
   );
 });
 
+test("pi adapter merges flat and nested scans for one sessions root", () => {
+  const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-pi-overlap-"));
+  const piAgentDir = path.join(fakeHome, ".pi", "agent");
+  const sessionsDir = path.join(piAgentDir, "sessions");
+  writePiSession(path.join(sessionsDir, "direct.jsonl"), {
+    id: "direct",
+    cwd: "/repo/demo",
+  });
+  writePiSession(path.join(sessionsDir, "-repo-demo", "nested.jsonl"), {
+    id: "nested",
+    cwd: "/repo/demo",
+  });
+
+  withPiStoreEnv({ homeDir: fakeHome, piAgentDir, piSessionDir: sessionsDir }, () => {
+    assert.deepEqual(
+      pi
+        .enumerate()
+        .map((candidate) => path.basename(candidate.path))
+        .sort(),
+      ["direct.jsonl", "nested.jsonl"],
+    );
+  });
+});
+
 test("BB-managed Pi cwd values use the existing live and deleted worktree association", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-pi-association-"));
   const live = path.join(root, "live", "hexdeck");


### PR DESCRIPTION
## Intent

Add the smallest upstream-ready Backpass change that discovers BB-managed Pi sessions as well as standalone Pi sessions and associates their live or deleted worktree cwd values with the target repository through Backpass existing Git remote and worktree association. Use general provider-specific transcript roots and configurable BB data roots without hard-coding a user home path. Support PI_CODING_AGENT_DIR, PI_CODING_AGENT_SESSION_DIR, BB_DATA_DIR, and BB_PI_BRIDGE_SESSION_DIR; deduplicate overlapping roots and files; preserve other providers; cover session parsing, custom roots, live and deleted worktrees, and duplicate handling; and document the behavior. Do not include the unrelated symlink warning issue, install acpx, or run Backpass model analysis.

## What Changed

- Discover Pi transcripts from standalone stores and BB-managed bridge stores, including all supported Pi and BB environment overrides.
- Scan flat and nested session layouts while deduplicating overlapping roots and files.
- Document the new discovery behavior and cover custom roots, session parsing, duplicate handling, and live or deleted worktree association.

## Risk Assessment

✅ Low: The focused change now merges overlapping Pi root scan modes, deduplicates resolved files, preserves existing discovery paths, and has behavior-level coverage for the required roots and associations.

## Testing

Reproduced the overlap bug on commit 8123ad7, passed the focused Pi regressions and adapter-level provider checks, then verified an end-to-end `backpass scan` across every configured Pi root with deduplication and live/deleted worktree association; the reviewer-visible JSON evidence passed exact assertions, and temporary files were removed.

<details>
<summary>Evidence: Backpass Pi scan evidence</summary>

`CLI scan found five unique Pi sessions across standalone, BB-managed, custom, overlapping flat, and nested roots. Live worktrees used tier 1; the deleted worktree used tier 3.`

```text
{
  "repo": "demo",
  "perHarness": {
    "pi": {
      "scanned": 5,
      "matched": 5,
      "cached": 0,
      "skipped": 0,
      "self": 0,
      "error": null
    }
  },
  "transcripts": [
    {
      "harness": "pi",
      "id": "pi-bb-custom-live",
      "nativeId": "bb-custom-live",
      "path": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/bb-data/pi-bridge-sessions/bb-custom-live.jsonl",
      "cwd": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo",
      "gitBranch": null,
      "title": null,
      "model": null,
      "startedAt": 1787918400000,
      "mtimeMs": 1787929814687.707,
      "bytes": 258,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /private/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo"
      },
      "extra": {}
    },
    {
      "harness": "pi",
      "id": "pi-bb-default-deleted",
      "nativeId": "bb-default-deleted",
      "path": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/home/.bb/pi-bridge-sessions/bb-default-deleted.jsonl",
      "cwd": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/deleted/demo",
      "gitBranch": null,
      "title": null,
      "model": null,
      "startedAt": 1787918400000,
      "mtimeMs": 1787929814687.4634,
      "bytes": 265,
      "experimental": false,
      "association": {
        "tier": 3,
        "confidence": "path",
        "reason": "dead path ending in /demo"
      },
      "extra": {}
    },
    {
      "harness": "pi",
      "id": "pi-custom-nested",
      "nativeId": "custom-nested",
      "path": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/pi-agent/sessions/-live-demo/custom-nested.jsonl",
      "cwd": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo",
      "gitBranch": null,
      "title": null,
      "model": null,
      "startedAt": 1787918400000,
      "mtimeMs": 1787929814687.2476,
      "bytes": 257,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /private/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo"
      },
      "extra": {}
    },
    {
      "harness": "pi",
      "id": "pi-custom-direct",
      "nativeId": "custom-direct",
      "path": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/pi-agent/sessions/custom-direct.jsonl",
      "cwd": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo",
      "gitBranch": null,
      "title": null,
      "model": null,
      "startedAt": 1787918400000,
      "mtimeMs": 1787929814687.1047,
      "bytes": 257,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /private/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo"
      },
      "extra": {}
    },
    {
      "harness": "pi",
      "id": "pi-standalone-live",
      "nativeId": "standalone-live",
      "path": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/home/.pi/agent/sessions/-live-demo/standalone-live.jsonl",
      "cwd": "/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo",
      "gitBranch": null,
      "title": null,
      "model": null,
      "startedAt": 1787918400000,
      "mtimeMs": 1787929814686.9077,
      "bytes": 259,
      "experimental": false,
      "association": {
        "tier": 1,
        "confidence": "exact",
        "reason": "cwd is worktree /private/var/folders/3y/shh4k8sd4_b165xsrcnm3wt80000gn/T/backpass-pr.GAJfOE/no-mistakes-codex/worktrees/1de86adb66c7/01M1385AW52NQKF7K8ZY8NZDD7/.tmp-pi-e2e/live/demo"
      },
      "extra": {}
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1f509a490fa90352787998c2e707fc07f3c55674","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/discovery/adapters/pi.js:65` - The required criterion says to “Support PI_CODING_AGENT_DIR, PI_CODING_AGENT_SESSION_DIR ... [and] deduplicate overlapping roots and files.” If `PI_CODING_AGENT_DIR=/x` and `PI_CODING_AGENT_SESSION_DIR=/x/sessions`, Pi writes custom-session JSONL files directly in `/x/sessions`. The nested spec is inserted first, so this line discards the later flat spec and `enumerate()` checks only child directories. It silently misses every direct JSONL file. The common case where `PI_CODING_AGENT_SESSION_DIR` points to the default sessions root fails too. Merge duplicate roots’ scan modes and scan both flat and nested layouts before file-level deduplication.

🔧 Fix: Merge overlapping Pi transcript scan modes
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='pi adapter (reads|enumerates|merges)|BB-managed Pi cwd' test/adapters.test.js`
- `node --test test/adapters.test.js`
- <code>Used `git archive 8123ad7 ...` with the isolated fixtures to reproduce the prior regression: the nested session was found, but the overlapping direct session was missed.</code>
- <code>Created isolated standalone, default BB, custom BB, flat, nested, live-worktree, and deleted-worktree Pi fixtures; then ran `HOME=&#34;$manual_root/home&#34; XDG_CONFIG_HOME=&#34;$manual_root/xdg&#34; PI_CODING_AGENT_DIR=&#34;$manual_root/pi-agent&#34; PI_CODING_AGENT_SESSION_DIR=&#34;$manual_root/pi-agent/sessions&#34; BB_DATA_DIR=&#34;$manual_root/bb-data&#34; BB_PI_BRIDGE_SESSION_DIR=&#34;$manual_root/bb-data/pi-bridge-sessions&#34; NO_COLOR=1 node &#34;$source_root/bin/backpass.js&#34; scan --harness pi --since all --json`.</code>
- `Parsed the generated CLI JSON and asserted the exact five unique session IDs, scan totals, tier-1 live associations, and tier-3 deleted-worktree association.`
- `Removed all temporary worktree fixtures and confirmed the worktree has no new changes.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
