### PR TITLE
feat(prompts): make gap domain a causal test and soften the extraction nudge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   open entries, `foldForRun` runs ONE consolidation call (`src/consolidate.js`) that merges paraphrased entries
   (`mergeGapEntries`) - record, consolidate, prune, in that order. Consolidation failure
   degrades to lexical identity with a warning, never an abort. Gaps also carry `domain`;
-  `orchestration` sightings (task-harness mistakes, not this repo's engineering) are
-  counted in `totals.orchestrationGapSightings` and excluded from clustering, so they can
+  `orchestration` sightings (mistakes caused by the external harness or tooling that
+  orchestrated the task, not by this repo) are counted in
+  `totals.orchestrationGapSightings` and excluded from clustering, so they can
   never reach a proposal - there is deliberately no orchestrator-memory write path.
 - **backpass must never analyze itself.** Its own acpx calls are filed by each harness
   under the repo's cwd, a tier-1 match. Every prompt starts with `SELF_SESSION_SENTINEL`

--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ strict JSON: which instructions helped, which were violated, and what mistakes n
 instruction covers. Every negative carries a class - `harm` (following the instruction
 caused damage), `non-compliance` (the agent ignored it), or `irrelevant` - because those
 argue for opposite fates: harm argues against an instruction, non-compliance argues for
-reinforcing it. Every gap carries a domain - `project` for this repository's own
-engineering, `orchestration` for the task-management layer around the session - and the
+reinforcing it. Every gap carries a domain - `orchestration` when the mistake was caused
+not by this repository but by an external agent harness or tooling that orchestrated the
+task, `project` for every other mistake - and the
 analysis is shown the ledger's open gaps so it can cite an existing gap id instead of
 coining a paraphrase of it.
 
@@ -193,8 +194,9 @@ consolidation call sees the full open gap set and merges entries that describe t
 mistake. That second judgment is what lets two sightings of a brand-new gap in the same
 run's parallel fan-out corroborate. A failed consolidation call degrades the run to
 lexical identity and says so; it never aborts. Orchestration-domain gaps are counted and
-reported but never cluster: mistakes about the task harness around a session do not
-become instructions in the project's memory file.
+reported but never cluster: a mistake caused not by this repository but by the external
+agent harness or tooling that orchestrated a session does not become an instruction in the
+project's memory file.
 
 Only evidence judged against the _current_ memory-file set hash is folded into a proposal. A
 transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the

--- a/src/fold.js
+++ b/src/fold.js
@@ -91,9 +91,9 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
     }
   }
 
-  // Orchestration-domain sightings are about the task-management layer around the
-  // session, not this repository's engineering; they are counted for legibility but
-  // never cluster, so they can never corroborate into a project proposal.
+  // Orchestration-domain sightings are mistakes caused not by this repository but by the
+  // external agent harness or tooling that orchestrated the session; they are counted for
+  // legibility but never cluster, so they can never corroborate into a project proposal.
   const allObservations = gapObservations ?? recordObservations;
   const projectObservations = allObservations.filter((obs) => obs?.domain !== "orchestration");
   const orchestrationGapSightings = allObservations.length - projectObservations.length;
