### PR TITLE
feat: judge gap identity and safeguard instruction removals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,7 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 - **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other
   values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each
-  quote - the no-mistakes postmortem traced a wrong deletion to that field being stripped.
-  Records from before the class existed carry none, and none never counts as harm.
+  quote. Records from before the class existed carry none, and none never counts as harm.
 - **Skills only count if a harness loads them.** Extractions target `.agents/skills` with
   `.claude/skills -> ../.agents/skills` as a symlink (`ensureSkillsLayout` in
   `src/skills.js`, run at write time); a bare `skills/` dir is never auto-detected and a
@@ -159,8 +158,8 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 - **Gap identity is judged, not word-matched.** Bigram similarity cannot recognize real
   paraphrase (measured on production data: max cross-session score 0.34 vs the 0.45 bar),
   so it is only the fallback. The analysis turn cites open-gap ids (`matchesGap`, shown via
-  `renderOpenGapIndex`; an invalid citation falls back, never fails), and `foldForRun` runs
-  ONE consolidation call per run (`src/consolidate.js`) that merges paraphrased entries
+  `renderOpenGapIndex`; an invalid citation falls back, never fails), and, with at least two
+  open entries, `foldForRun` runs ONE consolidation call (`src/consolidate.js`) that merges paraphrased entries
   (`mergeGapEntries`) - record, consolidate, prune, in that order. Consolidation failure
   degrades to lexical identity with a warning, never an abort. Gaps also carry `domain`;
   `orchestration` sightings (task-harness mistakes, not this repo's engineering) are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   why, so a change that argues one of those calls should go the other way starts there.
 - `README.md` documents the user-facing surface; `src/cli.js` is the authoritative flag list.
 - The pipeline is one stage per module, in order: `src/discovery/` -> `src/sample.js` (cap) -> `src/distill.js` ->
-  `src/analyze.js` -> `src/fold.js` -> `src/synthesize.js` (with `src/workspace.js` + `src/diff.js`) ->
+  `src/analyze.js` -> `src/consolidate.js` (gap-identity merge, inside `foldForRun`) -> `src/fold.js` ->
+  `src/synthesize.js` (with `src/workspace.js` + `src/diff.js`) ->
   `src/proposal.js` -> `src/apply/`. Each module's header comment explains its role; read those
   before changing a stage.
 - **User-facing step names are the training-loop terms**, not the module names: discover =
@@ -106,6 +107,20 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   half-accepted. `buildProposal` allows N skills only when they share ONE hunk; separately
   measured skills must stay separate edits. Edits carry `skills: []`; read them through
   `editSkills` (`src/skills.js`), which also understands the pre-0.1.8 single `skill`.
+- **Extraction and deletion never share one decision.** `measureWorkspace` splits a pure
+  removal that mixes skill-carried and vanishing text at that boundary (`splitRemovalHunk`;
+  a split that cannot anchor uniquely keeps the merged hunk instead of guessing). In
+  `buildProposal`, an extract's skills must carry every line its hunks remove
+  (dash-and-whitespace-folded, `normalizeRecoveryLine`), and any other edit whose hunk only
+  deletes memory-file text is a removal whatever its kind: each deleted unit needs
+  `minGapEvidence` distinct sessions of `class: "harm"` negatives (`harmSessions` in the
+  fold). Non-compliance never satisfies the floor; the >= 20%-relevance placement table
+  stays prompt guidance by the captain's explicit decision - do not harden it.
+- **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
+  negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other
+  values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each
+  quote - the no-mistakes postmortem traced a wrong deletion to that field being stripped.
+  Records from before the class existed carry none, and none never counts as harm.
 - **Skills only count if a harness loads them.** Extractions target `.agents/skills` with
   `.claude/skills -> ../.agents/skills` as a symlink (`ensureSkillsLayout` in
   `src/skills.js`, run at write time); a bare `skills/` dir is never auto-detected and a
@@ -141,6 +156,16 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   Record this run's evidence _before_ pruning - old evidence files stay on disk and would
   re-add an expired or covered sighting otherwise. Uncorroborated gaps stay hidden; never
   surface singletons to the prompt or report.
+- **Gap identity is judged, not word-matched.** Bigram similarity cannot recognize real
+  paraphrase (measured on production data: max cross-session score 0.34 vs the 0.45 bar),
+  so it is only the fallback. The analysis turn cites open-gap ids (`matchesGap`, shown via
+  `renderOpenGapIndex`; an invalid citation falls back, never fails), and `foldForRun` runs
+  ONE consolidation call per run (`src/consolidate.js`) that merges paraphrased entries
+  (`mergeGapEntries`) - record, consolidate, prune, in that order. Consolidation failure
+  degrades to lexical identity with a warning, never an abort. Gaps also carry `domain`;
+  `orchestration` sightings (task-harness mistakes, not this repo's engineering) are
+  counted in `totals.orchestrationGapSightings` and excluded from clustering, so they can
+  never reach a proposal - there is deliberately no orchestrator-memory write path.
 - **backpass must never analyze itself.** Its own acpx calls are filed by each harness
   under the repo's cwd, a tier-1 match. Every prompt starts with `SELF_SESSION_SENTINEL`
   (`src/prompts.js`) and discovery drops transcripts whose first user message begins with

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ analysis is shown the ledger's open gaps so it can cite an existing gap id inste
 coining a paraphrase of it.
 
 **Every claim must carry a verbatim quote.** Quoteless items are discarded - the single
-most important defence against a model confabulating influence. Negative evidence (a
-visible violation) is weighted highest.
+most important defence against a model confabulating influence. Negative evidence is
+weighted highest, but its class determines what it supports: non-compliance supports
+reinforcement, while only harm supports removal.
 
 Results are cached per transcript, keyed to both the transcript's content _and_ the effective
 memory-file set hash: edit the weights and the evidence correctly re-computes; change nothing
@@ -186,14 +187,14 @@ dropped. One bad session never rewrites the weights.
 
 Whether two sightings are one gap is a judgment call, not a word-overlap score - models
 paraphrase, and a paraphrase that fails a lexical match would hide real recurrence.
-Identity is judged twice, both times anchored to quotes: the analysis turn cites an
-existing gap id when it sees a gap already on the books, and one bounded consolidation
-call per run sees the full open gap set and merges entries that are the same gap - which
-is what lets two sightings of a brand-new gap in the same run's parallel fan-out
-corroborate. A failed consolidation call degrades the run to lexical identity and says
-so; it never aborts. Orchestration-domain gaps are counted and reported but never
-cluster: mistakes about the task harness around a session do not become instructions in
-the project's memory file.
+Identity is judged twice: the quote-anchored analysis turn cites an existing gap id when
+it sees a gap already on the books, and, when at least two open entries exist, one bounded
+consolidation call sees the full open gap set and merges entries that describe the same
+mistake. That second judgment is what lets two sightings of a brand-new gap in the same
+run's parallel fan-out corroborate. A failed consolidation call degrades the run to
+lexical identity and says so; it never aborts. Orchestration-domain gaps are counted and
+reported but never cluster: mistakes about the task harness around a session do not
+become instructions in the project's memory file.
 
 Only evidence judged against the _current_ memory-file set hash is folded into a proposal. A
 transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the
@@ -243,9 +244,10 @@ Neighbouring removals are merged into one measured change, and a merged change c
 accepted in halves - so when several sections leave together, their skills arrive as one
 extract with several skills, which is one honest accept/reject decision. Skills whose
 removals were measured separately stay separate decisions, and bundling them is refused.
-The one boundary the measurement always splits on is extraction vs deletion: a contiguous
-removal that mixes text carried into skills with text that simply vanishes is measured as
-two changes, so accepting the extraction never silently accepts the deletion beside it.
+The measurement splits a contiguous removal at an extraction-vs-deletion boundary when
+both resulting changes can be anchored safely, so accepting the extraction does not
+silently accept the deletion beside it. If either change cannot be anchored uniquely, it
+keeps the merged change rather than guessing.
 
 A malformed answer or gate violation triggers a re-prompt naming the exact breach (at
 most two). If those also fail, backpass **fails loudly** and preserves the latest parseable

--- a/README.md
+++ b/README.md
@@ -155,7 +155,13 @@ equally reproducible sample.
 
 Each distilled trace goes to a cheap model with the memory file and a rubric. It returns
 strict JSON: which instructions helped, which were violated, and what mistakes no current
-instruction covers.
+instruction covers. Every negative carries a class - `harm` (following the instruction
+caused damage), `non-compliance` (the agent ignored it), or `irrelevant` - because those
+argue for opposite fates: harm argues against an instruction, non-compliance argues for
+reinforcing it. Every gap carries a domain - `project` for this repository's own
+engineering, `orchestration` for the task-management layer around the session - and the
+analysis is shown the ledger's open gaps so it can cite an existing gap id instead of
+coining a paraphrase of it.
 
 **Every claim must carry a verbatim quote.** Quoteless items are discarded - the single
 most important defence against a model confabulating influence. Negative evidence (a
@@ -170,12 +176,24 @@ broken." Evidence files that are not refreshed remain on disk but are excluded w
 hash is stale. They become eligible again if the memory-file set returns to that hash;
 evidence for transcripts included in the new analysis is replaced with fresh judgments.
 
-### 4. Aggregate gradients - deterministic, no model
+### 4. Aggregate gradients - and one judged consolidation call
 
-Evidence is grouped by instruction, giving each one a positive/negative count and a
-**relevance** figure: the share of analyzed sessions in which it mattered at all. Duplicate
-gaps across sessions are clustered, and clusters seen in fewer than `minGapEvidence`
-sessions (default 2) are dropped. One bad session never rewrites the weights.
+Evidence is grouped by instruction, giving each one a positive/negative count, a count of
+distinct sessions with harm-class negatives, and a **relevance** figure: the share of
+analyzed sessions in which it mattered at all. Duplicate gaps across sessions are
+clustered, and clusters seen in fewer than `minGapEvidence` sessions (default 2) are
+dropped. One bad session never rewrites the weights.
+
+Whether two sightings are one gap is a judgment call, not a word-overlap score - models
+paraphrase, and a paraphrase that fails a lexical match would hide real recurrence.
+Identity is judged twice, both times anchored to quotes: the analysis turn cites an
+existing gap id when it sees a gap already on the books, and one bounded consolidation
+call per run sees the full open gap set and merges entries that are the same gap - which
+is what lets two sightings of a brand-new gap in the same run's parallel fan-out
+corroborate. A failed consolidation call degrades the run to lexical identity and says
+so; it never aborts. Orchestration-domain gaps are counted and reported but never
+cluster: mistakes about the task harness around a session do not become instructions in
+the project's memory file.
 
 Only evidence judged against the _current_ memory-file set hash is folded into a proposal. A
 transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the
@@ -211,6 +229,12 @@ Then mechanical gates run, and they are not negotiable:
   is a violation, so is an edit that names no change
 - new instructions need evidence from `minGapEvidence` distinct sessions (an edit that
   only adds text is a new instruction, whatever the model calls it)
+- removing an instruction outright needs harm-class negatives from `minGapEvidence`
+  distinct sessions - non-compliance never counts, because a rule that was skipped needs
+  reinforcement, not deletion (a change that only deletes text outside an extraction is a
+  removal, whatever the model calls it)
+- an extraction preserves every line it removes in the skills it creates; a deletion is
+  never part of an extract
 - every edit carries a verbatim quote
 - the post-edit file must fit the budget, measured on the staged file
 
@@ -219,6 +243,9 @@ Neighbouring removals are merged into one measured change, and a merged change c
 accepted in halves - so when several sections leave together, their skills arrive as one
 extract with several skills, which is one honest accept/reject decision. Skills whose
 removals were measured separately stay separate decisions, and bundling them is refused.
+The one boundary the measurement always splits on is extraction vs deletion: a contiguous
+removal that mixes text carried into skills with text that simply vanishes is measured as
+two changes, so accepting the extraction never silently accepts the deletion beside it.
 
 A malformed answer or gate violation triggers a re-prompt naming the exact breach (at
 most two). If those also fail, backpass **fails loudly** and preserves the latest parseable

--- a/VISION.md
+++ b/VISION.md
@@ -13,7 +13,7 @@ A visible violation outranks any number of "it went fine" observations, because 
 A new instruction needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
 Removing an instruction takes the same corroboration adding one does, and only harm from following it counts, because a rule that was merely skipped argues for reinforcement rather than deletion.
 Corroboration accumulates across runs in a ledger rather than resetting each run, so a gap seen today and again next week still graduates.
-Whether two sightings are one gap is judged against their quotes rather than scored by word overlap, because models paraphrase and a paraphrase must never hide recurrence.
+Whether two sightings are one gap is judged from their evidence rather than scored by word overlap, because models paraphrase and a paraphrase must never hide recurrence.
 A mistake that belongs to the task harness around a session is counted and set aside, never written into the project's file.
 An uncorroborated gap never becomes a proposal, though counting one is fair where that helps a person understand a run.
 One bad session never rewrites the weights, because a single session can go wrong for reasons that have nothing to do with the file.

--- a/VISION.md
+++ b/VISION.md
@@ -11,7 +11,10 @@ Every claim a model makes carries a verbatim quote copied from the trace, and a 
 A signal extracted mechanically, with no judgment applied to it, is noise until a quote anchors it to a real moment, so there is no quoteless path into the file.
 A visible violation outranks any number of "it went fine" observations, because negative evidence is what proves the file was steering anything at all.
 A new instruction needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
+Removing an instruction takes the same corroboration adding one does, and only harm from following it counts, because a rule that was merely skipped argues for reinforcement rather than deletion.
 Corroboration accumulates across runs in a ledger rather than resetting each run, so a gap seen today and again next week still graduates.
+Whether two sightings are one gap is judged against their quotes rather than scored by word overlap, because models paraphrase and a paraphrase must never hide recurrence.
+A mistake that belongs to the task harness around a session is counted and set aside, never written into the project's file.
 An uncorroborated gap never becomes a proposal, though counting one is fair where that helps a person understand a run.
 One bad session never rewrites the weights, because a single session can go wrong for reasons that have nothing to do with the file.
 

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -6,6 +6,7 @@ import { distill } from "./distill.js";
 import { readTranscript } from "./discovery/index.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt } from "./prompts.js";
+import { renderOpenGapIndex } from "./gap-ledger.js";
 import { evidenceKey, isEvidenceFresh, safeFileName } from "./state.js";
 import { emitProgress } from "./progress.js";
 import { UserError, color, info, warn } from "./logger.js";
@@ -33,6 +34,9 @@ function noteOnce(note) {
   warn(note);
 }
 
+/** Negative evidence carries one of these classes; anything else is dropped as unjudged. */
+export const NEGATIVE_CLASSES = ["harm", "non-compliance", "irrelevant"];
+
 /** Evidence items without a verbatim quote are dropped - the rubric's central rule. */
 export function sanitizeEvidence(parsed) {
   const clean = { positive: [], negative: [], gaps: [], usedRawTranscript: Boolean(parsed?.usedRawTranscript) };
@@ -43,23 +47,33 @@ export function sanitizeEvidence(parsed) {
   for (const key of ["positive", "negative"]) {
     for (const item of Array.isArray(parsed[key]) ? parsed[key] : []) {
       if (!hasQuote(item) || typeof item.instruction !== "string") continue;
-      clean[key].push({
+      const entry = {
         instruction: item.instruction.trim(),
         moment: String(item.moment ?? "").slice(0, 80),
         effect: String(item.effect ?? "").slice(0, 400),
         quote: item.quote.trim().slice(0, 600),
-      });
+      };
+      // The class is what keeps "the agent skipped the rule" from being read as "the
+      // rule caused harm" downstream. Only an explicit judged value is kept; records
+      // from before the field existed simply carry none, and none never counts as harm.
+      if (key === "negative" && NEGATIVE_CLASSES.includes(item.class)) entry.class = item.class;
+      clean[key].push(entry);
     }
   }
 
   for (const item of Array.isArray(parsed.gaps) ? parsed.gaps : []) {
     if (!hasQuote(item) || typeof item.proposedInstruction !== "string") continue;
-    clean.gaps.push({
+    const gap = {
       mistake: String(item.mistake ?? "").slice(0, 400),
       proposedInstruction: item.proposedInstruction.trim().slice(0, 400),
       recurrenceRisk: ["high", "medium", "low"].includes(item.recurrenceRisk) ? item.recurrenceRisk : "medium",
       quote: item.quote.trim().slice(0, 600),
-    });
+      domain: item.domain === "orchestration" ? "orchestration" : "project",
+    };
+    if (typeof item.matchesGap === "string" && /^[0-9a-f]{16}$/.test(item.matchesGap.trim())) {
+      gap.matchesGap = item.matchesGap.trim();
+    }
+    clean.gaps.push(gap);
   }
 
   return clean;
@@ -84,7 +98,7 @@ function promptPathFor(state, transcript) {
   return path.join(state.applyDir, "..", "prompts", `${safeFileName(transcriptIdentity(transcript))}.md`);
 }
 
-async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
+async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0, openGapIndex = "(none yet)" }) {
   const raw = await readTranscript(transcript);
   const distilled = distill(raw.events, {
     ...transcript,
@@ -120,6 +134,7 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0 }) {
   const prompt = renderPrompt("analysis", {
     MEMORY_PATH: memoryFile.path,
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
+    OPEN_GAPS: openGapIndex,
     TRACE: distilled.trace,
   });
 
@@ -242,6 +257,10 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
       `${pick.model ? ` (${pick.model})` : ""}${pick.effort ? ` effort=${pick.effort}` : ""} at jobs=${config.jobs}`,
   );
 
+  // Rendered once per run: the ledger's open gaps, so each analysis can cite an existing
+  // gap id instead of coining a paraphrase of it (`matchesGap` in the reply schema).
+  const openGapIndex = renderOpenGapIndex(state.readGapLedger(), memoryFile.path);
+
   let done = 0;
   const evidenceTotals = { positive: 0, negative: 0, gaps: 0 };
   await pool(pending, config.jobs, async (transcript, _index, slot) => {
@@ -271,7 +290,7 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
     });
 
     try {
-      const result = await analyzeOne({ transcript, memoryFile, config, repo, slot });
+      const result = await analyzeOne({ transcript, memoryFile, config, repo, slot, openGapIndex });
       if (result.status === "skipped") {
         summary.skipped += 1;
         state.writeEvidence(transcript, { ...base, status: "skipped", reason: result.reason });

--- a/src/cli.js
+++ b/src/cli.js
@@ -109,7 +109,7 @@ MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
 BUDGET AND SHAPE
   --budget <tokens>        always-loaded budget per memory file         [5000]
   --max-edits <n>          edits per run - the learning rate            [adaptive]
-  --min-gap-evidence <n>   sessions needed before a new instruction     [2]
+  --min-gap-evidence <n>   sessions needed to add or remove instruction [2]
   --memory-file <path>     memory file to optimize (repeatable)
   --skills-dir <path>      where skill extractions are written          [.agents/skills]
 

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -8,7 +8,7 @@ import { ProposalViolation } from "../proposal.js";
 import { synthesizeProposal } from "../synthesize.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { discoverForRun } from "./scan.js";
-import { foldForRun, printProposal } from "./propose.js";
+import { accountForConsolidationUsage, foldForRun, printProposal } from "./propose.js";
 
 /**
  * Bootstrap: the default run when the repo has no memory file at all.
@@ -41,6 +41,7 @@ export async function bootstrapRun(ctx, deps = {}) {
   const discover = deps.discover || discoverForRun;
   const analyze = deps.analyze || analyzeTranscripts;
   const synthesize = deps.synthesize || synthesizeProposal;
+  const fold = deps.fold || foldForRun;
   const { canonical, pointer } = bootstrapTargets(config.memoryFiles);
 
   const { transcripts, perHarness } = await discover(ctx);
@@ -101,7 +102,7 @@ export async function bootstrapRun(ctx, deps = {}) {
       `${result.summary.skipped} too short · ${result.summary.failed} failed`,
   );
 
-  const folded = await foldForRun(ctx, memoryFile, memoryHash);
+  const folded = await fold(ctx, memoryFile, memoryHash);
   config.state.writeSummary(folded);
   emitProgress("fold:done", {
     instructions: folded.instructions.length,
@@ -121,6 +122,7 @@ export async function bootstrapRun(ctx, deps = {}) {
       transcripts,
       runNote: BOOTSTRAP_RUN_NOTE,
     });
+    accountForConsolidationUsage(proposal, folded);
     const decisions = Object.fromEntries(proposal.edits.map((e) => [e.id, "accepted"]));
     const applied = applyDecisions({ proposal, decisions, repo, state: config.state, config });
     proposal.appliedAt = new Date().toISOString();

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -1,3 +1,4 @@
+import { consolidateGapLedger } from "../consolidate.js";
 import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
 import { synthesizeProposal } from "../synthesize.js";
@@ -33,14 +34,26 @@ export async function foldForRun(ctx, memoryFile, memoryHash) {
 
   const ledger = state.readGapLedger();
   recordGapObservations(ledger, relevant);
+  // Consolidate after recording, so the pass sees this run's sightings too: two
+  // sessions coining the same brand-new gap in one parallel fan-out can only line up
+  // here. One bounded judged call; a failure degrades to lexical identity and the run
+  // continues. Prune afterwards so a merged-then-covered gap retires as one entry.
+  const consolidation = await consolidateGapLedger({
+    ledger,
+    memoryPath: memoryFile.path,
+    config: ctx.config,
+    repo: ctx.repo,
+  });
   pruneGapLedger(ledger, { memoryFile, memoryPath: memoryFile.path, maxAge: gapLedgerMaxAge });
   state.writeGapLedger(ledger);
 
-  return foldEvidence(relevant, {
+  const summary = foldEvidence(relevant, {
     minGapEvidence,
     memoryFile,
     gapObservations: ledgerGapObservations(ledger, memoryFile.path),
   });
+  summary.consolidation = consolidation;
+  return summary;
 }
 
 export async function runProposal(ctx, precomputed = null) {
@@ -78,6 +91,9 @@ export async function runProposal(ctx, precomputed = null) {
     transcripts,
   });
 
+  // The consolidation call is part of this proposal's cost; account for it with the
+  // synthesis turns rather than letting it vanish.
+  if (summary.consolidation?.usage) proposal.usage = [summary.consolidation.usage, ...(proposal.usage || [])];
   config.state.writeProposal(proposal);
   return { proposal, summary, memoryFile: file };
 }

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -56,6 +56,12 @@ export async function foldForRun(ctx, memoryFile, memoryHash) {
   return summary;
 }
 
+export function accountForConsolidationUsage(proposal, summary) {
+  if (summary.consolidation?.usage) {
+    proposal.usage = [summary.consolidation.usage, ...(proposal.usage || [])];
+  }
+}
+
 export async function runProposal(ctx, precomputed = null) {
   const { repo, config } = ctx;
   // Starting a new proposal run invalidates the previous result immediately. Discovery,
@@ -91,9 +97,7 @@ export async function runProposal(ctx, precomputed = null) {
     transcripts,
   });
 
-  // The consolidation call is part of this proposal's cost; account for it with the
-  // synthesis turns rather than letting it vanish.
-  if (summary.consolidation?.usage) proposal.usage = [summary.consolidation.usage, ...(proposal.usage || [])];
+  accountForConsolidationUsage(proposal, summary);
   config.state.writeProposal(proposal);
   return { proposal, summary, memoryFile: file };
 }

--- a/src/consolidate.js
+++ b/src/consolidate.js
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { execOneShot, extractJson, sessionPrompt, usageRecord } from "./acpx.js";
+import { mergeGapEntries } from "./gap-ledger.js";
+import { renderPrompt } from "./prompts.js";
+import { warn } from "./logger.js";
+
+/**
+ * Pre-synthesis gap consolidation: one bounded model call that sees the full open gap
+ * set for the memory file and merges entries that are paraphrases of one gap.
+ *
+ * This is the second half of gap identity. The first half - the analysis turn citing an
+ * existing gap id (`matchesGap`) - covers a sighting that arrives AFTER its partner is
+ * already on the books. It cannot cover two sightings of a brand-new gap landing in the
+ * same run's parallel fan-out: neither analysis saw the other's entry, so both coin one.
+ * Consolidation runs after this run's observations are recorded and before the fold
+ * clusters, so those same-run paraphrases still corroborate.
+ *
+ * Judgment is required here by design: word-bigram similarity cannot recognize a real
+ * paraphrase (measured on a production ledger: 89 entries containing at least six
+ * multi-session gaps, highest cross-session score 0.34 against the 0.45 bar). The model
+ * is asked only "same gap or not", the merge itself is mechanical (`mergeGapEntries`),
+ * unknown ids and malformed groups are dropped, and a session is never double-counted
+ * however the entries merge. Strict admission is untouched: merging changes how
+ * sightings line up, never how many distinct sessions a proposal needs.
+ *
+ * Exactly one call per run, and only when at least two entries exist. Failure is
+ * fail-soft with a warning: the run degrades to lexical identity (the pre-consolidation
+ * behavior), it never aborts - the next run re-judges the same open entries.
+ */
+
+/** Ledger entries below this count never need a call; nothing could merge. */
+const MIN_ENTRIES = 2;
+
+let callCounter = 0;
+
+function renderEntries(entries) {
+  return entries
+    .map((entry) => {
+      const sessions = Object.keys(entry.sessions).length;
+      const mistake = firstMistake(entry);
+      return (
+        `[${entry.id}] (sessions=${sessions}) ${entry.proposedInstruction}` +
+        (mistake ? `\n    mistake: ${mistake}` : "")
+      );
+    })
+    .join("\n");
+}
+
+function firstMistake(entry) {
+  for (const obs of Object.values(entry.sessions)) {
+    const flat = String(obs.mistake || "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (flat) return flat.length > 160 ? `${flat.slice(0, 160)}...` : flat;
+  }
+  return "";
+}
+
+/**
+ * Run the consolidation call and apply the merges to `ledger` in place.
+ * Returns `{ merged, usage }`, `{ skipped }`, or `{ failed }` - never throws for a
+ * model-side failure, because a run without consolidation is still a valid run.
+ */
+export async function consolidateGapLedger({ ledger, memoryPath, config, repo }) {
+  const entries = Object.values(ledger.entries).filter((e) => e.memoryPath === memoryPath);
+  if (entries.length < MIN_ENTRIES) return { skipped: "fewer than two open gaps" };
+  if (!config.agents) return { skipped: "no agent resolver" };
+
+  const prompt = renderPrompt("consolidate", { GAP_ENTRIES: renderEntries(entries) });
+  const promptFile = path.join(config.state.root, "prompts", "consolidate-gaps.md");
+  fs.mkdirSync(path.dirname(promptFile), { recursive: true });
+  fs.writeFileSync(promptFile, prompt);
+
+  let ranWith = null;
+  let result;
+  try {
+    result = await config.agents.withFallthrough("analysis", async (pick) => {
+      ranWith = pick.agent;
+      const call = {
+        agent: pick.agent,
+        model: pick.model,
+        promptFile,
+        cwd: repo.root,
+        timeoutSeconds: config.timeoutSeconds,
+        promptRetries: config.promptRetries,
+      };
+      if (!pick.effort) return execOneShot(call);
+      callCounter += 1;
+      return sessionPrompt({
+        ...call,
+        effort: pick.effort,
+        sessionName: `backpass-consolidate-${process.pid}-${callCounter}`,
+      });
+    });
+  } catch (err) {
+    warn(`gap consolidation failed (${err.message}); continuing with lexical gap identity for this run`);
+    return { failed: err.message };
+  }
+
+  const parsed = extractJson(result.text);
+  if (!parsed || !Array.isArray(parsed.merges)) {
+    warn("gap consolidation returned no parseable merge list; continuing with lexical gap identity for this run");
+    return { failed: "no parseable merge list", usage: usageRecord(ranWith, result) };
+  }
+
+  const merged = mergeGapEntries(ledger, parsed.merges);
+  return { merged, usage: usageRecord(ranWith, result) };
+}

--- a/src/diff.js
+++ b/src/diff.js
@@ -161,7 +161,7 @@ export function rawHunks(ops) {
  * Occurrences may overlap (a run of identical lines): counting them non-overlapping
  * would call a window unique while the first match sits somewhere else entirely.
  */
-function countOccurrences(haystack, needle) {
+export function countOccurrences(haystack, needle) {
   if (!needle) return 0;
   let count = 0;
   let at = haystack.indexOf(needle);
@@ -178,7 +178,7 @@ function countOccurrences(haystack, needle) {
  * newline *before* it instead. Both sides of a hunk share tail-ness (the suffix after the
  * change is identical), so `find` and `replace` built this way splice cleanly.
  */
-function span(lines, start, end) {
+export function span(lines, start, end) {
   if (end <= start) return "";
   const body = lines.slice(start, end).join("\n");
   if (end === lines.length) return `${start > 0 ? "\n" : ""}${body}`;

--- a/src/fold.js
+++ b/src/fold.js
@@ -12,7 +12,10 @@ import { GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
  *     evidence / sessions analyzed. That ratio is what decides memory-file vs skill
  *     placement in section 7.
  *  2. Near-duplicate gaps from different sessions are clustered, so "three sessions
- *     re-derived the db schema" arrives as one item with three quotes.
+ *     re-derived the db schema" arrives as one item with three quotes. Judged identity
+ *     happens upstream (analysis citations and the consolidation pass reshape the
+ *     ledger); the clustering here stays deterministic. Orchestration-domain sightings
+ *     are excluded before clustering and surfaced only as a count.
  *  3. Gap clusters below `minGapEvidence` are dropped. Batch size > 1: one bad session
  *     never rewrites the weights. Sessions are counted across runs, not per run: when the
  *     caller passes `gapObservations` (the pruned gap ledger, `src/gap-ledger.js`) the
@@ -40,6 +43,7 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
         positive: 0,
         negative: 0,
         sessions: new Set(),
+        harmSessions: new Set(),
         quotes: [],
       });
     }
@@ -55,8 +59,20 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
       for (const item of record[polarity] || []) {
         const entry = touch(item.instruction);
         entry[polarity] += 1;
-        entry.sessions.add(record.transcript.identity || record.transcript.id);
-        entry.quotes.push({ polarity, text: item.quote, effect: item.effect, moment: item.moment, source });
+        const sessionIdentity = record.transcript.identity || record.transcript.id;
+        entry.sessions.add(sessionIdentity);
+        // `class` is what a negative means (harm vs non-compliance vs irrelevant);
+        // `harmSessions` is what the removal-evidence floor counts. A record from
+        // before the class existed carries none and never counts as harm.
+        if (polarity === "negative" && item.class === "harm") entry.harmSessions.add(sessionIdentity);
+        entry.quotes.push({
+          polarity,
+          text: item.quote,
+          effect: item.effect,
+          moment: item.moment,
+          class: polarity === "negative" ? (item.class ?? null) : undefined,
+          source,
+        });
         if (polarity === "positive") positiveCount += 1;
         else negativeCount += 1;
       }
@@ -70,11 +86,19 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
         recurrenceRisk: gap.recurrenceRisk,
         source,
         sessionId: record.transcript.identity || record.transcript.id,
+        domain: gap.domain === "orchestration" ? "orchestration" : "project",
       });
     }
   }
 
-  const gapClusters = clusterGapObservations(gapObservations ?? recordObservations);
+  // Orchestration-domain sightings are about the task-management layer around the
+  // session, not this repository's engineering; they are counted for legibility but
+  // never cluster, so they can never corroborate into a project proposal.
+  const allObservations = gapObservations ?? recordObservations;
+  const projectObservations = allObservations.filter((obs) => obs?.domain !== "orchestration");
+  const orchestrationGapSightings = allObservations.length - projectObservations.length;
+
+  const gapClusters = clusterGapObservations(projectObservations);
 
   // Instructions that exist in the file but drew no evidence at all are the strongest
   // removal / extraction candidates, so they must appear in the summary too.
@@ -89,6 +113,7 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
         instruction: entry.instruction,
         positive: entry.positive,
         negative: entry.negative,
+        harmSessions: entry.harmSessions.size,
         sessions: entry.sessions.size,
         relevance: analyzedSessions ? entry.sessions.size / analyzedSessions : 0,
         tokens: unit?.tokens ?? null,
@@ -120,6 +145,7 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
       negative: negativeCount,
       gapClusters: gaps.length,
       droppedGapSingletons,
+      orchestrationGapSightings,
       usedRawTranscript: usedRawCount,
     },
     instructions: instructionRows,
@@ -179,20 +205,35 @@ export function renderEvidenceForPrompt(summary) {
   );
   lines.push("");
   lines.push("### Per-instruction evidence");
+  lines.push(
+    "A negative's class is what it means: `harm` = following the instruction caused damage " +
+      "(evidence against it); `non-compliance` = the agent ignored it (evidence it failed to " +
+      "steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.",
+  );
   for (const row of summary.instructions) {
     const relevance = `${(row.relevance * 100).toFixed(1)}%`;
     const cost = row.tokens === null ? "" : ` cost=${row.tokens}tok`;
+    const harm = row.negative > 0 ? ` harm-sessions=${row.harmSessions ?? 0}` : "";
     lines.push(
-      `- [${row.instruction}] +${row.positive} -${row.negative} sessions=${row.sessions} relevance=${relevance}${cost}` +
+      `- [${row.instruction}] +${row.positive} -${row.negative}${harm} sessions=${row.sessions} relevance=${relevance}${cost}` +
         (row.known ? "" : " (id not found in current file - stale reference)"),
     );
     for (const quote of row.quotes.slice(0, 3)) {
-      lines.push(`    ${quote.polarity === "negative" ? "-" : "+"} "${oneLine(quote.text)}" (${quote.source})`);
+      const sign = quote.polarity === "negative" ? "-" : "+";
+      const cls = quote.polarity === "negative" ? ` [${quote.class ?? "unclassified"}]` : "";
+      const effect = quote.effect ? ` :: ${oneLine(quote.effect, 200)}` : "";
+      lines.push(`    ${sign}${cls} "${oneLine(quote.text)}"${effect} (${quote.source})`);
     }
   }
 
   lines.push("");
   lines.push("### Gap clusters (mistakes no current instruction covers)");
+  if (summary.totals.orchestrationGapSightings) {
+    lines.push(
+      `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) about the ` +
+        `task-management layer were excluded; they never enter this repository's memory file`,
+    );
+  }
   if (!summary.gaps.length) {
     lines.push("- none above the evidence threshold");
   }
@@ -206,9 +247,9 @@ export function renderEvidenceForPrompt(summary) {
   return lines.join("\n");
 }
 
-function oneLine(text) {
+function oneLine(text, max = 240) {
   const flat = String(text || "")
     .replace(/\s+/g, " ")
     .trim();
-  return flat.length > 240 ? `${flat.slice(0, 240)}...` : flat;
+  return flat.length > max ? `${flat.slice(0, max)}...` : flat;
 }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -15,10 +15,23 @@ import { sha256 } from "./state.js";
  *
  * Identity and freshness rules:
  *
- *  - A gap's identity is its proposed instruction, matched by the same bigram similarity
- *    the in-run clustering uses (`GAP_SIMILARITY_THRESHOLD`), against the ledger's
- *    canonical phrasing (the shortest seen). The entry id is a hash of the first phrasing
- *    and never changes, so rephrasing does not split an entry.
+ *  - A gap's identity is judged first and matched lexically second. The analysis turn is
+ *    shown the ledger's open entries (`renderOpenGapIndex`) and cites an entry id
+ *    (`matchesGap`) when its gap is one already on the books; a valid citation wins
+ *    outright, because word overlap cannot recognize a paraphrase and the analysis model
+ *    has both sentences in front of it. Without a citation, bigram similarity
+ *    (`GAP_SIMILARITY_THRESHOLD`) against the canonical phrasing (the shortest seen) is
+ *    the fallback. The entry id is a hash of the first phrasing and never changes, so
+ *    rephrasing does not split an entry. Two entries later judged to be one gap are
+ *    merged by the pre-synthesis consolidation pass (`mergeGapEntries`, driven by
+ *    `src/consolidate.js`), which is what lets two same-run parallel sightings - neither
+ *    of which could cite the other - still corroborate.
+ *  - Every observation carries the `domain` the analysis judged: `project` for mistakes
+ *    about this repository's own engineering, `orchestration` for mistakes about the
+ *    task-management layer around it (briefs, scout scope, status records, approvals).
+ *    Orchestration sightings are recorded for legibility but never counted toward
+ *    corroboration and never surface in a proposal; a missing domain counts as project,
+ *    so evidence from before the field existed keeps its old behavior.
  *  - Sessions are keyed by transcript id (harness + native session id), so re-analyzing
  *    or re-sampling the same session overwrites its observation and never adds a count.
  *  - A gap is a fact about its session: re-analysis that no longer mentions it is model
@@ -90,7 +103,13 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
     if (!sessionIdentity) continue;
     for (const gap of record.gaps || []) {
       if (!gap || !gap.proposedInstruction) continue;
-      let entry = findGapEntry(ledger, record.memoryPath, gap.proposedInstruction);
+      // A citation from the analysis turn wins over word overlap: the model saw both
+      // sentences and judged them the same gap. An id that names nothing (stale index,
+      // typo) falls back to the lexical match rather than failing the record.
+      const cited = gap.matchesGap ? ledger.entries[gap.matchesGap] : null;
+      let entry =
+        (cited && cited.memoryPath === record.memoryPath ? cited : null) ||
+        findGapEntry(ledger, record.memoryPath, gap.proposedInstruction);
       if (!entry) {
         const id = gapEntryId(record.memoryPath, gap.proposedInstruction);
         entry = ledger.entries[id] = {
@@ -121,6 +140,7 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         mistake: gap.mistake,
         quote: gap.quote,
         recurrenceRisk: gap.recurrenceRisk,
+        domain: gap.domain === "orchestration" ? "orchestration" : "project",
       };
       recorded += 1;
     }
@@ -176,8 +196,69 @@ export function ledgerGapObservations(ledger, memoryPath) {
         mistake: obs.mistake,
         quote: obs.quote,
         recurrenceRisk: obs.recurrenceRisk,
+        domain: obs.domain === "orchestration" ? "orchestration" : "project",
       });
     }
   }
   return observations;
+}
+
+/**
+ * The ledger's open entries for one memory path, rendered for the analysis prompt so the
+ * model can cite an existing gap instead of coining a paraphrase of it. An accumulator,
+ * not a detector: a gap nobody has reported yet is simply absent, and the analysis
+ * reports it fresh.
+ */
+export function renderOpenGapIndex(ledger, memoryPath, { max = 200 } = {}) {
+  const entries = Object.values(ledger.entries).filter((e) => e.memoryPath === memoryPath);
+  if (!entries.length) return "(none yet)";
+  const lines = entries.slice(0, max).map((e) => `[gap:${e.id}] ${e.proposedInstruction}`);
+  if (entries.length > max) lines.push(`... ${entries.length - max} more`);
+  return lines.join("\n");
+}
+
+/**
+ * Merge groups of ledger entries the consolidation pass judged to be one gap. Each group
+ * keeps the entry with the most sessions (its id stays citable), unions the session maps
+ * without ever double-counting a session (an observation already present keeps its
+ * earliest firstObservedAt), and keeps the shortest phrasing as canonical - the same rule
+ * recording uses. Unknown ids, cross-path groups, and groups that shrink below two known
+ * entries are dropped rather than guessed at. Returns how many entries were absorbed.
+ */
+export function mergeGapEntries(ledger, groups) {
+  let absorbed = 0;
+  const claimed = new Set();
+  for (const group of Array.isArray(groups) ? groups : []) {
+    const ids = [...new Set((Array.isArray(group) ? group : []).map(String))].filter(
+      (id) => ledger.entries[id] && !claimed.has(id),
+    );
+    if (ids.length < 2) continue;
+    const paths = new Set(ids.map((id) => ledger.entries[id].memoryPath));
+    if (paths.size !== 1) continue;
+    for (const id of ids) claimed.add(id);
+
+    const entries = ids.map((id) => ledger.entries[id]);
+    const target = entries.reduce((best, e) =>
+      Object.keys(e.sessions).length > Object.keys(best.sessions).length ? e : best,
+    );
+    for (const entry of entries) {
+      if (entry === target) continue;
+      for (const [sessionId, obs] of Object.entries(entry.sessions)) {
+        const prior = target.sessions[sessionId];
+        if (!prior) {
+          target.sessions[sessionId] = obs;
+        } else {
+          const earlier =
+            Date.parse(obs.firstObservedAt || obs.observedAt) < Date.parse(prior.firstObservedAt || prior.observedAt);
+          if (earlier) prior.firstObservedAt = obs.firstObservedAt || obs.observedAt;
+        }
+      }
+      if (entry.proposedInstruction.length < target.proposedInstruction.length) {
+        target.proposedInstruction = entry.proposedInstruction;
+      }
+      delete ledger.entries[entry.id];
+      absorbed += 1;
+    }
+  }
+  return absorbed;
 }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -86,7 +86,8 @@ export function findGapEntry(ledger, memoryPath, proposedInstruction) {
   let bestScore = 0;
   for (const entry of Object.values(ledger.entries)) {
     if (entry.memoryPath !== memoryPath) continue;
-    const score = similarity(entry.proposedInstruction, proposedInstruction);
+    const phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || [])])];
+    const score = Math.max(...phrasings.map((phrasing) => similarity(phrasing, proposedInstruction)));
     if (score >= GAP_SIMILARITY_THRESHOLD && score > bestScore) {
       best = entry;
       bestScore = score;
@@ -124,11 +125,15 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
           id: deterministicId,
           memoryPath: record.memoryPath,
           proposedInstruction: gap.proposedInstruction,
+          phrasings: [gap.proposedInstruction],
           sessions: {},
         };
-      } else if (gap.proposedInstruction.length < entry.proposedInstruction.length) {
-        // Keep the shortest phrasing: it generalizes best (same rule as the in-run fold).
-        entry.proposedInstruction = gap.proposedInstruction;
+      } else {
+        entry.phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || []), gap.proposedInstruction])];
+        if (gap.proposedInstruction.length < entry.proposedInstruction.length) {
+          // Keep the shortest phrasing: it generalizes best (same rule as the in-run fold).
+          entry.proposedInstruction = gap.proposedInstruction;
+        }
       }
       const identityPrior = entry.sessions[sessionIdentity];
       const aliasPrior = transcript.id && transcript.id !== sessionIdentity ? entry.sessions[transcript.id] : null;
