### PR TITLE
feat(apply): visualize gap evidence funnel on review board

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ not duplicate content.
 
 `backpass apply` is the only command that writes. It serves a review surface through
 [`lavish-axi`](https://github.com/kunchenguid/lavish-axi): one card per edit with the diff,
-the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT.
+the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT. A compact
+gap funnel shows how accumulated sightings narrowed through domain filtering and clustering
+to the gaps eligible for a proposal; older proposals without recorded funnel counts omit it.
 
 The surface is a static template shipped in the package - the CLI injects one JSON payload,
 so it is instant, deterministic, and identical every run. Nothing there is model-generated.

--- a/README.md
+++ b/README.md
@@ -314,8 +314,9 @@ not duplicate content.
 `backpass apply` is the only command that writes. It serves a review surface through
 [`lavish-axi`](https://github.com/kunchenguid/lavish-axi): one card per edit with the diff,
 the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT. A compact
-gap funnel shows how accumulated sightings narrowed through domain filtering and clustering
-to the gaps eligible for a proposal; older proposals without recorded funnel counts omit it.
+gap funnel shows how accumulated sightings narrowed through domain filtering, clustering,
+and the corroboration floor to the gaps eligible for a proposal; older proposals without
+recorded funnel counts omit it.
 
 The surface is a static template shipped in the package - the CLI injects one JSON payload,
 so it is instant, deterministic, and identical every run. Nothing there is model-generated.

--- a/src/fold.js
+++ b/src/fold.js
@@ -143,6 +143,10 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
     totals: {
       positive: positiveCount,
       negative: negativeCount,
+      // The gap funnel's top: every sighting this fold clustered over (the pruned ledger
+      // when one is passed, this run's records otherwise). Orchestration sightings are the
+      // slice excluded before clustering; project-domain is the difference.
+      gapSightings: allObservations.length,
       gapClusters: gaps.length,
       droppedGapSingletons,
       orchestrationGapSightings,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -489,6 +489,13 @@ export function buildProposal(rawResult, context) {
       positive: summary?.totals?.positive ?? 0,
       negative: summary?.totals?.negative ?? 0,
       gapClusters: summary?.totals?.gapClusters ?? 0,
+      // The gap funnel, for the apply surface: sightings -> project-domain (sightings
+      // minus orchestration) -> distinct gaps (clusters + dropped) -> eligible
+      // (clusters). `null`, never 0, when the summary predates a count - the surface
+      // hides what was not recorded rather than showing an invented zero.
+      gapSightings: summary?.totals?.gapSightings ?? null,
+      orchestrationGapSightings: summary?.totals?.orchestrationGapSightings ?? null,
+      droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,
       skillExtractions: accepted.reduce((n, e) => n + editSkills(e).length, 0),
     },
     edits: accepted,

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -132,11 +132,25 @@
       [hidden] {
         display: none !important;
       }
-      .funnel {
+      .ctx {
         border: 1px solid var(--line);
+        background: var(--line);
+        display: grid;
+        grid-template-columns: minmax(0, 3fr) minmax(280px, 2fr);
+        gap: 1px;
+        margin-bottom: 36px;
+      }
+      .ctx-funnel {
         background: var(--panel);
         padding: 13px 18px 14px;
-        margin-bottom: 36px;
+        min-width: 0;
+      }
+      .ctx-stats {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-auto-rows: 1fr;
+        gap: 1px;
+        min-width: 0;
       }
       .funnel-head {
         display: flex;
@@ -676,6 +690,9 @@
           padding: 12px 16px;
           gap: 12px;
         }
+        .ctx {
+          grid-template-columns: minmax(0, 1fr);
+        }
         .frow .fl {
           width: 92px;
         }
@@ -696,13 +713,16 @@
 
       <div class="statrow" id="statrow" hidden></div>
 
-      <div class="funnel" id="funnel" hidden>
-        <div class="funnel-head">
-          <span class="t">Gap funnel · counted across runs</span>
-          <span class="facts num" id="run-facts"></span>
+      <div class="ctx" id="ctx" hidden>
+        <div class="ctx-funnel">
+          <div class="funnel-head">
+            <span class="t">Gap funnel · counted across runs</span>
+            <span class="facts num" id="funnel-floor"></span>
+          </div>
+          <div id="funnel-bars"></div>
+          <div class="funnel-note" id="funnel-note" hidden></div>
         </div>
-        <div id="funnel-bars"></div>
-        <div class="funnel-note" id="funnel-note" hidden></div>
+        <div class="ctx-stats" id="ctx-stats"></div>
       </div>
 
       <div class="gauge-block">
@@ -787,15 +807,15 @@
           document.createTextNode(" transcripts" + (harnessBits.length ? " (" + harnessBits.join(" · ") + ")" : "")),
         );
 
-        // ---- run context: the gap funnel, with the run facts in its header ----
-        // One panel tells the gap story as proportional bars - sightings recorded by
-        // analysis -> project-domain (orchestration excluded) -> distinct gaps after
-        // clustering -> eligible to propose - with each drop-off explained in plain
-        // words. The run facts (edits, evidence, skills) live in the panel head; a
-        // separate stat row would duplicate the funnel's last stage. Every count is
-        // recorded by the fold (`totals` in evidence-summary.json); a proposal saved
-        // before the counts existed falls back to the classic stat row rather than
-        // showing zeros nobody measured.
+        // ---- run context: one frame, the gap funnel beside the run stats ----
+        // A single bordered band. The left pane tells the gap story as proportional
+        // bars - sightings recorded by analysis -> project-domain (orchestration
+        // excluded) -> distinct gaps after clustering -> eligible to propose - with
+        // each drop-off explained in plain words. The right pane holds the run facts
+        // (edits, evidence, skills) as stat cells; a separate stat row would duplicate
+        // the funnel's last stage. Every count is recorded by the fold (`totals` in
+        // evidence-summary.json); a proposal saved before the counts existed falls
+        // back to the classic stat row rather than showing zeros nobody measured.
         function funnelCounts() {
           if (typeof (P.stats || {}).gapSightings !== "number") return null;
           var eligible = P.stats.gapClusters || 0;
@@ -857,17 +877,22 @@
           );
           funnelBar(bars, funnel.eligible, "eligible to propose", funnel.sighted, true);
 
-          var facts = document.getElementById("run-facts");
-          var fact = function (value, label) {
-            facts.appendChild(el("b", null, value));
-            facts.appendChild(document.createTextNode(" " + label));
-          };
-          fact(String(edits.length) + "/" + String((P.config || {}).maxEditsPerRun || edits.length), "edits");
-          facts.appendChild(document.createTextNode(" · "));
-          fact("+" + fmt(P.stats.positive) + " / −" + fmt(P.stats.negative), "evidence");
-          facts.appendChild(document.createTextNode(" · "));
-          fact(fmt(P.stats.skillExtractions), "skills");
-          facts.appendChild(document.createTextNode(" · floor " + funnel.floor + " sessions"));
+          document.getElementById("funnel-floor").textContent = "corroboration floor · " + funnel.floor + " sessions";
+          var statHost = document.getElementById("ctx-stats");
+          [
+            [
+              String(edits.length) + "/" + String((P.config || {}).maxEditsPerRun || edits.length),
+              "edits proposed / cap",
+            ],
+            [fmt(P.stats.positive), "positive evidence"],
+            [fmt(P.stats.negative), "negative evidence"],
+            [fmt(P.stats.skillExtractions), "skill extractions"],
+          ].forEach(function (s) {
+            var box = el("div", "stat");
+            box.appendChild(el("div", "v num", s[0]));
+            box.appendChild(el("div", "k", s[1]));
+            statHost.appendChild(box);
+          });
 
           // The drop lines carry the takeaway; the visible note only speaks when there
           // are no bars to read. funnelNote itself still feeds the zero-edit empty state.
@@ -897,7 +922,7 @@
             noteEl.textContent = funnelNote;
             noteEl.hidden = false;
           }
-          document.getElementById("funnel").hidden = false;
+          document.getElementById("ctx").hidden = false;
         } else {
           // A proposal from before the funnel counts existed: the classic stat row.
           var statrow = document.getElementById("statrow");

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -127,13 +127,15 @@
       }
 
       /* ---------- gap funnel ---------- */
-      .wrap.has-funnel .statrow {
-        margin-bottom: 10px;
+      /* The template's own display rules (.statrow's grid) would beat the UA
+         stylesheet's [hidden]; this keeps the hidden attribute authoritative. */
+      [hidden] {
+        display: none !important;
       }
       .funnel {
         border: 1px solid var(--line);
         background: var(--panel);
-        padding: 13px 18px 15px;
+        padding: 13px 18px 14px;
         margin-bottom: 36px;
       }
       .funnel-head {
@@ -142,85 +144,87 @@
         align-items: baseline;
         flex-wrap: wrap;
         gap: 8px;
-        margin-bottom: 12px;
+        margin-bottom: 10px;
       }
       .funnel-head .t {
         font-size: 13px;
         color: var(--dim);
       }
-      .funnel-head .floor {
+      .funnel-head .facts {
         font-family: var(--mono);
         font-size: 11px;
         color: var(--faint);
       }
-      .funnel-row {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        gap: 26px;
-      }
-      .fstage {
-        min-width: 0;
-        position: relative;
-      }
-      .fstage:not(:last-child)::after {
-        content: "\203A";
-        position: absolute;
-        right: -17px;
-        top: 1px;
-        color: var(--faint);
-        font-family: var(--mono);
-        font-size: 14px;
-      }
-      .fstage .v {
-        font-family: var(--mono);
-        font-size: 17px;
-        font-weight: 500;
+      .funnel-head .facts b {
         color: var(--text);
+        font-weight: 500;
       }
-      .fstage.zero .v {
-        color: var(--faint);
+      .frow {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 4px 0;
       }
-      .fstage.lit .v {
-        color: var(--accent);
-      }
-      .fstage .k {
+      .frow .fl {
+        width: 148px;
+        flex: none;
         font-family: var(--mono);
         font-size: 10px;
         letter-spacing: 0.11em;
         text-transform: uppercase;
         color: var(--faint);
-        margin-top: 2px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .fstage .bar {
-        height: 4px;
+      .frow .fb {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        align-items: center;
+        height: 16px;
         background: var(--panel-2);
         border: 1px solid var(--line-soft);
-        margin-top: 8px;
-        position: relative;
       }
-      .fstage .bar i {
-        position: absolute;
-        inset: 0 auto 0 0;
-        background: rgba(110, 168, 255, 0.45);
+      .frow .fb i {
+        display: block;
+        height: 100%;
+        background: rgba(110, 168, 255, 0.38);
+        border-right: 1px solid rgba(110, 168, 255, 0.75);
       }
-      .fstage.lit .bar i {
-        background: var(--accent);
+      .frow.lit .fb i {
+        background: rgba(79, 227, 193, 0.4);
+        border-right-color: var(--accent);
       }
-      .fstage .d {
+      .frow.zero .fb i {
+        border-right: none;
+      }
+      .frow .fv {
+        flex: none;
+        width: 34px;
         font-family: var(--mono);
-        font-size: 10.5px;
+        font-size: 12.5px;
+        color: var(--text);
+      }
+      .frow.zero .fv {
         color: var(--faint);
-        margin-top: 5px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+      }
+      .frow.lit .fv {
+        color: var(--accent);
+      }
+      .fdrop {
+        margin: 1px 0 6px 160px;
+        font-size: 12px;
+        color: var(--dim);
+      }
+      .fdrop b {
+        font-family: var(--mono);
+        font-weight: 500;
+        color: var(--faint);
       }
       .funnel-note {
-        margin-top: 12px;
-        padding-top: 10px;
+        margin-top: 10px;
+        padding-top: 9px;
         border-top: 1px dashed var(--line-soft);
         font-size: 12.5px;
         color: var(--dim);
@@ -672,12 +676,11 @@
           padding: 12px 16px;
           gap: 12px;
         }
-        .funnel-row {
-          grid-template-columns: repeat(2, minmax(0, 1fr));
-          gap: 16px;
+        .frow .fl {
+          width: 92px;
         }
-        .fstage:not(:last-child)::after {
-          content: none;
+        .fdrop {
+          margin-left: 0;
         }
       }
     </style>
@@ -691,14 +694,14 @@
       </div>
       <div class="runline" id="runline"></div>
 
-      <div class="statrow" id="statrow"></div>
+      <div class="statrow" id="statrow" hidden></div>
 
       <div class="funnel" id="funnel" hidden>
         <div class="funnel-head">
           <span class="t">Gap funnel · counted across runs</span>
-          <span class="floor num" id="funnel-floor"></span>
+          <span class="facts num" id="run-facts"></span>
         </div>
-        <div class="funnel-row" id="funnel-row"></div>
+        <div id="funnel-bars"></div>
         <div class="funnel-note" id="funnel-note" hidden></div>
       </div>
 
@@ -784,97 +787,136 @@
           document.createTextNode(" transcripts" + (harnessBits.length ? " (" + harnessBits.join(" · ") + ")" : "")),
         );
 
-        // ---- stats ----
-        var stats = [
-          [
-            String(edits.length) + "/" + String((P.config || {}).maxEditsPerRun || edits.length),
-            "edits proposed / cap",
-            null,
-          ],
-          [fmt(P.stats.positive), "positive evidence", "accent"],
-          [fmt(P.stats.negative), "negative evidence", "reject"],
-          [fmt(P.stats.gapClusters), "eligible gaps", "defer"],
-          [fmt(P.stats.skillExtractions), "skill extractions", null],
-        ];
-        var statrow = document.getElementById("statrow");
-        stats.forEach(function (s) {
-          var box = el("div", "stat");
-          var v = el("div", "v num", s[0]);
-          box.appendChild(v);
-          box.appendChild(el("div", "k", s[1]));
-          statrow.appendChild(box);
-        });
-
-        // ---- gap funnel ----
-        // What happened to the gap evidence, stage by stage: sightings recorded by
+        // ---- run context: the gap funnel, with the run facts in its header ----
+        // One panel tells the gap story as proportional bars - sightings recorded by
         // analysis -> project-domain (orchestration excluded) -> distinct gaps after
-        // clustering -> eligible for a proposal. Every count is recorded by the fold
-        // (`totals` in evidence-summary.json); a proposal saved before the counts
-        // existed hides the funnel rather than showing zeros nobody measured.
-        var funnelNote = null;
-        if (typeof (P.stats || {}).gapSightings === "number") {
-          var floor = Number((P.config || {}).minGapEvidence) || 2;
-          var sighted = P.stats.gapSightings;
+        // clustering -> eligible to propose - with each drop-off explained in plain
+        // words. The run facts (edits, evidence, skills) live in the panel head; a
+        // separate stat row would duplicate the funnel's last stage. Every count is
+        // recorded by the fold (`totals` in evidence-summary.json); a proposal saved
+        // before the counts existed falls back to the classic stat row rather than
+        // showing zeros nobody measured.
+        function funnelCounts() {
+          if (typeof (P.stats || {}).gapSightings !== "number") return null;
+          var eligible = P.stats.gapClusters || 0;
+          var dropped = P.stats.droppedGapSingletons || 0;
           var orch = P.stats.orchestrationGapSightings || 0;
-          var projectSighted = Math.max(0, sighted - orch);
-          var eligibleGaps = P.stats.gapClusters || 0;
-          var droppedGaps = P.stats.droppedGapSingletons || 0;
-          var distinctGaps = eligibleGaps + droppedGaps;
+          var project = Math.max(0, P.stats.gapSightings - orch);
+          return {
+            floor: Number((P.config || {}).minGapEvidence) || 2,
+            sighted: P.stats.gapSightings,
+            orch: orch,
+            project: project,
+            distinct: eligible + dropped,
+            merged: Math.max(0, project - (eligible + dropped)),
+            dropped: dropped,
+            eligible: eligible,
+          };
+        }
+        function funnelBar(host, value, label, max, lit) {
+          var row = el("div", "frow" + (value === 0 ? " zero" : lit ? " lit" : ""));
+          row.appendChild(el("span", "fl", label));
+          var track = el("div", "fb");
+          var fill = el("i");
+          fill.style.width = max > 0 ? Math.max((value / max) * 100, value > 0 ? 2 : 0) + "%" : "0%";
+          track.appendChild(fill);
+          row.appendChild(track);
+          row.appendChild(el("span", "fv num", fmt(value)));
+          host.appendChild(row);
+        }
+        function funnelDrop(host, n, text) {
+          if (!n) return;
+          var line = el("div", "fdrop");
+          line.appendChild(el("b", null, "− " + fmt(n) + " "));
+          line.appendChild(document.createTextNode(text));
+          host.appendChild(line);
+        }
+        var funnelNote = null;
+        var funnel = funnelCounts();
+        if (funnel) {
+          var bars = document.getElementById("funnel-bars");
+          funnelBar(bars, funnel.sighted, "sightings", funnel.sighted);
+          funnelDrop(
+            bars,
+            funnel.orch,
+            "orchestration: mistakes in how the task was run, not in this project - excluded from proposals by design",
+          );
+          funnelBar(bars, funnel.project, "project-domain", funnel.sighted);
+          funnelDrop(
+            bars,
+            funnel.merged,
+            "merged: repeat sightings of a gap already counted - they corroborate it rather than add a new one",
+          );
+          funnelBar(bars, funnel.distinct, "distinct gaps", funnel.sighted);
+          funnelDrop(
+            bars,
+            funnel.dropped,
+            "below the corroboration floor: seen in fewer than " +
+              funnel.floor +
+              " sessions so far - more transcripts can corroborate them",
+          );
+          funnelBar(bars, funnel.eligible, "eligible to propose", funnel.sighted, true);
 
-          var funnelStages = [
-            { v: sighted, k: "sightings", d: "recorded by analysis" },
-            { v: projectSighted, k: "project-domain", d: orch ? "−" + orch + " orchestration" : "" },
-            { v: distinctGaps, k: "distinct gaps", d: "after clustering" },
-            {
-              v: eligibleGaps,
-              k: "eligible to propose",
-              d: droppedGaps ? "−" + droppedGaps + " below floor" : "≥ " + floor + " sessions",
-              lit: true,
-            },
-          ];
-          var funnelRow = document.getElementById("funnel-row");
-          funnelStages.forEach(function (stage) {
-            var cell = el("div", "fstage" + (stage.v === 0 ? " zero" : stage.lit ? " lit" : ""));
-            cell.appendChild(el("div", "v num", fmt(stage.v)));
-            cell.appendChild(el("div", "k", stage.k));
-            var bar = el("div", "bar");
-            var fill = el("i");
-            fill.style.width = sighted > 0 ? Math.max((stage.v / sighted) * 100, stage.v > 0 ? 3 : 0) + "%" : "0%";
-            bar.appendChild(fill);
-            cell.appendChild(bar);
-            cell.appendChild(el("div", "d", stage.d || " "));
-            funnelRow.appendChild(cell);
-          });
+          var facts = document.getElementById("run-facts");
+          var fact = function (value, label) {
+            facts.appendChild(el("b", null, value));
+            facts.appendChild(document.createTextNode(" " + label));
+          };
+          fact(String(edits.length) + "/" + String((P.config || {}).maxEditsPerRun || edits.length), "edits");
+          facts.appendChild(document.createTextNode(" · "));
+          fact("+" + fmt(P.stats.positive) + " / −" + fmt(P.stats.negative), "evidence");
+          facts.appendChild(document.createTextNode(" · "));
+          fact(fmt(P.stats.skillExtractions), "skills");
+          facts.appendChild(document.createTextNode(" · floor " + funnel.floor + " sessions"));
 
-          if (!sighted) {
+          // The drop lines carry the takeaway; the visible note only speaks when there
+          // are no bars to read. funnelNote itself still feeds the zero-edit empty state.
+          if (!funnel.sighted) {
             funnelNote = "Analysis reported no uncovered gaps.";
-          } else if (!eligibleGaps && droppedGaps) {
+          } else if (!funnel.eligible && funnel.dropped) {
             funnelNote =
-              droppedGaps +
+              funnel.dropped +
               " distinct gap" +
-              (droppedGaps === 1 ? " is" : "s are") +
+              (funnel.dropped === 1 ? " is" : "s are") +
               " still below the " +
-              floor +
+              funnel.floor +
               "-session corroboration floor - more transcripts may corroborate " +
-              (droppedGaps === 1 ? "it." : "them.");
-          } else if (!eligibleGaps && orch >= sighted) {
+              (funnel.dropped === 1 ? "it." : "them.");
+          } else if (!funnel.eligible && funnel.orch >= funnel.sighted) {
             funnelNote =
               "All " +
-              sighted +
+              funnel.sighted +
               " sighting" +
-              (sighted === 1 ? " was" : "s were") +
+              (funnel.sighted === 1 ? " was" : "s were") +
               " orchestration-domain (caused by the orchestrating harness, not this repository) and " +
-              (sighted === 1 ? "is" : "are") +
+              (funnel.sighted === 1 ? "is" : "are") +
               " excluded by design.";
           }
-          if (funnelNote) {
+          if (funnelNote && !funnel.sighted) {
             var noteEl = document.getElementById("funnel-note");
             noteEl.textContent = funnelNote;
             noteEl.hidden = false;
           }
-          document.getElementById("funnel-floor").textContent = "corroboration floor · " + floor + " sessions";
           document.getElementById("funnel").hidden = false;
-          document.querySelector(".wrap").classList.add("has-funnel");
+        } else {
+          // A proposal from before the funnel counts existed: the classic stat row.
+          var statrow = document.getElementById("statrow");
+          statrow.hidden = false;
+          [
+            [
+              String(edits.length) + "/" + String((P.config || {}).maxEditsPerRun || edits.length),
+              "edits proposed / cap",
+            ],
+            [fmt(P.stats.positive), "positive evidence"],
+            [fmt(P.stats.negative), "negative evidence"],
+            [fmt(P.stats.gapClusters), "eligible gaps"],
+            [fmt(P.stats.skillExtractions), "skill extractions"],
+          ].forEach(function (s) {
+            var box = el("div", "stat");
+            box.appendChild(el("div", "v num", s[0]));
+            box.appendChild(el("div", "k", s[1]));
+            statrow.appendChild(box);
+          });
         }
 
         // ---- budget gauge ----

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -126,6 +126,106 @@
         margin-top: 3px;
       }
 
+      /* ---------- gap funnel ---------- */
+      .wrap.has-funnel .statrow {
+        margin-bottom: 10px;
+      }
+      .funnel {
+        border: 1px solid var(--line);
+        background: var(--panel);
+        padding: 13px 18px 15px;
+        margin-bottom: 36px;
+      }
+      .funnel-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 12px;
+      }
+      .funnel-head .t {
+        font-size: 13px;
+        color: var(--dim);
+      }
+      .funnel-head .floor {
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--faint);
+      }
+      .funnel-row {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 26px;
+      }
+      .fstage {
+        min-width: 0;
+        position: relative;
+      }
+      .fstage:not(:last-child)::after {
+        content: "\203A";
+        position: absolute;
+        right: -17px;
+        top: 1px;
+        color: var(--faint);
+        font-family: var(--mono);
+        font-size: 14px;
+      }
+      .fstage .v {
+        font-family: var(--mono);
+        font-size: 17px;
+        font-weight: 500;
+        color: var(--text);
+      }
+      .fstage.zero .v {
+        color: var(--faint);
+      }
+      .fstage.lit .v {
+        color: var(--accent);
+      }
+      .fstage .k {
+        font-family: var(--mono);
+        font-size: 10px;
+        letter-spacing: 0.11em;
+        text-transform: uppercase;
+        color: var(--faint);
+        margin-top: 2px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .fstage .bar {
+        height: 4px;
+        background: var(--panel-2);
+        border: 1px solid var(--line-soft);
+        margin-top: 8px;
+        position: relative;
+      }
+      .fstage .bar i {
+        position: absolute;
+        inset: 0 auto 0 0;
+        background: rgba(110, 168, 255, 0.45);
+      }
+      .fstage.lit .bar i {
+        background: var(--accent);
+      }
+      .fstage .d {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--faint);
+        margin-top: 5px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .funnel-note {
+        margin-top: 12px;
+        padding-top: 10px;
+        border-top: 1px dashed var(--line-soft);
+        font-size: 12.5px;
+        color: var(--dim);
+      }
+
       /* ---------- budget gauge ---------- */
       .gauge-block {
         border: 1px solid var(--line);
@@ -572,6 +672,13 @@
           padding: 12px 16px;
           gap: 12px;
         }
+        .funnel-row {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 16px;
+        }
+        .fstage:not(:last-child)::after {
+          content: none;
+        }
       }
     </style>
   </head>
@@ -585,6 +692,15 @@
       <div class="runline" id="runline"></div>
 
       <div class="statrow" id="statrow"></div>
+
+      <div class="funnel" id="funnel" hidden>
+        <div class="funnel-head">
+          <span class="t">Gap funnel · counted across runs</span>
+          <span class="floor num" id="funnel-floor"></span>
+        </div>
+        <div class="funnel-row" id="funnel-row"></div>
+        <div class="funnel-note" id="funnel-note" hidden></div>
+      </div>
 
       <div class="gauge-block">
         <div class="gauge-head">
@@ -677,7 +793,7 @@
           ],
           [fmt(P.stats.positive), "positive evidence", "accent"],
           [fmt(P.stats.negative), "negative evidence", "reject"],
-          [fmt(P.stats.gapClusters), "gap clusters", "defer"],
+          [fmt(P.stats.gapClusters), "eligible gaps", "defer"],
           [fmt(P.stats.skillExtractions), "skill extractions", null],
         ];
         var statrow = document.getElementById("statrow");
@@ -688,6 +804,78 @@
           box.appendChild(el("div", "k", s[1]));
           statrow.appendChild(box);
         });
+
+        // ---- gap funnel ----
+        // What happened to the gap evidence, stage by stage: sightings recorded by
+        // analysis -> project-domain (orchestration excluded) -> distinct gaps after
+        // clustering -> eligible for a proposal. Every count is recorded by the fold
+        // (`totals` in evidence-summary.json); a proposal saved before the counts
+        // existed hides the funnel rather than showing zeros nobody measured.
+        var funnelNote = null;
+        if (typeof (P.stats || {}).gapSightings === "number") {
+          var floor = Number((P.config || {}).minGapEvidence) || 2;
+          var sighted = P.stats.gapSightings;
+          var orch = P.stats.orchestrationGapSightings || 0;
+          var projectSighted = Math.max(0, sighted - orch);
+          var eligibleGaps = P.stats.gapClusters || 0;
+          var droppedGaps = P.stats.droppedGapSingletons || 0;
+          var distinctGaps = eligibleGaps + droppedGaps;
+
+          var funnelStages = [
+            { v: sighted, k: "sightings", d: "recorded by analysis" },
+            { v: projectSighted, k: "project-domain", d: orch ? "−" + orch + " orchestration" : "" },
+            { v: distinctGaps, k: "distinct gaps", d: "after clustering" },
+            {
+              v: eligibleGaps,
+              k: "eligible to propose",
+              d: droppedGaps ? "−" + droppedGaps + " below floor" : "≥ " + floor + " sessions",
+              lit: true,
+            },
+          ];
+          var funnelRow = document.getElementById("funnel-row");
+          funnelStages.forEach(function (stage) {
+            var cell = el("div", "fstage" + (stage.v === 0 ? " zero" : stage.lit ? " lit" : ""));
+            cell.appendChild(el("div", "v num", fmt(stage.v)));
+            cell.appendChild(el("div", "k", stage.k));
+            var bar = el("div", "bar");
+            var fill = el("i");
+            fill.style.width = sighted > 0 ? Math.max((stage.v / sighted) * 100, stage.v > 0 ? 3 : 0) + "%" : "0%";
+            bar.appendChild(fill);
+            cell.appendChild(bar);
+            cell.appendChild(el("div", "d", stage.d || " "));
+            funnelRow.appendChild(cell);
+          });
+
+          if (!sighted) {
+            funnelNote = "Analysis reported no uncovered gaps.";
+          } else if (!eligibleGaps && droppedGaps) {
+            funnelNote =
+              droppedGaps +
+              " distinct gap" +
+              (droppedGaps === 1 ? " is" : "s are") +
+              " still below the " +
+              floor +
+              "-session corroboration floor - more transcripts may corroborate " +
+              (droppedGaps === 1 ? "it." : "them.");
+          } else if (!eligibleGaps && orch >= sighted) {
+            funnelNote =
+              "All " +
+              sighted +
+              " sighting" +
+              (sighted === 1 ? " was" : "s were") +
+              " orchestration-domain (caused by the orchestrating harness, not this repository) and " +
+              (sighted === 1 ? "is" : "are") +
+              " excluded by design.";
+          }
+          if (funnelNote) {
+            var noteEl = document.getElementById("funnel-note");
+            noteEl.textContent = funnelNote;
+            noteEl.hidden = false;
+          }
+          document.getElementById("funnel-floor").textContent = "corroboration floor · " + floor + " sessions";
+          document.getElementById("funnel").hidden = false;
+          document.querySelector(".wrap").classList.add("has-funnel");
+        }
 
         // ---- budget gauge ----
         document.getElementById("gauge-title").textContent = "Always-loaded budget · " + (P.memoryFile.path || "");
@@ -701,7 +889,11 @@
 
         if (!edits.length) {
           host.appendChild(
-            el("div", "empty", "No edits proposed. The evidence did not clear the thresholds this run."),
+            el(
+              "div",
+              "empty",
+              "No edits proposed. " + (funnelNote || "The evidence did not clear the thresholds this run."),
+            ),
           );
         }
 

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -132,7 +132,7 @@
       [hidden] {
         display: none !important;
       }
-      .ctx {
+      .run-context {
         border: 1px solid var(--line);
         background: var(--line);
         display: grid;
@@ -682,7 +682,7 @@
         cursor: not-allowed;
       }
 
-      @media (max-width: 640px) {
+      @media (max-width: 760px) {
         .wrap {
           padding: 28px 16px 170px;
         }
@@ -690,7 +690,7 @@
           padding: 12px 16px;
           gap: 12px;
         }
-        .ctx {
+        .run-context {
           grid-template-columns: minmax(0, 1fr);
         }
         .frow .fl {
@@ -713,7 +713,7 @@
 
       <div class="statrow" id="statrow" hidden></div>
 
-      <div class="ctx" id="ctx" hidden>
+      <div class="run-context" id="ctx" hidden>
         <div class="ctx-funnel">
           <div class="funnel-head">
             <span class="t">Gap funnel · counted across runs</span>

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -888,11 +888,20 @@
           edits.length + " of " + ((P.config || {}).maxEditsPerRun || edits.length) + " (learning-rate cap)";
 
         if (!edits.length) {
+          var eligibleWithoutEdits = Number((P.stats || {}).gapClusters) || 0;
+          var emptyReason = funnelNote;
+          if (!emptyReason && eligibleWithoutEdits > 0) {
+            emptyReason =
+              fmt(eligibleWithoutEdits) +
+              " eligible gap" +
+              (eligibleWithoutEdits === 1 ? "" : "s") +
+              " reached synthesis, but no edit was proposed this run.";
+          }
           host.appendChild(
             el(
               "div",
               "empty",
-              "No edits proposed. " + (funnelNote || "The evidence did not clear the thresholds this run."),
+              "No edits proposed. " + (emptyReason || "The evidence did not clear the thresholds this run."),
             ),
           );
         }

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -93,6 +93,46 @@ test("a gap seen in only one session is dropped - batch size greater than one", 
   assert.equal(summary.totals.droppedGapSingletons, 1);
 });
 
+test("the fold records the sightings it clustered over - the gap funnel's top", () => {
+  const fromRecords = foldEvidence(
+    [
+      record("s1", {
+        gaps: [
+          { proposedInstruction: "Always vendor the lockfile.", quote: "q", recurrenceRisk: "low" },
+          {
+            proposedInstruction: "Never bypass the release gate.",
+            quote: "q",
+            recurrenceRisk: "low",
+            domain: "orchestration",
+          },
+        ],
+      }),
+      record("s2", {
+        gaps: [{ proposedInstruction: "Always vendor the lockfile.", quote: "q", recurrenceRisk: "low" }],
+      }),
+    ],
+    { minGapEvidence: 2 },
+  );
+  assert.equal(fromRecords.totals.gapSightings, 3, "every sighting counts, orchestration included");
+  assert.equal(fromRecords.totals.orchestrationGapSightings, 1);
+  assert.equal(fromRecords.totals.gapClusters, 1);
+
+  // With a ledger the fold clusters over its observations, so the funnel counts those.
+  const fromLedger = foldEvidence([record("s1")], {
+    minGapEvidence: 2,
+    gapObservations: [
+      { proposedInstruction: "Always vendor the lockfile.", sessionId: "a", domain: "project" },
+      { proposedInstruction: "Always vendor the lockfile.", sessionId: "b", domain: "project" },
+      { proposedInstruction: "Never bypass the release gate.", sessionId: "a", domain: "orchestration" },
+      { proposedInstruction: "Pin the schema version.", sessionId: "c", domain: "project" },
+    ],
+  });
+  assert.equal(fromLedger.totals.gapSightings, 4);
+  assert.equal(fromLedger.totals.orchestrationGapSightings, 1);
+  assert.equal(fromLedger.totals.gapClusters, 1, "two sessions corroborate the lockfile gap");
+  assert.equal(fromLedger.totals.droppedGapSingletons, 1, "the schema gap stays below the floor");
+});
+
 test("the same gap repeated inside one session does not clear the threshold", () => {
   const summary = foldEvidence(
     [

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -279,6 +279,43 @@ test("token deltas and the projected budget are measured by backpass, not taken 
   );
 });
 
+test("the proposal carries the fold's gap-funnel counts for the apply surface", () => {
+  const edit = memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", ""));
+  const annotation = { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] };
+
+  const funneled = gate({
+    edit,
+    annotation,
+    context: {
+      summary: {
+        analyzedSessions: 16,
+        totals: {
+          positive: 34,
+          negative: 7,
+          gapSightings: 9,
+          gapClusters: 0,
+          droppedGapSingletons: 3,
+          orchestrationGapSightings: 6,
+        },
+        instructions: Array.from({ length: 20 }, (_, i) => ({
+          instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+          harmSessions: 4,
+        })),
+      },
+    },
+  });
+  assert.equal(funneled.proposal.stats.gapSightings, 9);
+  assert.equal(funneled.proposal.stats.orchestrationGapSightings, 6);
+  assert.equal(funneled.proposal.stats.droppedGapSingletons, 3);
+  assert.equal(funneled.proposal.stats.gapClusters, 0);
+
+  // A summary from before the counts existed yields null, never an invented zero.
+  const legacy = gate({ edit, annotation });
+  assert.equal(legacy.proposal.stats.gapSightings, null);
+  assert.equal(legacy.proposal.stats.orchestrationGapSightings, null);
+  assert.equal(legacy.proposal.stats.droppedGapSingletons, null);
+});
+
 test("a proposal that would exceed the budget fails the gate", () => {
   const big = "x".repeat(4800); // ~1,200 tok, over a tiny cap
   const { violations } = gate({


### PR DESCRIPTION
## Intent

Ship the backpass apply board gap-funnel layout the captain chose from three prototypes, on top of the already-validated funnel work in PR #69 (do NOT merge the PR - the captain reviews it himself because it is a visual judgment call). Original goal, unchanged: the board must show what happened to the gap evidence - sightings recorded by analysis, project-domain vs orchestration-domain, distinct gaps after clustering, eligible to propose - without stealing focus from the proposed-edits list, with every count coming from a real recorded field (totals.gapSightings recorded at source earlier on this branch; orchestrationGapSightings, gapClusters, droppedGapSingletons carried through proposal.stats; null, never zero, when a summary predates the counts). The captain's three explicit change requests, verbatim: use a bar chart layout to visualize the funnel better; each dropoff should have some explanation so people understand what dropped it; merge the top metadata row with the funnel chart because of redundancy, prototyping a few options for him to review. Three genuinely different merges were prototyped and rendered against his real incident run (9 sightings / 6 orchestration / 3 below-floor singletons / 0 eligible) and a healthy run (11/9/5/2). His first reply approved what turned out to be only the first prototype he had seen, which briefly landed the funnel-first layout (commit f167e85, deliberately kept in history); after re-presenting all three side by side he chose OPTION 1 through the review board's decision form: ONE FRAME - a single bordered context band with the gap funnel on the left and the run facts (edits proposed/cap, positive evidence, negative evidence, skill extractions) as a 2x2 grid of stat cells on the right, replacing the separate stat row whenever funnel counts exist (that row's 'eligible gaps' cell duplicated the funnel's terminal stage). The head commit implements exactly that: .ctx grid band (3fr funnel pane / 2fr stat pane, hairline-separated, collapsing to one column under 760px); funnel stages as horizontal proportional bars on a shared scale so the drop between stages is visible as shape; each drop-off explained in short plain language derived only from recorded numbers - orchestration ('mistakes in how the task was run, not in this project - excluded from proposals by design'), merged repeats ('repeat sightings of a gap already counted - they corroborate it rather than add a new one'), and the corroboration floor ('seen in fewer than N sessions so far - more transcripts can corroborate them'); the corroboration-floor readout sits in the funnel pane's head. Deliberate decisions: zero-eligible renders faint, never red (a filtered run is not an error); the visible funnel note only speaks when there are zero sightings because the drop lines carry the takeaway, while the funnelNote variable still feeds the zero-edit empty state including the earlier pipeline fix's eligible-but-no-edits case; a proposal saved before the recorded counts falls back to the classic five-cell stat row unchanged, kept genuinely hidden otherwise by a global [hidden]{display:none!important} guard because .statrow's display:grid author rule otherwise beats the UA stylesheet's [hidden]; the 'used in final report' stage stays omitted (no measured gap-to-edit linkage exists). Constraints unchanged: hand-authored markup in the board's existing CSS tokens and mono/sans conventions, no charting library, no new dependencies, no changes to proposal semantics, gates, thresholds, prompts, or the board's accept/reject mechanics. Visual verification: rendered from the captain's real 0.1.12 proposal.json across incident, healthy, zero-edit, all-orchestration, and legacy (pre-counts) states plus a 600px viewport with no horizontal overflow, matching the exact prototype the captain picked. pnpm run check green, 339 tests.

## What Changed

- Record total gap sightings during folding and carry measured funnel counts into proposals, using `null` for legacy summaries without those counts.
- Add a responsive context band combining proportional funnel bars, explained drop-offs, and run statistics without displacing proposed edits.
- Preserve the classic statistics row for legacy proposals and clarify zero-edit states when eligible gaps reached synthesis.

## Risk Assessment

✅ Low: The change is well-bounded, preserves proposal semantics, correctly carries recorded counts, handles legacy proposals, and implements the selected responsive layout without material source risks found.

## Testing

Alongside the supplied green `pnpm run check` baseline, targeted fold, proposal, rendering, and decision tests passed; browser-rendered incident, healthy, zero-sighting, all-orchestration, legacy, and 600px responsive states matched the requested behavior with no horizontal overflow.

- Evidence: [Healthy funnel with proposed edit](https://github.com/kunchenguid/backpass/blob/f250f5f42c32c50491fedd3377fadb6d47abff5e/.no-mistakes/evidence/fm/backpass-apply-board-gap-funnel-r1/healthy-desktop.png)
- Evidence: [Incident funnel with no eligible gaps](https://github.com/kunchenguid/backpass/blob/f250f5f42c32c50491fedd3377fadb6d47abff5e/.no-mistakes/evidence/fm/backpass-apply-board-gap-funnel-r1/incident-desktop.png)
- Evidence: [Healthy funnel at 600px viewport](https://github.com/kunchenguid/backpass/blob/f250f5f42c32c50491fedd3377fadb6d47abff5e/.no-mistakes/evidence/fm/backpass-apply-board-gap-funnel-r1/healthy-mobile-600px.png)
- Evidence: [All-orchestration funnel and empty-state explanation](https://github.com/kunchenguid/backpass/blob/f250f5f42c32c50491fedd3377fadb6d47abff5e/.no-mistakes/evidence/fm/backpass-apply-board-gap-funnel-r1/all-orchestration-desktop.png)
- Evidence: [Zero-sightings funnel note](https://github.com/kunchenguid/backpass/blob/f250f5f42c32c50491fedd3377fadb6d47abff5e/.no-mistakes/evidence/fm/backpass-apply-board-gap-funnel-r1/zero-sightings-desktop.png)
- Evidence: [Legacy five-cell stat-row fallback](https://github.com/kunchenguid/backpass/blob/f250f5f42c32c50491fedd3377fadb6d47abff5e/.no-mistakes/evidence/fm/backpass-apply-board-gap-funnel-r1/legacy-desktop.png)

<details>
<summary>Evidence: Browser layout and overflow verification</summary>

Source: [Browser layout and overflow verification](https://github.com/kunchenguid/backpass/blob/f250f5f42c32c50491fedd3377fadb6d47abff5e/.no-mistakes/evidence/fm/backpass-apply-board-gap-funnel-r1/layout-check.json)

```text
{
  "healthy": {
    "scenario": "healthy-mobile-600px",
    "viewport": 600,
    "scrollWidth": 600,
    "horizontalOverflow": 0,
    "contextVisible": true,
    "classicStatRowHidden": true,
    "contextColumns": "566px",
    "bars": [
      "sightings: 11",
      "project-domain: 9",
      "distinct gaps: 5",
      "eligible to propose: 2"
    ],
    "editCards": 1
  },
  "legacy": {
    "scenario": "legacy-mobile-600px",
    "contextHidden": true,
    "classicStatRowVisible": true,
    "classicLabels": [
      "edits proposed / cap",
      "positive evidence",
      "negative evidence",
      "eligible gaps",
      "skill extractions"
    ],
    "horizontalOverflow": 0
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f4c1afb957c045a0d0c6467634ef6fd72949b881","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `templates/apply.html:135` - The new global `.ctx` rule also matches existing diff context-line spans rendered by `diffLines`. Although `.diff .ctx` overrides display and padding, each context line still inherits the new border, background, gap, and 36px bottom margin, severely breaking every edit diff. Rename the run-context class or scope its styles to the top-level band.
- 🚨 `templates/apply.html:685` - The required layout says the context band must collapse below 760px, but the changed media query remains `max-width: 640px`. Widths from 641px through 760px therefore retain the two-column layout, contradicting the authoritative visual requirement. Confirm with the user whether the breakpoint should be 760px.

🔧 Fix: Isolate context styles and correct responsive breakpoint
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec node --test --test-name-pattern='fold records the sightings|proposal carries the fold.s gap-funnel counts|renderApplySurface writes one valid document|decision vector from the review surface' test/fold.test.js test/proposal.test.js`
- <code>Generated apply-board HTML through the real `injectPayload` interface for healthy, incident, all-orchestration, zero-sightings, and legacy proposals.</code>
- `Rendered each scenario with headless Google Chrome at 1280px and rendered the healthy proposal at a 600px viewport.`
- `Used Chrome DevTools Protocol to verify the 600px healthy layout had zero horizontal overflow, showed the one-frame context band, hid the classic stat row, and displayed funnel values 11, 9, 5, and 2.`
- `Used Chrome DevTools Protocol to verify the legacy proposal hid the funnel, restored all five classic stat cells, and had zero horizontal overflow.`
- <code>`git status --short` and temporary-profile check confirmed testing left the worktree clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