@@ -230,8 +230,8 @@ export function renderEvidenceForPrompt(summary) {
   lines.push("### Gap clusters (mistakes no current instruction covers)");
   if (summary.totals.orchestrationGapSightings) {
     lines.push(
-      `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) about the ` +
-        `task-management layer were excluded; they never enter this repository's memory file`,
+      `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) caused by the ` +
+        `orchestrating harness or tooling were excluded; they never enter this repository's memory file`,
     );
   }
   if (!summary.gaps.length) {

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -26,9 +26,9 @@ import { sha256 } from "./state.js";
  *    merged by the pre-synthesis consolidation pass (`mergeGapEntries`, driven by
  *    `src/consolidate.js`), which is what lets two same-run parallel sightings - neither
  *    of which could cite the other - still corroborate.
- *  - Every observation carries the `domain` the analysis judged: `project` for mistakes
- *    about this repository's own engineering, `orchestration` for mistakes about the
- *    task-management layer around it (briefs, scout scope, status records, approvals).
+ *  - Every observation carries the `domain` the analysis judged: `orchestration` when the
+ *    mistake was not caused by this repository but by an external agent harness or tooling
+ *    that orchestrated the task, `project` for every other mistake.
  *    Orchestration sightings are recorded for legibility but never counted toward
  *    corroboration and never surface in a proposal; a missing domain counts as project,
  *    so evidence from before the field existed keeps its old behavior.

--- a/src/prompts/analysis.md
+++ b/src/prompts/analysis.md
@@ -53,12 +53,12 @@ Rules, in order of importance:
    or violated the instruction - evidence the instruction failed to steer, which argues
    for reinforcing it, never for deleting it. `irrelevant`: on inspection the moment
    does not actually bear on this instruction. Never report a skipped rule as `harm`.
-4. **`domain` states whose mistake a gap is.** `project`: about this repository's own
-   engineering - its code, tests, build, docs, releases, conventions. `orchestration`:
-   about the task-management layer around the session - task briefs and their scope
-   (scout/read-only rules), status reporting to a supervisor, approval and authorization
-   flows, delivery-lifecycle process imposed from outside the repository. Orchestration
-   gaps are counted but never proposed into this repository's memory file.
+4. **`domain` states what caused a gap.** A gap is `orchestration` when the mistake was
+   not caused by this repository, but by an external agent harness or tooling that
+   orchestrated the task (a task brief, a supervisor's process, the harness itself - by
+   way of illustration only, not a list to match against); every other gap is `project`.
+   Ask the causal question, not which category the wording resembles. Orchestration gaps
+   are counted but never proposed into this repository's memory file.
 5. **Do not confabulate influence.** Only call something positive when the trace shows
    the agent doing the specific thing the instruction asks for. An outcome that would
    have happened anyway is not evidence.

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -81,7 +81,7 @@ analyzed sessions in which an instruction drew any evidence at all.
 5. **Every edit must be backed by at least one verbatim quote** from the evidence. You
    will attach the quotes in the next step, so only make changes you can back.
 6. **Budget:** {{BUDGET_RULE}}
-7. Prefer extracting a long, narrow, crisply-triggered section over deleting anything:
+7. You can extract a long, narrow, crisply-triggered section instead of deleting it:
    extraction frees the same always-loaded tokens and loses nothing.
 8. Change only `./{{MEMORY_PATH}}` and files under `./{{SKILLS_DIR}}/`. Never delete a
    file. Do not create notes, scripts, or scratch files.
@@ -94,7 +94,7 @@ analyzed sessions in which an instruction drew any evidence at all.
 | Conditional / narrow     | **skill** (the description is the condition) | deletion candidate |
 
 A skill's description is always loaded and its body is free until triggered, so moving a
-long, narrow, crisply-triggered section into a skill is nearly pure budget profit.
+section into a skill trades its always-loaded cost for that one description line.
 
 **Skill descriptions are weights too.** If the evidence shows an agent lacked knowledge
 an existing skill already contains, that is a failed trigger: rewrite that skill's

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -1,0 +1,182 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { State } from "../src/state.js";
+import { resolveMemoryFiles } from "../src/memory.js";
+import { foldForRun } from "../src/commands/propose.js";
+import { renderEvidenceForPrompt } from "../src/fold.js";
+
+/**
+ * A gap's `domain` decides whether it can ever become an instruction, so this drives the
+ * real CLI (`backpass analyze` against a fake acpx) and then folds the evidence the way
+ * `backpass propose` does, asserting both halves of the contract a user depends on:
+ * the analysis prompt actually handed to the model states the causal test for
+ * `orchestration` (the mistake was caused by the harness around the session, not by this
+ * repository), and the mechanics behind it are unchanged - orchestration sightings are
+ * recorded and counted but never corroborate, while a gap with no domain at all is still
+ * treated as `project`.
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CLI = path.join(ROOT, "bin", "backpass.js");
+
+const ORCHESTRATION_GAP = "Stop after the report on scout tasks.";
+const UNLABELLED_GAP = "Always run lint before pushing.";
+
+const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-domain-bin-"));
+const fakePi = path.join(binDir, "pi");
+const fakeAcpx = path.join(binDir, "acpx");
+
+fs.writeFileSync(fakePi, `#!${process.execPath}\nprocess.exit(0);\n`);
+fs.chmodSync(fakePi, 0o755);
+
+// Every analysis call answers with the same two gaps: one the model judged
+// `orchestration`, and one from before the field existed (no `domain` at all).
+fs.writeFileSync(
+  fakeAcpx,
+  `#!${process.execPath}
+const argv = process.argv.slice(2);
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write(JSON.stringify({ agents: {} }) + "\\n");
+  process.exit(0);
+}
+if (argv.includes("--file")) {
+  process.stdout.write(JSON.stringify({
+    positive: [],
+    negative: [],
+    gaps: [
+      {
+        mistake: "kept working after the brief said to report and stop",
+        proposedInstruction: ${JSON.stringify(ORCHESTRATION_GAP)},
+        recurrenceRisk: "high",
+        domain: "orchestration",
+        quote: "opened a PR during a scout task",
+      },
+      {
+        mistake: "skipped lint",
+        proposedInstruction: ${JSON.stringify(UNLABELLED_GAP)},
+        recurrenceRisk: "high",
+        quote: "skipped lint entirely this time",
+      },
+    ],
+  }) + "\\n");
+  process.exit(0);
+}
+process.exit(0);
+`,
+);
+fs.chmodSync(fakeAcpx, 0o755);
+
+function git(args, cwd) {
+  spawnSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function initRepo() {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-domain-repo-")));
+  git(["init", "--quiet", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  fs.writeFileSync(path.join(dir, "AGENTS.md"), "# Agent instructions\n\n- Run `make build` before every push.\n");
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "-m", "memory"], dir);
+  return dir;
+}
+
+/** A minimal Pi session, non-trivial enough to clear the triviality filter. */
+function writeSession(home, id, cwd) {
+  const dir = path.join(home, ".pi", "agent", "sessions", id);
+  fs.mkdirSync(dir, { recursive: true });
+  const entries = [
+    { type: "session", version: 3, id, timestamp: new Date().toISOString(), cwd },
+    { type: "message", message: { role: "user", content: "Please build the project." } },
+    { type: "message", message: { role: "assistant", content: "Ran make build as instructed." } },
+    { type: "message", message: { role: "user", content: "Now run the tests too." } },
+    { type: "message", message: { role: "assistant", content: "Tests pass." } },
+  ];
+  fs.writeFileSync(
+    path.join(dir, `${Date.now()}_${id}.jsonl`),
+    `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`,
+  );
+}
+
+function runAnalyze(dir, home) {
+  const args = ["analyze", "--harness", "pi", "--since", "all", "--analysis-agent", "pi", "--jobs", "1", "--json"];
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      BACKPASS_ACPX_BIN: fakeAcpx,
+      NO_COLOR: "1",
+    },
+    encoding: "utf8",
+    timeout: 20000,
+  });
+  return { ...result, output: `${result.stdout}${result.stderr}` };
+}
+
+function analyzedRepo() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-domain-home-"));
+  const dir = initRepo();
+  writeSession(home, "session-a", dir);
+  writeSession(home, "session-b", dir);
+  const run = runAnalyze(dir, home);
+  assert.equal(run.status, 0, run.output);
+  return dir;
+}
+
+test("the analysis prompt the model receives asks what caused the gap, not which category it resembles", () => {
+  const dir = analyzedRepo();
+  const promptDir = path.join(dir, ".backpass", "prompts");
+  const prompts = fs.readdirSync(promptDir).map((f) => fs.readFileSync(path.join(promptDir, f), "utf8"));
+  assert.equal(prompts.length, 2, "both analyzed sessions got a prompt");
+
+  for (const prompt of prompts) {
+    assert.match(
+      prompt,
+      /`orchestration` when the mistake was\s+not caused by this repository, but by an external agent harness or tooling that\s+orchestrated the task/,
+      "the causal test is what the model is asked to apply",
+    );
+    assert.match(prompt, /every other gap is `project`/);
+    assert.match(prompt, /illustration only, not a list to match against/, "examples cannot read as exhaustive");
+    assert.ok(
+      !/task briefs and their scope|status reporting to a supervisor|delivery-lifecycle process/.test(prompt),
+      "the old enumeration no longer stands in for the definition",
+    );
+    assert.match(prompt, /Orchestration gaps\s+are counted but never proposed into this repository's memory file/);
+  }
+});
+
+test("an orchestration gap is counted but never corroborates, while a gap with no domain is project", async () => {
+  const dir = analyzedRepo();
+  const state = new State(dir).ensure();
+  const resolved = resolveMemoryFiles(dir, ["AGENTS.md", "CLAUDE.md"]);
+  const summary = await foldForRun(
+    { config: { state, minGapEvidence: 2, gapLedgerMaxAge: "90d" } },
+    resolved.primary,
+    resolved.hash,
+  );
+
+  assert.equal(summary.analyzedSessions, 2, "both sessions saw both gaps, so both clear the two-session floor");
+  assert.equal(summary.totals.orchestrationGapSightings, 2, "orchestration sightings are recorded, not dropped");
+  assert.deepEqual(
+    summary.gaps.map((gap) => gap.proposedInstruction),
+    [UNLABELLED_GAP],
+    "only the domain-less gap - counted as project - can reach a proposal",
+  );
+
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.ok(!rendered.includes(ORCHESTRATION_GAP), "the orchestration gap never reaches the synthesis prompt");
+  assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/, "the run stays legible about what it cut");
+
+  const ledger = state.readGapLedger();
+  const domains = Object.values(ledger.entries).map((entry) => Object.values(entry.sessions)[0].domain);
+  assert.deepEqual(domains.sort(), ["orchestration", "project"], "the ledger keeps the judged domain of each sighting");
+});

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -315,6 +315,15 @@ test("skills whose removals merged into one change ship as one decision, and app
   );
   assert.match(editPrompt, /harm-sessions=3/);
 