@@ -170,7 +175,7 @@ export function pruneGapLedger(
 
   for (const [id, entry] of Object.entries(ledger.entries)) {
     const applies = memoryPath === null || entry.memoryPath === memoryPath;
-    if (applies && memoryFile && isCovered(memoryFile, entry.proposedInstruction)) {
+    if (applies && memoryFile && isCovered(memoryFile, entry)) {
       stats.covered += Object.keys(entry.sessions).length;
       delete ledger.entries[id];
       continue;
@@ -187,8 +192,11 @@ export function pruneGapLedger(
   return stats;
 }
 
-function isCovered(memoryFile, proposedInstruction) {
-  return (memoryFile.units || []).some((unit) => similarity(unit.text, proposedInstruction) >= GAP_COVERED_THRESHOLD);
+function isCovered(memoryFile, entry) {
+  const phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || [])])];
+  return (memoryFile.units || []).some((unit) =>
+    phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD),
+  );
 }
 
 /** Flatten the ledger into the observation list `foldEvidence` clusters over. */
@@ -262,6 +270,14 @@ export function mergeGapEntries(ledger, groups) {
         }
       }
       target.aliases = [...new Set([...(target.aliases || []), entry.id, ...(entry.aliases || [])])];
+      target.phrasings = [
+        ...new Set([
+          target.proposedInstruction,
+          ...(target.phrasings || []),
+          entry.proposedInstruction,
+          ...(entry.phrasings || []),
+        ]),
+      ];
       if (entry.proposedInstruction.length < target.proposedInstruction.length) {
         target.proposedInstruction = entry.proposedInstruction;
       }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -74,6 +74,12 @@ export function gapEntryId(memoryPath, proposedInstruction) {
   return sha256(`${memoryPath}\n${normalize(proposedInstruction)}`).slice(0, 16);
 }
 
