### PR TITLE
fix(apply): stop replacement-token expansion from corrupting apply.html

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   each wait state once and never per cycle. Session URLs are printed as `url: "http://..."`,
   so parse them with `extractUrl`, never a bare `\S+`. Browser launch is best effort
   (`src/apply/browser.js`): the printed URL is the contract. `test/fixtures/fake-lavish/`
-  stands in for the CLI via `BACKPASS_LAVISH_BIN` in tests.
+  stands in for the CLI via `BACKPASS_LAVISH_BIN` in tests. `injectPayload` in
+  `src/apply/lavish.js` must splice the templated `<script>` tag into `apply.html` with a
+  function replacer, never a string one: a string second argument to `String.prototype.replace`
+  interprets `$&`, `` $` ``, `$'`, and `$$` in it as replacement patterns, and the spliced
+  text embeds untrusted proposal/evidence prose that can contain those sequences verbatim.
 - Cursor IDE support is deliberately deferred to v1.1 (`--include-cursor-ide`, best effort);
   see the header of `src/discovery/adapters/cursor-ide.js` for why.
 

--- a/src/apply/lavish.js
+++ b/src/apply/lavish.js
@@ -26,7 +26,10 @@ export function injectPayload(template, payload, toolVersion) {
     .replace(/\u2029/g, "\\u2029");
   const tag = `<script>window.__BACKPASS_PROPOSAL__ = ${json};</script>`;
   if (!template.includes("</head>")) return `${tag}\n${template}`;
-  return template.replace("</head>", `${tag}\n</head>`);
+  // A function replacer, not a string one: a string second argument to `replace` treats
+  // `$&`, `` $` ``, `$'`, and `$$` in it as replacement patterns, and `tag` embeds
+  // untrusted proposal text that can contain any of those sequences verbatim.
+  return template.replace("</head>", () => `${tag}\n</head>`);
 }
 
 export function renderApplySurface(proposal, state, toolVersion) {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -13,9 +13,9 @@ import {
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
 import { estimateTokens } from "../src/tokens.js";
-import { isSuppressedByRejection, recordRejection } from "../src/state.js";
+import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
-import { injectPayload, parseDecisions } from "../src/apply/lavish.js";
+import { injectPayload, parseDecisions, renderApplySurface } from "../src/apply/lavish.js";
 import { extractJson, parseTokenLine, stripAcpxNoise } from "../src/acpx.js";
 import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
 
@@ -868,6 +868,78 @@ test("the apply surface receives one payload, with markup in the data neutralise
   assert.ok(!html.includes("</script><img"), "injected markup must not break out of the script tag");
   assert.ok(html.includes("\\u003c/script"));
   assert.ok(html.indexOf("__BACKPASS_PROPOSAL__") < html.indexOf("</head>"));
+});
+
+// A string second argument to `String.prototype.replace` treats `$&`, `` $` ``, `$'`, and
+// `$$` as replacement-pattern tokens, not literal text. Proposal evidence is untrusted
+// human/model prose and can contain any of these verbatim (a possessive "the tool$'s
+// state", a shell snippet with "$(...)" abbreviated as "$`...`", a price "$$5"), so the
+// injector must treat the whole payload as opaque data regardless of its content.
+const REPLACEMENT_TOKEN_PAYLOADS = {
+  "dollar-apostrophe": "the agent read the tool$'s cached state",
+  "dollar-ampersand": "grep matched $& in the log line",
+  "dollar-backtick": "ran a subshell command: $`date`",
+  "doubled-dollar": "the invoice showed a $$5 line item",
+  combination: "$$ then $& then $`x` then it's $'s turn, all in one line",
+  "evidence-shaped": [
+    "Session AG-014: the agent tried $'hi\\x27' to test ANSI-C quoting,",
+    "then noted the budget was $$50 over and the diff matched $& in its own grep,",
+    "before falling back to a subshell: $`date`.",
+  ].join(" "),
+};
+
+function extractInjectedPayload(html) {
+  const match = /window\.__BACKPASS_PROPOSAL__ = (.*);<\/script>/.exec(html);
+  assert.ok(match, `no injected payload found in:\n${html}`);
+  return JSON.parse(match[1]);
+}
+
+for (const [name, title] of Object.entries(REPLACEMENT_TOKEN_PAYLOADS)) {
+  test(`injectPayload treats a ${name} evidence payload as opaque data`, () => {
+    const template = "<html><head><title>t</title></head><body>ORIGINAL BODY MARKER</body></html>";
+    const payload = { edits: [{ title, evidence: [{ quote: title }] }] };
+    const html = injectPayload(template, payload, "0.1.0");
+
+    assert.equal((html.match(/<body>/g) || []).length, 1, "template suffix must not duplicate");
+    assert.equal((html.match(/<\/html>/g) || []).length, 1, "template suffix must not duplicate");
+    assert.equal((html.match(/<\/head>/g) || []).length, 1, "injection point must not duplicate");
+    assert.equal((html.match(/ORIGINAL BODY MARKER/g) || []).length, 1, "body content must not duplicate");
+
+    const parsed = extractInjectedPayload(html);
+    assert.deepEqual(parsed, { ...payload, toolVersion: "0.1.0" }, "the full payload must survive unchanged");
+  });
+}
+
+test("replacement tokens combined with markup still get both defenses", () => {
+  const template = "<html><head></head><body>MARKER</body></html>";
+  const title = "</script><img onerror=alert(1)> and a possessive tool$'s state, plus $$ $&";
+  const html = injectPayload(template, { edits: [{ title }] }, "0.1.0");
+
+  assert.equal((html.match(/<body>/g) || []).length, 1, "template suffix must not duplicate");
+  assert.equal((html.match(/MARKER/g) || []).length, 1, "body content must not duplicate");
+  assert.ok(!html.includes("</script><img"), "injected markup must not break out of the script tag");
+  assert.deepEqual(extractInjectedPayload(html), { edits: [{ title }], toolVersion: "0.1.0" });
+});
+
+test("renderApplySurface writes one valid document through the real template", () => {
+  const repo = makeRepo();
+  const state = new State(repo.root);
+  const payload = {
+    edits: [
+      { title: REPLACEMENT_TOKEN_PAYLOADS["combination"] },
+      { title: REPLACEMENT_TOKEN_PAYLOADS["evidence-shaped"] },
+    ],
+  };
+
+  const target = renderApplySurface(payload, state, "0.1.0");
+  const html = fs.readFileSync(target, "utf8");
+
+  assert.equal((html.match(/<!doctype html>/gi) || []).length, 1, "must be a single document");
+  assert.equal((html.match(/<body[ >]/gi) || []).length, 1, "template suffix must not duplicate");
+  assert.equal((html.match(/<\/html>/gi) || []).length, 1, "template suffix must not duplicate");
+  assert.equal((html.match(/<\/head>/gi) || []).length, 1, "injection point must not duplicate");
+
+  assert.deepEqual(extractInjectedPayload(html), { ...payload, toolVersion: "0.1.0" });
 });
 
 test("the decision vector from the review surface is parsed back into decisions", () => {


### PR DESCRIPTION
## Summary

- `injectPayload` in `src/apply/lavish.js` spliced the templated `<script>` payload into `apply.html` using a **string** second argument to `String.prototype.replace`. A string replacement argument treats `$&`, `` $` ``, `$'`, and `$$` as special replacement-pattern tokens, not literal text.
- Proposal evidence text is untrusted human/model prose and can contain those sequences verbatim (e.g. a possessive `tool$'s state`). When it did, the template suffix was duplicated in the generated `apply.html` (reproduced: a 360KB file with one doctype but three `<body>`/`</html>` sections), and Lavish rendered raw JSON instead of the review UI.
- Fix: use a **function** replacer instead (`template.replace("</head>", () => ...)`), which is never interpreted for special patterns, so arbitrary proposal text is always spliced in as literal data. This is a one-line change; no proposal/evidence content is touched, and the existing `<`, U+2028, U+2029 script-breakout defenses are untouched.

## Test plan

- [x] Added `test/proposal.test.js` regressions exercising `injectPayload` through the public interface with dollar-apostrophe, dollar-ampersand, dollar-backtick, doubled-dollar, combination, and evidence-shaped payloads - asserting single-document structure and exact payload round-trip.
- [x] Added a regression exercising the real render path (`renderApplySurface` with the real `templates/apply.html`), asserting one doctype/body/head/html in the output.
- [x] Verified regressions fail against the pre-fix code (3x duplication, matching the originally reported corruption) and pass against the fix.
- [x] `pnpm run check` (lint, format:check, typecheck, full test suite - 299 tests) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)