+  // Extraction is offered as an available option, not urged: the deciding model must not
+  // read the prompt as pushing it toward a skill when the evidence does not ask for one.
+  assert.match(editPrompt, /You can extract a long, narrow, crisply-triggered section instead of deleting it/);
+  assert.ok(!/Prefer extracting/.test(editPrompt), "hard rule 7 states permission, never preference");
+  assert.ok(
+    !/nearly pure budget profit/.test(editPrompt),
+    "the placement table's follow-up states the mechanics, it does not re-add the nudge",
+  );
+
   const proposal = proposalOf(dir);
   assert.equal(proposal.edits.length, 1, "one merged change cannot be accepted in halves, so it is one decision");
   assert.equal(proposal.edits[0].hunks.length, 1);


### PR DESCRIPTION
## Intent

Two prompt-wording changes the captain asked for in backpass's own prompts, deliberately small, surgical and behavioural - NOT a redesign of gap handling or extraction.

CHANGE 1 - simplify the orchestration-domain definition. src/prompts/analysis.md rule 4 defined `domain` by enumerating categories ('the task-management layer around the session - task briefs and their scope (scout/read-only rules), status reporting to a supervisor, approval and authorization flows, delivery-lifecycle process imposed from outside the repository'). The captain's words: 'i think the orchestration definition is too rigid. we should simplify it to something like: not caused by the current repository, but by an external agent harness or tooling that orchestrated the task.' The enumeration must STOP BEING THE TEST; the causal question is the test. Rule 4 now states: a gap is `orchestration` when the mistake was not caused by this repository, but by an external agent harness or tooling that orchestrated the task; every other gap is `project`. One short parenthetical of examples is deliberately kept but explicitly marked 'by way of illustration only, not a list to match against', plus one line telling the model to ask the causal question rather than match wording. The existing sentence that orchestration gaps are counted but never proposed into this repository's memory file is kept verbatim in substance.