+function gapEntryById(ledger, id) {
+  const direct = ledger.entries[id];
+  if (direct) return direct;
+  return Object.values(ledger.entries).find((entry) => (entry.aliases || []).includes(id)) || null;
+}
+
 /** The ledger entry a proposed instruction belongs to, or null. */
 export function findGapEntry(ledger, memoryPath, proposedInstruction) {
   let best = null;
@@ -106,14 +112,16 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
       // A citation from the analysis turn wins over word overlap: the model saw both
       // sentences and judged them the same gap. An id that names nothing (stale index,
       // typo) falls back to the lexical match rather than failing the record.
-      const cited = gap.matchesGap ? ledger.entries[gap.matchesGap] : null;
+      const cited = gap.matchesGap ? gapEntryById(ledger, gap.matchesGap) : null;
+      const deterministicId = gapEntryId(record.memoryPath, gap.proposedInstruction);
+      const deterministic = gapEntryById(ledger, deterministicId);
       let entry =
         (cited && cited.memoryPath === record.memoryPath ? cited : null) ||
-        findGapEntry(ledger, record.memoryPath, gap.proposedInstruction);
+        findGapEntry(ledger, record.memoryPath, gap.proposedInstruction) ||
+        (deterministic && deterministic.memoryPath === record.memoryPath ? deterministic : null);
       if (!entry) {
-        const id = gapEntryId(record.memoryPath, gap.proposedInstruction);
-        entry = ledger.entries[id] = {
-          id,
+        entry = ledger.entries[deterministicId] = {
+          id: deterministicId,
           memoryPath: record.memoryPath,
           proposedInstruction: gap.proposedInstruction,
           sessions: {},
@@ -253,6 +261,7 @@ export function mergeGapEntries(ledger, groups) {
           if (earlier) prior.firstObservedAt = obs.firstObservedAt || obs.observedAt;
         }
       }
+      target.aliases = [...new Set([...(target.aliases || []), entry.id, ...(entry.aliases || [])])];
       if (entry.proposedInstruction.length < target.proposedInstruction.length) {
         target.proposedInstruction = entry.proposedInstruction;
       }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -129,7 +129,9 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
           sessions: {},
         };
       } else {
-        entry.phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || []), gap.proposedInstruction])];
+        entry.phrasings = [
+          ...new Set([entry.proposedInstruction, ...(entry.phrasings || []), gap.proposedInstruction]),
+        ];
         if (gap.proposedInstruction.length < entry.proposedInstruction.length) {
           // Keep the shortest phrasing: it generalizes best (same rule as the in-run fold).
           entry.proposedInstruction = gap.proposedInstruction;

--- a/src/prompts/analysis.md
+++ b/src/prompts/analysis.md
@@ -10,6 +10,15 @@ Each instruction has a stable id in [brackets]. Refer to instructions ONLY by th
 
 {{INSTRUCTION_INDEX}}
 
+## Gaps already on the books
+
+Earlier sessions reported these gaps; each has a stable id. If a gap you found is the
+same underlying gap as one below - one instruction would prevent both - cite that id in
+`matchesGap` and still describe what you saw. A gap that matches nothing here is new:
+omit `matchesGap`.
+
+{{OPEN_GAPS}}
+
 ## The distilled session trace
 
 Tool calls are one-line summaries and tool output is truncated. The raw transcript path
@@ -26,8 +35,8 @@ Return ONE JSON object and nothing else. No prose before or after, no markdown f
 ```
 {
   "positive":  [{"instruction": "AG-042", "moment": "turn 12", "effect": "what following it achieved", "quote": "verbatim text from the trace"}],
-  "negative":  [{"instruction": "AG-017", "moment": "turn 3",  "effect": "what going against it cost", "quote": "verbatim text from the trace"}],
-  "gaps":      [{"mistake": "what went wrong", "proposedInstruction": "one sentence that would have prevented it", "recurrenceRisk": "high|medium|low", "quote": "verbatim text from the trace"}],
+  "negative":  [{"instruction": "AG-017", "moment": "turn 3",  "effect": "what happened and what it cost", "class": "harm|non-compliance|irrelevant", "quote": "verbatim text from the trace"}],
+  "gaps":      [{"mistake": "what went wrong", "proposedInstruction": "one sentence that would have prevented it", "recurrenceRisk": "high|medium|low", "domain": "project|orchestration", "matchesGap": "<id from the list above, omit when new>", "quote": "verbatim text from the trace"}],
   "usedRawTranscript": false
 }
 ```
@@ -38,11 +47,23 @@ Rules, in order of importance:
    a real quote are discarded downstream, so an unquotable claim is wasted work.
 2. **Negative evidence is the most valuable.** A visible violation, misreading, or
    ignored instruction outranks a dozen "it went fine" observations.
-3. **Do not confabulate influence.** Only call something positive when the trace shows
+3. **`class` states what a negative means, and the difference decides the instruction's
+   fate.** `harm`: the agent FOLLOWED the instruction and following it caused damage or
+   cost - evidence against the instruction itself. `non-compliance`: the agent ignored
+   or violated the instruction - evidence the instruction failed to steer, which argues
+   for reinforcing it, never for deleting it. `irrelevant`: on inspection the moment
+   does not actually bear on this instruction. Never report a skipped rule as `harm`.
+4. **`domain` states whose mistake a gap is.** `project`: about this repository's own
+   engineering - its code, tests, build, docs, releases, conventions. `orchestration`:
+   about the task-management layer around the session - task briefs and their scope
+   (scout/read-only rules), status reporting to a supervisor, approval and authorization
+   flows, delivery-lifecycle process imposed from outside the repository. Orchestration
+   gaps are counted but never proposed into this repository's memory file.
+5. **Do not confabulate influence.** Only call something positive when the trace shows
    the agent doing the specific thing the instruction asks for. An outcome that would
    have happened anyway is not evidence.
-4. `gaps` are mistakes NOT covered by any current instruction. If an instruction exists
-   and was ignored, that is `negative`, not a gap.
-5. `proposedInstruction` must be one imperative sentence, specific enough to act on and
+6. `gaps` are mistakes NOT covered by any current instruction. If an instruction exists
+   and was ignored, that is `negative` with `class: "non-compliance"`, not a gap.
+7. `proposedInstruction` must be one imperative sentence, specific enough to act on and
    general enough to apply beyond this one session.
-6. An empty array is a valid and useful answer. Report nothing rather than something weak.
+8. An empty array is a valid and useful answer. Report nothing rather than something weak.

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -39,14 +39,20 @@ Hard rules - a violation fails the whole proposal:
 4. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
    sessions.** `transcripts` is how many distinct sessions back the edit; an edit that
    only adds text is a new instruction whatever its `kind` says.
-5. `kind: "extract"` is an edit whose changes are one or more created `SKILL.md` files
-   plus the change(s) to {{MEMORY_PATH}} that pay for them. One skill per extract is the
-   normal shape. Several skills belong in ONE extract exactly when their removals landed
-   in a **single** measured change: adjacent removals are merged into one change, and a
-   merged change cannot be accepted in halves. If each skill has its own measured change,
-   give each its own extract. Any other kind must not include a created file, and an edit
-   changes one file only.
-6. **Budget:** {{BUDGET_RULE}}
+5. **Removing an instruction outright needs harm evidence from at least
+   {{MIN_GAP_EVIDENCE}} distinct sessions** (`harm-sessions` in the evidence). Only
+   `harm` negatives argue against an instruction; `non-compliance` never justifies a
+   deletion. A change that only deletes text and is not part of an extract is a removal
+   whatever its `kind` says - if it lacks the evidence, revert it in the file first.
+6. `kind: "extract"` is an edit whose changes are one or more created `SKILL.md` files
+   plus the change(s) to {{MEMORY_PATH}} that pay for them. **The skills must carry every
+   line those changes remove** - a deletion is never part of an extract; give it its own
+   `remove` edit. One skill per extract is the normal shape. Several skills belong in ONE
+   extract exactly when their removals landed in a **single** measured change: adjacent
+   removals are merged into one change, and a merged change cannot be accepted in halves.
+   If each skill has its own measured change, give each its own extract. Any other kind
+   must not include a created file, and an edit changes one file only.
+7. **Budget:** {{BUDGET_RULE}}
 
 If you still need to change the files, do that first and then answer; backpass
 re-measures after this reply and shows you the new ids if anything moved. Re-measuring

--- a/src/prompts/consolidate.md
+++ b/src/prompts/consolidate.md
@@ -1,0 +1,29 @@
+You are consolidating the gap ledger of a backward pass over a repository's agent
+memory file. Each entry below is a mistake some past agent session hit that no current
+instruction covers, phrased as the instruction that would have prevented it. Different
+sessions phrase the same underlying gap differently, and a gap only graduates into a
+proposal once enough DISTINCT sessions have hit it - so paraphrases of one gap must be
+recognized as one entry, or real recurrence stays invisible.
+
+## Open gap entries
+
+{{GAP_ENTRIES}}
+
+## What to return
+
+Return ONE JSON object and nothing else. No prose, no markdown fence.
+
+```
+{"merges": [["<id>", "<id>", ...], ...]}
+```
+
+Each inner array lists two or more entry ids that are the SAME underlying gap. Rules:
+
+1. Merge only when one instruction would prevent every entry in the group - the same
+   mistake, not merely the same topic. Two gaps about the same subsystem that call for
+   different instructions stay separate.
+2. When unsure, do not merge. A wrong merge fabricates corroboration and can write a
+   weakly-supported instruction into the memory file; a missed merge only waits for
+   another sighting.
+3. An id may appear in at most one group. Ids not listed stay untouched.
+4. `{"merges": []}` is a valid and common answer.

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -69,12 +69,21 @@ analyzed sessions in which an instruction drew any evidence at all.
    speculative one.
 2. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
    sessions.** One bad session never rewrites the weights.
-3. **Every edit must be backed by at least one verbatim quote** from the evidence. You
+3. **Removing an instruction outright needs harm evidence from at least
+   {{MIN_GAP_EVIDENCE}} distinct sessions** (`harm-sessions` in the evidence rows).
+   Only `harm` negatives - following the instruction caused damage - argue against an
+   instruction. `non-compliance` means it failed to steer: reinforce it, reposition it,
+   or improve its trigger, never delete it for being ignored. Text you delete that does
+   not land in a created skill is a removal, whatever the edit is called.
+4. **An extraction preserves every line it removes** in the SKILL.md it creates. A
+   deletion is never part of an extract: it is its own `remove` edit, decided on its
+   own evidence.
+5. **Every edit must be backed by at least one verbatim quote** from the evidence. You
    will attach the quotes in the next step, so only make changes you can back.
-4. **Budget:** {{BUDGET_RULE}}
-5. Prefer removing a dead instruction over adding a new one. Instructions with high
-   token cost and zero positive evidence across many sessions are the best removals.
-6. Change only `./{{MEMORY_PATH}}` and files under `./{{SKILLS_DIR}}/`. Never delete a
+6. **Budget:** {{BUDGET_RULE}}
+7. Prefer extracting a long, narrow, crisply-triggered section over deleting anything:
+   extraction frees the same always-loaded tokens and loses nothing.
+8. Change only `./{{MEMORY_PATH}}` and files under `./{{SKILLS_DIR}}/`. Never delete a
    file. Do not create notes, scripts, or scratch files.
 
 ## Where an instruction belongs

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,6 +1,7 @@
 import { renderHunkLines } from "./diff.js";
 import { editSkills } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
+import { normalizeRecoveryLine, recoveredLineSet } from "./workspace.js";
 
 /**
  * The proposal model: what a synthesis pass is allowed to produce, and the mechanical
@@ -101,6 +102,25 @@ function normalizeEvidence(evidence) {
 function countSources(evidence) {
   if (!Array.isArray(evidence)) return 0;
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
+}
+
+/** The del-line texts of a hunk that are not carried by `lineSet` (blank lines ignored). */
+function unrecoveredRemovedLines(hunk, lineSet) {
+  const missing = [];
+  for (const line of hunk.lines || []) {
+    if (line.type !== "del") continue;
+    const normalized = normalizeRecoveryLine(line.text);
+    if (normalized && !lineSet.has(normalized)) missing.push(line.text);
+  }
+  return missing;
+}
+
+/**
+ * The memory units a pure-removal hunk deletes. For a pure removal every file line in
+ * [oldStart, oldEnd] is removed, so this is a plain range intersection with unit lines.
+ */
+function unitsRemovedBy(hunk, memoryFile) {
+  return memoryFile.units.filter((unit) => unit.startLine <= hunk.oldEnd && unit.endLine >= hunk.oldStart);
 }
 
 /** Overlapping count: a run of identical lines must not pass as unique. */
@@ -308,6 +328,19 @@ export function buildProposal(rawResult, context) {
         violations.push(`edit ${edit.id}: ${unusable.file} needs YAML frontmatter with \`name:\` and \`description:\``);
         continue;
       }
+      // An extraction moves text; it never doubles as a deletion. Every line its hunks
+      // remove must land in the skills it creates - a real deletion goes in its own
+      // remove edit, where the removal-evidence floor below can judge it on its own.
+      const carried = recoveredLineSet(created.map((c) => c.text));
+      const missing = hunks.flatMap((h) => unrecoveredRemovedLines(h, carried));
+      if (missing.length) {
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") removes text its created skill(s) do not carry ` +
+            `(first: "${missing[0].trim().slice(0, 80)}"); an extraction preserves every line it removes - ` +
+            `revert that text, or make its deletion a separate "remove" edit`,
+        );
+        continue;
+      }
     } else if (created.length) {
       violations.push(`edit ${edit.id}: only kind "extract" may include a created file (${created[0].id})`);
       continue;
@@ -321,6 +354,34 @@ export function buildProposal(rawResult, context) {
           `${config.minGapEvidence} are required`,
       );
       continue;
+    }
+
+    // A removal is measured the same way: a hunk that only deletes text, outside an
+    // extraction, deletes instructions - whatever the edit's kind says. Deleting an
+    // instruction needs the same corroboration adding one does, and only negatives the
+    // analysis classified as `harm` (following the rule caused damage) count toward it.
+    // Non-compliance is the rule failing to steer; it never justifies deletion. This is
+    // the removal-evidence floor; the >= 20%-relevance placement table stays guidance.
+    if (edit.kind !== "extract" && files[0] === memoryFile.path) {
+      const rows = new Map((summary?.instructions ?? []).map((row) => [row.instruction, row]));
+      const unsupported = [];
+      for (const hunk of hunks) {
+        if (!hunk.removed || hunk.added) continue;
+        for (const unit of unitsRemovedBy(hunk, memoryFile)) {
+          const harm = rows.get(unit.id)?.harmSessions ?? 0;
+          if (harm < config.minGapEvidence) unsupported.push({ unit, harm });
+        }
+      }
+      if (unsupported.length) {
+        const worst = unsupported[0];
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") deletes [${worst.unit.id}] "${worst.unit.text.slice(0, 80)}" backed by ` +
+            `${worst.harm} session(s) of harm-class negative evidence; removing an instruction needs ` +
+            `${config.minGapEvidence}, and non-compliance never counts - revert the deletion` +
+            (unsupported.length > 1 ? ` (${unsupported.length} unit(s) affected)` : ""),
+        );
+        continue;
+      }
     }
 
     const file = files[0];

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,7 +1,7 @@
 import { renderHunkLines } from "./diff.js";
 import { editSkills } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
