### PR TITLE
fix: keep EOF-reaching mixed removals merged

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -128,8 +128,8 @@ export function recoveredLineCounts(texts) {
  * skill carries whole sections.
  *
  * Returns the sub-hunks, or null when there is nothing to split (one kind only) or the
- * split cannot be anchored safely (a sub-hunk's bare text is not unique in the file -
- * widening it with context could overlap its sibling, so the merged hunk is kept instead).
+ * sub-hunks cannot be given unique, non-overlapping spans, in which case the merged hunk
+ * is kept instead.
  */
 export function splitRemovalHunk(hunk, { oldText, oldLines, recovered }) {
   // A removal that reaches the file's true tail cannot be split into independent

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -132,6 +132,16 @@ export function recoveredLineCounts(texts) {
  * widening it with context could overlap its sibling, so the merged hunk is kept instead).
  */
 export function splitRemovalHunk(hunk, { oldText, oldLines, recovered }) {
+  // A removal that reaches the file's true tail cannot be split into independent
+  // sub-hunks: `span`'s tail rule gives the final sub-hunk a LEADING newline, and that
+  // is the same character its predecessor owns as its trailing newline. Applying one
+  // decision then consumes the separator the other one's `find` needs, so the pair
+  // composes in only one order - which breaks the any-subset-any-order contract the
+  // writer relies on. No non-overlapping anchoring exists at that seam; keep the
+  // merged hunk instead (a file ending in "\n" is unaffected: its final split("\n")
+  // element is the empty string, which no text removal reaches).
+  if (hunk.oldEnd === oldLines.length) return null;
+
   const lineKinds = new Map();
   for (let lineNo = hunk.oldStart; lineNo <= hunk.oldEnd; lineNo += 1) {
     const normalized = normalizeRecoveryLine(oldLines[lineNo - 1]);

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1361,3 +1361,49 @@ test("an extract cannot smuggle the adjacent deletion: its skills must carry eve
     violations.join("\n"),
   );
 });
+
+test("a mixed removal reaching EOF without a trailing newline stays one merged hunk", () => {
+  // The reachable layout from review: at the file's true tail, span's tail rule makes
+  // the final sub-hunk's leading newline the same character as its predecessor's
+  // trailing newline, so split decisions would compose in only one order. The split
+  // must fail soft to the merged hunk, where the extract gate still tells the truth.
+  const text = [
+    "# Memory",
+    "",
+    "## Doomed",
+    "",
+    "- Delete this instruction.",
+    "",
+    "## Carried",
+    "",
+    "- Keep this instruction in a skill.",
+  ].join("\n");
+  const skill = [
+    "---",
+    "name: carried",
+    "description: Carries the tail section.",
+    "---",
+    "",
+    "## Carried",
+    "",
+    "- Keep this instruction in a skill.",
+    "",
+  ].join("\n");
+  const staged = gate({
+    text,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", () => "# Memory\n");
+      writeIn(root, ".agents/skills/carried/SKILL.md", skill);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "tail extraction" })] },
+    context: { summary: betaRows({ harmSessions: 0 }) },
+  });
+
+  const memoryHunks = staged.measured.changes.filter((change) => change.kind === "hunk");
+  assert.equal(memoryHunks.length, 1, "no split at the unanchorable tail seam");
+  assert.match(memoryHunks[0].find, /## Doomed[\s\S]*## Carried/);
+  assert.ok(
+    staged.violations.some((violation) => /do not carry/.test(violation)),
+    "the merged hunk still cannot smuggle the deletion through the extract gate",
+  );
+});


### PR DESCRIPTION
## Intent

Follow-up fix for a high-risk finding that PR 64 disclosed in its body but merged without fixing (the fix commit existed locally but had not been pushed when the PR was merged; this PR carries exactly that one fix and its regression test, nothing else). Finding split-removal-tail-anchors-overlap, also echoed by Greptile on PR 64: the extraction-vs-deletion split introduced by PR 64 cannot build independently composable sub-hunk anchors when a mixed pure removal reaches the true tail of a file that lacks a trailing newline - span's tail rule gives the final sub-hunk a LEADING newline that is the same character its predecessor owns as a trailing newline, so the two split decisions compose in only one order, violating the any-subset-any-order contract the apply writer relies on. Fix, exactly as the finding recommended: fail soft to the merged hunk when hunk.oldEnd equals oldLines.length (the only seam where span's tail rule engages) - no non-overlapping anchoring exists there. Files ending in a newline are unaffected because their final split element is the empty string no text removal reaches, so the common case keeps splitting. The behavioral regression test stages that exact EOF layout through the real measurement path and asserts the removal stays one merged hunk AND that the extract gate still refuses the smuggled deletion on the merged hunk, so failing soft never weakens the removal safeguards PR 64 added. Deliberately minimal: one guard clause with an explanatory comment in src/workspace.js plus one test in test/proposal.test.js; no other behavior changes.

## What Changed

- Keep mixed removal hunks merged when they reach a file's true EOF without a trailing newline, avoiding overlapping split anchors.
- Add a regression test confirming the merged hunk still rejects deletions not carried into the extracted skill.

## Risk Assessment

✅ Low: The minimal guard correctly preserves the merged hunk at the unanchorable EOF seam, and the behavioral regression test covers both measurement and extraction safeguards.

## Testing

Compared the two-commit diff, reproduced the anchor-overlap regression against the base, passed focused current-commit tests covering the EOF fix, extraction safeguard, and newline-terminated common case, then captured an executable proposal-gate demonstration showing one merged removal and refusal of the smuggled deletion.

<details>
<summary>Evidence: EOF split measurement and proposal-gate demonstration</summary>

Source: [EOF split measurement and proposal-gate demonstration](https://github.com/kunchenguid/backpass/blob/772f0232513eba0b8d6ef8840f16695045aed759/.no-mistakes/evidence/fm/backpass-eof-split-anchor-fix-r1/eof-split-gate-demo.txt)

```text
End-user synthesis measurement and proposal-gate demonstration
Original ends with newline: false
Measured memory removal decisions: 1
Merged anchor covers doomed section: true
Merged anchor covers carried section: true
Created skill measured separately: true
Proposal gate result:
REFUSED: edit e1 ("tail extraction") removes text its created skill(s) do not carry (first: "## Doomed"); an extraction preserves every line it removes - revert that text, or make its deletion a separate "remove" edit
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"00a6f47798c2e6b7cd0905c1ff0d44d37ceca469","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='removal mixing extracted and deleted text|mixed removal reaching EOF without a trailing newline|extract cannot smuggle' test/proposal.test.js`
- <code>Ran the new EOF regression test against base commit `85d5105`; it failed as expected because the removal produced two hunks instead of one.</code>
- `Executed the real staging measurement and proposal gate with a no-trailing-newline memory file, adjacent deletion, and extracted tail skill; captured the resulting merged hunk and refusal output.`
- <code>`git status --short` to verify testing left no transient worktree files.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