Mechanics are deliberately UNCHANGED: orchestration sightings still record, still never corroborate, still never reach a proposal, and a gap with a missing domain still counts as `project`. Doc surfaces that restated the old enumeration were updated so no surface contradicts the new definition: the src/gap-ledger.js header comment, the src/fold.js code comment and its excluded-sightings report line, README.md (two places: the analysis-step domain sentence and the orchestration paragraph in the gap-identity section), and AGENTS.md. VISION.md never restated it, so it is untouched.

CHANGE 2 - soften the extraction nudge. src/prompts/synthesis.md hard rule 7 read 'Prefer extracting a long, narrow, crisply-triggered section over deleting anything: extraction frees the same always-loaded tokens and loses nothing.' The captain's words: 'the skill extraction can be kept - but prefer feels like a strong nudge. can we just soften that a bit? like: you can extract ...'. Rewritten as permission rather than preference, in the same position: 'You can extract a long, narrow, crisply-triggered section instead of deleting it: extraction frees the same always-loaded tokens and loses nothing.' The substance (extraction preserves content where deletion loses it) is kept.

The captain also asked me to check the surrounding text for the same nudge expressed elsewhere. The placement table's follow-up line pushed in the same direction ('so moving a long, narrow, crisply-triggered section into a skill is nearly pure budget profit' - an inducement, not a fact), so only its second clause was softened to a neutral statement of the mechanics: 'so moving a section into a skill trades its always-loaded cost for that one description line.' The placement table itself and where content is said to belong are unchanged.