-import { normalizeRecoveryLine, recoveredLineSet } from "./workspace.js";
+import { normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
 
 /**
  * The proposal model: what a synthesis pass is allowed to produce, and the mechanical
@@ -104,13 +104,16 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-/** The del-line texts of a hunk that are not carried by `lineSet` (blank lines ignored). */
-function unrecoveredRemovedLines(hunk, lineSet) {
+/** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
+function unrecoveredRemovedLines(hunk, lineCounts) {
   const missing = [];
   for (const line of hunk.lines || []) {
     if (line.type !== "del") continue;
     const normalized = normalizeRecoveryLine(line.text);
-    if (normalized && !lineSet.has(normalized)) missing.push(line.text);
+    if (!normalized) continue;
+    const remaining = lineCounts.get(normalized) || 0;
+    if (remaining > 0) lineCounts.set(normalized, remaining - 1);
+    else missing.push(line.text);
   }
   return missing;
 }
@@ -331,7 +334,7 @@ export function buildProposal(rawResult, context) {
       // An extraction moves text; it never doubles as a deletion. Every line its hunks
       // remove must land in the skills it creates - a real deletion goes in its own
       // remove edit, where the removal-evidence floor below can judge it on its own.
-      const carried = recoveredLineSet(created.map((c) => c.text));
+      const carried = recoveredLineCounts(created.map((c) => c.text));
       const missing = hunks.flatMap((h) => unrecoveredRemovedLines(h, carried));
       if (missing.length) {
         violations.push(

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -70,10 +70,12 @@ function budgetRule(memoryFile, config, maxEdits) {
       `This file is ALREADY ${Math.abs(remaining)} tokens OVER budget, so this run is a SHRINK ` +
       `PLAN. You are NOT expected to reach ${config.budgetTokens} tokens in one run - the ` +
       `${maxEdits}-edit cap for this run makes that impossible and later runs continue the work. ` +
-      `What is required is real progress: the edit set MUST be net-negative, so lead with the ` +
-      `highest-cost instructions that have no positive evidence, and with skill extractions of ` +
-      `long narrow sections. Any addition must name the removal that pays for it. Make the ` +
-      `largest honest reduction you can justify from the evidence.`
+      `What is required is real progress: the edit set MUST be net-negative, so lead with skill ` +
+      `extractions of long, narrow, crisply-triggered sections - extraction frees the same ` +
+      `always-loaded tokens and loses nothing, and it never needs removal evidence. Deleting an ` +
+      `instruction outright still needs its harm-evidence floor; the budget never lowers that ` +
+      `bar. Any addition must name the removal or extraction that pays for it. Make the largest ` +
+      `honest reduction you can justify from the evidence.`
     );
   }
   if (remaining < config.budgetTokens * 0.15) {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { anchoredHunks } from "./diff.js";
+import { anchoredHunks, countOccurrences, span } from "./diff.js";
 import { parseFrontmatter } from "./skills.js";
 import { sha256 } from "./state.js";
 
@@ -95,6 +95,75 @@ export function parseSkillFile(relative, text) {
 }
 
 /**
+ * One line's identity for extraction-recovery checks: verbatim modulo the noise a
+ * faithful move is allowed to make. Unicode dashes fold to "-" (house style normalizes
+ * them during moves) and interior whitespace collapses; anything more is a real change.
+ */
+export function normalizeRecoveryLine(line) {
+  return String(line ?? "")
+    .replace(/[‐-―−]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** The normalized non-blank lines of a set of file texts, for recovery membership tests. */
+export function recoveredLineSet(texts) {
+  const set = new Set();
+  for (const text of texts) {
+    for (const line of String(text ?? "").split("\n")) {
+      const normalized = normalizeRecoveryLine(line);
+      if (normalized) set.add(normalized);
+    }
+  }
+  return set;
+}
+
+/**
+ * Split one pure-removal memory-file hunk at the boundary between text that lands in a
+ * created skill and text that vanishes. Adjacent removals merge into one measured change
+ * (`anchoredHunks`), so without this split an extraction and an unrelated deletion that
+ * happen to sit next to each other in the file fuse into a single accept/reject decision.
+ * The boundary is a decision boundary, and it falls on instruction-unit edges because a
+ * skill carries whole sections.
+ *
+ * Returns the sub-hunks, or null when there is nothing to split (one kind only) or the
+ * split cannot be anchored safely (a sub-hunk's bare text is not unique in the file -
+ * widening it with context could overlap its sibling, so the merged hunk is kept instead).
+ */
+export function splitRemovalHunk(hunk, { oldText, oldLines, recovered }) {
+  // Group the removed lines into maximal runs by recovery; blank lines never start a
+  // run and attach to whichever run surrounds them.
+  const runs = [];
+  for (let lineNo = hunk.oldStart; lineNo <= hunk.oldEnd; lineNo += 1) {
+    const normalized = normalizeRecoveryLine(oldLines[lineNo - 1]);
+    if (!normalized) continue;
+    const kind = recovered.has(normalized) ? "recovered" : "deleted";
+    const current = runs[runs.length - 1];
+    if (current && current.kind === kind) current.last = lineNo;
+    else runs.push({ kind, first: lineNo, last: lineNo });
+  }
+  if (runs.length < 2) return null;
+
+  const subHunks = runs.map((run, index) => {
+    const start = index === 0 ? hunk.oldStart : runs[index - 1].last + 1;
+    const end = index === runs.length - 1 ? hunk.oldEnd : run.last;
+    const find = span(oldLines, start - 1, end);
+    return {
+      find,
+      replace: "",
+      oldStart: start,
+      oldEnd: end,
+      removed: end - start + 1,
+      added: 0,
+      lines: oldLines.slice(start - 1, end).map((text) => ({ type: "del", text })),
+    };
+  });
+
+  if (subHunks.some((sub) => !sub.find || countOccurrences(oldText, sub.find) !== 1)) return null;
+  return subHunks;
+}
+
+/**
  * Everything that differs between the originals and the workspace now, as changes with
  * stable ids the annotate turn refers to:
  *
@@ -136,6 +205,24 @@ export function measureWorkspace(workspace) {
     const text = fs.readFileSync(path.join(root, relative), "utf8");
     texts.set(relative, text);
     changes.push({ kind: "created", file: relative, text, skill: parseSkillFile(relative, text) });
+  }
+
+  // With the created files known, split any memory-file removal that mixes extracted
+  // text (recovered in a created file) with deleted text, so the deletion is its own
+  // measured change and stays independently decidable.
+  const createdTexts = changes.filter((c) => c.kind === "created").map((c) => c.text);
+  if (createdTexts.length) {
+    const recovered = recoveredLineSet(createdTexts);
+    const oldText = originals.get(memoryPath) ?? "";
+    const oldLines = oldText.split("\n");
+    for (let index = changes.length - 1; index >= 0; index -= 1) {
+      const change = changes[index];
+      if (change.kind !== "hunk" || change.file !== memoryPath || !change.removed || change.added) continue;
+      const subHunks = splitRemovalHunk(change, { oldText, oldLines, recovered });
+      if (subHunks) {
+        changes.splice(index, 1, ...subHunks.map((sub) => ({ kind: "hunk", file: memoryPath, ...sub })));
+      }
+    }
   }
 
   changes.forEach((change, index) => {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { anchoredHunks, countOccurrences, span } from "./diff.js";
+import { parseMemoryUnits } from "./memory.js";
 import { parseFrontmatter } from "./skills.js";
 import { sha256 } from "./state.js";
 
@@ -131,6 +132,18 @@ export function recoveredLineSet(texts) {
  * widening it with context could overlap its sibling, so the merged hunk is kept instead).
  */
 export function splitRemovalHunk(hunk, { oldText, oldLines, recovered }) {
+  for (const unit of parseMemoryUnits(oldText)) {
+    const start = Math.max(unit.startLine, hunk.oldStart);
+    const end = Math.min(unit.endLine, hunk.oldEnd);
+    if (start > end) continue;
+    const kinds = new Set();
+    for (let lineNo = start; lineNo <= end; lineNo += 1) {
+      const normalized = normalizeRecoveryLine(oldLines[lineNo - 1]);
+      if (normalized) kinds.add(recovered.has(normalized) ? "recovered" : "deleted");
+    }
+    if (kinds.size > 1) return null;
+  }
+
   // Group the removed lines into maximal runs by recovery; blank lines never start a
   // run and attach to whichever run surrounds them.
   const runs = [];

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -107,16 +107,16 @@ export function normalizeRecoveryLine(line) {
     .trim();
 }
 
-/** The normalized non-blank lines of a set of file texts, for recovery membership tests. */
-export function recoveredLineSet(texts) {
-  const set = new Set();
+/** The normalized non-blank lines of a set of file texts, with occurrence counts. */
+export function recoveredLineCounts(texts) {
+  const counts = new Map();
   for (const text of texts) {
     for (const line of String(text ?? "").split("\n")) {
       const normalized = normalizeRecoveryLine(line);
-      if (normalized) set.add(normalized);
+      if (normalized) counts.set(normalized, (counts.get(normalized) || 0) + 1);
     }
   }
-  return set;
+  return counts;
 }
 
 /**
@@ -132,25 +132,40 @@ export function recoveredLineSet(texts) {
  * widening it with context could overlap its sibling, so the merged hunk is kept instead).
  */
 export function splitRemovalHunk(hunk, { oldText, oldLines, recovered }) {
+  const lineKinds = new Map();
+  for (let lineNo = hunk.oldStart; lineNo <= hunk.oldEnd; lineNo += 1) {
+    const normalized = normalizeRecoveryLine(oldLines[lineNo - 1]);
+    if (!normalized) continue;
+    const remaining = recovered.get(normalized) || 0;
+    lineKinds.set(lineNo, remaining > 0 ? "recovered" : "deleted");
+    if (remaining > 0) recovered.set(normalized, remaining - 1);
+  }
+
   for (const unit of parseMemoryUnits(oldText)) {
     const start = Math.max(unit.startLine, hunk.oldStart);
     const end = Math.min(unit.endLine, hunk.oldEnd);
     if (start > end) continue;
     const kinds = new Set();
     for (let lineNo = start; lineNo <= end; lineNo += 1) {
-      const normalized = normalizeRecoveryLine(oldLines[lineNo - 1]);
-      if (normalized) kinds.add(recovered.has(normalized) ? "recovered" : "deleted");
+      if (lineKinds.has(lineNo)) kinds.add(lineKinds.get(lineNo));
     }
     if (kinds.size > 1) return null;
+  }
+
+  for (let lineNo = hunk.oldStart; lineNo <= hunk.oldEnd; lineNo += 1) {
+    if (!/^#{1,6}\s+/.test(oldLines[lineNo - 1] || "")) continue;
+    let contentLine = lineNo + 1;
+    while (contentLine <= hunk.oldEnd && !normalizeRecoveryLine(oldLines[contentLine - 1])) contentLine += 1;
+    if (contentLine > hunk.oldEnd || /^#{1,6}\s+/.test(oldLines[contentLine - 1] || "")) continue;
+    if (lineKinds.get(lineNo) !== lineKinds.get(contentLine)) return null;
   }
 
   // Group the removed lines into maximal runs by recovery; blank lines never start a
   // run and attach to whichever run surrounds them.
   const runs = [];
   for (let lineNo = hunk.oldStart; lineNo <= hunk.oldEnd; lineNo += 1) {
-    const normalized = normalizeRecoveryLine(oldLines[lineNo - 1]);
-    if (!normalized) continue;
-    const kind = recovered.has(normalized) ? "recovered" : "deleted";
+    const kind = lineKinds.get(lineNo);
+    if (!kind) continue;
     const current = runs[runs.length - 1];
     if (current && current.kind === kind) current.last = lineNo;
     else runs.push({ kind, first: lineNo, last: lineNo });
@@ -225,17 +240,20 @@ export function measureWorkspace(workspace) {
   // measured change and stays independently decidable.
   const createdTexts = changes.filter((c) => c.kind === "created").map((c) => c.text);
   if (createdTexts.length) {
-    const recovered = recoveredLineSet(createdTexts);
+    const recovered = recoveredLineCounts(createdTexts);
     const oldText = originals.get(memoryPath) ?? "";
     const oldLines = oldText.split("\n");
-    for (let index = changes.length - 1; index >= 0; index -= 1) {
-      const change = changes[index];
-      if (change.kind !== "hunk" || change.file !== memoryPath || !change.removed || change.added) continue;
-      const subHunks = splitRemovalHunk(change, { oldText, oldLines, recovered });
-      if (subHunks) {
-        changes.splice(index, 1, ...subHunks.map((sub) => ({ kind: "hunk", file: memoryPath, ...sub })));
+    const measured = [];
+    for (const change of changes) {
+      if (change.kind !== "hunk" || change.file !== memoryPath || !change.removed || change.added) {
+        measured.push(change);
+        continue;
       }
+      const subHunks = splitRemovalHunk(change, { oldText, oldLines, recovered });
+      if (subHunks) measured.push(...subHunks.map((sub) => ({ kind: "hunk", file: memoryPath, ...sub })));
+      else measured.push(change);
     }
+    changes.splice(0, changes.length, ...measured);
   }
 
   changes.forEach((change, index) => {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -7,6 +7,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { bootstrapRun } from "../src/commands/bootstrap.js";
+import { foldForRun } from "../src/commands/propose.js";
 import { renderPointer, renderStarterMemory } from "../src/bootstrap.js";
 import { loadConfig } from "../src/config.js";
 import { UserError, setLoggerSink } from "../src/logger.js";
@@ -180,14 +181,21 @@ test("with transcripts: analysis gaps become the first evidence-backed instructi
   const repo = makeRepo();
   const ctx = makeCtx(repo);
   const captured = { config: ctx.config, repo };
+  const consolidationUsage = { agent: "claude", usage: { input: 200, output: 10, total: 210 } };
+  const fold = async (...args) => {
+    const summary = await foldForRun(...args);
+    summary.consolidation = { merged: 1, usage: consolidationUsage };
+    return summary;
+  };
   const { result, lines } = await withSink(() =>
-    bootstrapRun(ctx, { discover: discoverTwo, analyze: fakeAnalyze, synthesize: fakeSynthesize(captured) }),
+    bootstrapRun(ctx, { discover: discoverTwo, analyze: fakeAnalyze, fold, synthesize: fakeSynthesize(captured) }),
   );
 
   assert.ok(lines.some((l) => /bootstrapping AGENTS\.md from 2 transcript\(s\) \+ defaults/.test(l)));
   assert.match(captured.runNote, /seeded from generic defaults/);
   assert.equal(captured.gapClusters, 1, "the two sessions' gaps folded into one cluster");
   assert.equal(result.seededFrom, "transcripts + defaults");
+  assert.deepEqual(result.proposal.usage, [consolidationUsage]);
   assert.deepEqual(
     result.applied.written.map((w) => w.file),
     ["AGENTS.md"],

--- a/test/consolidate.test.js
+++ b/test/consolidate.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * The pre-synthesis consolidation pass, end to end through `foldForRun` against a
+ * stand-in acpx: two sessions in ONE run phrase a brand-new gap differently, no lexical
+ * match or citation can line them up, and the consolidation call is the only thing that
+ * lets them corroborate. The fake prints whatever reply the test scripted (or fails),
+ * so the merge policy, the fail-soft path, and the bookkeeping are all observable.
+ */
+const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fake-consolidate-"));
+const fakeAcpx = path.join(fakeDir, "acpx");
+fs.writeFileSync(
+  fakeAcpx,
+  `#!${process.execPath}
+const fs = require("node:fs");
+const argv = process.argv.slice(2);
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write('{"agents":{}}\\n');
+  process.exit(0);
+}
+if (process.env.FAKE_CONSOLIDATE_EXIT) process.exit(Number(process.env.FAKE_CONSOLIDATE_EXIT));
+process.stdout.write(fs.readFileSync(process.env.FAKE_CONSOLIDATE_REPLY, "utf8"));
+process.stderr.write("[acpx] tokens: input=200 output=10 total=210\\n");
+`,
+);
+fs.chmodSync(fakeAcpx, 0o755);
+process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+
+const { foldForRun } = await import("../src/commands/propose.js");
+const { gapEntryId } = await import("../src/gap-ledger.js");
+const { parseMemoryUnits } = await import("../src/memory.js");
+const { SELF_SESSION_SENTINEL } = await import("../src/prompts.js");
+const { State } = await import("../src/state.js");
+const { setLoggerSink } = await import("../src/logger.js");
+
+setLoggerSink(() => {});
+
+const MEMORY_PATH = "AGENTS.md";
+const memoryFile = { path: MEMORY_PATH, units: parseMemoryUnits("# T\n\n- Keep the README current.\n") };
+
+// The same underlying gap, phrased far apart: word-bigram similarity cannot merge these.
+const SIGHTING_A = "Always bind the pipeline attestation to the exact head SHA before publishing.";
+const SIGHTING_B = "Require every published attestation to reference the precise commit it describes.";
+const UNRELATED = "Never force-push to main.";
+
+function record(id, proposedInstruction) {
+  return {
+    status: "ok",
+    transcript: { id, harness: "claude", startedAt: Date.parse("2026-08-01T00:00:00Z") },
+    memoryPath: MEMORY_PATH,
+    memoryHash: "h1",
+    positive: [],
+    negative: [],
+    gaps: [{ proposedInstruction, mistake: "hit it", quote: `quote from ${id}`, recurrenceRisk: "high" }],
+  };
+}
+
+const pick = { agent: "claude", model: null, effort: null, pinned: true };
+
+function harness(records, reply) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-consolidate-"));
+  const state = new State(root).ensure();
+  for (const r of records) state.writeEvidence(r.transcript.id, r);
+  const replyFile = path.join(root, "fake-reply.json");
+  if (reply !== undefined) fs.writeFileSync(replyFile, typeof reply === "string" ? reply : JSON.stringify(reply));
+  process.env.FAKE_CONSOLIDATE_REPLY = replyFile;
+  delete process.env.FAKE_CONSOLIDATE_EXIT;
+  const ctx = {
+    config: {
+      state,
+      minGapEvidence: 2,
+      gapLedgerMaxAge: "90d",
+      timeoutSeconds: 30,
+      promptRetries: 1,
+      agents: { resolve: async () => pick, withFallthrough: async (_role, fn) => fn(pick) },
+    },
+    repo: { root, name: "t" },
+  };
+  return { root, state, ctx };
+}
+
+test("two same-run paraphrases of one brand-new gap corroborate through the consolidation pass", async () => {
+  const idA = gapEntryId(MEMORY_PATH, SIGHTING_A);
+  const idB = gapEntryId(MEMORY_PATH, SIGHTING_B);
+  const h = harness([record("claude-s1", SIGHTING_A), record("codex-s2", SIGHTING_B)], {
+    merges: [[idA, idB]],
+  });
+
+  const summary = await foldForRun(h.ctx, memoryFile, "h1");
+
+  assert.equal(summary.gaps.length, 1, "the merged entry clears the two-session bar in a single run");
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(summary.consolidation.merged, 1);
+  assert.ok(summary.consolidation.usage, "the call is accounted for, never invisible");
+  assert.equal(Object.keys(h.state.readGapLedger().entries).length, 1);
+
+  // The judged call is a backpass self-session like every other model-facing prompt.
+  const prompt = fs.readFileSync(path.join(h.state.root, "prompts", "consolidate-gaps.md"), "utf8");
+  assert.ok(prompt.startsWith(SELF_SESSION_SENTINEL));
+  assert.ok(prompt.includes(idA) && prompt.includes(idB), "the model is shown the citable entry ids");
+});
+
+test("materially distinct gaps stay separate when the model declines to merge", async () => {
+  const h = harness([record("claude-s1", SIGHTING_A), record("codex-s2", UNRELATED)], { merges: [] });
+
+  const summary = await foldForRun(h.ctx, memoryFile, "h1");
+
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.totals.droppedGapSingletons, 2, "no fabricated corroboration");
+  assert.equal(summary.consolidation.merged, 0);
+  assert.equal(Object.keys(h.state.readGapLedger().entries).length, 2);
+});
+
+test("a failed consolidation call degrades to lexical identity and never aborts the run", async () => {
+  const h = harness([record("claude-s1", SIGHTING_A), record("codex-s2", SIGHTING_B)], { merges: [] });
+  process.env.FAKE_CONSOLIDATE_EXIT = "2";
+
+  const summary = await foldForRun(h.ctx, memoryFile, "h1");
+  delete process.env.FAKE_CONSOLIDATE_EXIT;
+
+  assert.ok(summary.consolidation.failed, "the failure is named, not hidden");
+  assert.equal(summary.gaps.length, 0, "the pre-consolidation behavior is what remains");
+  assert.equal(Object.keys(h.state.readGapLedger().entries).length, 2, "the ledger is untouched");
+});
+
+test("an unparseable consolidation reply is a named failure, not a guessed merge", async () => {
+  const h = harness([record("claude-s1", SIGHTING_A), record("codex-s2", SIGHTING_B)], "no json here at all");
+
+  const summary = await foldForRun(h.ctx, memoryFile, "h1");
+
+  assert.match(String(summary.consolidation.failed), /no parseable merge list/);
+  assert.equal(Object.keys(h.state.readGapLedger().entries).length, 2);
+});
+
+test("fewer than two open gaps never spends a model call", async () => {
+  const h = harness([record("claude-s1", SIGHTING_A)], undefined);
+  // No reply file exists: a call would crash the fake, so a green run proves no call ran.
+  const summary = await foldForRun(h.ctx, memoryFile, "h1");
+  assert.match(String(summary.consolidation.skipped), /fewer than two/);
+});

--- a/test/distill.test.js
+++ b/test/distill.test.js
@@ -137,3 +137,51 @@ test("sanitizeEvidence tolerates a malformed model response", () => {
   assert.deepEqual(clean, { positive: [], negative: [], gaps: [], usedRawTranscript: false });
   assert.deepEqual(sanitizeEvidence({ positive: "not an array" }).positive, []);
 });
+
+test("a negative's class survives only as one of the judged values, and never invents harm", () => {
+  const clean = sanitizeEvidence({
+    negative: [
+      { instruction: "AG-001", quote: "followed the stale pin and broke the build", class: "harm" },
+      { instruction: "AG-002", quote: "skipped the failing-test-first step", class: "non-compliance" },
+      { instruction: "AG-003", quote: "an unrelated grumble about tooling", class: "irrelevant" },
+      { instruction: "AG-004", quote: "a record from before the field existed" },
+      { instruction: "AG-005", quote: "a made-up value must not pass", class: "catastrophic" },
+    ],
+  });
+  assert.deepEqual(
+    clean.negative.map((item) => item.class),
+    ["harm", "non-compliance", "irrelevant", undefined, undefined],
+  );
+});
+
+test("a gap's domain defaults to project, and a citation is kept only when it looks like a ledger id", () => {
+  const clean = sanitizeEvidence({
+    gaps: [
+      {
+        proposedInstruction: "Bind the attestation to the exact head SHA.",
+        quote: "published an attestation for the wrong commit",
+        domain: "project",
+        matchesGap: "d5ff4883e71499f5",
+      },
+      {
+        proposedInstruction: "Stop after the report on scout tasks.",
+        quote: "opened a PR during a scout task",
+        domain: "orchestration",
+        matchesGap: "not-a-ledger-id",
+      },
+      {
+        proposedInstruction: "A legacy gap with neither field.",
+        quote: "walked migrations for 18 turns",
+        domain: "somewhere-else",
+      },
+    ],
+  });
+  assert.deepEqual(
+    clean.gaps.map((gap) => [gap.domain, gap.matchesGap]),
+    [
+      ["project", "d5ff4883e71499f5"],
+      ["orchestration", undefined],
+      ["project", undefined],
+    ],
+  );
+});

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -123,10 +123,14 @@ test("failed and skipped analyses are excluded from the fold", () => {
   assert.equal(summary.totals.positive, 1);
 });
 
-test("the rendered evidence block carries counts, relevance and quotes into the prompt", () => {
+test("the rendered evidence block carries counts, relevance, quotes, effects and classes into the prompt", () => {
   const summary = foldEvidence(
     [
-      record("s1", { negative: [{ instruction: "AG-002", quote: "used a bare #2731", effect: "follow-up needed" }] }),
+      record("s1", {
+        negative: [
+          { instruction: "AG-002", quote: "used a bare #2731", effect: "follow-up needed", class: "non-compliance" },
+        ],
+      }),
       record("s2", { negative: [{ instruction: "AG-002", quote: "again a bare number" }] }),
     ],
     { memoryFile },
@@ -134,7 +138,33 @@ test("the rendered evidence block carries counts, relevance and quotes into the 
 
   const rendered = renderEvidenceForPrompt(summary);
   assert.match(rendered, /Sessions analyzed: 2/);
-  assert.match(rendered, /\[AG-002\] \+0 -2 sessions=2 relevance=100\.0%/);
-  assert.match(rendered, /used a bare #2731/);
+  assert.match(rendered, /\[AG-002\] \+0 -2 harm-sessions=0 sessions=2 relevance=100\.0%/);
+  // The synthesis model must see what a negative MEANS, not only its sign: the effect
+  // text and the harm/non-compliance class both survive into the prompt.
+  assert.match(rendered, /- \[non-compliance\] "used a bare #2731" :: follow-up needed/);
+  assert.match(rendered, /- \[unclassified\] "again a bare number"/);
+  assert.match(rendered, /`non-compliance` = the agent ignored it/);
   assert.match(rendered, /none above the evidence threshold/);
+});
+
+test("harm-class negatives are counted per distinct session, and only explicit harm counts", () => {
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        negative: [
+          { instruction: "AG-001", quote: "q1", class: "harm" },
+          { instruction: "AG-001", quote: "q1b", class: "harm" },
+          { instruction: "AG-002", quote: "q2", class: "non-compliance" },
+        ],
+      }),
+      record("s2", { negative: [{ instruction: "AG-001", quote: "q3", class: "harm" }] }),
+      record("s3", { negative: [{ instruction: "AG-001", quote: "q4" }] }),
+    ],
+    { memoryFile },
+  );
+
+  const rows = new Map(summary.instructions.map((row) => [row.instruction, row]));
+  assert.equal(rows.get("AG-001").harmSessions, 2, "two distinct sessions, however many harm items each filed");
+  assert.equal(rows.get("AG-001").negative, 4);
+  assert.equal(rows.get("AG-002").harmSessions, 0, "non-compliance and unclassified never count as harm");
 });

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -8,7 +8,7 @@ import { State } from "../src/state.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
 import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
-import { gapEntryId, mergeGapEntries } from "../src/gap-ledger.js";
+import { gapEntryId, mergeGapEntries, recordGapObservations } from "../src/gap-ledger.js";
 
 const MEMORY_PATH = "AGENTS.md";
 const DAY = 86_400_000;
@@ -270,6 +270,30 @@ test("mergeGapEntries unions sessions without double-counting and keeps the shor
   assert.equal(entries.length, 1);
   assert.equal(entries[0].proposedInstruction, "The short phrasing.");
   assert.deepEqual(Object.keys(entries[0].sessions).sort(), ["s1", "s2", "shared"], "a session never counts twice");
+});
+
+test("merged gap identities remain durable as the canonical phrasing changes", () => {
+  const first = "Always inspect the database schema documentation before composing a production SQL query.";
+  const absorbed = "Consult schema before SQL.";
+  const shortest = "Check DB docs.";
+  const firstId = gapEntryId(MEMORY_PATH, first);
+  const absorbedId = gapEntryId(MEMORY_PATH, absorbed);
+  const ledger = ledgerWith(
+    { id: firstId, text: first, sessions: ["s1", "s2"] },
+    { id: absorbedId, text: absorbed, sessions: ["s3"] },
+  );
+
+  mergeGapEntries(ledger, [[firstId, absorbedId]]);
+  recordGapObservations(ledger, [
+    record("s4", [{ proposedInstruction: shortest, matchesGap: firstId }]),
+    record("s5", [first]),
+    record("s6", [absorbed]),
+  ]);
+
+  assert.deepEqual(Object.keys(ledger.entries), [firstId]);
+  assert.equal(ledger.entries[firstId].proposedInstruction, shortest);
+  assert.deepEqual(Object.keys(ledger.entries[firstId].sessions).sort(), ["s1", "s2", "s3", "s4", "s5", "s6"]);
+  assert.equal(ledger.entries[firstId].sessions.s1.firstObservedAt, "2026-08-01T00:00:00.000Z");
 });
 
 test("mergeGapEntries drops what it cannot verify instead of guessing", () => {

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -8,7 +8,7 @@ import { State } from "../src/state.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
 import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
-import { gapEntryId, mergeGapEntries, recordGapObservations } from "../src/gap-ledger.js";
+import { gapEntryId, mergeGapEntries, pruneGapLedger, recordGapObservations } from "../src/gap-ledger.js";
 
 const MEMORY_PATH = "AGENTS.md";
 const DAY = 86_400_000;
@@ -294,6 +294,24 @@ test("merged gap identities remain durable as the canonical phrasing changes", (
   assert.equal(ledger.entries[firstId].proposedInstruction, shortest);
   assert.deepEqual(Object.keys(ledger.entries[firstId].sessions).sort(), ["s1", "s2", "s3", "s4", "s5", "s6"]);
   assert.equal(ledger.entries[firstId].sessions.s1.firstObservedAt, "2026-08-01T00:00:00.000Z");
+});
+
+test("coverage by any judged phrasing retires a merged gap", () => {
+  const first = "Always inspect schema documentation before SQL.";
+  const shortest = "Check DB docs.";
+  const firstId = gapEntryId(MEMORY_PATH, first);
+  const shortestId = gapEntryId(MEMORY_PATH, shortest);
+  const ledger = ledgerWith(
+    { id: firstId, text: first, sessions: ["s1", "s2"] },
+    { id: shortestId, text: shortest, sessions: ["s3"] },
+  );
+
+  mergeGapEntries(ledger, [[firstId, shortestId]]);
+  const covered = memoryFile(`# T\n\n- ${first}\n`);
+  const stats = pruneGapLedger(ledger, { memoryFile: covered, memoryPath: MEMORY_PATH, maxAge: "all" });
+
+  assert.equal(stats.covered, 3);
+  assert.deepEqual(ledger.entries, {});
 });
 
 test("mergeGapEntries drops what it cannot verify instead of guessing", () => {

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -7,7 +7,8 @@ import path from "node:path";
 import { State } from "../src/state.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
-import { foldEvidence } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { gapEntryId, mergeGapEntries } from "../src/gap-ledger.js";
 
 const MEMORY_PATH = "AGENTS.md";
 const DAY = 86_400_000;
@@ -24,11 +25,12 @@ function record(id, gaps, { startedAt = Date.parse("2026-08-01T00:00:00Z"), memo
     memoryHash,
     positive: [],
     negative: [],
-    gaps: gaps.map((proposedInstruction) => ({
-      proposedInstruction,
+    gaps: gaps.map((gap) => ({
+      proposedInstruction: typeof gap === "string" ? gap : gap.proposedInstruction,
       mistake: "re-derived it",
       quote: `quote from ${id}`,
       recurrenceRisk: "high",
+      ...(typeof gap === "string" ? {} : gap),
     })),
   };
 }
@@ -188,4 +190,106 @@ test("foldEvidence without a ledger keeps the per-run behavior", () => {
     memoryFile: memoryFile(),
   });
   assert.equal(summary.gaps.length, 0, "one session reporting twice is still one session");
+});
+
+// ---------- judged identity: analysis citations ----------
+
+const PARAPHRASE = "Consult the database schema documentation prior to composing any SQL.";
+
+test("an analysis that cites an existing gap id corroborates it, however different the words", async () => {
+  const h = harness();
+  await run(h, [record("claude-s1", [GAP])]);
+  const entryId = gapEntryId(MEMORY_PATH, GAP);
+  assert.ok(h.state.readGapLedger().entries[entryId], "the first sighting created the citable entry");
+
+  // A later session phrases the same gap so differently that no lexical match exists;
+  // its analysis saw the open-gap index and cited the id instead.
+  const summary = await run(h, [record("codex-s2", [{ proposedInstruction: PARAPHRASE, matchesGap: entryId }])]);
+  assert.equal(summary.gaps.length, 1, "the citation is what lines the two sightings up");
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(Object.keys(h.state.readGapLedger().entries).length, 1, "no split entry for the paraphrase");
+});
+
+test("a citation to an id the ledger does not hold falls back to lexical identity", async () => {
+  const h = harness();
+  const summary = await run(h, [record("claude-s1", [{ proposedInstruction: GAP, matchesGap: "00000000deadbeef" }])]);
+  assert.equal(summary.gaps.length, 0);
+  const entries = Object.values(h.state.readGapLedger().entries);
+  assert.equal(entries.length, 1, "the sighting still lands as a fresh entry");
+  assert.equal(entries[0].proposedInstruction, GAP);
+});
+
+// ---------- orchestration-domain gaps stay out of project proposals ----------
+
+test("orchestration-domain gaps are counted but never cluster into a proposal", async () => {
+  const h = harness();
+  const orchestration = { proposedInstruction: "Stop after the report on scout tasks.", domain: "orchestration" };
+  const summary = await run(h, [record("claude-s1", [orchestration]), record("codex-s2", [orchestration])]);
+
+  assert.equal(summary.gaps.length, 0, "two sessions corroborate it, and it still never becomes a proposal");
+  assert.equal(summary.totals.orchestrationGapSightings, 2, "but the run stays legible about what it excluded");
+  assert.match(renderEvidenceForPrompt(summary), /2 orchestration-domain sighting\(s\).*excluded/);
+
+  // The same shape in the project domain clusters as usual - the exclusion is the
+  // domain, not the text.
+  const control = harness();
+  const project = { proposedInstruction: "Stop after the report on scout tasks.", domain: "project" };
+  const clustered = await run(control, [record("claude-s1", [project]), record("codex-s2", [project])]);
+  assert.equal(clustered.gaps.length, 1);
+});
+
+// ---------- consolidation-pass merges (the mechanical half) ----------
+
+function ledgerWith(...entries) {
+  const ledger = { version: 1, entries: {} };
+  for (const { id, text, sessions, memoryPath = MEMORY_PATH } of entries) {
+    ledger.entries[id] = {
+      id,
+      memoryPath,
+      proposedInstruction: text,
+      sessions: Object.fromEntries(
+        sessions.map((s) => [
+          s,
+          { firstObservedAt: "2026-08-01T00:00:00.000Z", observedAt: "2026-08-01T00:00:00.000Z" },
+        ]),
+      ),
+    };
+  }
+  return ledger;
+}
+
+test("mergeGapEntries unions sessions without double-counting and keeps the shortest phrasing", () => {
+  const ledger = ledgerWith(
+    { id: "a".repeat(16), text: "A long and winding phrasing of the same gap.", sessions: ["s1", "shared"] },
+    { id: "b".repeat(16), text: "The short phrasing.", sessions: ["s2", "shared"] },
+  );
+  const absorbed = mergeGapEntries(ledger, [["a".repeat(16), "b".repeat(16)]]);
+
+  assert.equal(absorbed, 1);
+  const entries = Object.values(ledger.entries);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].proposedInstruction, "The short phrasing.");
+  assert.deepEqual(Object.keys(entries[0].sessions).sort(), ["s1", "s2", "shared"], "a session never counts twice");
+});
+
+test("mergeGapEntries drops what it cannot verify instead of guessing", () => {
+  const ledger = ledgerWith(
+    { id: "a".repeat(16), text: "One gap.", sessions: ["s1"] },
+    { id: "b".repeat(16), text: "Another gap.", sessions: ["s2"] },
+    { id: "c".repeat(16), text: "A gap for another file.", sessions: ["s3"], memoryPath: "CLAUDE.md" },
+  );
+
+  assert.equal(mergeGapEntries(ledger, [["a".repeat(16), "0".repeat(16)]]), 0, "an unknown id shrinks the group");
+  assert.equal(mergeGapEntries(ledger, [["a".repeat(16), "c".repeat(16)]]), 0, "cross-path groups are refused");
+  assert.equal(mergeGapEntries(ledger, "not an array"), 0);
+  assert.equal(Object.keys(ledger.entries).length, 3, "nothing merged, nothing lost");
+
+  // An id already claimed by one group cannot be claimed again by a later one.
+  const twice = mergeGapEntries(ledger, [
+    ["a".repeat(16), "b".repeat(16)],
+    ["b".repeat(16), "c".repeat(16)],
+  ]);
+  assert.equal(twice, 1, "only the first group merged");
+  assert.ok(!ledger.entries["b".repeat(16)], "b was absorbed into a");
+  assert.ok(ledger.entries["c".repeat(16)], "c stayed untouched");
 });

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -150,7 +150,8 @@ export function makeCliRepo({ memory, sessions = 3, files = {} }) {
           {
             instruction: "AG-001",
             quote: `session ${i} re-derived the release steps by hand`,
-            effect: "wasted a turn",
+            effect: "following the stale steps wasted a turn",
+            class: "harm",
             moment: "turn 4",
           },
         ],

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1295,6 +1295,55 @@ test("a recovery transition inside a multiline instruction keeps the removal ind
   assert.ok(staged.violations.some((violation) => /do not carry/.test(violation)));
 });
 
+test("one carried copy cannot recover two identical removed instructions", () => {
+  const text = "# Memory\n\n## Rules\n\n- Repeat this rule.\n- Repeat this rule.\n";
+  const skill = [
+    "---",
+    "name: repeated-rule",
+    "description: Carries one repeated rule.",
+    "---",
+    "",
+    "- Repeat this rule.",
+    "",
+  ].join("\n");
+  const staged = gate({
+    text,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (memory) => memory.replace("- Repeat this rule.\n- Repeat this rule.\n", ""));
+      writeIn(root, ".agents/skills/repeated-rule/SKILL.md", skill);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract one repeated rule" })] },
+  });
+
+  assert.equal(staged.measured.changes.filter((change) => change.kind === "hunk").length, 1);
+  assert.ok(staged.violations.some((violation) => /do not carry/.test(violation)));
+});
+
+test("a recovered heading cannot be separated from its deleted instruction", () => {
+  const text = "# Memory\n\n## Extracted\n\n- This instruction vanishes.\n\n## Deleted\n\n- Delete this too.\n";
+  const skill = [
+    "---",
+    "name: heading-only",
+    "description: Carries only a heading.",
+    "---",
+    "",
+    "## Extracted",
+    "",
+  ].join("\n");
+  const staged = gate({
+    text,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", () => "# Memory\n");
+      writeIn(root, ".agents/skills/heading-only/SKILL.md", skill);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "heading-only extraction" })] },
+  });
+
+  const memoryHunks = staged.measured.changes.filter((change) => change.kind === "hunk");
+  assert.equal(memoryHunks.length, 1);
+  assert.match(memoryHunks[0].find, /## Extracted[\s\S]*This instruction vanishes/);
+});
+
 test("an extract cannot smuggle the adjacent deletion: its skills must carry every removed line", () => {
   const { violations } = gate({
     text: TWO_SECTIONS,

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -51,7 +51,22 @@ function config(overrides = {}) {
 function gate({ text = MEMORY_TEXT, files = {}, edit, annotation, config: cfg = config(), context = {} }) {
   const repo = makeRepo({ "AGENTS.md": text, ...files });
   const staged = stageAndMeasure({ repo, skillsDir: cfg.skillsDir, edit });
-  const summary = { analyzedSessions: 4, totals: { positive: 3, negative: 2, gapClusters: 1 } };
+  // Default: every unit carries harm-class corroboration, so removal fixtures whose
+  // subject is not the removal-evidence floor sail through it. Floor tests pass their
+  // own summary through `context`.
+  const summary = {
+    analyzedSessions: 4,
+    totals: { positive: 3, negative: 2, gapClusters: 1 },
+    instructions: Array.from({ length: 20 }, (_, i) => ({
+      instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+      positive: 0,
+      negative: 4,
+      harmSessions: 4,
+      sessions: 4,
+      relevance: 1,
+      quotes: [],
+    })),
+  };
   const result = buildProposal(annotation, {
     memoryFile: staged.memoryFile,
     config: cfg,
@@ -274,14 +289,20 @@ test("a proposal that would exceed the budget fails the gate", () => {
   assert.ok(violations.some((v) => /over the 100-token budget/.test(v)));
 });
 
-const skillFile = (name) => `---\nname: ${name}\ndescription: Load before ${name}.\n---\n\n## Steps\n\n1. do it\n`;
+// An extraction must carry every line it removes; `carried` is that line (or lines).
+const skillFile = (name, carried = "") =>
+  `---\nname: ${name}\ndescription: Load before ${name}.\n---\n\n## Steps\n\n1. do it\n${carried}`;
 
 test("an extract is the created SKILL.md file(s) grouped with the memory change that pays for them", () => {
   const extractEdit = (root) => {
     writeIn(root, "AGENTS.md", (t) =>
       t.replace("- Use Node 18 via nvm before running any script.", "- See the release-signing skill."),
     );
-    writeIn(root, ".agents/skills/release-signing/SKILL.md", skillFile("release-signing"));
+    writeIn(
+      root,
+      ".agents/skills/release-signing/SKILL.md",
+      skillFile("release-signing", "- Use Node 18 via nvm before running any script.\n"),
+    );
   };
 
   const good = gate({
@@ -291,7 +312,13 @@ test("an extract is the created SKILL.md file(s) grouped with the memory change 
   assert.deepEqual(good.violations, []);
   assert.deepEqual(
     good.proposal.edits[0].skills.map((s) => [s.path, s.name, s.body]),
-    [[".agents/skills/release-signing/SKILL.md", "release-signing", "## Steps\n\n1. do it"]],
+    [
+      [
+        ".agents/skills/release-signing/SKILL.md",
+        "release-signing",
+        "## Steps\n\n1. do it\n- Use Node 18 via nvm before running any script.",
+      ],
+    ],
   );
   assert.equal(good.proposal.stats.skillExtractions, 1);
 
@@ -323,8 +350,12 @@ test("skills whose removals were measured as one change may share an extract; se
           "- See the commit-style and node-setup skills.\n",
         ),
       );
-      writeIn(root, ".agents/skills/commit-style/SKILL.md", skillFile("commit-style"));
-      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillFile("node-setup"));
+      writeIn(root, ".agents/skills/commit-style/SKILL.md", skillFile("commit-style", "- Prefer small commits.\n"));
+      writeIn(
+        root,
+        ".agents/skills/node-setup/SKILL.md",
+        skillFile("node-setup", "- Use Node 18 via nvm before running any script.\n"),
+      );
     },
     annotation: { edits: [claim(["H1", "H2", "H3"], { kind: "extract", title: "extract two playbooks" })] },
   });
@@ -343,8 +374,16 @@ test("skills whose removals were measured as one change may share an extract; se
           .replace("- Whenever a PR is mentioned, include its URL.", "- See the url-policy skill.")
           .replace("- Use Node 18 via nvm before running any script.", "- See the node-setup skill."),
       );
-      writeIn(root, ".agents/skills/url-policy/SKILL.md", skillFile("url-policy"));
-      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillFile("node-setup"));
+      writeIn(
+        root,
+        ".agents/skills/url-policy/SKILL.md",
+        skillFile("url-policy", "- Whenever a PR is mentioned, include its URL.\n"),
+      );
+      writeIn(
+        root,
+        ".agents/skills/node-setup/SKILL.md",
+        skillFile("node-setup", "- Use Node 18 via nvm before running any script.\n"),
+      );
     },
     annotation: { edits: [claim(["H1", "H2", "H3", "H4"], { kind: "extract", title: "extract both" })] },
   });
@@ -744,7 +783,8 @@ test("an unchanged memory file still applies, so the freshness check costs nothi
 });
 
 test("a skill is written only when the memory-file edit that points at it lands", () => {
-  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
+  const skillText =
+    "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n- Use Node 18 via nvm before running any script.\n";
   const { proposal, repo, state } = gate({
     edit: (root) => {
       writeIn(root, "AGENTS.md", (t) =>
@@ -770,7 +810,8 @@ test("a skill is written only when the memory-file edit that points at it lands"
 });
 
 test("a failed later skill write rolls back skill paths written earlier", () => {
-  const skillText = "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n";
+  const skillText =
+    "---\nname: node-setup\ndescription: Load before running any script.\n---\n\nuse nvm\n- Use Node 18 via nvm before running any script.\n";
   const { proposal, repo, state } = gate({
     edit: (root) => {
       writeIn(root, "AGENTS.md", (text) =>
@@ -814,7 +855,7 @@ test("a failed later skill write rolls back skill paths written earlier", () => 
 
 test("an accepted extract writes the skill the agent drafted, in the canonical layout", () => {
   const skillText =
-    "---\nname: release-signing\ndescription: Load before tagging a release.\n---\n\n## Steps\n\n1. sign\n";
+    "---\nname: release-signing\ndescription: Load before tagging a release.\n---\n\n- Use Node 18 via nvm before running any script.\n\n## Steps\n\n1. sign\n";
   const { proposal, repo, state } = gate({
     edit: (root) => {
       writeIn(root, "AGENTS.md", (t) =>
@@ -1057,5 +1098,177 @@ test("the cap-exceeded violation fires above the effective adaptive cap, not the
   assert.ok(
     above.violations.some((v) => v.includes(`per-run cap is ${cap}`)),
     above.violations.join("\n"),
+  );
+});
+
+// ---------- the removal-evidence floor, and what deliberately stays soft ----------
+
+const TWO_SECTIONS = [
+  "# T",
+  "",
+  "## Alpha",
+  "",
+  "- Alpha one is a rule about the build.",
+  "- Alpha two is a rule about the tests.",
+  "",
+  "## Beta",
+  "",
+  "- Beta one is a rule about releases.",
+  "- Beta two is a rule about signing.",
+  "",
+  "## Keep",
+  "",
+  "- Stay here.",
+  "",
+].join("\n");
+
+const BETA_BLOCK = "## Beta\n\n- Beta one is a rule about releases.\n- Beta two is a rule about signing.\n\n";
+const ALPHA_AND_BETA =
+  "## Alpha\n\n- Alpha one is a rule about the build.\n- Alpha two is a rule about the tests.\n\n" + BETA_BLOCK;
+const ALPHA_SKILL =
+  "---\nname: alpha\ndescription: Load before build work.\n---\n\n" +
+  "## Alpha\n\n- Alpha one is a rule about the build.\n- Alpha two is a rule about the tests.\n";
+
+/** Summary rows for the two Beta units, with the class mix under test. */
+const betaRows = ({ harmSessions }) => ({
+  analyzedSessions: 10,
+  totals: { positive: 0, negative: 5, gapClusters: 0 },
+  instructions: ["AG-003", "AG-004"].map((id) => ({
+    instruction: id,
+    positive: 0,
+    negative: 5,
+    harmSessions,
+    sessions: 5,
+    relevance: 0.5,
+    quotes: [],
+  })),
+});
+
+test("non-compliance never satisfies the removal-evidence floor; harm does", () => {
+  const dropBeta = memoryEdit((t) => t.replace(BETA_BLOCK, ""));
+  const annotation = { edits: [claim(["H1"], { kind: "remove", title: "drop the beta rules" })] };
+
+  // Five sessions violated the Beta rules; not one shows harm from following them.
+  const skipped = gate({
+    text: TWO_SECTIONS,
+    edit: dropBeta,
+    annotation,
+    context: { summary: betaRows({ harmSessions: 0 }) },
+  });
+  assert.equal(skipped.proposal.edits.length, 0);
+  assert.ok(
+    skipped.violations.some((v) => /harm-class negative evidence/.test(v) && /non-compliance never counts/.test(v)),
+    skipped.violations.join("\n"),
+  );
+
+  // The same deletion with two sessions of harm-class evidence clears the floor.
+  const harmed = gate({
+    text: TWO_SECTIONS,
+    edit: dropBeta,
+    annotation,
+    context: { summary: betaRows({ harmSessions: 2 }) },
+  });
+  assert.deepEqual(harmed.violations, []);
+  assert.equal(harmed.proposal.edits.length, 1);
+});
+
+test("a removal is measured, not declared: relabeling the edit does not dodge the floor", () => {
+  const { violations } = gate({
+    text: TWO_SECTIONS,
+    edit: memoryEdit((t) => t.replace(BETA_BLOCK, "")),
+    annotation: { edits: [claim(["H1"], { kind: "rewrite", title: "tidy the beta section" })] },
+    context: { summary: betaRows({ harmSessions: 0 }) },
+  });
+  assert.ok(
+    violations.some((v) => /harm-class negative evidence/.test(v)),
+    violations.join("\n"),
+  );
+});
+
+test("the declined 20%-relevance retention rule is guidance, not a gate: extraction needs no such clearance", () => {
+  // The highest-relevance, purely-positive instruction in the corpus can still be
+  // extracted with zero violations - the captain kept retention as prompt guidance.
+  const { violations, proposal } = gate({
+    text: TWO_SECTIONS,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) =>
+        t.replace(
+          "## Alpha\n\n- Alpha one is a rule about the build.\n- Alpha two is a rule about the tests.\n",
+          "## Alpha\n\n- See the alpha skill.\n",
+        ),
+      );
+      writeIn(root, ".agents/skills/alpha/SKILL.md", ALPHA_SKILL);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract alpha" })] },
+    context: {
+      summary: {
+        analyzedSessions: 20,
+        totals: { positive: 17, negative: 0, gapClusters: 0 },
+        instructions: ["AG-001", "AG-002"].map((id) => ({
+          instruction: id,
+          positive: 17,
+          negative: 0,
+          harmSessions: 0,
+          sessions: 17,
+          relevance: 0.85,
+          quotes: [],
+        })),
+      },
+    },
+  });
+  assert.deepEqual(violations, [], "no retention gate exists in code, by decision");
+  assert.equal(proposal.edits.length, 1);
+});
+
+// ---------- adjacent extraction and deletion stay separate decisions ----------
+
+test("a removal mixing extracted and deleted text is measured as two changes, split at the decision boundary", () => {
+  const staged = gate({
+    text: TWO_SECTIONS,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) => t.replace(ALPHA_AND_BETA, ""));
+      writeIn(root, ".agents/skills/alpha/SKILL.md", ALPHA_SKILL);
+    },
+    annotation: {
+      edits: [
+        claim(["H1", "H3"], { kind: "extract", title: "extract alpha" }),
+        claim(["H2"], { kind: "remove", title: "drop the beta rules" }),
+      ],
+    },
+    context: { summary: betaRows({ harmSessions: 2 }) },
+  });
+
+  const memoryHunks = staged.measured.changes.filter((c) => c.kind === "hunk");
+  assert.equal(memoryHunks.length, 2, "one contiguous removal, two decisions, two measured changes");
+  assert.ok(memoryHunks[0].find.includes("## Alpha") && !memoryHunks[0].find.includes("## Beta"));
+  assert.ok(memoryHunks[1].find.includes("## Beta") && !memoryHunks[1].find.includes("## Alpha"));
+
+  assert.deepEqual(staged.violations, []);
+  assert.equal(staged.proposal.edits.length, 2);
+
+  // Independently applicable in every combination the reviewer may choose.
+  const onlyExtract = projectWithDecisions(TWO_SECTIONS, staged.proposal.edits, ["e1"], 5000);
+  assert.ok(!onlyExtract.text.includes("## Alpha") && onlyExtract.text.includes("## Beta"));
+  const onlyRemove = projectWithDecisions(TWO_SECTIONS, staged.proposal.edits, ["e2"], 5000);
+  assert.ok(onlyRemove.text.includes("## Alpha") && !onlyRemove.text.includes("## Beta"));
+  const both = projectWithDecisions(TWO_SECTIONS, staged.proposal.edits, ["e1", "e2"], 5000);
+  assert.ok(!both.text.includes("## Alpha") && !both.text.includes("## Beta") && both.text.includes("## Keep"));
+});
+
+test("an extract cannot smuggle the adjacent deletion: its skills must carry every removed line", () => {
+  const { violations } = gate({
+    text: TWO_SECTIONS,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) => t.replace(ALPHA_AND_BETA, ""));
+      writeIn(root, ".agents/skills/alpha/SKILL.md", ALPHA_SKILL);
+    },
+    annotation: { edits: [claim(["H1", "H2", "H3"], { kind: "extract", title: "extract alpha and more" })] },
+    context: { summary: betaRows({ harmSessions: 0 }) },
+  });
+  assert.ok(
+    violations.some(
+      (v) => /removes text its created skill\(s\) do not carry/.test(v) && /separate "remove" edit/.test(v),
+    ),
+    violations.join("\n"),
   );
 });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1255,6 +1255,46 @@ test("a removal mixing extracted and deleted text is measured as two changes, sp
   assert.ok(!both.text.includes("## Alpha") && !both.text.includes("## Beta") && both.text.includes("## Keep"));
 });
 
+test("a recovery transition inside a multiline instruction keeps the removal indivisible", () => {
+  const text = [
+    "# Memory",
+    "",
+    "## Rules",
+    "",
+    "- Carry this instruction into a skill.",
+    "  This continuation is part of the same instruction.",
+    "- Delete this adjacent instruction.",
+    "",
+  ].join("\n");
+  const skill = [
+    "---",
+    "name: partial",
+    "description: Partial extraction fixture.",
+    "---",
+    "",
+    "- Carry this instruction into a skill.",
+    "",
+  ].join("\n");
+  const staged = gate({
+    text,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (memory) =>
+        memory.replace(
+          "- Carry this instruction into a skill.\n  This continuation is part of the same instruction.\n- Delete this adjacent instruction.\n",
+          "",
+        ),
+      );
+      writeIn(root, ".agents/skills/partial/SKILL.md", skill);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "partial extraction" })] },
+  });
+
+  const memoryHunks = staged.measured.changes.filter((change) => change.kind === "hunk");
+  assert.equal(memoryHunks.length, 1);
+  assert.match(memoryHunks[0].find, /Carry this instruction[\s\S]*continuation[\s\S]*Delete this adjacent/);
+  assert.ok(staged.violations.some((violation) => /do not carry/.test(violation)));
+});
+
 test("an extract cannot smuggle the adjacent deletion: its skills must carry every removed line", () => {
   const { violations } = gate({
     text: TWO_SECTIONS,

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -84,7 +84,26 @@ const SPLIT = [
   "",
 ].join("\n");
 
-const skill = (name) => `---\nname: ${name}\ndescription: Load before ${name} work.\n---\n\n## Steps\n\n1. do it\n`;
+/** An extraction must carry every line it removes, so the fixture skills carry theirs. */
+const SKILL_BODIES = {
+  "release-checklist": [
+    "## Release checklist",
+    "",
+    "- Tag the release commit with the version.",
+    "- Push the tag before the artifacts.",
+    "- Never hand-edit CHANGELOG.md.",
+    "",
+  ].join("\n"),
+  "incident-response": [
+    "## Incident response",
+    "",
+    "- Page the on-call before rolling back.",
+    "- Write the postmortem within two days.",
+    "- Link the postmortem from the incident channel.",
+    "",
+  ].join("\n"),
+};
+const skill = (name) => `---\nname: ${name}\ndescription: Load before ${name} work.\n---\n\n${SKILL_BODIES[name]}`;
 
 const EDIT_TURN = {
   "AGENTS.md": { replace: [[BOTH_SECTIONS, POINTERS]] },
@@ -286,6 +305,16 @@ test("skills whose removals merged into one change ship as one decision, and app
   });
 
   assert.equal(run.status, 0, `two skills against one merged change is a legal extract:\n${run.output}`);
+
+  // The loss signal reaches the deciding model whole: the negative's class and its
+  // effect text are in the synthesis prompt, not just a sign and a bare quote.
+  const editPrompt = fs.readFileSync(path.join(dir, ".backpass", "prompts", "synthesis-edit.md"), "utf8");
+  assert.match(
+    editPrompt,
+    /- \[harm\] "session 1 re-derived the release steps by hand" :: following the stale steps wasted a turn/,
+  );
+  assert.match(editPrompt, /harm-sessions=3/);
+
   const proposal = proposalOf(dir);
   assert.equal(proposal.edits.length, 1, "one merged change cannot be accepted in halves, so it is one decision");
   assert.equal(proposal.edits[0].hunks.length, 1);

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -124,7 +124,12 @@ const tighten = (changes) => ({
 function summaryFor(sessions = 3) {
   return {
     analyzedSessions: sessions,
-    instructions: [],
+    // The removal fixtures delete AG-001/AG-002 (the first two sharp-edge bullets);
+    // the removal-evidence floor needs harm-class corroboration for them.
+    instructions: [
+      { instruction: "AG-001", positive: 0, negative: 2, harmSessions: 2, sessions: 2, relevance: 0.5, quotes: [] },
+      { instruction: "AG-002", positive: 0, negative: 2, harmSessions: 2, sessions: 2, relevance: 0.5, quotes: [] },
+    ],
     gaps: [],
     totals: { positive: 1, negative: 2, gapClusters: 0, droppedGapSingletons: 0 },
   };


### PR DESCRIPTION
## Intent

Implement the Backpass architecture decisions the captain approved on backpass-post-causality-architecture-r1 after the no-mistakes backward-pass causality postmortem (firstmate data/backpass-mechanical-output-gap-causality-s1/report.md). Q1/d - gap identity becomes judged rather than word-matched: the per-session analysis turn is shown the ledger's open-gap index and cites an existing gap id (matchesGap) or coins a new one, AND one bounded pre-synthesis consolidation call per run (src/consolidate.js, wired into foldForRun) sees the full same-run gap set and merges paraphrased entries so parallel same-run sightings can corroborate; an invalid citation falls back to the lexical match, and a failed or unparseable consolidation call degrades the run to lexical identity with a warning, never an abort. Q2 - analysis classifies each gap's domain; orchestration-domain gaps (task-harness mistakes: briefs, scout scope, status records, approvals) are counted in totals.orchestrationGapSightings for legibility but excluded from clustering so they can never reach a project proposal; deliberately NO orchestrator-memory write path. Q3a - preserve and render negative-evidence effect text plus an explicit harm/non-compliance/irrelevant class into the synthesis prompt (renderEvidenceForPrompt), with per-instruction harm-session counts, so non-compliance is never mistaken for harm; records from before the class existed carry none and none never counts as harm. Q3b - the ONLY new hard gate is the removal-evidence floor: deleting an instruction needs minGapEvidence distinct sessions of harm-class negatives, measured per removed memory unit, whatever kind the model declares (a hunk that only deletes text outside an extraction is a removal); per the captain's explicit words 'do 2 , but don't do 1', the >=20%-relevance/safety retention rule stays prompt guidance and must NOT be hardened into code - a test proves the gate's absence. Q3c - extraction and deletion never share one decision: measureWorkspace splits a pure removal that mixes skill-carried and vanishing text at that boundary (splitRemovalHunk, fail-soft to the merged hunk when a sub-hunk cannot anchor uniquely; recovery matching folds unicode dashes and whitespace so a faithful move is not misread as deletion), and buildProposal requires an extract's created skills to carry every line its hunks remove, so adjacent extraction/removal decisions stay independently reviewable and independently applicable. Item e, a deterministic shrink-mode extraction stage, was explicitly declined by the captain and is deliberately not built. Constraints honored: strict multi-session admission (minGapEvidence) unchanged, model calls bounded (exactly one consolidation call per run, skipped below two open entries), zero new runtime dependencies, no wrappers or control planes, the captain-committed no-mistakes memory result untouched. Behavioral tests drive real module and CLI interfaces: same-run and prior-run paraphrases consolidate while materially distinct gaps stay separate; an analysis can cite an existing gap id or coin a new one, with fallback on invalid ids; orchestration gaps never cluster while identical project-domain gaps do; effect and class visibly survive into the rendered synthesis prompt through the real CLI path; non-compliance cannot satisfy the removal floor while harm-class evidence passes it; relabeling a deletion as rewrite does not dodge the floor; the declined retention gate is proven absent; and split extraction/deletion decisions apply independently in every accept/reject combination. VISION.md, README.md, and AGENTS.md updated only where these observable contracts changed. Synthesis prompt guidance (hard rules, budget shrink text) updated so the model is steered toward extraction and told the floor exists, while the placement table remains guidance.

## What Changed

- Add judged gap identity through analysis citations and a bounded consolidation pass, while excluding orchestration gaps from project proposals and falling back to lexical matching on failure.
- Preserve negative-evidence classes and effects, and require corroborated harm evidence for any pure instruction deletion regardless of its declared edit kind.
- Split adjacent extraction and deletion changes when safely anchorable, and require extracted skills to preserve every removed line.

## Risk Assessment

🚨 High: The extraction/deletion split violates the required independent applicability invariant for a reachable EOF layout and should be fixed before merge.

## Testing

Inspected the targeted diff, ran focused behavioral tests for judged gap identity, domain filtering, evidence causality, removal gates, extraction splitting, and CLI synthesis, then demonstrated an end-to-end proposal and accepted extraction through the real CLI; all checks succeeded and the worktree remained clean.

<details>
<summary>Evidence: End-to-end Backpass propose/apply transcript showing harm evidence in the synthesis prompt, the extraction decision, and final persisted memory and skill</summary>

Source: [End-to-end Backpass propose/apply transcript showing harm evidence in the synthesis prompt, the extraction decision, and final persisted memory and skill](https://github.com/kunchenguid/backpass/blob/65e36bdedfe9a9513facc19792fde5a61c248286/.no-mistakes/evidence/fm/backpass-mechanical-output-gap-causality-s1/e2e-cli-transcript.txt)

```text
$ backpass propose --synthesis-agent claude --synthesis-model fake-model
exit: 0
proposal · backpass-cli-YIh2nQ · AGENTS.md · 1 edit(s) from 3 session(s)
  budget [................................] 25 -> 28 / 5,000 tok
  evidence: 0 positive · 3 negative · 0 gap clusters

  e1 EXTRACT  Extract release checklist (+3 tok, 3 transcript(s))

  tier-2 tokens: input=1,500 output=50 total=1,550

Review and apply with `backpass apply` (nothing has been written).
· synthesizing with claude (fake-model) effort=high

proposal decisions:
[
  {
    "id": "e1",
    "kind": "extract",
    "title": "Extract release checklist",
    "skills": [
      ".agents/skills/release/SKILL.md"
    ]
  }
]

evidence delivered to synthesis agent:
- [AG-001] +0 -3 harm-sessions=3 sessions=3 relevance=100.0% cost=7tok
    - [harm] "session 1 re-derived the release steps by hand" :: following the stale steps wasted a turn (claude · claude:s · unknown date)
    - [harm] "session 2 re-derived the release steps by hand" :: following the stale steps wasted a turn (claude · claude:s · unknown date)
    - [harm] "session 3 re-derived the release steps by hand" :: following the stale steps wasted a turn (claude · claude:s · unknown date)

$ backpass apply --no-open  # reviewer accepts e1
exit: 0
1 accepted · 0 rejected
  wrote AGENTS.md (e1)
    budget [................................] 25 -> 28 / 5,000 tok
  wrote .agents/skills/release/SKILL.md (new skill)
    created .agents/skills
    created .claude/skills -> ../.agents/skills
· review surface: http://127.0.0.1:4387/session/51233fdaf6389690
waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)

final AGENTS.md:
# Demo memory

## Release checklist

- See .agents/skills/release/SKILL.md.

## Style

- Keep output concise.

created skill:
---
name: release
description: Load before release work.
user-invocable: false
metadata:
  internal: true
---

## Release checklist

- Tag the release commit.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d47415505db12b913be1d797f062d33ff1dbf5a4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- ⚠️ `src/commands/propose.js:96` - Consolidation usage is added only by runProposal. The bootstrap path calls foldForRun and synthesize directly, then prints proposal.usage, so a bootstrap run with at least two open gaps silently omits the consolidation call from usage accounting. Propagate folded.consolidation.usage in bootstrap as well, or account for it at a shared boundary.

🔧 Fix: Account for bootstrap consolidation usage
2 errors still open:

- 🚨 `src/gap-ledger.js:115` - A judged merge can change the surviving entry&#39;s canonical phrasing while retaining its original id. On the next fold, cached evidence using that original, lexically dissimilar phrasing fails findGapEntry, derives the surviving id again, and this assignment overwrites the merged entry, discarding its sessions and first-seen timestamps. Preserve aliases from every absorbed id to the surviving entry and never replace an existing deterministic id during ingestion, so consolidation remains durable across runs and failures.
- 🚨 `src/workspace.js:140` - splitRemovalHunk classifies individual lines rather than instruction units. For a multiline instruction whose skill carries only some lines, it splits inside the unit; accepting only the extraction can leave an orphaned continuation, while accepting only the deletion can leave a truncated instruction. Split only at parsed memory-unit boundaries, or fail soft to the merged hunk when a recovery transition occurs inside a unit, so every accept/reject combination remains independently valid.

🔧 Fix: Preserve merged gaps and atomic instruction removals
2 errors still open:

- 🚨 `src/workspace.js:111` - Extraction recovery is modeled as a set of normalized line text, losing multiplicity and structural ownership. If two memory units contain the same line and a skill carries only one copy, both removals are treated as recovered and buildProposal accepts deletion of the second copy. Similarly, a heading recovered separately from its following unit can be split into the extraction, leaving that unit orphaned when only the extraction is accepted. Track consumed occurrences and split only at complete structural unit or section boundaries, failing soft to the merged hunk otherwise.
- 🚨 `src/gap-ledger.js:265` - A judged merge retains only the shortest canonical phrasing and absorbed ids, while pruneGapLedger checks coverage only against that phrasing. For example, after merging &#34;Always inspect schema documentation before SQL&#34; with &#34;Check DB docs&#34;, adding the first sentence verbatim to AGENTS.md does not retire the entry if the shorter phrase became canonical, so an already-covered gap remains eligible for another proposal. Preserve all judged phrasings and consider any of them when checking whether the current memory covers the merged gap.

🔧 Fix: Preserve extraction identity and merged gap coverage
1 error still open:

- 🚨 `src/workspace.js:178` - For a mixed removal reaching a file without a trailing newline, `span` gives the final sub-hunk a leading newline while the preceding sub-hunk owns that same separator as its trailing newline. If deleted text precedes recovered text at EOF, applying the extraction first removes the separator needed by the deletion, so the combined proposal fails composition even though either decision applies alone. Build non-overlapping sub-hunk anchors, or fail soft to the merged hunk when independent composition cannot be guaranteed.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat d177b06a5fa6767391f17a26efeab862b4bc258a..852b09d0a90345965e5df812e1da88393de2a524` and targeted change inspection</code>
- `node --test test/consolidate.test.js test/distill.test.js test/fold.test.js test/gap-ledger.test.js test/proposal.test.js test/synthesis-cli.test.js`
- <code>`node ~/.no-mistakes/evidence/01M153W98A39AB69NA8BQFBAFQ/e2e-evidence.mjs` - exercised real `backpass propose` and `backpass apply` CLI paths with reviewer acceptance</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