EXPLICITLY OUT OF SCOPE by the captain's instruction - these are intentionally NOT touched and must not be 'fixed': the budget rule text in src/synthesize.js (budgetRule), including the over-budget shrink-plan wording (a separate question the captain has not ruled on); the placement table's contents and thresholds; the >=20% relevance rule, which the captain deliberately keeps as prompt guidance and NOT a gate; and every hard rule other than 7 - the edit cap, the two-session evidence floor for new instructions, the harm-evidence floor for removals, the extraction-preserves-every-line rule, and the quote requirement all stay exactly as they are.

EXPECTED AND ACCEPTED CONSEQUENCES, not regressions: these changes may reduce how often extraction is proposed and may shift some gaps from orchestration to project. That is the intent. Context: the captain's 0.1.12 run on the backpass repo itself recorded 9 gaps - 6 classified orchestration and excluded, 3 project-domain singletons below the 2-session floor - so nothing was eligible and the only output was 4 skill extractions on a file at 4,188/5,000 tokens (mildest budget branch). The definition decided two thirds of that corpus and rule 7 produced the extractions when nothing forced a shrink.

COVERAGE, in the project's existing style and per its rule against source-text greps: assertions go through the real consumer path. New test/gap-domain-cli.test.js drives the real CLI (`backpass analyze` against a fake acpx, same pattern as test/analyze-reuse.test.js), reads the prompts actually written to .backpass/prompts/ - the generated prompt artifact delivered to the model, the same contract PR #64 asserted on for the negative's class/effect - and asserts they carry the causal test and no longer the enumeration; a second test folds that evidence via foldForRun exactly as `backpass propose` does and asserts the orchestration gap is recorded, counted in totals.orchestrationGapSightings, absent from summary.gaps and from renderEvidenceForPrompt, while the domain-less gap graduates as project, and the ledger keeps each sighting's judged domain. test/synthesis-cli.test.js extends its existing rendered-prompt assertions to cover hard rule 7's permission wording and the absence of both nudge phrasings in the synthesis-edit prompt. pnpm run check is green locally: lint, format, typecheck, 337 tests.

## What Changed

- Define orchestration gaps by whether an external harness or tool caused them, while preserving their existing recording and exclusion behavior.
- Present skill extraction as an option and describe its token tradeoff without preferring it over deletion.
- Add CLI-level coverage for rendered prompt wording and domain handling through folding and the gap ledger.

## Risk Assessment

✅ Low: The change is narrowly scoped to prompt and documentation wording, preserves the existing mechanics and required gates, and adds consumer-path coverage for the emitted prompts and domain behavior.

## Testing

Starting from the supplied green `pnpm run check` baseline, targeted CLI tests and an end-to-end artifact run confirmed that delivered analysis prompts use the causal orchestration test, orchestration sightings remain counted but excluded, missing domains graduate as project, and the delivered synthesis prompt offers extraction without the former preference or profit nudges. No visual artifact was needed because this changes model-facing CLI prompts rather than UI.

<details>
<summary>Evidence: Analysis prompt actually delivered to the fake model by `backpass analyze`</summary>

Source: [Analysis prompt actually delivered to the fake model by `backpass analyze`](https://github.com/kunchenguid/backpass/blob/a04a6d51ba45d536c35e73488e1a8caf02ec00fa/.no-mistakes/evidence/fm/backpass-prompt-domain-extract-softening-r1/analysis-prompt-delivered.md)

```text
<!-- backpass:self-session -->
You are auditing one past agent session against the repository's agent memory file.

Your job is NOT to review the code. It is to measure how well the memory file's
instructions actually steered this session, and to spot mistakes an instruction could
have prevented. This is the loss signal for a backward pass over the memory file.

## The memory file under audit: AGENTS.md

Each instruction has a stable id in [brackets]. Refer to instructions ONLY by these ids.

[AG-001] (10 tok, L3) <Agent instructions>
- Run `make build` before every push.

## Gaps already on the books

Earlier sessions reported these gaps; each has a stable id. If a gap you found is the
same underlying gap as one below - one instruction would prevent both - cite that id in
`matchesGap` and still describe what you saw. A gap that matches nothing here is new:
omit `matchesGap`.

(none yet)

## The distilled session trace

Tool calls are one-line summaries and tool output is truncated. The raw transcript path
is at the end of the trace: open it ONLY if a specific claim you want to make cannot be
verified from the distilled trace. Reading it is allowed but costs time, so do not do it
by default. Set `usedRawTranscript` accordingly.

# session pi-session-b
harness: pi
date: 2026-08-29T01:36:08.035Z
cwd: ~/.no-mistakes/evidence/01M15JF8JW2NT2B0Y38C00WB9Y/tmp/backpass-domain-repo-4AAlEA
association: tier 1 (exact)

\### turn 1 · user
Please build the project.

\### turn 2 · assistant
Ran make build as instructed.

\### turn 3 · user
Now run the tests too.

\### turn 4 · assistant
Tests pass.

---
raw transcript: ~/.no-mistakes/evidence/01M15JF8JW2NT2B0Y38C00WB9Y/tmp/backpass-domain-home-MbyIgV/.pi/agent/sessions/session-b/1787967368035_session-b.jsonl
Tool calls above are one-line summaries and tool output is truncated. Open the raw
transcript only if a specific claim needs the full text.


## What to report

Return ONE JSON object and nothing else. No prose before or after, no markdown fence.

`` `
{
  "positive":  [{"instruction": "AG-042", "moment": "turn 12", "effect": "what following it achieved", "quote": "verbatim text from the trace"}],
  "negative":  [{"instruction": "AG-017", "moment": "turn 3",  "effect": "what happened and what it cost", "class": "harm|non-compliance|irrelevant", "quote": "verbatim text from the trace"}],
  "gaps":      [{"mistake": "what went wrong", "proposedInstruction": "one sentence that would have prevented it", "recurrenceRisk": "high|medium|low", "domain": "project|orchestration", "matchesGap": "<id from the list above, omit when new>", "quote": "verbatim text from the trace"}],
  "usedRawTranscript": false
}
`` `

Rules, in order of importance:

1. **Every item needs a verbatim `quote` copied exactly from the trace.** Items without
   a real quote are discarded downstream, so an unquotable claim is wasted work.
2. **Negative evidence is the most valuable.** A visible violation, misreading, or
   ignored instruction outranks a dozen "it went fine" observations.
3. **`class` states what a negative means, and the difference decides the instruction's
   fate.** `harm`: the agent FOLLOWED the instruction and following it caused damage or
   cost - evidence against the instruction itself. `non-compliance`: the agent ignored
   or violated the instruction - evidence the instruction failed to steer, which argues
   for reinforcing it, never for deleting it. `irrelevant`: on inspection the moment
   does not actually bear on this instruction. Never report a skipped rule as `harm`.
4. **`domain` states what caused a gap.** A gap is `orchestration` when the mistake was
   not caused by this repository, but by an external agent harness or tooling that
   orchestrated the task (a task brief, a supervisor's process, the harness itself - by
   way of illustration only, not a list to match against); every other gap is `project`.
   Ask the causal question, not which category the wording resembles. Orchestration gaps
   are counted but never proposed into this repository's memory file.
5. **Do not confabulate influence.** Only call something positive when the trace shows
   the agent doing the specific thing the instruction asks for. An outcome that would
   have happened anyway is not evidence.
6. `gaps` are mistakes NOT covered by any current instruction. If an instruction exists
   and was ignored, that is `negative` with `class: "non-compliance"`, not a gap.
7. `proposedInstruction` must be one imperative sentence, specific enough to act on and
   general enough to apply beyond this one session.
8. An empty array is a valid and useful answer. Report nothing rather than something weak.
```
</details>
<details>
<summary>Evidence: Folded domain behavior showing two excluded orchestration sightings and the domain-less project gap eligible after two sessions</summary>

Source: [Folded domain behavior showing two excluded orchestration sightings and the domain-less project gap eligible after two sessions](https://github.com/kunchenguid/backpass/blob/a04a6d51ba45d536c35e73488e1a8caf02ec00fa/.no-mistakes/evidence/fm/backpass-prompt-domain-extract-softening-r1/folded-domain-result.json)

```text
{
  "analyzedSessions": 2,
  "orchestrationGapSightings": 2,
  "eligibleProjectGaps": [
    {
      "proposedInstruction": "Always run lint before pushing.",
      "sessions": 2
    }
  ],
  "synthesisEvidence": "Sessions analyzed: 2\nTotals: 0 positive, 0 negative, 1 gap clusters (0 singletons dropped below threshold)\n\n### Per-instruction evidence\nA negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.\n- [AG-001] +0 -0 sessions=0 relevance=0.0% cost=10tok\n\n### Gap clusters (mistakes no current instruction covers)\n- 2 orchestration-domain sighting(s) caused by the orchestrating harness or tooling were excluded; they never enter this repository's memory file\n- sessions=2 risk=high :: Always run lint before pushing.\n    \"skipped lint entirely this time\" (pi · b · 2026-08-29)\n    \"skipped lint entirely this time\" (pi · a · 2026-08-29)"
}
```
</details>
<details>
<summary>Evidence: Synthesis edit prompt actually delivered by `backpass propose`, including softened extraction wording</summary>

Source: [Synthesis edit prompt actually delivered by `backpass propose`, including softened extraction wording](https://github.com/kunchenguid/backpass/blob/a04a6d51ba45d536c35e73488e1a8caf02ec00fa/.no-mistakes/evidence/fm/backpass-prompt-domain-extract-softening-r1/synthesis-edit-prompt-delivered.md)

```text
<!-- backpass:self-session -->
You are performing the synthesis step of a backward pass over a repository's agent
memory file. Evidence from many past agent sessions has already been gathered and
folded. Your job is to turn that evidence into a small set of concrete, budget-aware
edits - one gradient step on the weights, not a rewrite - by editing the file directly.

## Repository

backpass-cli-v4aket - 3 sessions analyzed across none.


## Where you are

Your working directory is a staging copy, not the repository. It holds exactly two
things: the memory file at `./AGENTS.md` and the skills directory at
`./.agents/skills/`. The repository itself is at `~/.no-mistakes/evidence/01M15JF8JW2NT2B0Y38C00WB9Y/tmp/backpass-cli-v4aket` - open any file there
to ground or verify an edit against the real code, but NEVER write there. Nothing you
change in the staging copy reaches the repository until a human reviews each change.

**Make your edits by editing `./AGENTS.md` in place with your file tools.** Do not
paste the edited text into your reply; backpass measures what you changed in the file.

## Current memory file: AGENTS.md

Budget: 98 / 5000 estimated tokens (within budget).

Every token in this file is paid on every future session, forever, and instruction
following dilutes as the file grows. The budget is the constraint you optimize under.

The index below is a lookup table, not the file: it names each instruction (`AG-nnn`),
its always-loaded cost, and the lines it occupies in `./AGENTS.md`. The evidence
refers to instructions by these ids.

[AG-001] (10 tok, L5) <Demo agent memory > Build>
- Run `make build` before every push.

[AG-002] (11 tok, L9) <Demo agent memory > Release checklist>
- Tag the release commit with the version.

[AG-003] (9 tok, L10) <Demo agent memory > Release checklist>
- Push the tag before the artifacts.

[AG-004] (8 tok, L11) <Demo agent memory > Release checklist>
- Never hand-edit CHANGELOG.md.

[AG-005] (10 tok, L15) <Demo agent memory > Incident response>
- Page the on-call before rolling back.

[AG-006] (10 tok, L16) <Demo agent memory > Incident response>
- Write the postmortem within two days.

[AG-007] (12 tok, L17) <Demo agent memory > Incident response>
- Link the postmortem from the incident channel.

[AG-008] (6 tok, L21) <Demo agent memory > Style>
- Never use the em dash.

## Existing skills (load-on-trigger, in .agents/skills)

(no skills directory found in this repo)

To extract a section into a skill, create `./.agents/skills/<skill-name>/SKILL.md` with
this exact shape, then remove the extracted detail from `./AGENTS.md`
(optionally leaving a one-line pointer):

`` `
---
name: <skill-name>
description: <one line - this IS the trigger condition>
---

<the full markdown body of the skill>
`` `

To tune an existing skill's trigger, edit its `description:` line under `./.agents/skills/`.

## Folded evidence

`sessions` is how many distinct sessions produced the item. `relevance` is the share of
analyzed sessions in which an instruction drew any evidence at all.

Sessions analyzed: 3
Totals: 0 positive, 3 negative, 0 gap clusters (0 singletons dropped below threshold)

\### Per-instruction evidence
A negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.
- [AG-001] +0 -3 harm-sessions=3 sessions=3 relevance=100.0% cost=10tok
    - [harm] "session 1 re-derived the release steps by hand" :: following the stale steps wasted a turn (claude · claude:s · unknown date)
    - [harm] "session 2 re-derived the release steps by hand" :: following the stale steps wasted a turn (claude · claude:s · unknown date)
    - [harm] "session 3 re-derived the release steps by hand" :: following the stale steps wasted a turn (claude · claude:s · unknown date)
- [AG-002] +0 -0 sessions=0 relevance=0.0% cost=11tok
- [AG-003] +0 -0 sessions=0 relevance=0.0% cost=9tok
- [AG-004] +0 -0 sessions=0 relevance=0.0% cost=8tok
- [AG-005] +0 -0 sessions=0 relevance=0.0% cost=10tok
- [AG-006] +0 -0 sessions=0 relevance=0.0% cost=10tok
- [AG-007] +0 -0 sessions=0 relevance=0.0% cost=12tok
- [AG-008] +0 -0 sessions=0 relevance=0.0% cost=6tok

\### Gap clusters (mistakes no current instruction covers)
- none above the evidence threshold

## Previously rejected edits - do not re-propose these

(none)

## Hard rules - a violation fails the whole proposal

1. **At most 5 edits.** This is the learning rate. An edit is one change a
   human can decide on; pick the highest-signal ones. A small correct step beats a large
   speculative one.
2. **New instructions need evidence from at least 2 distinct
   sessions.** One bad session never rewrites the weights.
3. **Removing an instruction outright needs harm evidence from at least
   2 distinct sessions** (`harm-sessions` in the evidence rows).
   Only `harm` negatives - following the instruction caused damage - argue against an
   instruction. `non-compliance` means it failed to steer: reinforce it, reposition it,
   or improve its trigger, never delete it for being ignored. Text you delete that does
   not land in a created skill is a removal, whatever the edit is called.
4. **An extraction preserves every line it removes** in the SKILL.md it creates. A
   deletion is never part of an extract: it is its own `remove` edit, decided on its
   own evidence.
5. **Every edit must be backed by at least one verbatim quote** from the evidence. You
   will attach the quotes in the next step, so only make changes you can back.
6. **Budget:** The post-edit file must stay at or below 5000 tokens (4902 tokens of headroom today).
7. You can extract a long, narrow, crisply-triggered section instead of deleting it:
   extraction frees the same always-loaded tokens and loses nothing.
8. Change only `./AGENTS.md` and files under `./.agents/skills/`. Never delete a
   file. Do not create notes, scripts, or scratch files.

## Where an instruction belongs

|                          | Trigger fits in one description line | Trigger not detectable |
|--------------------------|--------------------------------------|------------------------|
| Broad (>= 20% of sessions, or safety-critical) | memory file | memory file |
| Conditional / narrow     | **skill** (the description is the condition) | deletion candidate |

A skill's description is always loaded and its body is free until triggered, so moving a
section into a skill trades its always-loaded cost for that one description line.

**Skill descriptions are weights too.** If the evidence shows an agent lacked knowledge
an existing skill already contains, that is a failed trigger: rewrite that skill's
description line instead of duplicating content in the memory file.

## When you are done

Reply with a short plain-text summary of what you changed and why (a few lines). No
JSON yet - backpass will measure the changes and ask you to annotate each one next.
If the evidence does not justify any change, change nothing and say so.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"17101b3fd6b4d12bad3a3391b5dc8a9d09576f45","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/gap-domain-cli.test.js`
- `node --test --test-name-pattern='skills whose removals merged into one change ship as one decision, and apply writes them together' test/synthesis-cli.test.js`
- <code>Re-ran both targeted checks with `TMPDIR=~/.no-mistakes/evidence/01M15JF8JW2NT2B0Y38C00WB9Y/tmp` to capture the actual generated model prompts and persisted fold state.</code>
- <code>Invoked `foldForRun` and `renderEvidenceForPrompt` against the CLI-generated evidence repository and saved the observable result to `folded-domain-result.json`.</code>
- <code>Verified `git status --short` remained clean and removed temporary evidence-generation directories.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
