### PR TITLE
feat: treat project skills as improvable memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   every other stage is read-only analysis, which is what makes a run safe to interrupt.
   Bootstrap (`src/commands/bootstrap.js`, a repo with no memory file) is the one run that
   writes without the apply gate, and it only ever creates files, never overwrites.
-  For proposals carrying a memory-file hash, nothing is written until five gates pass:
+  For proposals carrying a memory-file hash, nothing is written until the gates pass:
   the memory file still exists and hashes to `proposal.memoryFile.hash` (`memoryFileSnapshot`,
-  using `memoryTextHash` from `src/memory.js` so the check and the proposal cannot disagree), the
+  using `memoryTextHash` from `src/memory.js` so the check and the proposal cannot disagree),
+  every non-memory edit target still hashes to its `proposal.targetFiles` entry (same
+  contract, so a hand-edited skill refuses the apply instead of being patched blind), the
   accepted subset clears `budgetGateKind` (`src/tokens.js`), every accepted edit for a file
   composes against that file's one pre-write image, and every created skill target is still
   absent. Any of them failing writes nothing and records no rejection. Accepted paths are
@@ -114,8 +116,10 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   (dash-and-whitespace-folded, `normalizeRecoveryLine`), and any other edit whose hunk only
   deletes memory-file text is a removal whatever its kind: each deleted unit needs
   `minGapEvidence` distinct sessions of `class: "harm"` negatives (`harmSessions` in the
-  fold). Non-compliance never satisfies the floor; the >= 20%-relevance placement table
-  stays prompt guidance by the captain's explicit decision - do not harden it.
+  fold). The same floor covers skill files, where no evidence can attribute at all, so a
+  pure deletion inside a skill file is refused outright - skill content is rewritten or
+  extracted, never dropped. Non-compliance never satisfies the floor; the >= 20%-relevance
+  placement table stays prompt guidance by the captain's explicit decision - do not harden it.
 - **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other
   values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each
@@ -136,9 +140,15 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `{ agent, usage|null }` (`usageRecord` in `src/acpx.js`) and `src/commands/usage.js` is
   the one place that prints them - never `n/a`: nothing when no call ran, the harness by
   name when it stayed silent.
-- **Fold and this-run gap-ledger ingest are scoped to the current memory-set hash.**
+- **Fold and this-run gap-ledger ingest are scoped to the current memory-surface hash.**
+  The run hash (`primaryMemoryFile` in `src/commands/analyze.js`) is `memorySurfaceHash`:
+  the memory-set hash extended with every skill's description line - a description edit
+  invalidates cached evidence, a skill-body edit never does, and a repo without skills
+  keeps the plain set hash. The always-loaded budget gate measures the same surface
+  (memory file + description lines; bodies stay free until triggered), so a repo with
+  many skills re-tunes `budgetTokens` once - accepted by the captain's explicit decision.
   `foldForRun` (`src/commands/propose.js`) filters `state.listEvidence()` by `memoryPath`
-  AND `memoryHash === current set hash`, not path alone - a transcript that fell out of
+  AND `memoryHash === current surface hash`, not path alone - a transcript that fell out of
   this run's sample (window, cap, or the transcript itself gone) can leave an evidence file
   on disk stamped with a stale hash, and it must not count toward `analyzedSessions`,
   per-instruction scores, or this run's gap-ledger observations (positional `AG-nnn`
@@ -166,6 +176,12 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   orchestrated the task, not by this repo) are counted in
   `totals.orchestrationGapSightings` and excluded from clustering, so they can
   never reach a proposal - there is deliberately no orchestrator-memory write path.
+  A gap may also carry `coveredBySkill`: the analysis (shown every skill's name and
+  trigger line) judged an existing skill's content to cover the mistake - a failed
+  trigger. The fold counts those citations per skill onto the cluster
+  (`failedTriggerSkill`/`failedTriggerSessions`) so synthesis fixes the description
+  with real cross-session evidence, and skill content joins `pruneGapLedger` coverage
+  so a gap resolved by a skill retires instead of aging out.
 - **backpass must never analyze itself.** Its own acpx calls are filed by each harness
   under the repo's cwd, a tier-1 match. Every prompt starts with `SELF_SESSION_SENTINEL`
   (`src/prompts.js`) and discovery drops transcripts whose first user message begins with

--- a/README.md
+++ b/README.md
@@ -280,8 +280,14 @@ Every always-loaded token is paid on every future session, forever, and instruct
 following dilutes as the file grows. So the budget is the constraint the whole backward
 pass optimizes under.
 
-**Default: 5,000 estimated tokens (~20KB)** per always-loaded memory file, configurable.
+**Default: 5,000 estimated tokens (~20KB)** for the always-loaded surface, configurable.
 The estimator is bytes/4 - harness-neutral, ±15%.
+
+The gated number is the **memory file plus every skill's `description:` line** - that is
+what an agent actually pays on every session. Skill bodies stay free until triggered and
+never compete for this budget. (A repo that already carries many skills may find itself
+over budget with no file having changed when upgrading to this accounting - that is the
+one-time re-tune of `budgetTokens`, not a regression.)
 
 ```
 AGENTS.md      [###############.................] 2,412 / 5,000 tok · 63 instructions
@@ -307,7 +313,17 @@ line, and backpass reports the arithmetic: `−611 tok always-loaded, +35 tok de
 
 Skill descriptions are weights too. If the evidence shows an agent lacked knowledge a
 skill already contains, that is a _failed trigger_ - backpass proposes a description edit,
-not duplicate content.
+not duplicate content. Failed triggers are counted, not guessed: the analysis stage sees
+every skill's name and trigger line, stamps a gap it judges covered by an existing skill
+with `coveredBySkill`, and the gap ledger corroborates those citations across sessions
+before synthesis is told to fix the trigger. The same coverage check retires a ledger gap
+once a skill's content answers it, so a gap resolved by extraction stops resurfacing.
+
+Skills are protected by the same floors as the memory file: text deleted from a skill
+file is a removal, and since no evidence can attribute to skill text, no deletion there
+clears the harm floor - skill content is rewritten or extracted, never quietly dropped.
+Every skill file a proposal edits is fingerprinted, and an apply refuses a skill that
+changed since the proposal measured it, exactly as it refuses a drifted memory file.
 
 ### 8. Apply - the human gate
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ transcript that session leaves on disk is the loss signal - and today nothing re
 The loop only closes when a human happens to remember a failure and edits the file by hand.
 
 `backpass` closes it. It finds the agent sessions that actually ran in your repo, reads
-what happened in them, and proposes evidence-backed edits to your memory file - under a
-token budget, gated by you.
+what happened in them, and proposes evidence-backed edits to your memory surface - the
+memory file and project skills - under a token budget, gated by you.
 
 - **Local-first** - Reads the transcript stores of seven agent harnesses directly from disk.
   No API, no upload; transcripts never leave your machine except into an agent you already
@@ -42,7 +42,7 @@ token budget, gated by you.
   command, and it shows each edit with its evidence for you to accept or reject.
 
 ```
-AGENTS.md / CLAUDE.md          (the weights)
+AGENTS.md / CLAUDE.md + skills (the weights)
   → agent session               (forward pass)
   → transcript on disk          (loss signal)
   → backpass: collect samples, distill, calculate loss, aggregate gradients
@@ -153,9 +153,9 @@ weights still evolve as transcripts age, so the selected set can change over tim
 `--max-transcripts all` to analyze every transcript, or `--seed <n>` to draw a different,
 equally reproducible sample.
 
-Each distilled trace goes to a cheap model with the memory file and a rubric. It returns
-strict JSON: which instructions helped, which were violated, and what mistakes no current
-instruction covers. Every negative carries a class - `harm` (following the instruction
+Each distilled trace goes to a cheap model with the memory file, the project skill index,
+and a rubric. It returns strict JSON: which instructions helped, which were violated, and
+what mistakes no current instruction covers. Every negative carries a class - `harm` (following the instruction
 caused damage), `non-compliance` (the agent ignored it), or `irrelevant` - because those
 argue for opposite fates: harm argues against an instruction, non-compliance argues for
 reinforcing it. Every gap carries a domain - `orchestration` when the mistake was caused
@@ -170,13 +170,16 @@ weighted highest, but its class determines what it supports: non-compliance supp
 reinforcement, while only harm supports removal.
 
 Results are cached per transcript, keyed to both the transcript's content _and_ the effective
-memory-file set hash: edit the weights and the evidence correctly re-computes; change nothing
-and the next run is free. A memory-file edit therefore reanalyzes without `--force` - that is
-not a cache miss, it is the cache doing its job - and the run says so on stderr, naming the
-old and new hash, so a "0 reused" line reads as "the file changed" rather than "reuse is
-broken." Evidence files that are not refreshed remain on disk but are excluded while their
-hash is stale. They become eligible again if the memory-file set returns to that hash;
-evidence for transcripts included in the new analysis is replaced with fresh judgments.
+memory-surface hash: the memory-file set plus every project skill's name and description.
+Edit a memory file or skill description and the evidence correctly re-computes; edit only a
+skill body and the cache remains valid because bodies are inspected only for failed-trigger
+confirmation. A repo without skills keeps the prior memory-set hash. A surface edit therefore
+reanalyzes without `--force` - that is not a cache miss, it is the cache doing its job - and
+the run says so on stderr, naming the old and new hash, so a "0 reused" line reads as "the
+surface changed" rather than "reuse is broken." Evidence files that are not refreshed remain
+on disk but are excluded while their hash is stale. They become eligible again if the memory
+surface returns to that hash; evidence for transcripts included in the new analysis is
+replaced with fresh judgments.
 
 ### 4. Aggregate gradients - and one judged consolidation call
 
@@ -198,17 +201,17 @@ reported but never cluster: a mistake caused not by this repository but by the e
 agent harness or tooling that orchestrated a session does not become an instruction in the
 project's memory file.
 
-Only evidence judged against the _current_ memory-file set hash is folded into a proposal. A
+Only evidence judged against the _current_ memory-surface hash is folded into a proposal. A
 transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the
 transcript itself being gone - can leave an older evidence file on disk under a hash the
-memory-file set no longer has; that file is left untouched, but it does not count toward this
+memory surface no longer has; that file is left untouched, but it does not count toward this
 run's session total or instruction scores, or add a gap observation, until it is current
 again.
 
 Those sessions are counted across runs, not per run: every gap sighting is kept in
 `.backpass/gap-ledger.json` by gap and session, so a gap seen in one session today and in
 another session next week graduates on the later run. The same session never counts twice,
-a sighting retires once the memory file gains an instruction that covers it, and a session's
+a sighting retires once the memory file or a project skill covers it, and a session's
 sightings expire after `gapLedgerMaxAge` (default 90d). Until a gap corroborates it stays
 out of the proposal entirely.
 
@@ -217,29 +220,30 @@ out of the proposal entirely.
 A high-reasoning synthesis run turns the aggregated gradients into concrete edits: ADD,
 REMOVE, REWRITE, or EXTRACT→SKILL. The agent does not describe edits for backpass to
 splice in - it makes them, with its harness's own file tools, in a **staging copy** of the
-memory file under `.backpass/synthesis/` (the repo itself is read-only to it, for
-grounding). backpass then diffs the copy against the original and shows the agent the
+memory file and project skills under `.backpass/synthesis/` (the repo itself is read-only
+to it, for grounding). backpass then diffs the copy against the original and shows the agent the
 measured changes by id; the agent annotates each one with a title, rationale, and the
 verbatim evidence behind it. Nothing textual is ever taken from the model: every hunk's
 text is copied out of your file by construction, so an edit can never "not appear" in it.
 Then mechanical gates run, and they are not negotiable:
 
 - at most `maxEditsPerRun` edits (the learning rate). By default the cap is adaptive: 5
-  when the file is near or under budget, and in a shrink plan (file over budget) one edit
-  per ~40 tokens of overage, capped at 20, so badly overgrown files recover in fewer runs.
+  when the always-loaded surface is near or under budget, and in a shrink plan (surface
+  over budget) one edit per ~40 tokens of overage, capped at 20, so badly overgrown
+  surfaces recover in fewer runs.
   An explicit `--max-edits` or config value always pins it.
 - every measured change belongs to exactly one annotated edit - an unexplained change
   is a violation, so is an edit that names no change
 - new instructions need evidence from `minGapEvidence` distinct sessions (an edit that
   only adds text is a new instruction, whatever the model calls it)
-- removing an instruction outright needs harm-class negatives from `minGapEvidence`
-  distinct sessions - non-compliance never counts, because a rule that was skipped needs
-  reinforcement, not deletion (a change that only deletes text outside an extraction is a
-  removal, whatever the model calls it)
+- removing a memory-file instruction outright needs harm-class negatives from
+  `minGapEvidence` distinct sessions - non-compliance never counts, because a rule that
+  was skipped needs reinforcement, not deletion. A pure deletion in a skill file is also
+  a removal, but no evidence can attribute harm to skill-file text, so it is refused.
 - an extraction preserves every line it removes in the skills it creates; a deletion is
   never part of an extract
 - every edit carries a verbatim quote
-- the post-edit file must fit the budget, measured on the staged file
+- the post-edit always-loaded surface must fit the budget, measured from the staged files
 
 An extraction is the created `SKILL.md` plus the memory-file change that pays for it.
 Neighbouring removals are merged into one measured change, and a merged change cannot be
@@ -348,11 +352,11 @@ over. An incompatible set writes nothing and does not record rejections, so you 
 a compatible set and try again. If the run shrinks the file but leaves it above the cap,
 that is progress, not a failure: it is written, and the remaining overage is printed.
 
-Apply preflights every accepted edit before writing. The proposal was measured against one
-exact version of your memory file, so apply first checks the file still exists and is still
-that version. If it was removed or changed since - you pulled, edited it by hand, or another
+Apply preflights every decided edit before writing. The proposal was measured against exact
+versions of your memory file and every skill file it proposes editing, so apply first checks
+those files still exist and are still those versions. If one was removed or changed since - you pulled, edited it by hand, or another
 agent did - the edits no longer describe what is on disk, so nothing is written and you are
-told to run `backpass` again to re-propose against the current file. That rerun reanalyzes
+told to run `backpass` again to re-propose against the current repository. That rerun reanalyzes
 transcripts against the file that exists now; it does not reuse the stale judgments behind
 the refused proposal. Within a run every file is composed from one version: it takes every
 accepted edit or none of them. Apply also

--- a/VISION.md
+++ b/VISION.md
@@ -3,7 +3,7 @@
 `backpass` exists so that a repository's agent memory file improves from what actually happened in its agent sessions, instead of from whatever a human happened to remember.
 It serves the developer who owns that file, whether it is `AGENTS.md` or the `CLAUDE.md` Claude Code reads in its place, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
 The project file is the one it trains; a person's own `~/.claude/CLAUDE.md` is handwritten preference, and anything learned belongs in project memory instead.
-It owns exactly one thing: the backward pass from session transcripts to a proposed change in the memory file.
+It owns exactly one thing: the backward pass from session transcripts to a proposed change in the memory surface - the memory file and the project's skills.
 
 ## Evidence is the only currency
 

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -5,6 +5,7 @@ import { execOneShot, extractJson, sessionPrompt, usageRecord } from "./acpx.js"
 import { distill } from "./distill.js";
 import { readTranscript } from "./discovery/index.js";
 import { renderInstructionIndex } from "./memory.js";
+import { renderSkillIndexForAnalysis } from "./skills.js";
 import { renderPrompt } from "./prompts.js";
 import { renderOpenGapIndex } from "./gap-ledger.js";
 import { evidenceKey, isEvidenceFresh, safeFileName } from "./state.js";
@@ -73,6 +74,13 @@ export function sanitizeEvidence(parsed) {
     if (typeof item.matchesGap === "string" && /^[0-9a-f]{16}$/.test(item.matchesGap.trim())) {
       gap.matchesGap = item.matchesGap.trim();
     }
+    // A failed trigger: an existing skill's content would have prevented the mistake,
+    // but the skill was not in play. Kept as a judged citation so the fold can count
+    // failed triggers per skill; an absent or empty value simply means "no skill covers
+    // this" and records nothing.
+    if (typeof item.coveredBySkill === "string" && item.coveredBySkill.trim()) {
+      gap.coveredBySkill = item.coveredBySkill.trim().slice(0, 120);
+    }
     clean.gaps.push(gap);
   }
 
@@ -98,7 +106,15 @@ function promptPathFor(state, transcript) {
   return path.join(state.applyDir, "..", "prompts", `${safeFileName(transcriptIdentity(transcript))}.md`);
 }
 
-async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0, openGapIndex = "(none yet)" }) {
+async function analyzeOne({
+  transcript,
+  memoryFile,
+  config,
+  repo,
+  slot = 0,
+  openGapIndex = "(none yet)",
+  skillIndex = "(this repo has no skills)",
+}) {
   const raw = await readTranscript(transcript);
   const distilled = distill(raw.events, {
     ...transcript,
@@ -134,6 +150,7 @@ async function analyzeOne({ transcript, memoryFile, config, repo, slot = 0, open
   const prompt = renderPrompt("analysis", {
     MEMORY_PATH: memoryFile.path,
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
+    SKILLS: skillIndex,
     OPEN_GAPS: openGapIndex,
     TRACE: distilled.trace,
   });
@@ -198,7 +215,15 @@ async function pool(items, limit, worker) {
   return results;
 }
 
-export async function analyzeTranscripts({ transcripts, memoryFile, config, repo, memoryHash, force = false }) {
+export async function analyzeTranscripts({
+  transcripts,
+  memoryFile,
+  skills = [],
+  config,
+  repo,
+  memoryHash,
+  force = false,
+}) {
   const state = config.state;
   const pending = [];
   const summary = {
@@ -219,7 +244,7 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
       continue;
     }
     // Distinguish "no prior evidence" from "prior evidence exists, but it was judged
-    // against a memory-file set that no longer matches" - a re-analysis here, not a miss.
+    // against a memory surface that no longer matches" - a re-analysis here, not a miss.
     if (existing?.status === "ok" && existing.memoryHash && existing.memoryHash !== memoryHash) {
       summary.staleMemoryHash += 1;
       priorHashes.add(existing.memoryHash);
@@ -230,8 +255,8 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
   if (summary.staleMemoryHash) {
     info(
       `${color.yellow("·")} ${summary.staleMemoryHash} transcript(s) have evidence from a previous ` +
-        `memory-file set (${[...priorHashes].join(", ")} -> ${memoryHash}); that evidence is stale, not ` +
-        `missing, and reuse resumes once this pass re-judges it against the current memory-file set`,
+        `memory surface (${[...priorHashes].join(", ")} -> ${memoryHash}); that evidence is stale, not ` +
+        `missing, and reuse resumes once this pass re-judges it against the current memory file and skill descriptions`,
     );
   }
 
@@ -258,8 +283,11 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
   );
 
   // Rendered once per run: the ledger's open gaps, so each analysis can cite an existing
-  // gap id instead of coining a paraphrase of it (`matchesGap` in the reply schema).
+  // gap id instead of coining a paraphrase of it (`matchesGap` in the reply schema), and
+  // the skill index, so a mistake an existing skill's content covers is reported as a
+  // failed trigger (`coveredBySkill`) instead of a brand-new gap.
   const openGapIndex = renderOpenGapIndex(state.readGapLedger(), memoryFile.path);
+  const skillIndex = renderSkillIndexForAnalysis(skills);
 
   let done = 0;
   const evidenceTotals = { positive: 0, negative: 0, gaps: 0 };
@@ -290,7 +318,7 @@ export async function analyzeTranscripts({ transcripts, memoryFile, config, repo
     });
 
     try {
-      const result = await analyzeOne({ transcript, memoryFile, config, repo, slot, openGapIndex });
+      const result = await analyzeOne({ transcript, memoryFile, config, repo, slot, openGapIndex, skillIndex });
       if (result.status === "skipped") {
         summary.skipped += 1;
         state.writeEvidence(transcript, { ...base, status: "skipped", reason: result.reason });

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -18,8 +18,9 @@ import { transcriptIdentity } from "./transcript.js";
  * fanned out over a small worker pool.
  *
  * Everything expensive is cached. Evidence is keyed to the transcript's content
- * signature AND the memory-file hash it was judged against, so re-running after an
- * apply correctly re-analyzes against the new weights while an unchanged run is free.
+ * signature AND the memory-surface hash it was judged against, so re-running after a
+ * memory-file or skill-description change correctly re-analyzes against the new weights
+ * while an unchanged surface is free.
  */
 
 const MIN_ASSISTANT_TURNS = 4;

--- a/src/apply/terminal.js
+++ b/src/apply/terminal.js
@@ -42,7 +42,15 @@ export function renderEdit(edit, index, total) {
   const out = [];
   const kind = edit.kind === "extract" ? "EXTRACT -> SKILL" : edit.kind.toUpperCase();
   const delta = edit.deltaTokens || 0;
-  const deltaText = `${delta > 0 ? "+" : ""}${formatTokens(delta)} tok${edit.targetsMemoryFile ? "" : " (not always-loaded)"}`;
+  const descriptionDelta = edit.descriptionDelta || 0;
+  // A skill-file edit is on-trigger text except for its description line, which is
+  // always loaded and billed; say which part of the delta is which.
+  const signed = (n) => `${n > 0 ? "+" : ""}${formatTokens(n)}`;
+  const deltaText = edit.targetsMemoryFile
+    ? `${signed(delta)} tok${descriptionDelta ? ` (+${formatTokens(descriptionDelta)} tok skill description)` : ""}`
+    : descriptionDelta
+      ? `${signed(descriptionDelta)} tok always-loaded (description), ${signed(delta - descriptionDelta)} tok on trigger`
+      : `${signed(delta)} tok (not always-loaded)`;
 
   out.push("");
   out.push(`${color.bold(`[${index + 1}/${total}] ${kind}`)}  ${color.dim(deltaText)}`);

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -11,7 +11,7 @@ import {
   CLAUDE_SKILLS_LINK,
   editSkills,
   ensureSkillsLayout,
-  loadSkills,
+  loadProjectSkills,
   parseFrontmatter,
   removeOwnedSkillPaths,
   resolveOverflowTarget,
@@ -232,7 +232,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     repo.root,
     proposal.config?.skillsDir || config.skillsDir || CANONICAL_SKILLS_DIR,
   ).dir;
-  const skillsNow = loadSkills(repo.root, skillsDir);
+  const skillsNow = loadProjectSkills(repo.root, skillsDir);
   const descriptionTokensNow = skillDescriptionTokens(skillsNow);
 
   // Freshness for every non-memory file a decision targets, the same contract the

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -42,7 +42,11 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memo
     capTokens,
     descriptionTokensNow,
   );
-  const label = surfaceLabel(relative, descriptionTokensNow);
+  const acceptedDescriptionDelta = accepted.reduce((sum, edit) => sum + (edit.descriptionDelta || 0), 0);
+  const label = surfaceLabel(
+    relative,
+    Math.max(descriptionTokensNow, descriptionTokensNow + acceptedDescriptionDelta),
+  );
   const gate = budgetGateKind(budget);
   if (gate === "cap") {
     return {
@@ -468,7 +472,15 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
     // Shrinking over several runs is the design, so this is a heading, not a failure.
     if (budget && !budget.withinBudget) {
-      results.warnings.push(overBudgetWarning(surfaceLabel(relative, descriptionTokensNow), budget));
+      results.warnings.push(
+        overBudgetWarning(
+          surfaceLabel(
+            relative,
+            Math.max(descriptionTokensNow, descriptionTokensNow + landedDescriptionDelta),
+          ),
+          budget,
+        ),
+      );
     }
   }
 

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -236,11 +236,35 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   const skillsNow = loadSkills(repo.root, skillsDir);
   const descriptionTokensNow = skillDescriptionTokens(skillsNow);
 
-  // Freshness for every non-memory file an accepted edit targets, the same contract the
+  // Freshness for every non-memory file a decision targets, the same contract the
   // memory file gets: each hunk was cut from one exact image, and a file that changed
   // since no longer contains what the proposal describes - refuse, never patch blind.
   // Proposals from before the field existed carry no hashes and are left alone.
   const expectedTargetHashes = new Map((proposal.targetFiles ?? []).map((t) => [t.file, t.hash]));
+  const checkedTargets = new Set();
+  for (const edit of [...accepted, ...rejected]) {
+    const relative = edit.file;
+    if (!relative || relative === proposal.memoryFile?.path || checkedTargets.has(relative)) continue;
+    checkedTargets.add(relative);
+    const expected = expectedTargetHashes.get(relative);
+    if (!expected) continue;
+    const absolute = path.join(repo.root, relative);
+    if (!fs.existsSync(absolute)) {
+      results.failed.push({ file: relative, error: "file does not exist" });
+      continue;
+    }
+    const observed = memoryTextHash(fs.readFileSync(absolute, "utf8"));
+    if (observed !== expected) {
+      results.failed.push({
+        file: relative,
+        error:
+          `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
+          `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
+          `against the current repository.`,
+      });
+    }
+  }
+  if (results.failed.length) return results;
 
   for (const edit of accepted) {
     if (!byFile.has(edit.file)) byFile.set(edit.file, []);
@@ -261,20 +285,6 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
     const before =
       relative === proposal.memoryFile?.path && memoryText !== null ? memoryText : fs.readFileSync(absolute, "utf8");
-    const expected = relative === proposal.memoryFile?.path ? null : expectedTargetHashes.get(relative);
-    if (expected) {
-      const observed = memoryTextHash(before);
-      if (observed !== expected) {
-        results.failed.push({
-          file: relative,
-          error:
-            `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
-            `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
-            `against the current repository.`,
-        });
-        continue;
-      }
-    }
     let text = before;
     const applied = [];
     const failures = [];

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -191,13 +191,12 @@ function removeEmptyDirectories(directories) {
  * The only place in backpass that writes to the repo.
  *
  * Everything upstream is read-only analysis; a run only changes the weights here, after
- * a human accepted specific edits. Five gates run before the first byte is written:
- * the memory file must still be the file the proposal was measured against
- * (`memoryFileSnapshot`), the accepted subset must clear the same cap/shrink budget gate as
- * the full proposal (`budgetGateKind`), every accepted edit for a file must compose
- * against that file's single pre-write image, every created skill target must still be
- * absent, and accepted paths must resolve to distinct targets. Any of them failing writes
- * nothing and records no rejection.
+ * a human accepted specific edits. Before the first byte is written, the memory file and
+ * every decided non-memory target must still be the files the proposal measured; the
+ * accepted subset must clear the same cap/shrink budget gate as the full proposal
+ * (`budgetGateKind`); every accepted edit for a file must compose against that file's
+ * single pre-write image; every created skill target must still be absent; and accepted
+ * paths must resolve to distinct targets. Any failure writes nothing and records no rejection.
  *
  * A file is therefore applied all at once or not at all. Skills are written only after
  * every accepted edit has composed, and before the files that reference them.
@@ -476,7 +475,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
       })
     : null;
   for (const item of orderedPlanned) {
-    const { relative, resolved, before, text, applied } = item;
+    const { relative, resolved, text, applied } = item;
     const budget = item === budgetTarget ? surfaceBudget : null;
 
     let commit = null;

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -2,9 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import { applyEdit, projectWithDecisions } from "../proposal.js";
+import { applyEdit } from "../proposal.js";
 import { memoryTextHash } from "../memory.js";
-import { budgetGateKind, budgetStatus, formatTokens } from "../tokens.js";
+import { budgetGateKind, budgetStatus, estimateTokens, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
 import {
   CANONICAL_SKILLS_DIR,
@@ -12,6 +12,7 @@ import {
   editSkills,
   ensureSkillsLayout,
   loadSkills,
+  parseFrontmatter,
   removeOwnedSkillPaths,
   resolveOverflowTarget,
   skillDescriptionTokens,
@@ -27,26 +28,26 @@ function surfaceLabel(memoryPath, descriptionTokens) {
   return descriptionTokens ? `the always-loaded surface (${memoryPath} + skill descriptions)` : memoryPath;
 }
 
-function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText, descriptionTokensNow }) {
-  if (!accepted.length) return null;
+function descriptionTokensIn(text) {
+  return estimateTokens(parseFrontmatter(text).description || "");
+}
 
+function acceptedSubsetBudgetFailure({
+  proposal,
+  capTokens,
+  memoryText,
+  projectedMemoryText,
+  descriptionTokensNow,
+  descriptionTokensProjected,
+}) {
   const relative = proposal.memoryFile.path;
-  const absolute = path.join(repo.root, relative);
-  if (memoryText === null && !fs.existsSync(absolute)) return null;
+  if (memoryText === null) return null;
 
-  const before = memoryText ?? fs.readFileSync(absolute, "utf8");
-  const { budget } = projectWithDecisions(
-    before,
-    accepted,
-    accepted.map((edit) => edit.id),
-    capTokens,
-    descriptionTokensNow,
-  );
-  const acceptedDescriptionDelta = accepted.reduce((sum, edit) => sum + (edit.descriptionDelta || 0), 0);
-  const label = surfaceLabel(
-    relative,
-    Math.max(descriptionTokensNow, descriptionTokensNow + acceptedDescriptionDelta),
-  );
+  const budget = budgetStatus(memoryText, projectedMemoryText, capTokens, {
+    current: descriptionTokensNow,
+    projected: descriptionTokensProjected,
+  });
+  const label = surfaceLabel(relative, Math.max(descriptionTokensNow, descriptionTokensProjected));
   const gate = budgetGateKind(budget);
   if (gate === "cap") {
     return {
@@ -232,20 +233,8 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     repo.root,
     proposal.config?.skillsDir || config.skillsDir || CANONICAL_SKILLS_DIR,
   ).dir;
-  const descriptionTokensNow = skillDescriptionTokens(loadSkills(repo.root, skillsDir));
-
-  const budgetFailure = acceptedSubsetBudgetFailure({
-    proposal,
-    accepted,
-    repo,
-    capTokens: config.budgetTokens,
-    memoryText,
-    descriptionTokensNow,
-  });
-  if (budgetFailure) {
-    results.failed.push(budgetFailure);
-    return results;
-  }
+  const skillsNow = loadSkills(repo.root, skillsDir);
+  const descriptionTokensNow = skillDescriptionTokens(skillsNow);
 
   // Freshness for every non-memory file an accepted edit targets, the same contract the
   // memory file gets: each hunk was cut from one exact image, and a file that changed
@@ -362,6 +351,32 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
   if (results.failed.length) return results;
 
+  const existingSkillPaths = new Set(skillsNow.map((skill) => skill.path));
+  let descriptionTokensProjected = descriptionTokensNow;
+  for (const item of resolvedPlanned) {
+    if (!existingSkillPaths.has(item.relative)) continue;
+    descriptionTokensProjected += descriptionTokensIn(item.text) - descriptionTokensIn(item.before);
+  }
+  descriptionTokensProjected += plannedSkills.reduce(
+    (sum, { skill }) => sum + estimateTokens(skill.description || ""),
+    0,
+  );
+  const memoryPlan = resolvedPlanned.find((item) => item.relative === proposal.memoryFile.path);
+  if (accepted.length) {
+    const budgetFailure = acceptedSubsetBudgetFailure({
+      proposal,
+      capTokens: config.budgetTokens,
+      memoryText,
+      projectedMemoryText: memoryPlan?.text ?? memoryText,
+      descriptionTokensNow,
+      descriptionTokensProjected,
+    });
+    if (budgetFailure) {
+      results.failed.push(budgetFailure);
+      return results;
+    }
+  }
+
   const canonical = plannedSkills.find(
     ({ skill }) => skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`),
   );
@@ -442,10 +457,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     }
     results.written = [];
   };
-  const landedDescriptionDelta = accepted
-    .filter((edit) => landed.has(edit.id))
-    .reduce((sum, edit) => sum + (edit.descriptionDelta || 0), 0);
-  const memoryPlan = orderedPlanned.find((item) => item.relative === proposal.memoryFile.path);
+  const landedDescriptionDelta = descriptionTokensProjected - descriptionTokensNow;
   const budgetTarget = memoryPlan || orderedPlanned[0];
   const surfaceBudget = budgetTarget
     ? budgetStatus(memoryText, memoryPlan?.text ?? memoryText, config.budgetTokens, {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -11,11 +11,22 @@ import {
   CLAUDE_SKILLS_LINK,
   editSkills,
   ensureSkillsLayout,
+  loadSkills,
   removeOwnedSkillPaths,
+  skillDescriptionTokens,
   writeSkill,
 } from "../skills.js";
 
-function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText }) {
+/**
+ * The always-loaded label a budget number carries: the surface when skill descriptions
+ * are part of the count, the bare file when there are none - a number shown to a person
+ * must describe the thing it measures.
+ */
+function surfaceLabel(memoryPath, descriptionTokens) {
+  return descriptionTokens ? `the always-loaded surface (${memoryPath} + skill descriptions)` : memoryPath;
+}
+
+function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memoryText, descriptionTokensNow }) {
   if (!accepted.length) return null;
 
   const relative = proposal.memoryFile.path;
@@ -28,13 +39,15 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memo
     accepted,
     accepted.map((edit) => edit.id),
     capTokens,
+    descriptionTokensNow,
   );
+  const label = surfaceLabel(relative, descriptionTokensNow);
   const gate = budgetGateKind(budget);
   if (gate === "cap") {
     return {
       file: relative,
       error:
-        `accepted edits leave ${relative} at ${budget.projected} tokens, ${budget.over} over the ` +
+        `accepted edits leave ${label} at ${budget.projected} tokens, ${budget.over} over the ` +
         `${capTokens}-token budget; choose a compatible set of edits`,
     };
   }
@@ -42,7 +55,7 @@ function acceptedSubsetBudgetFailure({ proposal, accepted, repo, capTokens, memo
     return {
       file: relative,
       error:
-        `${relative} is already ${budget.current - capTokens} tokens over the ${capTokens}-token budget, ` +
+        `${label} is already ${budget.current - capTokens} tokens over the ${capTokens}-token budget, ` +
         `so accepted edits must shrink it, but they change it by ${budget.delta >= 0 ? "+" : ""}${budget.delta} ` +
         "tokens; choose a compatible set of edits",
     };
@@ -101,9 +114,9 @@ function memoryFileSnapshot(proposal, repo) {
   };
 }
 
-function overBudgetWarning(relative, budget) {
+function overBudgetWarning(label, budget) {
   return (
-    `${relative} is still ${formatTokens(budget.over)} tokens over the ${formatTokens(budget.capTokens)}-token ` +
+    `${label} is still ${formatTokens(budget.over)} tokens over the ${formatTokens(budget.capTokens)}-token ` +
     "budget; run `backpass` again for the next shrink step"
   );
 }
@@ -208,17 +221,30 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     memoryText = snapshot.text;
   }
 
+  // The always-loaded skill layer as it exists on disk right now - the budget below
+  // covers the whole surface, not the memory file alone.
+  const descriptionTokensNow = skillDescriptionTokens(
+    loadSkills(repo.root, proposal.config?.skillsDir || CANONICAL_SKILLS_DIR),
+  );
+
   const budgetFailure = acceptedSubsetBudgetFailure({
     proposal,
     accepted,
     repo,
     capTokens: config.budgetTokens,
     memoryText,
+    descriptionTokensNow,
   });
   if (budgetFailure) {
     results.failed.push(budgetFailure);
     return results;
   }
+
+  // Freshness for every non-memory file an accepted edit targets, the same contract the
+  // memory file gets: each hunk was cut from one exact image, and a file that changed
+  // since no longer contains what the proposal describes - refuse, never patch blind.
+  // Proposals from before the field existed carry no hashes and are left alone.
+  const expectedTargetHashes = new Map((proposal.targetFiles ?? []).map((t) => [t.file, t.hash]));
 
   for (const edit of accepted) {
     if (!byFile.has(edit.file)) byFile.set(edit.file, []);
@@ -239,6 +265,20 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
     const before =
       relative === proposal.memoryFile?.path && memoryText !== null ? memoryText : fs.readFileSync(absolute, "utf8");
+    const expected = relative === proposal.memoryFile?.path ? null : expectedTargetHashes.get(relative);
+    if (expected) {
+      const observed = memoryTextHash(before);
+      if (observed !== expected) {
+        results.failed.push({
+          file: relative,
+          error:
+            `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
+            `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
+            `against the current repository.`,
+        });
+        continue;
+      }
+    }
     let text = before;
     const applied = [];
     const failures = [];
@@ -395,9 +435,18 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     }
     results.written = [];
   };
+  const landedDescriptionDelta = accepted
+    .filter((edit) => landed.has(edit.id))
+    .reduce((sum, edit) => sum + (edit.descriptionDelta || 0), 0);
   for (const item of orderedPlanned) {
     const { relative, resolved, before, text, applied } = item;
-    const budget = relative === proposal.memoryFile.path ? budgetStatus(before, text, config.budgetTokens) : null;
+    const budget =
+      relative === proposal.memoryFile.path
+        ? budgetStatus(before, text, config.budgetTokens, {
+            current: descriptionTokensNow,
+            projected: descriptionTokensNow + landedDescriptionDelta,
+          })
+        : null;
 
     let commit = null;
     try {
@@ -415,7 +464,9 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     results.written.push({ file: relative, edits: applied, budget, dryRun });
 
     // Shrinking over several runs is the design, so this is a heading, not a failure.
-    if (budget && !budget.withinBudget) results.warnings.push(overBudgetWarning(relative, budget));
+    if (budget && !budget.withinBudget) {
+      results.warnings.push(overBudgetWarning(surfaceLabel(relative, descriptionTokensNow), budget));
+    }
   }
 
   if (!dryRun && canonical) {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -13,6 +13,7 @@ import {
   ensureSkillsLayout,
   loadSkills,
   removeOwnedSkillPaths,
+  resolveOverflowTarget,
   skillDescriptionTokens,
   writeSkill,
 } from "../skills.js";
@@ -223,9 +224,11 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
   // The always-loaded skill layer as it exists on disk right now - the budget below
   // covers the whole surface, not the memory file alone.
-  const descriptionTokensNow = skillDescriptionTokens(
-    loadSkills(repo.root, proposal.config?.skillsDir || CANONICAL_SKILLS_DIR),
-  );
+  const skillsDir = resolveOverflowTarget(
+    repo.root,
+    proposal.config?.skillsDir || config.skillsDir || CANONICAL_SKILLS_DIR,
+  ).dir;
+  const descriptionTokensNow = skillDescriptionTokens(loadSkills(repo.root, skillsDir));
 
   const budgetFailure = acceptedSubsetBudgetFailure({
     proposal,

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -445,15 +445,17 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   const landedDescriptionDelta = accepted
     .filter((edit) => landed.has(edit.id))
     .reduce((sum, edit) => sum + (edit.descriptionDelta || 0), 0);
+  const memoryPlan = orderedPlanned.find((item) => item.relative === proposal.memoryFile.path);
+  const budgetTarget = memoryPlan || orderedPlanned[0];
+  const surfaceBudget = budgetTarget
+    ? budgetStatus(memoryText, memoryPlan?.text ?? memoryText, config.budgetTokens, {
+        current: descriptionTokensNow,
+        projected: descriptionTokensNow + landedDescriptionDelta,
+      })
+    : null;
   for (const item of orderedPlanned) {
     const { relative, resolved, before, text, applied } = item;
-    const budget =
-      relative === proposal.memoryFile.path
-        ? budgetStatus(before, text, config.budgetTokens, {
-            current: descriptionTokensNow,
-            projected: descriptionTokensNow + landedDescriptionDelta,
-          })
-        : null;
+    const budget = item === budgetTarget ? surfaceBudget : null;
 
     let commit = null;
     try {
@@ -469,19 +471,18 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     }
     committed.push({ ...item, commit });
     results.written.push({ file: relative, edits: applied, budget, dryRun });
+  }
 
-    // Shrinking over several runs is the design, so this is a heading, not a failure.
-    if (budget && !budget.withinBudget) {
-      results.warnings.push(
-        overBudgetWarning(
-          surfaceLabel(
-            relative,
-            Math.max(descriptionTokensNow, descriptionTokensNow + landedDescriptionDelta),
-          ),
-          budget,
+  if (surfaceBudget && !surfaceBudget.withinBudget) {
+    results.warnings.push(
+      overBudgetWarning(
+        surfaceLabel(
+          proposal.memoryFile.path,
+          Math.max(descriptionTokensNow, descriptionTokensNow + landedDescriptionDelta),
         ),
-      );
-    }
+        surfaceBudget,
+      ),
+    );
   }
 
   if (!dryRun && canonical) {

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,6 +1,7 @@
 import { analyzeTranscripts } from "../analyze.js";
 import { UserError, color, info, json, out, warn } from "../logger.js";
-import { resolveMemoryFiles } from "../memory.js";
+import { memorySurfaceHash, resolveMemoryFiles } from "../memory.js";
+import { loadSkills, resolveOverflowTarget } from "../skills.js";
 import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
 import { printUsage } from "./usage.js";
@@ -12,6 +13,12 @@ import { capTranscripts } from "../sample.js";
  * `@AGENTS.md` is covered by optimizing AGENTS.md and needs no mention. A second file
  * with its own content is NOT updated - that would either be ignored silently or
  * double-written into divergence - so the run says so and recommends consolidating.
+ *
+ * `hash` is the memory-surface hash: the memory files plus the skill description
+ * lines, since analysis is judged against both. Evidence keys, fold scoping, and the
+ * gap ledger all flow from this one value, so analyze and propose can never disagree
+ * about which surface a judgment belongs to. The loaded `skills` ride along so every
+ * downstream stage reads the same snapshot this hash describes.
  *
  * When no configured file exists, `backpass` (the default run) bootstraps one; every
  * other command fails with a pointer to that.
@@ -31,12 +38,21 @@ export function primaryMemoryFile(repo, config) {
         `(a single line: @${resolved.primary.path}).`,
     );
   }
-  return { file: resolved.primary, all: resolved.all, hash: resolved.hash, resolved };
+  // Overflow-layout warnings are the synthesis stage's to print; this resolution is read-only.
+  const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
+  const skills = loadSkills(repo.root, overflow.dir);
+  return {
+    file: resolved.primary,
+    all: resolved.all,
+    hash: memorySurfaceHash(resolved.hash, skills),
+    resolved,
+    skills,
+  };
 }
 
 export async function runAnalysis(ctx) {
   const { repo, config } = ctx;
-  const { file, hash } = primaryMemoryFile(repo, config);
+  const { file, hash, skills } = primaryMemoryFile(repo, config);
   // Deterministic by design: tokens and units come from parsing the file, no model.
   emitProgress("memory", {
     path: file.path,
@@ -49,19 +65,20 @@ export async function runAnalysis(ctx) {
 
   if (!transcripts.length) {
     info(`${color.yellow("·")} no transcripts associated with this repo`);
-    return { file, hash, transcripts, perHarness, summary: null };
+    return { file, hash, skills, transcripts, perHarness, summary: null };
   }
 
   const summary = await analyzeTranscripts({
     transcripts,
     memoryFile: file,
+    skills,
     config,
     repo,
     memoryHash: hash,
     force: Boolean(ctx.flags.force),
   });
 
-  return { file, hash, transcripts, perHarness, summary };
+  return { file, hash, skills, transcripts, perHarness, summary };
 }
 
 export async function cmdAnalyze(ctx) {

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,7 +1,7 @@
 import { analyzeTranscripts } from "../analyze.js";
 import { UserError, color, info, json, out, warn } from "../logger.js";
 import { memorySurfaceHash, resolveMemoryFiles } from "../memory.js";
-import { loadSkills, resolveOverflowTarget, skillDescriptionTokens } from "../skills.js";
+import { loadProjectSkills, resolveOverflowTarget, skillDescriptionTokens } from "../skills.js";
 import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
 import { printUsage } from "./usage.js";
@@ -40,7 +40,7 @@ export function primaryMemoryFile(repo, config) {
   }
   // Overflow-layout warnings are the synthesis stage's to print; this resolution is read-only.
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
-  const skills = loadSkills(repo.root, overflow.dir);
+  const skills = loadProjectSkills(repo.root, overflow.dir);
   return {
     file: resolved.primary,
     all: resolved.all,

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,7 +1,7 @@
 import { analyzeTranscripts } from "../analyze.js";
 import { UserError, color, info, json, out, warn } from "../logger.js";
 import { memorySurfaceHash, resolveMemoryFiles } from "../memory.js";
-import { loadSkills, resolveOverflowTarget } from "../skills.js";
+import { loadSkills, resolveOverflowTarget, skillDescriptionTokens } from "../skills.js";
 import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
 import { printUsage } from "./usage.js";
@@ -54,9 +54,11 @@ export async function runAnalysis(ctx) {
   const { repo, config } = ctx;
   const { file, hash, skills } = primaryMemoryFile(repo, config);
   // Deterministic by design: tokens and units come from parsing the file, no model.
+  const descriptionTokens = skillDescriptionTokens(skills);
   emitProgress("memory", {
     path: file.path,
-    tokens: file.tokens,
+    label: skills.length ? `${file.path} + skill descriptions` : file.path,
+    tokens: file.tokens + descriptionTokens,
     budget: config.budgetTokens,
     units: file.units.length,
   });

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -11,18 +11,19 @@ import { printUsage } from "./usage.js";
 import { discoverForRun } from "./scan.js";
 
 /**
- * Fold on-disk evidence for the memory file. Gap corroboration is counted through the
+ * Fold on-disk evidence for the memory surface. Gap corroboration is counted through the
  * persisted ledger so sessions accumulate across runs: record this run's observations,
- * prune what the current file now covers or what aged out (after recording, because the
- * evidence files that fed an expired sighting are still on disk and would re-add it),
+ * prune what the current surface now covers or what aged out (after recording, because
+ * the evidence files that fed an expired sighting are still on disk and would re-add it),
  * then cluster from the ledger.
  *
  * Evidence is also filtered to `memoryHash`: a transcript's evidence file is rewritten
- * every time it is re-analyzed against a changed memory file, but a transcript that fell
- * out of this run's sample (window, cap, or discovery drift) leaves its last evidence file
- * on disk under whatever hash it was last judged against. That leftover file is real and
- * reusable the moment its transcript is re-analyzed - or immediately, if the memory file's
- * bytes return to that hash - but folding it into *this* proposal would score it against
+ * every time it is re-analyzed against a changed memory file or skill description, but a
+ * transcript that fell out of this run's sample (window, cap, or discovery drift) leaves
+ * its last evidence file on disk under whatever hash it was last judged against. That
+ * leftover file is real and reusable the moment its transcript is re-analyzed - or
+ * immediately, if the memory surface returns to that hash - but folding it into *this*
+ * proposal would score it against
  * an instruction index it was never judged against (aliases are positional) and inflate
  * `analyzedSessions` with a session this run never touched. Nothing is migrated, rewritten,
  * or deleted here - only excluded from this run's fold.

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -33,7 +33,7 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = []) {
   const relevant = evidence.filter((e) => e.memoryPath === memoryFile.path && e.memoryHash === memoryHash);
 
   const ledger = state.readGapLedger();
-  recordGapObservations(ledger, relevant);
+  recordGapObservations(ledger, relevant, { skills });
   // Consolidate after recording, so the pass sees this run's sightings too: two
   // sessions coining the same brand-new gap in one parallel fan-out can only line up
   // here. One bounded judged call; a failure degrades to lexical identity and the run

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -27,7 +27,7 @@ import { discoverForRun } from "./scan.js";
  * `analyzedSessions` with a session this run never touched. Nothing is migrated, rewritten,
  * or deleted here - only excluded from this run's fold.
  */
-export async function foldForRun(ctx, memoryFile, memoryHash) {
+export async function foldForRun(ctx, memoryFile, memoryHash, skills = []) {
   const { state, minGapEvidence, gapLedgerMaxAge } = ctx.config;
   const evidence = state.listEvidence();
   const relevant = evidence.filter((e) => e.memoryPath === memoryFile.path && e.memoryHash === memoryHash);
@@ -38,13 +38,15 @@ export async function foldForRun(ctx, memoryFile, memoryHash) {
   // sessions coining the same brand-new gap in one parallel fan-out can only line up
   // here. One bounded judged call; a failure degrades to lexical identity and the run
   // continues. Prune afterwards so a merged-then-covered gap retires as one entry.
+  // Skills join the coverage check: a gap resolved by an extraction or a skill fix
+  // retires instead of haunting the open-gap index until it expires.
   const consolidation = await consolidateGapLedger({
     ledger,
     memoryPath: memoryFile.path,
     config: ctx.config,
     repo: ctx.repo,
   });
-  pruneGapLedger(ledger, { memoryFile, memoryPath: memoryFile.path, maxAge: gapLedgerMaxAge });
+  pruneGapLedger(ledger, { memoryFile, memoryPath: memoryFile.path, skills, maxAge: gapLedgerMaxAge });
   state.writeGapLedger(ledger);
 
   const summary = foldEvidence(relevant, {
@@ -68,11 +70,11 @@ export async function runProposal(ctx, precomputed = null) {
   // folding, and agent resolution can all fail before synthesis starts; none of those
   // failures may leave an older proposal available to apply as if it came from this run.
   config.state.clearProposal();
-  const { file, hash } = precomputed || primaryMemoryFile(repo, config);
+  const { file, hash, skills } = precomputed || primaryMemoryFile(repo, config);
   const transcripts = precomputed?.transcripts || (await discoverForRun(ctx)).transcripts;
 
   const foldStarted = Date.now();
-  const summary = await foldForRun(ctx, file, hash);
+  const summary = await foldForRun(ctx, file, hash, skills ?? []);
   config.state.writeSummary(summary);
   emitProgress("fold:done", {
     instructions: summary.instructions.length,

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -52,7 +52,7 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = []) {
   const summary = foldEvidence(relevant, {
     minGapEvidence,
     memoryFile,
-    gapObservations: ledgerGapObservations(ledger, memoryFile.path),
+    gapObservations: ledgerGapObservations(ledger, memoryFile.path, skills),
   });
   summary.consolidation = consolidation;
   return summary;

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,6 +4,7 @@ import { runAnalysis } from "./analyze.js";
 import { bootstrapJson, bootstrapRun, printBootstrap } from "./bootstrap.js";
 import { printProposal, printSynthesisFailure, runProposal, synthesisFailureHint } from "./propose.js";
 import { budgetBar, formatTokens } from "../tokens.js";
+import { skillDescriptionTokens } from "../skills.js";
 import { startTui } from "../tui/index.js";
 import { resolveMemoryFiles } from "../memory.js";
 
@@ -55,12 +56,17 @@ export async function cmdRun(ctx) {
       return 0;
     }
 
+    // The banner shows what the gate measures: the always-loaded surface, which is the
+    // memory file plus every skill description line.
+    const descriptionTokens = skillDescriptionTokens(analysis.skills || []);
+    const alwaysLoaded = analysis.file.tokens + descriptionTokens;
     const budget = budgetBar({
-      utilization: analysis.file.tokens / config.budgetTokens,
-      withinBudget: analysis.file.tokens <= config.budgetTokens,
+      utilization: alwaysLoaded / config.budgetTokens,
+      withinBudget: alwaysLoaded <= config.budgetTokens,
     });
     info(
-      `${color.cyan("·")} ${analysis.file.path}: ${budget} ${formatTokens(analysis.file.tokens)} / ` +
+      `${color.cyan("·")} ${analysis.file.path}${descriptionTokens ? " + skill descriptions" : ""}: ${budget} ` +
+        `${formatTokens(alwaysLoaded)} / ` +
         `${formatTokens(config.budgetTokens)} tok · ${analysis.file.units.length} instructions`,
     );
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -3,7 +3,12 @@ import path from "node:path";
 
 import { color, json, out } from "../logger.js";
 import { resolveMemoryFiles } from "../memory.js";
-import { loadSkills, resolveOverflowTarget, skillDescriptionTokens } from "../skills.js";
+import {
+  loadProjectSkills,
+  resolveOverflowTarget,
+  resolveProjectSkillDirs,
+  skillDescriptionTokens,
+} from "../skills.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 import { table } from "./scan.js";
 import { DEFAULT_EFFORT } from "../config.js";
@@ -24,7 +29,8 @@ export async function cmdStatus(ctx) {
   const proposal = state.readProposal();
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
-  const skills = loadSkills(repo.root, overflow.dir);
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir);
+  const skills = loadProjectSkills(repo.root, overflow.dir);
   const descriptionTokens = skillDescriptionTokens(skills);
 
   const budgets = files.map((file) => {
@@ -77,7 +83,7 @@ export async function cmdStatus(ctx) {
     const skillTokens = skills.reduce((n, s) => n + s.bodyTokens, 0);
     out(
       color.dim(
-        `  overflow: ${skills.length} skill(s) in ${overflow.dir} · ${formatTokens(skillTokens)} tok on trigger, ` +
+        `  overflow: ${skills.length} skill(s) in ${skillDirs.join(", ")} · ${formatTokens(skillTokens)} tok on trigger, ` +
           `${formatTokens(descriptionTokens)} tok always loaded`,
       ),
     );

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -75,6 +75,15 @@ export async function cmdStatus(ctx) {
           `${formatTokens(descTokens)} tok always loaded`,
       ),
     );
+    if (resolved.primary) {
+      // The number the budget gate actually measures: memory file + description lines.
+      const surface = budgetStatus(resolved.primary.text, null, config.budgetTokens, { current: descTokens });
+      out(
+        `  ${"always-loaded".padEnd(14)} ${budgetBar(surface)} ${formatTokens(surface.current)} / ` +
+          `${formatTokens(surface.capTokens)} tok · memory + descriptions` +
+          (surface.withinBudget ? "" : color.red(` ${surface.over} OVER`)),
+      );
+    }
   }
   out("");
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { color, json, out } from "../logger.js";
 import { resolveMemoryFiles } from "../memory.js";
-import { loadSkills, resolveOverflowTarget } from "../skills.js";
+import { loadSkills, resolveOverflowTarget, skillDescriptionTokens } from "../skills.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 import { table } from "./scan.js";
 import { DEFAULT_EFFORT } from "../config.js";
@@ -25,14 +25,21 @@ export async function cmdStatus(ctx) {
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
   const skills = loadSkills(repo.root, overflow.dir);
+  const descriptionTokens = skillDescriptionTokens(skills);
 
-  const budgets = files.map((file) => ({
-    path: file.path,
-    ...budgetStatus(file.text, null, config.budgetTokens),
-    instructions: file.units.length,
-    pointerTo: resolved.pointers.includes(file) ? resolved.primary.path : null,
-    separate: resolved.separate.includes(file),
-  }));
+  const budgets = files.map((file) => {
+    const includesSkills = file === resolved.primary && skills.length > 0;
+    return {
+      path: file.path,
+      label: includesSkills ? `${file.path} + skill descriptions` : file.path,
+      ...budgetStatus(file.text, null, config.budgetTokens, {
+        current: includesSkills ? descriptionTokens : 0,
+      }),
+      instructions: file.units.length,
+      pointerTo: resolved.pointers.includes(file) ? resolved.primary.path : null,
+      separate: resolved.separate.includes(file),
+    };
+  });
 
   if (ctx.flags.json) {
     json({
@@ -62,28 +69,18 @@ export async function cmdStatus(ctx) {
       (b.withinBudget ? "" : color.red(` ${b.over} OVER`)) +
       (b.separate ? color.yellow(" separate - not optimized") : "");
     out(
-      `  ${b.path.padEnd(14)} ${budgetBar(b)} ${formatTokens(b.current)} / ${formatTokens(b.capTokens)} tok` +
+      `  ${b.label.padEnd(14)} ${budgetBar(b)} ${formatTokens(b.current)} / ${formatTokens(b.capTokens)} tok` +
         ` · ${b.instructions} instructions${state_}`,
     );
   }
   if (skills.length) {
     const skillTokens = skills.reduce((n, s) => n + s.bodyTokens, 0);
-    const descTokens = skills.reduce((n, s) => n + s.descriptionTokens, 0);
     out(
       color.dim(
         `  overflow: ${skills.length} skill(s) in ${overflow.dir} · ${formatTokens(skillTokens)} tok on trigger, ` +
-          `${formatTokens(descTokens)} tok always loaded`,
+          `${formatTokens(descriptionTokens)} tok always loaded`,
       ),
     );
-    if (resolved.primary) {
-      // The number the budget gate actually measures: memory file + description lines.
-      const surface = budgetStatus(resolved.primary.text, null, config.budgetTokens, { current: descTokens });
-      out(
-        `  ${"always-loaded".padEnd(14)} ${budgetBar(surface)} ${formatTokens(surface.current)} / ` +
-          `${formatTokens(surface.capTokens)} tok · memory + descriptions` +
-          (surface.withinBudget ? "" : color.red(` ${surface.over} OVER`)),
-      );
-    }
   }
   out("");
 

--- a/src/fold.js
+++ b/src/fold.js
@@ -87,6 +87,7 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
         source,
         sessionId: record.transcript.identity || record.transcript.id,
         domain: gap.domain === "orchestration" ? "orchestration" : "project",
+        ...(gap.coveredBySkill ? { coveredBySkill: gap.coveredBySkill } : {}),
       });
     }
   }
@@ -130,6 +131,7 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
       sessions: cluster.sessions.size,
       recurrenceRisk: highestRisk(cluster.items),
       quotes: cluster.items.slice(0, 6).map((i) => ({ text: i.quote, effect: i.mistake, source: i.source })),
+      ...failedTriggerOf(cluster.items),
     }))
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
@@ -174,6 +176,7 @@ export function clusterGapObservations(observations) {
       recurrenceRisk: obs.recurrenceRisk,
       source: obs.source,
       sessionId: obs.sessionId,
+      ...(obs.coveredBySkill ? { coveredBySkill: obs.coveredBySkill } : {}),
     };
     if (cluster) {
       if (!cluster.sessions.has(obs.sessionId)) cluster.items.push(item);
@@ -196,6 +199,25 @@ export function clusterGapObservations(observations) {
 function highestRisk(items) {
   const order = { high: 3, medium: 2, low: 1 };
   return items.reduce((best, i) => (order[i.recurrenceRisk] > order[best] ? i.recurrenceRisk : best), "low");
+}
+
+/**
+ * The failed-trigger reading of a cluster: which existing skill the analyses judged to
+ * already cover this mistake, and in how many of the cluster's sessions. Items are one
+ * per session, so counting items counts sessions. The most-cited skill wins; a cluster
+ * nobody tied to a skill contributes nothing.
+ */
+function failedTriggerOf(items) {
+  const counts = new Map();
+  for (const item of items) {
+    if (!item.coveredBySkill) continue;
+    counts.set(item.coveredBySkill, (counts.get(item.coveredBySkill) || 0) + 1);
+  }
+  let best = null;
+  for (const [skill, sessions] of counts) {
+    if (!best || sessions > best.sessions) best = { skill, sessions };
+  }
+  return best ? { failedTriggerSkill: best.skill, failedTriggerSessions: best.sessions } : {};
 }
 
 /** Compact rendering of the folded evidence for the synthesis prompt. */
@@ -243,6 +265,13 @@ export function renderEvidenceForPrompt(summary) {
   }
   for (const gap of summary.gaps) {
     lines.push(`- sessions=${gap.sessions} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
+    if (gap.failedTriggerSkill) {
+      lines.push(
+        `    FAILED TRIGGER: the existing skill "${gap.failedTriggerSkill}" already covers this ` +
+          `(judged so in ${gap.failedTriggerSessions} session(s)) - fix that skill's description ` +
+          `line instead of duplicating its content in the memory file`,
+      );
+    }
     for (const quote of gap.quotes.slice(0, 3)) {
       lines.push(`    "${oneLine(quote.text)}" (${quote.source})`);
     }

--- a/src/fold.js
+++ b/src/fold.js
@@ -131,7 +131,7 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
       sessions: cluster.sessions.size,
       recurrenceRisk: highestRisk(cluster.items),
       quotes: cluster.items.slice(0, 6).map((i) => ({ text: i.quote, effect: i.mistake, source: i.source })),
-      ...failedTriggerOf(cluster.items),
+      ...failedTriggerOf(cluster.items, minGapEvidence),
     }))
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
@@ -207,7 +207,7 @@ function highestRisk(items) {
  * per session, so counting items counts sessions. The most-cited skill wins; a cluster
  * nobody tied to a skill contributes nothing.
  */
-function failedTriggerOf(items) {
+function failedTriggerOf(items, minGapEvidence) {
   const counts = new Map();
   for (const item of items) {
     if (!item.coveredBySkill) continue;
@@ -217,7 +217,9 @@ function failedTriggerOf(items) {
   for (const [skill, sessions] of counts) {
     if (!best || sessions > best.sessions) best = { skill, sessions };
   }
-  return best ? { failedTriggerSkill: best.skill, failedTriggerSessions: best.sessions } : {};
+  return best && best.sessions >= minGapEvidence
+    ? { failedTriggerSkill: best.skill, failedTriggerSessions: best.sessions }
+    : {};
 }
 
 /** Compact rendering of the folded evidence for the synthesis prompt. */

--- a/src/fold.js
+++ b/src/fold.js
@@ -176,10 +176,15 @@ export function clusterGapObservations(observations) {
       recurrenceRisk: obs.recurrenceRisk,
       source: obs.source,
       sessionId: obs.sessionId,
-      ...(obs.coveredBySkill ? { coveredBySkill: obs.coveredBySkill } : {}),
+      coveredBySkills: new Set(obs.coveredBySkill ? [obs.coveredBySkill] : []),
     };
     if (cluster) {
-      if (!cluster.sessions.has(obs.sessionId)) cluster.items.push(item);
+      const sessionItem = cluster.items.find((candidate) => candidate.sessionId === obs.sessionId);
+      if (sessionItem) {
+        if (obs.coveredBySkill) sessionItem.coveredBySkills.add(obs.coveredBySkill);
+      } else {
+        cluster.items.push(item);
+      }
       cluster.sessions.add(obs.sessionId);
       // Keep the shortest phrasing: it generalizes best.
       if (obs.proposedInstruction.length < cluster.proposedInstruction.length) {
@@ -210,8 +215,9 @@ function highestRisk(items) {
 function failedTriggerOf(items, minGapEvidence) {
   const counts = new Map();
   for (const item of items) {
-    if (!item.coveredBySkill) continue;
-    counts.set(item.coveredBySkill, (counts.get(item.coveredBySkill) || 0) + 1);
+    for (const skill of item.coveredBySkills) {
+      counts.set(skill, (counts.get(skill) || 0) + 1);
+    }
   }
   let best = null;
   for (const [skill, sessions] of counts) {

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -207,21 +207,24 @@ export function pruneGapLedger(
 function coverageUnits(memoryFile, skills) {
   return [
     ...(memoryFile?.units || []).map((unit) => ({ text: unit.text })),
-    ...(skills || []).flatMap((skill) =>
-      [skill.description || "", ...parseMemoryUnits(skill.body || "").map((unit) => unit.text)].map((text) => ({
-        text,
+    ...(skills || []).flatMap((skill) => [
+      { text: skill.description || "", skill: skill.name, kind: "description" },
+      ...parseMemoryUnits(skill.body || "").map((unit) => ({
+        text: unit.text,
         skill: skill.name,
+        kind: "body",
       })),
-    ),
+    ]),
   ].filter((unit) => unit.text.trim());
 }
 
 function isCovered(coverage, entry) {
   const phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || [])])];
   return coverage.some((unit) => {
-    const isFailedTrigger =
-      unit.skill && Object.values(entry.sessions).some((observation) => observation.coveredBySkill === unit.skill);
-    return !isFailedTrigger && phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD);
+    const isCitedBody =
+      unit.kind === "body" &&
+      Object.values(entry.sessions).some((observation) => observation.coveredBySkill === unit.skill);
+    return !isCitedBody && phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD);
   });
 }
 

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -1,4 +1,4 @@
-import { similarity } from "./memory.js";
+import { parseMemoryUnits, similarity } from "./memory.js";
 import { parseSince } from "./config.js";
 import { sha256 } from "./state.js";
 
@@ -36,8 +36,9 @@ import { sha256 } from "./state.js";
  *    or re-sampling the same session overwrites its observation and never adds a count.
  *  - A gap is a fact about its session: re-analysis that no longer mentions it is model
  *    noise, not the session changing, so observations are only ever replaced, not removed
- *    by absence. They retire in exactly two ways: the memory file gains an instruction
- *    that covers the gap (`GAP_COVERED_THRESHOLD`, the `reanchor` bar), or the sighting
+ *    by absence. They retire in exactly two ways: the memory surface gains content
+ *    that covers the gap - a memory-file instruction or a skill's description/body
+ *    (`GAP_COVERED_THRESHOLD`, the `reanchor` bar) - or the sighting
  *    has waited longer than `gapLedgerMaxAge` for a partner, counted from when backpass
  *    first saw it (re-analysis never refreshes that clock; session age itself is already
  *    bounded by discovery's `since` at entry). Keying to the memory hash instead would
@@ -156,6 +157,10 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         quote: gap.quote,
         recurrenceRisk: gap.recurrenceRisk,
         domain: gap.domain === "orchestration" ? "orchestration" : "project",
+        // A failed trigger: the analysis judged an existing skill's content to cover
+        // this mistake. Absent when no skill covers it (including all pre-existing
+        // observations), and absence never counts as a citation.
+        ...(gap.coveredBySkill ? { coveredBySkill: gap.coveredBySkill } : {}),
       };
       recorded += 1;
     }
@@ -165,19 +170,23 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
 
 /**
  * Retire observations that no longer count: sightings first seen more than `maxAge` ago
- * (a duration like `90d`, `all` to disable) and gaps the current memory file now covers.
+ * (a duration like `90d`, `all` to disable) and gaps the current memory surface now
+ * covers - a memory-file instruction OR a skill's content (its description line or a
+ * body unit). Skills count because a gap resolved by extracting or writing a skill is
+ * resolved; without them the entry would haunt every analysis prompt until it expires.
  */
 export function pruneGapLedger(
   ledger,
-  { memoryFile = null, memoryPath = null, maxAge = "90d", now = new Date() } = {},
+  { memoryFile = null, memoryPath = null, skills = [], maxAge = "90d", now = new Date() } = {},
 ) {
   const maxAgeMs = parseSince(maxAge);
   const cutoff = maxAgeMs === null ? -Infinity : new Date(now).getTime() - maxAgeMs;
   const stats = { expired: 0, covered: 0 };
+  const coverage = coverageTexts(memoryFile, skills);
 
   for (const [id, entry] of Object.entries(ledger.entries)) {
     const applies = memoryPath === null || entry.memoryPath === memoryPath;
-    if (applies && memoryFile && isCovered(memoryFile, entry)) {
+    if (applies && coverage.length && isCovered(coverage, entry)) {
       stats.covered += Object.keys(entry.sessions).length;
       delete ledger.entries[id];
       continue;
@@ -194,11 +203,20 @@ export function pruneGapLedger(
   return stats;
 }
 
-function isCovered(memoryFile, entry) {
+/** Every unit of always-available knowledge a gap can be covered by. */
+function coverageTexts(memoryFile, skills) {
+  return [
+    ...(memoryFile?.units || []).map((unit) => unit.text),
+    ...(skills || []).flatMap((skill) => [
+      skill.description || "",
+      ...parseMemoryUnits(skill.body || "").map((unit) => unit.text),
+    ]),
+  ].filter((text) => text.trim());
+}
+
+function isCovered(coverage, entry) {
   const phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || [])])];
-  return (memoryFile.units || []).some((unit) =>
-    phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD),
-  );
+  return coverage.some((text) => phrasings.some((phrasing) => similarity(text, phrasing) >= GAP_COVERED_THRESHOLD));
 }
 
 /** Flatten the ledger into the observation list `foldEvidence` clusters over. */
@@ -215,6 +233,7 @@ export function ledgerGapObservations(ledger, memoryPath) {
         quote: obs.quote,
         recurrenceRisk: obs.recurrenceRisk,
         domain: obs.domain === "orchestration" ? "orchestration" : "project",
+        ...(obs.coveredBySkill ? { coveredBySkill: obs.coveredBySkill } : {}),
       });
     }
   }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -300,6 +300,7 @@ export function mergeGapEntries(ledger, groups) {
           const earlier =
             Date.parse(obs.firstObservedAt || obs.observedAt) < Date.parse(prior.firstObservedAt || prior.observedAt);
           if (earlier) prior.firstObservedAt = obs.firstObservedAt || obs.observedAt;
+          if (!prior.coveredBySkill && obs.coveredBySkill) prior.coveredBySkill = obs.coveredBySkill;
         }
       }
       target.aliases = [...new Set([...(target.aliases || []), entry.id, ...(entry.aliases || [])])];

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -101,8 +101,9 @@ export function findGapEntry(ledger, memoryPath, proposedInstruction) {
  * Fold this run's evidence into the ledger. One observation per (gap, session); a
  * session seen again replaces its own observation and keeps its first-seen timestamp.
  */
-export function recordGapObservations(ledger, evidenceRecords, { now = new Date() } = {}) {
+export function recordGapObservations(ledger, evidenceRecords, { now = new Date(), skills = [] } = {}) {
   const observedAt = new Date(now).toISOString();
+  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]));
   let recorded = 0;
   for (const record of evidenceRecords) {
     if (!record || record.status !== "ok" || !record.memoryPath) continue;
@@ -146,6 +147,13 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         .filter((value) => Number.isFinite(Date.parse(value)))
         .sort((a, b) => Date.parse(a) - Date.parse(b))[0];
       if (aliasPrior) delete entry.sessions[transcript.id];
+      const priorFailedTrigger = priors.find(
+        (observation) =>
+          observation.coveredBySkill === gap.coveredBySkill && observation.coveredBySkillHash,
+      );
+      const citedSkill = gap.coveredBySkill ? skillsByName.get(gap.coveredBySkill) : null;
+      const coveredBySkillHash = priorFailedTrigger?.coveredBySkillHash ||
+        (citedSkill ? skillCoverageHash(citedSkill) : null);
       entry.sessions[sessionIdentity] = {
         firstObservedAt: firstObservedAt || observedAt,
         observedAt,
@@ -161,6 +169,7 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         // this mistake. Absent when no skill covers it (including all pre-existing
         // observations), and absence never counts as a citation.
         ...(gap.coveredBySkill ? { coveredBySkill: gap.coveredBySkill } : {}),
+        ...(coveredBySkillHash ? { coveredBySkillHash } : {}),
       };
       recorded += 1;
     }
@@ -182,7 +191,7 @@ export function pruneGapLedger(
   const maxAgeMs = parseSince(maxAge);
   const cutoff = maxAgeMs === null ? -Infinity : new Date(now).getTime() - maxAgeMs;
   const stats = { expired: 0, covered: 0 };
-  const coverage = coverageTexts(memoryFile, skills);
+  const coverage = coverageUnits(memoryFile, skills);
 
   for (const [id, entry] of Object.entries(ledger.entries)) {
     const applies = memoryPath === null || entry.memoryPath === memoryPath;
@@ -204,19 +213,38 @@ export function pruneGapLedger(
 }
 
 /** Every unit of always-available knowledge a gap can be covered by. */
-function coverageTexts(memoryFile, skills) {
+function coverageUnits(memoryFile, skills) {
   return [
-    ...(memoryFile?.units || []).map((unit) => unit.text),
-    ...(skills || []).flatMap((skill) => [
-      skill.description || "",
-      ...parseMemoryUnits(skill.body || "").map((unit) => unit.text),
-    ]),
-  ].filter((text) => text.trim());
+    ...(memoryFile?.units || []).map((unit) => ({ text: unit.text })),
+    ...(skills || []).flatMap((skill) => {
+      const hash = skillCoverageHash(skill);
+      return [skill.description || "", ...parseMemoryUnits(skill.body || "").map((unit) => unit.text)].map((text) => ({
+        text,
+        skill: skill.name,
+        hash,
+      }));
+    }),
+  ].filter((unit) => unit.text.trim());
+}
+
+function skillCoverageHash(skill) {
+  return sha256(`${skill.path || ""}\n${skill.name || ""}\n${skill.description || ""}\n${skill.body || ""}`);
 }
 
 function isCovered(coverage, entry) {
   const phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || [])])];
-  return coverage.some((text) => phrasings.some((phrasing) => similarity(text, phrasing) >= GAP_COVERED_THRESHOLD));
+  return coverage.some((unit) => {
+    const isUnchangedFailedTrigger =
+      unit.skill &&
+      Object.values(entry.sessions).some(
+        (observation) =>
+          observation.coveredBySkill === unit.skill && observation.coveredBySkillHash === unit.hash,
+      );
+    return (
+      !isUnchangedFailedTrigger &&
+      phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD)
+    );
+  });
 }
 
 /** Flatten the ledger into the observation list `foldEvidence` clusters over. */

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -1,4 +1,4 @@
-import { parseMemoryUnits, similarity } from "./memory.js";
+import { parseMemoryUnits, similarity, unitHash } from "./memory.js";
 import { parseSince } from "./config.js";
 import { sha256 } from "./state.js";
 
@@ -149,11 +149,12 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
       if (aliasPrior) delete entry.sessions[transcript.id];
       const priorFailedTrigger = priors.find(
         (observation) =>
-          observation.coveredBySkill === gap.coveredBySkill && observation.coveredBySkillHash,
+          observation.coveredBySkill === gap.coveredBySkill && observation.coveredBySkillHashes?.length,
       );
       const citedSkill = gap.coveredBySkill ? skillsByName.get(gap.coveredBySkill) : null;
-      const coveredBySkillHash = priorFailedTrigger?.coveredBySkillHash ||
-        (citedSkill ? skillCoverageHash(citedSkill) : null);
+      const coveredBySkillHashes =
+        priorFailedTrigger?.coveredBySkillHashes ||
+        (citedSkill ? matchingCoverageHashes(citedSkill, gap.proposedInstruction) : []);
       entry.sessions[sessionIdentity] = {
         firstObservedAt: firstObservedAt || observedAt,
         observedAt,
@@ -169,7 +170,7 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         // this mistake. Absent when no skill covers it (including all pre-existing
         // observations), and absence never counts as a citation.
         ...(gap.coveredBySkill ? { coveredBySkill: gap.coveredBySkill } : {}),
-        ...(coveredBySkillHash ? { coveredBySkillHash } : {}),
+        ...(coveredBySkillHashes.length ? { coveredBySkillHashes } : {}),
       };
       recorded += 1;
     }
@@ -216,19 +217,20 @@ export function pruneGapLedger(
 function coverageUnits(memoryFile, skills) {
   return [
     ...(memoryFile?.units || []).map((unit) => ({ text: unit.text })),
-    ...(skills || []).flatMap((skill) => {
-      const hash = skillCoverageHash(skill);
-      return [skill.description || "", ...parseMemoryUnits(skill.body || "").map((unit) => unit.text)].map((text) => ({
+    ...(skills || []).flatMap((skill) =>
+      [skill.description || "", ...parseMemoryUnits(skill.body || "").map((unit) => unit.text)].map((text) => ({
         text,
         skill: skill.name,
-        hash,
-      }));
-    }),
+        hash: unitHash(text),
+      })),
+    ),
   ].filter((unit) => unit.text.trim());
 }
 
-function skillCoverageHash(skill) {
-  return sha256(`${skill.path || ""}\n${skill.name || ""}\n${skill.description || ""}\n${skill.body || ""}`);
+function matchingCoverageHashes(skill, phrasing) {
+  return coverageUnits(null, [skill])
+    .filter((unit) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD)
+    .map((unit) => unit.hash);
 }
 
 function isCovered(coverage, entry) {
@@ -238,7 +240,7 @@ function isCovered(coverage, entry) {
       unit.skill &&
       Object.values(entry.sessions).some(
         (observation) =>
-          observation.coveredBySkill === unit.skill && observation.coveredBySkillHash === unit.hash,
+          observation.coveredBySkill === unit.skill && observation.coveredBySkillHashes?.includes(unit.hash),
       );
     return (
       !isUnchangedFailedTrigger &&
@@ -248,8 +250,9 @@ function isCovered(coverage, entry) {
 }
 
 /** Flatten the ledger into the observation list `foldEvidence` clusters over. */
-export function ledgerGapObservations(ledger, memoryPath) {
+export function ledgerGapObservations(ledger, memoryPath, skills = null) {
   const observations = [];
+  const skillNames = skills ? new Set(skills.map((skill) => skill.name)) : null;
   for (const entry of Object.values(ledger.entries)) {
     if (entry.memoryPath !== memoryPath) continue;
     for (const [sessionId, obs] of Object.entries(entry.sessions)) {
@@ -261,7 +264,9 @@ export function ledgerGapObservations(ledger, memoryPath) {
         quote: obs.quote,
         recurrenceRisk: obs.recurrenceRisk,
         domain: obs.domain === "orchestration" ? "orchestration" : "project",
-        ...(obs.coveredBySkill ? { coveredBySkill: obs.coveredBySkill } : {}),
+        ...(obs.coveredBySkill && (!skillNames || skillNames.has(obs.coveredBySkill))
+          ? { coveredBySkill: obs.coveredBySkill }
+          : {}),
       });
     }
   }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -100,8 +100,11 @@ export function findGapEntry(ledger, memoryPath, proposedInstruction) {
 /**
  * Fold this run's evidence into the ledger. One observation per (gap, session); a
  * session seen again replaces its own observation and keeps its first-seen timestamp.
+ *
+ * @param {{ now?: Date, skills?: unknown[] }} [options]
  */
-export function recordGapObservations(ledger, evidenceRecords, { now = new Date() } = {}) {
+export function recordGapObservations(ledger, evidenceRecords, options = {}) {
+  const { now = new Date() } = options;
   const observedAt = new Date(now).toISOString();
   let recorded = 0;
   for (const record of evidenceRecords) {

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -1,4 +1,4 @@
-import { parseMemoryUnits, similarity, unitHash } from "./memory.js";
+import { parseMemoryUnits, similarity } from "./memory.js";
 import { parseSince } from "./config.js";
 import { sha256 } from "./state.js";
 
@@ -101,9 +101,8 @@ export function findGapEntry(ledger, memoryPath, proposedInstruction) {
  * Fold this run's evidence into the ledger. One observation per (gap, session); a
  * session seen again replaces its own observation and keeps its first-seen timestamp.
  */
-export function recordGapObservations(ledger, evidenceRecords, { now = new Date(), skills = [] } = {}) {
+export function recordGapObservations(ledger, evidenceRecords, { now = new Date() } = {}) {
   const observedAt = new Date(now).toISOString();
-  const skillsByName = new Map(skills.map((skill) => [skill.name, skill]));
   let recorded = 0;
   for (const record of evidenceRecords) {
     if (!record || record.status !== "ok" || !record.memoryPath) continue;
@@ -147,14 +146,6 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         .filter((value) => Number.isFinite(Date.parse(value)))
         .sort((a, b) => Date.parse(a) - Date.parse(b))[0];
       if (aliasPrior) delete entry.sessions[transcript.id];
-      const priorFailedTrigger = priors.find(
-        (observation) =>
-          observation.coveredBySkill === gap.coveredBySkill && observation.coveredBySkillHashes?.length,
-      );
-      const citedSkill = gap.coveredBySkill ? skillsByName.get(gap.coveredBySkill) : null;
-      const coveredBySkillHashes =
-        priorFailedTrigger?.coveredBySkillHashes ||
-        (citedSkill ? matchingCoverageHashes(citedSkill, gap.proposedInstruction) : []);
       entry.sessions[sessionIdentity] = {
         firstObservedAt: firstObservedAt || observedAt,
         observedAt,
@@ -170,7 +161,6 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         // this mistake. Absent when no skill covers it (including all pre-existing
         // observations), and absence never counts as a citation.
         ...(gap.coveredBySkill ? { coveredBySkill: gap.coveredBySkill } : {}),
-        ...(coveredBySkillHashes.length ? { coveredBySkillHashes } : {}),
       };
       recorded += 1;
     }
@@ -221,44 +211,24 @@ function coverageUnits(memoryFile, skills) {
       [skill.description || "", ...parseMemoryUnits(skill.body || "").map((unit) => unit.text)].map((text) => ({
         text,
         skill: skill.name,
-        hash: unitHash(text),
       })),
     ),
   ].filter((unit) => unit.text.trim());
 }
 
-function matchingCoverageHashes(skill, phrasing) {
-  return coverageUnits(null, [skill])
-    .filter((unit) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD)
-    .map((unit) => unit.hash);
-}
-
 function isCovered(coverage, entry) {
   const phrasings = [...new Set([entry.proposedInstruction, ...(entry.phrasings || [])])];
   return coverage.some((unit) => {
-    const isUnchangedFailedTrigger =
-      unit.skill &&
-      Object.values(entry.sessions).some(
-        (observation) =>
-          observation.coveredBySkill === unit.skill && observation.coveredBySkillHashes?.includes(unit.hash),
-      );
-    return (
-      !isUnchangedFailedTrigger &&
-      phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD)
-    );
+    const isFailedTrigger =
+      unit.skill && Object.values(entry.sessions).some((observation) => observation.coveredBySkill === unit.skill);
+    return !isFailedTrigger && phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD);
   });
 }
 
 /** Flatten the ledger into the observation list `foldEvidence` clusters over. */
 export function ledgerGapObservations(ledger, memoryPath, skills = null) {
   const observations = [];
-  const skillCoverage = skills
-    ? coverageUnits(null, skills).reduce((byName, unit) => {
-        if (!byName.has(unit.skill)) byName.set(unit.skill, new Set());
-        byName.get(unit.skill).add(unit.hash);
-        return byName;
-      }, new Map())
-    : null;
+  const skillNames = skills ? new Set(skills.map((skill) => skill.name)) : null;
   for (const entry of Object.values(ledger.entries)) {
     if (entry.memoryPath !== memoryPath) continue;
     for (const [sessionId, obs] of Object.entries(entry.sessions)) {
@@ -270,9 +240,7 @@ export function ledgerGapObservations(ledger, memoryPath, skills = null) {
         quote: obs.quote,
         recurrenceRisk: obs.recurrenceRisk,
         domain: obs.domain === "orchestration" ? "orchestration" : "project",
-        ...(obs.coveredBySkill &&
-        (!skillCoverage ||
-          obs.coveredBySkillHashes?.some((hash) => skillCoverage.get(obs.coveredBySkill)?.has(hash)))
+        ...(obs.coveredBySkill && (!skillNames || skillNames.has(obs.coveredBySkill))
           ? { coveredBySkill: obs.coveredBySkill }
           : {}),
       });

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -252,7 +252,13 @@ function isCovered(coverage, entry) {
 /** Flatten the ledger into the observation list `foldEvidence` clusters over. */
 export function ledgerGapObservations(ledger, memoryPath, skills = null) {
   const observations = [];
-  const skillNames = skills ? new Set(skills.map((skill) => skill.name)) : null;
+  const skillCoverage = skills
+    ? coverageUnits(null, skills).reduce((byName, unit) => {
+        if (!byName.has(unit.skill)) byName.set(unit.skill, new Set());
+        byName.get(unit.skill).add(unit.hash);
+        return byName;
+      }, new Map())
+    : null;
   for (const entry of Object.values(ledger.entries)) {
     if (entry.memoryPath !== memoryPath) continue;
     for (const [sessionId, obs] of Object.entries(entry.sessions)) {
@@ -264,7 +270,9 @@ export function ledgerGapObservations(ledger, memoryPath, skills = null) {
         quote: obs.quote,
         recurrenceRisk: obs.recurrenceRisk,
         domain: obs.domain === "orchestration" ? "orchestration" : "project",
-        ...(obs.coveredBySkill && (!skillNames || skillNames.has(obs.coveredBySkill))
+        ...(obs.coveredBySkill &&
+        (!skillCoverage ||
+          obs.coveredBySkillHashes?.some((hash) => skillCoverage.get(obs.coveredBySkill)?.has(hash)))
           ? { coveredBySkill: obs.coveredBySkill }
           : {}),
       });

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -146,6 +146,8 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         .filter((value) => Number.isFinite(Date.parse(value)))
         .sort((a, b) => Date.parse(a) - Date.parse(b))[0];
       if (aliasPrior) delete entry.sessions[transcript.id];
+      const coveredBySkill =
+        gap.coveredBySkill || priors.find((observation) => observation.coveredBySkill)?.coveredBySkill;
       entry.sessions[sessionIdentity] = {
         firstObservedAt: firstObservedAt || observedAt,
         observedAt,
@@ -160,7 +162,7 @@ export function recordGapObservations(ledger, evidenceRecords, { now = new Date(
         // A failed trigger: the analysis judged an existing skill's content to cover
         // this mistake. Absent when no skill covers it (including all pre-existing
         // observations), and absence never counts as a citation.
-        ...(gap.coveredBySkill ? { coveredBySkill: gap.coveredBySkill } : {}),
+        ...(coveredBySkill ? { coveredBySkill } : {}),
       };
       recorded += 1;
     }

--- a/src/memory.js
+++ b/src/memory.js
@@ -159,7 +159,7 @@ export function memorySetHash(files) {
  */
 export function memorySurfaceHash(setHash, skills) {
   if (!skills?.length) return setHash;
-  const layer = skills.map((s) => `${s.path}:${s.description || ""}`).join("|");
+  const layer = skills.map((s) => `${s.path}:${s.name || ""}:${s.description || ""}`).join("|");
   return `sha256:${sha256(`${setHash}|${layer}`).slice(0, 16)}`;
 }
 

--- a/src/memory.js
+++ b/src/memory.js
@@ -150,6 +150,20 @@ export function memorySetHash(files) {
 }
 
 /**
+ * The memory-surface hash: the memory-set hash extended with the always-loaded skill
+ * layer, which is exactly the description lines. Analysis is judged against the
+ * instruction index AND the skill descriptions, so editing a description invalidates
+ * cached evidence the same way editing the memory file does - while a body edit
+ * invalidates nothing, because nothing is judged against bodies. A repo without skills
+ * keeps the plain set hash, so its cached evidence survives this hash unchanged.
+ */
+export function memorySurfaceHash(setHash, skills) {
+  if (!skills?.length) return setHash;
+  const layer = skills.map((s) => `${s.path}:${s.description || ""}`).join("|");
+  return `sha256:${sha256(`${setHash}|${layer}`).slice(0, 16)}`;
+}
+
+/**
  * Render the instruction index that both prompt tiers see. It is a lookup table keyed
  * by alias, never a stand-in for the file: units are listed with the lines they occupy
  * so the synthesis agent can find them in the raw file it edits.

--- a/src/prompts/analysis.md
+++ b/src/prompts/analysis.md
@@ -10,6 +10,16 @@ Each instruction has a stable id in [brackets]. Refer to instructions ONLY by th
 
 {{INSTRUCTION_INDEX}}
 
+## Project skills (load-on-trigger)
+
+These skills exist in the repo. Each one's body is loaded only when its trigger fires,
+so it is NOT shown here - only the trigger description is. If a mistake you found is
+covered by one of these skills' content, it is a failed trigger: still report the gap,
+and name that skill in `coveredBySkill`. Open the skill's file (path in parentheses)
+only when you need its body to confirm the coverage.
+
+{{SKILLS}}
+
 ## Gaps already on the books
 
 Earlier sessions reported these gaps; each has a stable id. If a gap you found is the
@@ -36,7 +46,7 @@ Return ONE JSON object and nothing else. No prose before or after, no markdown f
 {
   "positive":  [{"instruction": "AG-042", "moment": "turn 12", "effect": "what following it achieved", "quote": "verbatim text from the trace"}],
   "negative":  [{"instruction": "AG-017", "moment": "turn 3",  "effect": "what happened and what it cost", "class": "harm|non-compliance|irrelevant", "quote": "verbatim text from the trace"}],
-  "gaps":      [{"mistake": "what went wrong", "proposedInstruction": "one sentence that would have prevented it", "recurrenceRisk": "high|medium|low", "domain": "project|orchestration", "matchesGap": "<id from the list above, omit when new>", "quote": "verbatim text from the trace"}],
+  "gaps":      [{"mistake": "what went wrong", "proposedInstruction": "one sentence that would have prevented it", "recurrenceRisk": "high|medium|low", "domain": "project|orchestration", "matchesGap": "<id from the list above, omit when new>", "coveredBySkill": "<skill name from the skills list, omit when none covers it>", "quote": "verbatim text from the trace"}],
   "usedRawTranscript": false
 }
 ```
@@ -63,7 +73,10 @@ Rules, in order of importance:
    the agent doing the specific thing the instruction asks for. An outcome that would
    have happened anyway is not evidence.
 6. `gaps` are mistakes NOT covered by any current instruction. If an instruction exists
-   and was ignored, that is `negative` with `class: "non-compliance"`, not a gap.
+   and was ignored, that is `negative` with `class: "non-compliance"`, not a gap. A
+   mistake covered only by a SKILL's content is still a gap - skills have no
+   instruction ids - but cite the skill in `coveredBySkill`: that is a failed trigger,
+   and the fix is that skill's description, not new memory-file text.
 7. `proposedInstruction` must be one imperative sentence, specific enough to act on and
    general enough to apply beyond this one session.
 8. An empty array is a valid and useful answer. Report nothing rather than something weak.

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -44,6 +44,8 @@ Hard rules - a violation fails the whole proposal:
    `harm` negatives argue against an instruction; `non-compliance` never justifies a
    deletion. A change that only deletes text and is not part of an extract is a removal
    whatever its `kind` says - if it lacks the evidence, revert it in the file first.
+   Text deleted from an existing skill file can never carry that evidence (skills have
+   no instruction ids), so revert any skill-file deletion.
 6. `kind: "extract"` is an edit whose changes are one or more created `SKILL.md` files
    plus the change(s) to {{MEMORY_PATH}} that pay for them. **The skills must carry every
    line those changes remove** - a deletion is never part of an extract; give it its own

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -21,9 +21,11 @@ paste the edited text into your reply; backpass measures what you changed in the
 
 ## Current memory file: {{MEMORY_PATH}}
 
-Budget: {{CURRENT_TOKENS}} / {{BUDGET_TOKENS}} estimated tokens ({{BUDGET_STATE}}).
+Budget: {{CURRENT_TOKENS}} / {{BUDGET_TOKENS}} estimated always-loaded tokens
+({{BUDGET_STATE}}). The count is this file PLUS every skill's `description:` line;
+skill bodies are free until triggered.
 
-Every token in this file is paid on every future session, forever, and instruction
+Every always-loaded token is paid on every future session, forever, and instruction
 following dilutes as the file grows. The budget is the constraint you optimize under.
 
 The index below is a lookup table, not the file: it names each instruction (`AG-nnn`),
@@ -74,7 +76,9 @@ analyzed sessions in which an instruction drew any evidence at all.
    Only `harm` negatives - following the instruction caused damage - argue against an
    instruction. `non-compliance` means it failed to steer: reinforce it, reposition it,
    or improve its trigger, never delete it for being ignored. Text you delete that does
-   not land in a created skill is a removal, whatever the edit is called.
+   not land in a created skill is a removal, whatever the edit is called - including
+   text deleted from an existing skill file, where no evidence can attribute at all, so
+   no skill-file deletion clears the floor: rewrite skill content, never remove it.
 4. **An extraction preserves every line it removes** in the SKILL.md it creates. A
    deletion is never part of an extract: it is its own `remove` edit, decided on its
    own evidence.
@@ -94,7 +98,9 @@ analyzed sessions in which an instruction drew any evidence at all.
 | Conditional / narrow     | **skill** (the description is the condition) | deletion candidate |
 
 A skill's description is always loaded and its body is free until triggered, so moving a
-section into a skill trades its always-loaded cost for that one description line.
+section into a skill trades its always-loaded cost for that one description line. That
+line is real budget: description tokens count toward the cap above, so keep descriptions
+to one crisp trigger condition.
 
 **Skill descriptions are weights too.** If the evidence shows an agent lacked knowledge
 an existing skill already contains, that is a failed trigger: rewrite that skill's

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -478,7 +478,7 @@ export function buildProposal(rawResult, context) {
     }
     edit.applicable = true;
     edit.deltaTokens = estimateTokens(next) - estimateTokens(before);
-    edit.descriptionDelta = descriptionDeltaOf(edit, before, next, config.skillsDir);
+    edit.descriptionDelta = descriptionDeltaOf(edit, before, next, config.skillDirs || config.skillsDir);
     running.set(edit.file, next);
   }
 
@@ -548,6 +548,7 @@ export function buildProposal(rawResult, context) {
       maxEditsPerRun: maxEdits,
       minGapEvidence: config.minGapEvidence,
       skillsDir: config.skillsDir,
+      skillDirs: config.skillDirs,
       analysis: config.analysis,
       synthesis: config.synthesis,
     },

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,7 +1,8 @@
 import { renderHunkLines } from "./diff.js";
-import { editSkills } from "./skills.js";
+import { memoryTextHash } from "./memory.js";
+import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
-import { normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
+import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
 
 /**
  * The proposal model: what a synthesis pass is allowed to produce, and the mechanical
@@ -39,9 +40,9 @@ export const SHRINK_MAX_EDITS = 20;
 /** A typical memory-file instruction removal or tightening trims about this many tokens. */
 export const SHRINK_EDIT_TOKENS = 40;
 
-export function effectiveMaxEdits(memoryFile, config) {
+export function effectiveMaxEdits(memoryFile, config, alwaysLoadedExtraTokens = 0) {
   if (Number.isInteger(config.maxEditsPerRun) && config.maxEditsPerRun > 0) return config.maxEditsPerRun;
-  const overage = memoryFile.tokens - config.budgetTokens;
+  const overage = memoryFile.tokens + alwaysLoadedExtraTokens - config.budgetTokens;
   if (overage <= 0) return DEFAULT_MAX_EDITS;
   return Math.min(SHRINK_MAX_EDITS, Math.max(DEFAULT_MAX_EDITS, Math.ceil(overage / SHRINK_EDIT_TOKENS)));
 }
@@ -124,6 +125,22 @@ function unrecoveredRemovedLines(hunk, lineCounts) {
  */
 function unitsRemovedBy(hunk, memoryFile) {
   return memoryFile.units.filter((unit) => unit.startLine <= hunk.oldEnd && unit.endLine >= hunk.oldStart);
+}
+
+/**
+ * One edit's always-loaded cost outside the memory file, measured from the real texts:
+ * an extract pays for the description line(s) of the skills it creates, and an edit to
+ * an existing skill pays (or earns) the change to its `description:` line. Everything
+ * else in a skill file is body - loaded on trigger, never billed here.
+ */
+function descriptionDeltaOf(edit, before, next, skillsDir) {
+  if (edit.kind === "extract") {
+    return editSkills(edit).reduce((sum, skill) => sum + estimateTokens(skill.description || ""), 0);
+  }
+  if (edit.targetsMemoryFile || !edit.file || !skillsDir || !isSkillFilePath(edit.file, skillsDir)) return 0;
+  const beforeDescription = parseFrontmatter(before).description || "";
+  const nextDescription = parseFrontmatter(next).description || "";
+  return estimateTokens(nextDescription) - estimateTokens(beforeDescription);
 }
 
 /** Overlapping count: a run of identical lines must not pass as unique. */
@@ -244,6 +261,7 @@ export function buildProposal(rawResult, context) {
     harnessCounts = {},
     rejections = { entries: {} },
     isSuppressed = () => false,
+    skillFiles = [],
   } = context;
 
   const violations = [];
@@ -252,7 +270,10 @@ export function buildProposal(rawResult, context) {
   const edits = rawEdits.map((raw, i) => normalizeEdit(raw, i));
   const changesById = new Map(measured.changes.map((c) => [c.id, c]));
 
-  const maxEdits = effectiveMaxEdits(memoryFile, config);
+  // Skill description lines are always loaded, so they sit under the same cap as the
+  // memory file: one always-loaded budget, per the captain's ruling.
+  const descriptionTokensNow = skillDescriptionTokens(skillFiles);
+  const maxEdits = effectiveMaxEdits(memoryFile, config, descriptionTokensNow);
   if (edits.length > maxEdits) {
     violations.push(`proposed ${edits.length} edits but the per-run cap is ${maxEdits} (the learning rate)`);
   }
@@ -387,6 +408,25 @@ export function buildProposal(rawResult, context) {
       }
     }
 
+    // The same floor covers every other staged file. Evidence cannot attribute to
+    // skill-file text at all - there are no instruction ids for it - so no pure
+    // deletion there can reach the harm bar, whatever the edit is called. Rewrites
+    // (a hunk that also adds text) stay possible; only vanishing text is refused.
+    if (edit.kind !== "extract" && files[0] !== memoryFile.path) {
+      const deleted = hunks
+        .filter((hunk) => hunk.removed && !hunk.added)
+        .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "del").map((line) => line.text))
+        .filter((text) => text.trim());
+      if (deleted.length) {
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") deletes "${deleted[0].trim().slice(0, 80)}" from ${files[0]}; ` +
+            `no evidence can attribute to skill files, so no deletion there clears the ` +
+            `${config.minGapEvidence}-session harm floor - revert the deletion`,
+        );
+        continue;
+      }
+    }
+
     const file = files[0];
     const proposed = {
       id: edit.id,
@@ -418,7 +458,10 @@ export function buildProposal(rawResult, context) {
     accepted.push(proposed);
   }
 
-  // Deltas are measured here, never taken from the model.
+  // Deltas are measured here, never taken from the model. `descriptionDelta` is the
+  // edit's always-loaded cost outside the memory file: the change to a skill's
+  // description line, or the description line(s) a created skill adds. Bodies stay
+  // free-until-triggered and never enter it.
   const running = new Map();
   for (const edit of accepted) {
     const before =
@@ -430,15 +473,22 @@ export function buildProposal(rawResult, context) {
       violations.push(err.message);
       edit.applicable = false;
       edit.deltaTokens = 0;
+      edit.descriptionDelta = 0;
       continue;
     }
     edit.applicable = true;
     edit.deltaTokens = estimateTokens(next) - estimateTokens(before);
+    edit.descriptionDelta = descriptionDeltaOf(edit, before, next, config.skillsDir);
     running.set(edit.file, next);
   }
 
   const projectedText = running.get(memoryFile.path) ?? memoryFile.text;
-  const budget = budgetStatus(memoryFile.text, projectedText, config.budgetTokens);
+  const descriptionTokensProjected =
+    descriptionTokensNow + accepted.reduce((sum, edit) => sum + (edit.descriptionDelta || 0), 0);
+  const budget = budgetStatus(memoryFile.text, projectedText, config.budgetTokens, {
+    current: descriptionTokensNow,
+    projected: descriptionTokensProjected,
+  });
 
   /**
    * The budget gate has two modes (design section 6).
@@ -448,18 +498,27 @@ export function buildProposal(rawResult, context) {
    * every run on exactly the repos that need backpass most. There, the run is a shrink
    * plan and the gate is progress: the edit set must be strictly net-negative.
    */
-  budget.mode = memoryFile.tokens > config.budgetTokens ? "shrink" : "cap";
+  budget.mode = memoryFile.tokens + descriptionTokensNow > config.budgetTokens ? "shrink" : "cap";
   budget.startedOverBudget = budget.mode === "shrink";
+  // For displays: how much of `current` is the skill layer, so a surface number is
+  // never presented as if it measured the file alone.
+  budget.descriptionTokens = descriptionTokensNow;
 
+  // With skills present the gated number is the surface, not the file alone; name what
+  // the number actually measures.
+  const surfaceLabel =
+    descriptionTokensNow || descriptionTokensProjected !== descriptionTokensNow
+      ? `the always-loaded surface (${memoryFile.path} + skill descriptions)`
+      : memoryFile.path;
   const gate = budgetGateKind(budget);
   if (gate === "cap") {
     violations.push(
-      `applying every proposed edit leaves ${memoryFile.path} at ${budget.projected} tokens, ` +
+      `applying every proposed edit leaves ${surfaceLabel} at ${budget.projected} tokens, ` +
         `${budget.over} over the ${config.budgetTokens}-token budget`,
     );
   } else if (gate === "shrink") {
     violations.push(
-      `${memoryFile.path} is already ${budget.current - config.budgetTokens} tokens over the ` +
+      `${surfaceLabel} is already ${budget.current - config.budgetTokens} tokens over the ` +
         `${config.budgetTokens}-token budget, so this run must shrink it, but the proposed edits ` +
         `change it by ${budget.delta >= 0 ? "+" : ""}${budget.delta} tokens`,
     );
@@ -468,12 +527,21 @@ export function buildProposal(rawResult, context) {
   for (const file of measured.stray || [])
     notes.push(`ignored ${file}: synthesis wrote it outside the memory file and skills`);
 
+  // Every non-memory file an accepted edit targets, with the fingerprint of the exact
+  // image its hunks were cut from. The writer re-checks these before composing, the
+  // same freshness contract `memoryFileSnapshot` gives the memory file - a skill file
+  // that changed after the proposal must refuse the apply, never be patched blind.
+  const targetFiles = [...new Set(accepted.filter((edit) => !edit.targetsMemoryFile).map((edit) => edit.file))]
+    .filter((file) => measured.originals?.has(file))
+    .map((file) => ({ file, hash: memoryTextHash(measured.originals.get(file)) }));
+
   const proposal = {
     version: 2,
     tool: "backpass",
     generatedAt: new Date().toISOString(),
     repo: { name: repo.name, root: repo.root },
     memoryFile: { path: memoryFile.path, hash: memoryFile.hash, tokens: memoryFile.tokens },
+    targetFiles,
     budget,
     config: {
       budgetTokens: config.budgetTokens,
@@ -519,8 +587,11 @@ export function slug(text) {
 /**
  * Project the memory file forward under a specific set of accepted edit ids - used by
  * both the apply surface's live budget gauge and the actual writer.
+ * `descriptionTokensCurrent` is the always-loaded skill layer measured by the caller
+ * (the descriptions on disk at apply time); each accepted edit's measured
+ * `descriptionDelta` moves it, so the budget describes the whole surface.
  */
-export function projectWithDecisions(memoryText, edits, acceptedIds, capTokens) {
+export function projectWithDecisions(memoryText, edits, acceptedIds, capTokens, descriptionTokensCurrent = 0) {
   const chosen = edits.filter((e) => acceptedIds.includes(e.id) && e.targetsMemoryFile && e.applicable !== false);
   let text = memoryText;
   for (const edit of chosen) {
@@ -530,5 +601,14 @@ export function projectWithDecisions(memoryText, edits, acceptedIds, capTokens) 
       // Skip an edit that no longer applies; the writer reports it.
     }
   }
-  return { text, budget: budgetStatus(memoryText, text, capTokens) };
+  const descriptionDelta = edits
+    .filter((e) => acceptedIds.includes(e.id) && e.applicable !== false)
+    .reduce((sum, e) => sum + (e.descriptionDelta || 0), 0);
+  return {
+    text,
+    budget: budgetStatus(memoryText, text, capTokens, {
+      current: descriptionTokensCurrent,
+      projected: descriptionTokensCurrent + descriptionDelta,
+    }),
+  };
 }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -9,7 +9,7 @@ import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./w
  * gates it must clear before a human ever sees it (design sections 3, 6, 7). The
  * budget gate (`budgetGateKind`) runs again on the accepted subset at apply.
  *
- * The synthesis agent edits a staging copy of the memory file natively
+ * The synthesis agent edits a staging copy of the memory file and project skills natively
  * (`src/workspace.js`); backpass measures the result as anchored hunks (`src/diff.js`)
  * and the agent annotates them - kind, title, rationale, evidence - by id. An edit is
  * therefore a group of measured changes against one file:
@@ -493,9 +493,9 @@ export function buildProposal(rawResult, context) {
   /**
    * The budget gate has two modes (design section 6).
    *
-   * Normally the post-edit file must fit the budget. But a file that is ALREADY over
-   * budget cannot be brought under it in one capped step - demanding that would fail
-   * every run on exactly the repos that need backpass most. There, the run is a shrink
+   * Normally the post-edit always-loaded surface must fit the budget. But a surface that
+   * is ALREADY over budget cannot be brought under it in one capped step - demanding that
+   * would fail every run on exactly the repos that need backpass most. There, the run is a shrink
    * plan and the gate is progress: the edit set must be strictly net-negative.
    */
   budget.mode = memoryFile.tokens + descriptionTokensNow > config.budgetTokens ? "shrink" : "cap";

--- a/src/skills.js
+++ b/src/skills.js
@@ -61,6 +61,41 @@ export function loadSkills(repoRoot, skillsDir) {
   return skills.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/**
+ * Every project-level skill root a supported harness can load. The overflow target is
+ * included even when custom-configured, and roots resolving to the same directory (the
+ * normal `.claude/skills` symlink) are counted only once.
+ */
+export function resolveProjectSkillDirs(repoRoot, overflowDir = CANONICAL_SKILLS_DIR) {
+  const dirs = [];
+  const seen = new Set();
+  for (const dir of [overflowDir, CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK]) {
+    if (!dir) continue;
+    const absolute = path.join(repoRoot, dir);
+    const exists = fs.existsSync(absolute);
+    if (!exists && dir !== overflowDir) continue;
+    let identity = path.resolve(absolute);
+    if (exists) {
+      try {
+        identity = fs.realpathSync(absolute);
+      } catch {
+        continue;
+      }
+    }
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    dirs.push(dir);
+  }
+  return dirs;
+}
+
+/** Load generated and human-authored project skills across every supported root. */
+export function loadProjectSkills(repoRoot, overflowDir = CANONICAL_SKILLS_DIR) {
+  return resolveProjectSkillDirs(repoRoot, overflowDir)
+    .flatMap((dir) => loadSkills(repoRoot, dir))
+    .sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
+}
+
 /** The markdown after the frontmatter block - what a harness loads when the trigger fires. */
 export function skillBody(text) {
   const end = /^---\n[\s\S]*?\n---\n?/.exec(text);

--- a/src/skills.js
+++ b/src/skills.js
@@ -52,12 +52,28 @@ export function loadSkills(repoRoot, skillsDir) {
       name: frontmatter.name || entry.name.replace(/\.md$/, ""),
       description: frontmatter.description || "",
       path: path.relative(repoRoot, file),
+      body: skillBody(text),
       bodyTokens: estimateTokens(text),
       descriptionTokens: estimateTokens(frontmatter.description || ""),
     });
   }
 
   return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** The markdown after the frontmatter block - what a harness loads when the trigger fires. */
+export function skillBody(text) {
+  const end = /^---\n[\s\S]*?\n---\n?/.exec(text);
+  return (end ? text.slice(end[0].length) : text).trim();
+}
+
+/**
+ * The always-loaded token cost of the skill layer: every description line, nothing
+ * else. Bodies are free until triggered by design - this sum is what joins the memory
+ * file under the one always-loaded budget cap.
+ */
+export function skillDescriptionTokens(skills) {
+  return (skills || []).reduce((sum, s) => sum + (s.descriptionTokens ?? estimateTokens(s.description || "")), 0);
 }
 
 /** Minimal YAML frontmatter reader: only `key: value` and folded multi-line values. */
@@ -86,6 +102,17 @@ export function renderSkillIndex(skills) {
         `- ${s.name} (${s.bodyTokens} tok body, ${s.descriptionTokens} tok description) :: ${s.description || "(no description)"}`,
     )
     .join("\n");
+}
+
+/**
+ * The skill index the analysis prompt sees: name, path, and trigger description only.
+ * Bodies are deliberately absent - the analysis turn opens a SKILL.md by path when a
+ * description looks relevant to a mistake, instead of paying for every body on every
+ * transcript.
+ */
+export function renderSkillIndexForAnalysis(skills) {
+  if (!skills.length) return "(this repo has no skills)";
+  return skills.map((s) => `- ${s.name} (${s.path}) :: ${s.description || "(no description)"}`).join("\n");
 }
 
 /** Serialize a skill draft to the common SKILL.md shape. */

--- a/src/state.js
+++ b/src/state.js
@@ -205,7 +205,7 @@ function migrateEvidenceRecord(record, transcript, identity) {
 
 /**
  * Cache key for a transcript's analysis: the transcript's own content signature plus
- * the memory-file hash it was judged against. Either changing invalidates the evidence.
+ * the memory-surface hash it was judged against. Either changing invalidates the evidence.
  */
 export function evidenceKey(transcript, memoryHash) {
   return `${transcriptIdentity(transcript)}:${transcript.mtimeMs}:${transcript.bytes}:${memoryHash}`;

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -6,7 +6,7 @@ import { renderEvidenceForPrompt } from "./fold.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt, render, loadPrompt } from "./prompts.js";
 import { buildProposal, effectiveMaxEdits, ProposalViolation, renderChangesForPrompt } from "./proposal.js";
-import { loadSkills, renderSkillIndex, resolveOverflowTarget } from "./skills.js";
+import { loadSkills, renderSkillIndex, resolveOverflowTarget, skillDescriptionTokens } from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
 import { measureWorkspace, prepareWorkspace, repoFingerprint } from "./workspace.js";
@@ -63,33 +63,48 @@ const EMPTY_TURN_VIOLATION =
 const UNPARSEABLE_VIOLATION = "synthesis answered with text, but not with a JSON object";
 const KEPT_EDITING_VIOLATION = "synthesis kept editing the staging copy instead of annotating the measured changes";
 
-function budgetRule(memoryFile, config, maxEdits) {
-  const remaining = config.budgetTokens - memoryFile.tokens;
+/**
+ * The budget the prompts frame is the always-loaded surface: the memory file plus
+ * every skill description line, the same sum the mechanical gate measures
+ * (`buildProposal`). Framing one number and gating another would set the model up to
+ * fail a gate it was never told about.
+ */
+function budgetRule(memoryFile, config, maxEdits, descriptionTokens = 0) {
+  const remaining = config.budgetTokens - memoryFile.tokens - descriptionTokens;
+  const counted = descriptionTokens
+    ? ` The budget counts this file plus every skill description line (${descriptionTokens} tok of descriptions today); skill bodies stay free until triggered.`
+    : "";
   if (remaining <= 0) {
     return (
-      `This file is ALREADY ${Math.abs(remaining)} tokens OVER budget, so this run is a SHRINK ` +
+      `The always-loaded surface is ALREADY ${Math.abs(remaining)} tokens OVER budget, so this run is a SHRINK ` +
       `PLAN. You are NOT expected to reach ${config.budgetTokens} tokens in one run - the ` +
       `${maxEdits}-edit cap for this run makes that impossible and later runs continue the work. ` +
       `What is required is real progress: the edit set MUST be net-negative, so lead with skill ` +
-      `extractions of long, narrow, crisply-triggered sections - extraction frees the same ` +
-      `always-loaded tokens and loses nothing, and it never needs removal evidence. Deleting an ` +
+      `extractions of long, narrow, crisply-triggered sections - extraction frees the removed ` +
+      `always-loaded tokens for the price of one description line and loses nothing, and it never needs removal ` +
+      `evidence. Deleting an ` +
       `instruction outright still needs its harm-evidence floor; the budget never lowers that ` +
       `bar. Any addition must name the removal or extraction that pays for it. Make the largest ` +
-      `honest reduction you can justify from the evidence.`
+      `honest reduction you can justify from the evidence.` +
+      counted
     );
   }
   if (remaining < config.budgetTokens * 0.15) {
     return (
       `Only ${remaining} tokens of headroom remain. Treat this as zero-sum: every addition must ` +
-      `name its offsetting removal or skill extraction. The post-edit file must stay at or below ` +
-      `${config.budgetTokens} tokens.`
+      `name its offsetting removal or skill extraction. The post-edit always-loaded surface must stay at or below ` +
+      `${config.budgetTokens} tokens.` +
+      counted
     );
   }
-  return `The post-edit file must stay at or below ${config.budgetTokens} tokens (${remaining} tokens of headroom today).`;
+  return (
+    `The post-edit always-loaded surface must stay at or below ${config.budgetTokens} tokens ` +
+    `(${remaining} tokens of headroom today).${counted}`
+  );
 }
 
-function budgetState(memoryFile, config) {
-  const ratio = memoryFile.tokens / config.budgetTokens;
+function budgetState(memoryFile, config, descriptionTokens = 0) {
+  const ratio = (memoryFile.tokens + descriptionTokens) / config.budgetTokens;
   if (ratio > 1) return "OVER BUDGET";
   if (ratio > 0.85) return "near budget";
   return "within budget";
@@ -134,11 +149,12 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
   for (const w of overflow.warnings) warn(w);
   const skillFiles = loadSkills(repo.root, overflow.dir);
-  const maxEdits = effectiveMaxEdits(memoryFile, config);
+  const descriptionTokens = skillDescriptionTokens(skillFiles);
+  const maxEdits = effectiveMaxEdits(memoryFile, config, descriptionTokens);
 
   const common = {
     MEMORY_PATH: memoryFile.path,
-    BUDGET_RULE: budgetRule(memoryFile, config, maxEdits),
+    BUDGET_RULE: budgetRule(memoryFile, config, maxEdits, descriptionTokens),
     MAX_EDITS: String(maxEdits),
     MIN_GAP_EVIDENCE: String(config.minGapEvidence),
   };
@@ -157,7 +173,7 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const promptDir = path.join(state.root, "prompts");
   fs.mkdirSync(promptDir, { recursive: true });
 
-  return { state, rejections, overflow, skillFiles, maxEdits, common, context, promptDir };
+  return { state, rejections, overflow, skillFiles, descriptionTokens, maxEdits, common, context, promptDir };
 }
 
 /**
@@ -166,14 +182,14 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
  * fresh session used after an empty reply would otherwise be asked to quote evidence it
  * has never been shown.
  */
-function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot }) {
+function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0 }) {
   return render(loadPrompt("annotate-preface"), {
     MEMORY_PATH: memoryFile.path,
     REPO_NAME: repo.name,
     REPO_ROOT: repo.root,
     WORKSPACE_ROOT: workspaceRoot,
-    CURRENT_TOKENS: String(memoryFile.tokens),
-    BUDGET_STATE: budgetState(memoryFile, config),
+    CURRENT_TOKENS: String(memoryFile.tokens + descriptionTokens),
+    BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
     TRANSCRIPT_COUNT: String(summary.analyzedSessions),
     EVIDENCE: renderEvidenceForPrompt(summary),
   });
@@ -356,13 +372,14 @@ async function annotateLoop({
 export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
   config.state.clearProposal();
   const harnessCounts = harnessCountsOf(transcripts);
-  const { state, rejections, overflow, skillFiles, maxEdits, common, context, promptDir } = synthesisSetup({
-    memoryFile,
-    summary,
-    config,
-    repo,
-    harnessCounts,
-  });
+  const { state, rejections, overflow, skillFiles, descriptionTokens, maxEdits, common, context, promptDir } =
+    synthesisSetup({
+      memoryFile,
+      summary,
+      config,
+      repo,
+      harnessCounts,
+    });
 
   const editValues = {
     ...common,
@@ -374,9 +391,9 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       Object.entries(harnessCounts)
         .map(([h, n]) => `${h} ${n}`)
         .join(" · ") || "none",
-    CURRENT_TOKENS: String(memoryFile.tokens),
+    CURRENT_TOKENS: String(memoryFile.tokens + descriptionTokens),
     BUDGET_TOKENS: String(config.budgetTokens),
-    BUDGET_STATE: budgetState(memoryFile, config),
+    BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
     SKILLS_DIR: overflow.dir,
     SKILL_INDEX: renderSkillIndex(skillFiles),
@@ -493,7 +510,8 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       noteOnce,
       overflow,
       progress,
-      renderPreface: () => prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root }),
+      renderPreface: () =>
+        prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root, descriptionTokens }),
     });
   } finally {
     await holder.session.close();

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -6,7 +6,13 @@ import { renderEvidenceForPrompt } from "./fold.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt, render, loadPrompt } from "./prompts.js";
 import { buildProposal, effectiveMaxEdits, ProposalViolation, renderChangesForPrompt } from "./proposal.js";
-import { loadSkills, renderSkillIndex, resolveOverflowTarget, skillDescriptionTokens } from "./skills.js";
+import {
+  loadProjectSkills,
+  renderSkillIndex,
+  resolveOverflowTarget,
+  resolveProjectSkillDirs,
+  skillDescriptionTokens,
+} from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
 import { measureWorkspace, prepareWorkspace, repoFingerprint } from "./workspace.js";
@@ -148,7 +154,8 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
   for (const w of overflow.warnings) warn(w);
-  const skillFiles = loadSkills(repo.root, overflow.dir);
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir);
+  const skillFiles = loadProjectSkills(repo.root, overflow.dir);
   const descriptionTokens = skillDescriptionTokens(skillFiles);
   const maxEdits = effectiveMaxEdits(memoryFile, config, descriptionTokens);
 
@@ -161,7 +168,7 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
 
   const context = {
     memoryFile,
-    config: { ...config, skillsDir: overflow.dir },
+    config: { ...config, skillsDir: overflow.dir, skillDirs },
     repo,
     summary,
     harnessCounts,
@@ -173,7 +180,18 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
   const promptDir = path.join(state.root, "prompts");
   fs.mkdirSync(promptDir, { recursive: true });
 
-  return { state, rejections, overflow, skillFiles, descriptionTokens, maxEdits, common, context, promptDir };
+  return {
+    state,
+    rejections,
+    overflow,
+    skillDirs,
+    skillFiles,
+    descriptionTokens,
+    maxEdits,
+    common,
+    context,
+    promptDir,
+  };
 }
 
 /**
@@ -372,14 +390,24 @@ async function annotateLoop({
 export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
   config.state.clearProposal();
   const harnessCounts = harnessCountsOf(transcripts);
-  const { state, rejections, overflow, skillFiles, descriptionTokens, maxEdits, common, context, promptDir } =
-    synthesisSetup({
-      memoryFile,
-      summary,
-      config,
-      repo,
-      harnessCounts,
-    });
+  const {
+    state,
+    rejections,
+    overflow,
+    skillDirs,
+    skillFiles,
+    descriptionTokens,
+    maxEdits,
+    common,
+    context,
+    promptDir,
+  } = synthesisSetup({
+    memoryFile,
+    summary,
+    config,
+    repo,
+    harnessCounts,
+  });
 
   const editValues = {
     ...common,
@@ -458,7 +486,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     holder.ranWith = current.agent;
     chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir });
+    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, skillDirs });
     progress("edit", { attempt: 1 });
     holder.session = await openSession({
       agent: current.agent,

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -17,8 +17,8 @@ import { UserError, color, info, warn } from "./logger.js";
  * evidence into concrete edits.
  *
  * The agent never describes an edit for backpass to locate - it makes the edit, with its
- * harness's own file tools, in a staging copy of the memory file (`src/workspace.js`).
- * A run starts in one session with two kinds of turn:
+ * harness's own file tools, in a staging copy of the memory file and project skills
+ * (`src/workspace.js`). A run starts in one session with two kinds of turn:
  *
  *   edit      the synthesis prompt; the agent edits `./AGENTS.md` in the staging copy
  *   annotate  backpass measures the copy against the original (`src/diff.js`) and shows

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -23,12 +23,15 @@ export function formatTokens(n) {
 }
 
 /**
- * Budget verdict for one always-loaded memory file.
+ * Budget verdict for the always-loaded surface. The texts are the memory file;
+ * `alwaysLoadedExtra` carries the token counts loaded alongside it - today the skill
+ * description lines - so one cap covers everything an agent pays on every session.
  * `over` is the amount by which projected exceeds the cap (0 when within).
  */
-export function budgetStatus(currentText, projectedText, capTokens) {
-  const current = estimateTokens(currentText);
-  const projected = estimateTokens(projectedText ?? currentText);
+export function budgetStatus(currentText, projectedText, capTokens, alwaysLoadedExtra = {}) {
+  const extraCurrent = alwaysLoadedExtra.current ?? 0;
+  const current = estimateTokens(currentText) + extraCurrent;
+  const projected = estimateTokens(projectedText ?? currentText) + (alwaysLoadedExtra.projected ?? extraCurrent);
   return {
     capTokens,
     current,

--- a/src/tui/index.js
+++ b/src/tui/index.js
@@ -115,7 +115,13 @@ export function reduceEvent(state, event, data, now = Date.now()) {
 
   switch (event) {
     case "memory":
-      state.memory = { path: data.path, tokens: data.tokens, budget: data.budget, units: data.units };
+      state.memory = {
+        path: data.path,
+        label: data.label || data.path,
+        tokens: data.tokens,
+        budget: data.budget,
+        units: data.units,
+      };
       break;
 
     case "discover:start":

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -173,7 +173,7 @@ function headerLines(state, theme, width, spin) {
     const cells = state.narrow ? 16 : 24;
     const over = memory.tokens > memory.budget;
     const left =
-      `${theme.paint(memory.path, "dim")}  ${gaugeBar(theme, ratio, cells)}  ` +
+      `${theme.paint(memory.label || memory.path, "dim")}  ${gaugeBar(theme, ratio, cells)}  ` +
       `${theme.paint(formatCount(memory.tokens), over ? "red" : "mint")} ${theme.paint("/", "faint")} ${theme.paint(`${formatCount(memory.budget)} tok`, "text")}`;
     const right = over
       ? `${theme.paint("OVER", "red", { bold: true })}${theme.paint(" · shrink plan", "faint")}`

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -29,7 +29,7 @@ export function workspaceRoot(state) {
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
+export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs = [skillsDir] }) {
   const root = workspaceRoot(state);
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
@@ -40,19 +40,20 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir }) {
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
 
-  const skillsSource = path.join(repo.root, skillsDir);
-  if (fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
+  for (const sourceDir of skillDirs) {
+    const skillsSource = path.join(repo.root, sourceDir);
+    if (!fs.existsSync(skillsSource) || !fs.statSync(skillsSource).isDirectory()) continue;
     for (const relative of walkFiles(skillsSource)) {
       const from = path.join(skillsSource, relative);
-      const to = path.join(root, skillsDir, relative);
+      const to = path.join(root, sourceDir, relative);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      originals.set(path.posix.join(skillsDir, relative), fs.readFileSync(from, "utf8"));
+      originals.set(path.posix.join(sourceDir, relative), fs.readFileSync(from, "utf8"));
     }
   }
   fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
 
-  return { root, memoryPath: memoryFile.path, skillsDir, originals };
+  return { root, memoryPath: memoryFile.path, skillsDir, skillDirs, originals };
 }
 
 function walkFiles(dir, prefix = "") {
@@ -73,12 +74,15 @@ function walkFiles(dir, prefix = "") {
 
 /** A created file counts as a skill only in the layouts `loadSkills` reads. */
 export function isSkillFilePath(relative, skillsDir) {
-  const prefix = `${skillsDir}/`;
-  if (!relative.startsWith(prefix)) return false;
-  const inside = relative.slice(prefix.length);
-  const parts = inside.split("/");
-  if (parts.length === 1) return parts[0].endsWith(".md");
-  return parts.length === 2 && parts[1] === "SKILL.md";
+  const dirs = Array.isArray(skillsDir) ? skillsDir : [skillsDir];
+  return dirs.some((dir) => {
+    const prefix = `${dir}/`;
+    if (!relative.startsWith(prefix)) return false;
+    const inside = relative.slice(prefix.length);
+    const parts = inside.split("/");
+    if (parts.length === 1) return parts[0].endsWith(".md");
+    return parts.length === 2 && parts[1] === "SKILL.md";
+  });
 }
 
 /** Split a SKILL.md into the fields `writeSkill` needs; null when the frontmatter is unusable. */
@@ -212,7 +216,7 @@ export function splitRemovalHunk(hunk, { oldText, oldLines, recovered }) {
  * workspace yields identical ids.
  */
 export function measureWorkspace(workspace) {
-  const { root, memoryPath, skillsDir, originals } = workspace;
+  const { root, memoryPath, skillsDir, skillDirs = [skillsDir], originals } = workspace;
   /** @type {any[]} */
   const changes = [];
   const stray = [];
@@ -234,7 +238,7 @@ export function measureWorkspace(workspace) {
 
   for (const relative of [...present].sort()) {
     if (originals.has(relative)) continue;
-    if (!isSkillFilePath(relative, skillsDir)) {
+    if (!isSkillFilePath(relative, skillDirs)) {
       stray.push(relative);
       continue;
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { anchoredHunks, countOccurrences, span } from "./diff.js";
 import { parseMemoryUnits } from "./memory.js";
-import { parseFrontmatter } from "./skills.js";
+import { parseFrontmatter, skillBody } from "./skills.js";
 import { sha256 } from "./state.js";
 
 /**
@@ -85,13 +85,11 @@ export function isSkillFilePath(relative, skillsDir) {
 export function parseSkillFile(relative, text) {
   const frontmatter = parseFrontmatter(text);
   if (!frontmatter.name || !frontmatter.description) return null;
-  const end = /^---\n[\s\S]*?\n---\n?/.exec(text);
-  const body = end ? text.slice(end[0].length) : text;
   return {
     name: String(frontmatter.name).trim(),
     description: String(frontmatter.description).trim(),
     path: relative,
-    body: body.trim(),
+    body: skillBody(text),
   };
 }
 

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -946,9 +946,7 @@
 
         // ---- budget gauge ----
         document.getElementById("gauge-title").textContent =
-          "Always-loaded budget · " +
-          (P.memoryFile.path || "") +
-          (budget.descriptionTokens ? " + skill descriptions" : "");
+          "Always-loaded budget · " + (P.memoryFile.path || "");
         document.getElementById("cap-label").textContent = fmt(budget.capTokens) + " tok cap";
         document.getElementById("gauge-now").style.width = pct(budget.current, budget.capTokens) + "%";
 
@@ -985,16 +983,20 @@
           head.appendChild(el("span", "kind", edit.kind === "extract" ? "EXTRACT -> SKILL" : edit.kind.toUpperCase()));
           head.appendChild(el("span", "title", edit.title));
           var delta = edit.deltaTokens || 0;
-          var deltaNode = el(
-            "span",
-            "delta num " + (delta < 0 ? "pos" : delta > 0 ? "neg" : ""),
-            "Δ " +
-              (delta > 0 ? "+" : "") +
-              fmt(delta) +
-              " tok" +
-              (edit.targetsMemoryFile ? "" : " (not always-loaded)"),
+          var descriptionDelta = edit.descriptionDelta || 0;
+          function deltaNode(label, value) {
+            return el(
+              "span",
+              "delta num " + (value < 0 ? "pos" : value > 0 ? "neg" : ""),
+              "Δ " + label + " " + (value > 0 ? "+" : "") + fmt(value) + " tok",
+            );
+          }
+          head.appendChild(
+            edit.targetsMemoryFile
+              ? deltaNode("memory", delta)
+              : deltaNode("on trigger", delta - descriptionDelta),
           );
-          head.appendChild(deltaNode);
+          if (descriptionDelta) head.appendChild(deltaNode("description (always-loaded)", descriptionDelta));
           card.appendChild(head);
 
           var body = el("div", "edit-body");
@@ -1132,7 +1134,8 @@
         function recompute() {
           var accepted = 0,
             rejected = 0,
-            tok = budget.current;
+            tok = budget.current,
+            descriptionTok = budget.descriptionTokens || 0;
           edits.forEach(function (e) {
             if (decisions[e.id] === "accepted") {
               accepted += 1;
@@ -1141,12 +1144,17 @@
               // description a created skill adds). Skill bodies never move this bar.
               if (e.targetsMemoryFile) tok += e.deltaTokens || 0;
               tok += e.descriptionDelta || 0;
+              descriptionTok += e.descriptionDelta || 0;
             } else if (decisions[e.id] === "rejected") {
               rejected += 1;
             }
           });
           var over = tok > budget.capTokens;
 
+          document.getElementById("gauge-title").textContent =
+            "Always-loaded budget · " +
+            (P.memoryFile.path || "") +
+            (descriptionTok > 0 ? " + skill descriptions" : "");
           document.getElementById("n-accept").textContent = accepted;
           document.getElementById("n-reject").textContent = rejected;
 

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -945,8 +945,7 @@
         }
 
         // ---- budget gauge ----
-        document.getElementById("gauge-title").textContent =
-          "Always-loaded budget · " + (P.memoryFile.path || "");
+        document.getElementById("gauge-title").textContent = "Always-loaded budget · " + (P.memoryFile.path || "");
         document.getElementById("cap-label").textContent = fmt(budget.capTokens) + " tok cap";
         document.getElementById("gauge-now").style.width = pct(budget.current, budget.capTokens) + "%";
 
@@ -992,9 +991,7 @@
             );
           }
           head.appendChild(
-            edit.targetsMemoryFile
-              ? deltaNode("memory", delta)
-              : deltaNode("on trigger", delta - descriptionDelta),
+            edit.targetsMemoryFile ? deltaNode("memory", delta) : deltaNode("on trigger", delta - descriptionDelta),
           );
           if (descriptionDelta) head.appendChild(deltaNode("description (always-loaded)", descriptionDelta));
           card.appendChild(head);
@@ -1152,9 +1149,7 @@
           var over = tok > budget.capTokens;
 
           document.getElementById("gauge-title").textContent =
-            "Always-loaded budget · " +
-            (P.memoryFile.path || "") +
-            (descriptionTok > 0 ? " + skill descriptions" : "");
+            "Always-loaded budget · " + (P.memoryFile.path || "") + (descriptionTok > 0 ? " + skill descriptions" : "");
           document.getElementById("n-accept").textContent = accepted;
           document.getElementById("n-reject").textContent = rejected;
 

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -945,7 +945,10 @@
         }
 
         // ---- budget gauge ----
-        document.getElementById("gauge-title").textContent = "Always-loaded budget · " + (P.memoryFile.path || "");
+        document.getElementById("gauge-title").textContent =
+          "Always-loaded budget · " +
+          (P.memoryFile.path || "") +
+          (budget.descriptionTokens ? " + skill descriptions" : "");
         document.getElementById("cap-label").textContent = fmt(budget.capTokens) + " tok cap";
         document.getElementById("gauge-now").style.width = pct(budget.current, budget.capTokens) + "%";
 
@@ -1133,7 +1136,11 @@
           edits.forEach(function (e) {
             if (decisions[e.id] === "accepted") {
               accepted += 1;
+              // The always-loaded projection: memory-file deltas plus each edit's
+              // measured description-line delta (a tuned skill trigger, or the
+              // description a created skill adds). Skill bodies never move this bar.
               if (e.targetsMemoryFile) tok += e.deltaTokens || 0;
+              tok += e.descriptionDelta || 0;
             } else if (decisions[e.id] === "rejected") {
               rejected += 1;
             }

--- a/test/analyze-progress.test.js
+++ b/test/analyze-progress.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runAnalysis } from "../src/commands/analyze.js";
+import { loadConfig } from "../src/config.js";
+import { clearProgressSink, setProgressSink } from "../src/progress.js";
+import { State } from "../src/state.js";
+import { estimateTokens } from "../src/tokens.js";
+import { makeRepo } from "./helpers/staging.js";
+
+const MEMORY = "# Rules\n\n- Keep changes focused.\n";
+const DESCRIPTION = "Load before changing database queries.";
+const SKILL = `---\nname: database\ndescription: ${DESCRIPTION}\n---\n\nRead the schema first.\n`;
+
+test("analysis emits the always-loaded surface for live progress", async () => {
+  const repo = makeRepo({
+    "AGENTS.md": MEMORY,
+    ".agents/skills/database/SKILL.md": SKILL,
+  });
+  const config = loadConfig(repo.root, {
+    memoryFiles: ["AGENTS.md"],
+    skillsDir: ".agents/skills",
+    discovery: { harnesses: [] },
+  });
+  config.state = new State(repo.root).ensure();
+
+  const events = [];
+  setProgressSink((event, data) => events.push({ event, data }));
+  try {
+    await runAnalysis({ repo, config, flags: {}, strict: false });
+  } finally {
+    clearProgressSink();
+  }
+
+  const memory = events.find((event) => event.event === "memory");
+  assert.ok(memory);
+  assert.equal(memory.data.label, "AGENTS.md + skill descriptions");
+  assert.equal(memory.data.tokens, estimateTokens(MEMORY) + estimateTokens(DESCRIPTION));
+});

--- a/test/analyze-reuse.test.js
+++ b/test/analyze-reuse.test.js
@@ -165,9 +165,51 @@ test("editing AGENTS.md without --force reanalyzes and explains that prior evide
     "a memory-file edit invalidates the cache, exactly as documented",
   );
   assert.equal(third.summary.staleMemoryHash, 1, "the invalidation is attributed to the hash change, not a plain miss");
-  assert.match(third.stderr, /evidence from a previous memory-file set/);
+  assert.match(third.stderr, /evidence from a previous memory surface/);
   assert.match(third.stderr, /stale, not missing/);
   assert.match(third.stderr, /sha256:\w+ -> sha256:\w+/, "names the old and new hash");
+});
+
+test("a skill description edit invalidates cached evidence; a body edit is free", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-home-"));
+  const dir = initRepo(MEMORY);
+  const skillFile = path.join(dir, ".agents", "skills", "db", "SKILL.md");
+  const skill = (description, body) => `---\nname: db\ndescription: ${description}\n---\n\n${body}\n`;
+  fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+  fs.writeFileSync(skillFile, skill("old trigger", "- body v1"));
+  writeSession(home, "session-a", dir);
+
+  const first = runAnalyze(dir, home);
+  assert.equal(first.status, 0, first.output);
+  assert.deepEqual([first.summary.analyzed, first.summary.cached], [1, 0]);
+  // The skill layer is part of what the analysis is judged against: the prompt the
+  // model actually received names the skill and its trigger.
+  const promptDir = path.join(dir, ".backpass", "prompts");
+  const prompts = fs.readdirSync(promptDir).map((f) => fs.readFileSync(path.join(promptDir, f), "utf8"));
+  assert.ok(
+    prompts.some((p) => p.includes("db (.agents/skills/db/SKILL.md) :: old trigger")),
+    "the analysis prompt carries the skill index",
+  );
+
+  fs.writeFileSync(skillFile, skill("old trigger", "- body v2, changed"));
+  const second = runAnalyze(dir, home);
+  assert.equal(second.status, 0, second.output);
+  assert.deepEqual(
+    [second.summary.analyzed, second.summary.cached],
+    [0, 1],
+    "nothing is judged against skill bodies, so a body edit is a free rerun",
+  );
+
+  fs.writeFileSync(skillFile, skill("new trigger", "- body v2, changed"));
+  const third = runAnalyze(dir, home);
+  assert.equal(third.status, 0, third.output);
+  assert.deepEqual(
+    [third.summary.analyzed, third.summary.cached],
+    [1, 0],
+    "a description line is always loaded, so editing it re-judges the evidence",
+  );
+  assert.equal(third.summary.staleMemoryHash, 1);
+  assert.match(third.stderr, /evidence from a previous memory surface/);
 });
 
 test("old-hash leftover evidence cannot change the current fold's session count, instruction scores, or gap observations", () => {

--- a/test/distill.test.js
+++ b/test/distill.test.js
@@ -138,6 +138,22 @@ test("sanitizeEvidence tolerates a malformed model response", () => {
   assert.deepEqual(sanitizeEvidence({ positive: "not an array" }).positive, []);
 });
 
+test("a gap's coveredBySkill citation survives sanitization; junk values record nothing", () => {
+  const gap = (extra) => ({
+    proposedInstruction: "Wrap migrations in a transaction.",
+    quote: "dropped the column with no backfill plan",
+    recurrenceRisk: "high",
+    ...extra,
+  });
+  const clean = sanitizeEvidence({
+    gaps: [gap({ coveredBySkill: "  db-schema  " }), gap({ coveredBySkill: "" }), gap({ coveredBySkill: 42 })],
+  });
+  assert.equal(clean.gaps.length, 3);
+  assert.equal(clean.gaps[0].coveredBySkill, "db-schema");
+  assert.ok(!("coveredBySkill" in clean.gaps[1]), "an empty citation is no citation");
+  assert.ok(!("coveredBySkill" in clean.gaps[2]), "a non-string citation is dropped, not coerced");
+});
+
 test("a negative's class survives only as one of the judged values, and never invents harm", () => {
   const clean = sanitizeEvidence({
     negative: [

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -250,6 +250,35 @@ test("failed-trigger citations count per skill and reach the synthesis prompt wi
   );
   assert.equal(partlyCited.gaps.length, 1, "the gap itself still clears its corroboration floor");
   assert.equal(partlyCited.gaps[0].failedTriggerSkill, undefined, "one skill citation cannot clear a two-session floor");
+
+  const citedAfterDuplicate = foldEvidence(
+    [
+      record("s1", {
+        gaps: [
+          { proposedInstruction: "Wrap migrations in a transaction.", quote: "first uncited s1" },
+          {
+            proposedInstruction: "Wrap migrations in a transaction.",
+            quote: "later cited s1",
+            coveredBySkill: "db-schema",
+          },
+        ],
+      }),
+      record("s2", {
+        gaps: [
+          { proposedInstruction: "Wrap migrations in one transaction.", quote: "first uncited s2" },
+          {
+            proposedInstruction: "Wrap migrations in one transaction.",
+            quote: "later cited s2",
+            coveredBySkill: "db-schema",
+          },
+        ],
+      }),
+    ],
+    { memoryFile, minGapEvidence: 2 },
+  );
+  assert.equal(citedAfterDuplicate.gaps[0].sessions, 2);
+  assert.equal(citedAfterDuplicate.gaps[0].failedTriggerSkill, "db-schema");
+  assert.equal(citedAfterDuplicate.gaps[0].failedTriggerSessions, 2);
 });
 
 test("a cluster nobody tied to a skill renders without a failed-trigger line", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -249,7 +249,11 @@ test("failed-trigger citations count per skill and reach the synthesis prompt wi
     { memoryFile, minGapEvidence: 2 },
   );
   assert.equal(partlyCited.gaps.length, 1, "the gap itself still clears its corroboration floor");
-  assert.equal(partlyCited.gaps[0].failedTriggerSkill, undefined, "one skill citation cannot clear a two-session floor");
+  assert.equal(
+    partlyCited.gaps[0].failedTriggerSkill,
+    undefined,
+    "one skill citation cannot clear a two-session floor",
+  );
 
   const citedAfterDuplicate = foldEvidence(
     [

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -238,6 +238,18 @@ test("failed-trigger citations count per skill and reach the synthesis prompt wi
   // The floor is untouched: one cited sighting is still a hidden singleton.
   const single = foldEvidence([covered("s1", "Wrap migrations in a transaction.")], { memoryFile, minGapEvidence: 2 });
   assert.equal(single.gaps.length, 0, "a failed-trigger citation never lowers the corroboration bar");
+
+  const partlyCited = foldEvidence(
+    [
+      covered("s1", "Wrap migrations in a transaction."),
+      record("s2", {
+        gaps: [{ proposedInstruction: "Wrap migrations in one transaction.", quote: "migration escaped" }],
+      }),
+    ],
+    { memoryFile, minGapEvidence: 2 },
+  );
+  assert.equal(partlyCited.gaps.length, 1, "the gap itself still clears its corroboration floor");
+  assert.equal(partlyCited.gaps[0].failedTriggerSkill, undefined, "one skill citation cannot clear a two-session floor");
 });
 
 test("a cluster nobody tied to a skill renders without a failed-trigger line", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -208,3 +208,49 @@ test("harm-class negatives are counted per distinct session, and only explicit h
   assert.equal(rows.get("AG-001").negative, 4);
   assert.equal(rows.get("AG-002").harmSessions, 0, "non-compliance and unclassified never count as harm");
 });
+
+test("failed-trigger citations count per skill and reach the synthesis prompt with the cluster", () => {
+  const covered = (id, phrasing) =>
+    record(id, {
+      gaps: [
+        {
+          proposedInstruction: phrasing,
+          quote: `dropped a column in ${id}`,
+          recurrenceRisk: "high",
+          coveredBySkill: "db-schema",
+        },
+      ],
+    });
+
+  const summary = foldEvidence(
+    [covered("s1", "Wrap migrations in a transaction."), covered("s2", "Wrap migrations in one transaction.")],
+    { memoryFile, minGapEvidence: 2 },
+  );
+
+  assert.equal(summary.gaps.length, 1, "the two phrasings are one gap");
+  assert.equal(summary.gaps[0].failedTriggerSkill, "db-schema");
+  assert.equal(summary.gaps[0].failedTriggerSessions, 2);
+
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.match(rendered, /FAILED TRIGGER: the existing skill "db-schema" already covers this/);
+  assert.match(rendered, /fix that skill's description/);
+
+  // The floor is untouched: one cited sighting is still a hidden singleton.
+  const single = foldEvidence([covered("s1", "Wrap migrations in a transaction.")], { memoryFile, minGapEvidence: 2 });
+  assert.equal(single.gaps.length, 0, "a failed-trigger citation never lowers the corroboration bar");
+});
+
+test("a cluster nobody tied to a skill renders without a failed-trigger line", () => {
+  const summary = foldEvidence(
+    [
+      record("s1", { gaps: [{ proposedInstruction: "Pin the Node version.", quote: "used system node v20" }] }),
+      record("s2", {
+        gaps: [{ proposedInstruction: "Pin the Node version everywhere.", quote: "node drifted again" }],
+      }),
+    ],
+    { memoryFile, minGapEvidence: 2 },
+  );
+  assert.equal(summary.gaps.length, 1);
+  assert.equal(summary.gaps[0].failedTriggerSkill, undefined);
+  assert.ok(!renderEvidenceForPrompt(summary).includes("FAILED TRIGGER"));
+});

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -342,32 +342,47 @@ test("mergeGapEntries drops what it cannot verify instead of guessing", () => {
   assert.ok(ledger.entries["c".repeat(16)], "c stayed untouched");
 });
 
-test("a skill whose content covers a gap retires it; an unrelated skill leaves it open", () => {
+test("failed-trigger evidence survives unchanged skill coverage and retires after a skill fix", () => {
   const phrasing = "Run pnpm lint before committing changes.";
+  const citedSkill = {
+    name: "lint-ritual",
+    path: ".agents/skills/lint-ritual/SKILL.md",
+    description: "Load before committing.",
+    body: `- ${phrasing}\n`,
+  };
   const ledger = { version: 1, entries: {} };
-  recordGapObservations(ledger, [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])]);
+  recordGapObservations(
+    ledger,
+    [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])],
+    { skills: [citedSkill] },
+  );
 
-  // The citation is durable: it survives the ledger round-trip into the fold's input.
   const entry = Object.values(ledger.entries)[0];
   assert.equal(Object.values(entry.sessions)[0].coveredBySkill, "lint-ritual");
   assert.equal(ledgerGapObservations(ledger, MEMORY_PATH)[0].coveredBySkill, "lint-ritual");
 
-  const unrelated = pruneGapLedger(ledger, {
+  const unchanged = pruneGapLedger(ledger, {
     memoryFile: memoryFile(),
     memoryPath: MEMORY_PATH,
     maxAge: "all",
-    skills: [{ description: "Load when cutting a release.", body: "- Tag the release.\n" }],
+    skills: [citedSkill],
   });
-  assert.equal(unrelated.covered, 0, "an unrelated skill covers nothing");
+  assert.equal(unchanged.covered, 0, "the cited pre-existing body is evidence of a failed trigger");
   assert.equal(Object.keys(ledger.entries).length, 1);
 
+  const fixedSkill = { ...citedSkill, body: `# Fixed trigger\n\n- ${phrasing}\n` };
+  recordGapObservations(
+    ledger,
+    [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])],
+    { skills: [fixedSkill] },
+  );
   const stats = pruneGapLedger(ledger, {
     memoryFile: memoryFile(),
     memoryPath: MEMORY_PATH,
     maxAge: "all",
-    skills: [{ description: "Load before committing.", body: `- ${phrasing}\n` }],
+    skills: [fixedSkill],
   });
-  assert.equal(stats.covered, 1, "a gap resolved by a skill retires instead of aging out");
+  assert.equal(stats.covered, 1, "changed skill content that resolves the gap retires it");
   assert.deepEqual(ledger.entries, {});
 });
 

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -8,7 +8,13 @@ import { State } from "../src/state.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
 import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
-import { gapEntryId, mergeGapEntries, pruneGapLedger, recordGapObservations } from "../src/gap-ledger.js";
+import {
+  gapEntryId,
+  ledgerGapObservations,
+  mergeGapEntries,
+  pruneGapLedger,
+  recordGapObservations,
+} from "../src/gap-ledger.js";
 
 const MEMORY_PATH = "AGENTS.md";
 const DAY = 86_400_000;
@@ -334,4 +340,48 @@ test("mergeGapEntries drops what it cannot verify instead of guessing", () => {
   assert.equal(twice, 1, "only the first group merged");
   assert.ok(!ledger.entries["b".repeat(16)], "b was absorbed into a");
   assert.ok(ledger.entries["c".repeat(16)], "c stayed untouched");
+});
+
+test("a skill whose content covers a gap retires it; an unrelated skill leaves it open", () => {
+  const phrasing = "Run pnpm lint before committing changes.";
+  const ledger = { version: 1, entries: {} };
+  recordGapObservations(ledger, [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])]);
+
+  // The citation is durable: it survives the ledger round-trip into the fold's input.
+  const entry = Object.values(ledger.entries)[0];
+  assert.equal(Object.values(entry.sessions)[0].coveredBySkill, "lint-ritual");
+  assert.equal(ledgerGapObservations(ledger, MEMORY_PATH)[0].coveredBySkill, "lint-ritual");
+
+  const unrelated = pruneGapLedger(ledger, {
+    memoryFile: memoryFile(),
+    memoryPath: MEMORY_PATH,
+    maxAge: "all",
+    skills: [{ description: "Load when cutting a release.", body: "- Tag the release.\n" }],
+  });
+  assert.equal(unrelated.covered, 0, "an unrelated skill covers nothing");
+  assert.equal(Object.keys(ledger.entries).length, 1);
+
+  const stats = pruneGapLedger(ledger, {
+    memoryFile: memoryFile(),
+    memoryPath: MEMORY_PATH,
+    maxAge: "all",
+    skills: [{ description: "Load before committing.", body: `- ${phrasing}\n` }],
+  });
+  assert.equal(stats.covered, 1, "a gap resolved by a skill retires instead of aging out");
+  assert.deepEqual(ledger.entries, {});
+});
+
+test("a skill's description line alone can cover a gap", () => {
+  const phrasing = "Always inspect schema documentation before SQL.";
+  const ledger = { version: 1, entries: {} };
+  recordGapObservations(ledger, [record("s1", [phrasing])]);
+
+  const stats = pruneGapLedger(ledger, {
+    memoryFile: memoryFile(),
+    memoryPath: MEMORY_PATH,
+    maxAge: "all",
+    skills: [{ description: "Always inspect schema documentation before writing SQL.", body: "" }],
+  });
+  assert.equal(stats.covered, 1);
+  assert.deepEqual(ledger.entries, {});
 });

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -342,7 +342,7 @@ test("mergeGapEntries drops what it cannot verify instead of guessing", () => {
   assert.ok(ledger.entries["c".repeat(16)], "c stayed untouched");
 });
 
-test("failed-trigger evidence survives unchanged skill coverage and retires after a skill fix", () => {
+test("failed-trigger evidence survives skill body edits", () => {
   const phrasing = "Run pnpm lint before committing changes.";
   const citedSkill = {
     name: "lint-ritual",
@@ -384,21 +384,21 @@ test("failed-trigger evidence survives unchanged skill coverage and retires afte
   });
   assert.equal(afterUnrelatedEdit.covered, 0, "an unrelated body edit preserves the failed-trigger evidence");
 
-  const fixedSkill = {
+  const rewrittenBody = {
     ...unrelatedEdit,
     body: "# Notes\n\nUnrelated details changed.\n\n- Run pnpm lint before committing changes every time.\n",
   };
-  const stats = pruneGapLedger(ledger, {
+  const afterBodyRewrite = pruneGapLedger(ledger, {
     memoryFile: memoryFile(),
     memoryPath: MEMORY_PATH,
     maxAge: "all",
-    skills: [fixedSkill],
+    skills: [rewrittenBody],
   });
-  assert.equal(stats.covered, 1, "changed covering content that resolves the gap retires it");
-  assert.deepEqual(ledger.entries, {});
+  assert.equal(afterBodyRewrite.covered, 0, "body edits never invalidate judged failed-trigger evidence");
+  assert.equal(Object.keys(ledger.entries).length, 1);
 });
 
-test("an unavailable or non-covering cited skill remains ordinary gap evidence", () => {
+test("a missing skill suppresses its citation while body edits preserve judged citations", () => {
   const phrasing = "Run pnpm lint before committing changes.";
   const citedSkill = {
     name: "lint-ritual",
@@ -420,11 +420,11 @@ test("an unavailable or non-covering cited skill remains ordinary gap evidence",
   assert.equal(missing.length, 2);
   assert.ok(missing.every((observation) => observation.coveredBySkill === undefined));
 
-  const noLongerCovered = ledgerGapObservations(ledger, MEMORY_PATH, [
+  const bodyEdited = ledgerGapObservations(ledger, MEMORY_PATH, [
     { ...citedSkill, body: "- Run the formatter before committing.\n" },
   ]);
-  assert.equal(noLongerCovered.length, 2);
-  assert.ok(noLongerCovered.every((observation) => observation.coveredBySkill === undefined));
+  assert.equal(bodyEdited.length, 2);
+  assert.ok(bodyEdited.every((observation) => observation.coveredBySkill === "lint-ritual"));
   assert.equal(Object.values(ledger.entries)[0].sessions.s1.coveredBySkill, "lint-ritual");
   assert.equal(Object.values(ledger.entries)[0].sessions.s2.coveredBySkill, "lint-ritual");
 });

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -396,6 +396,16 @@ test("failed-trigger evidence survives skill body edits", () => {
   });
   assert.equal(afterBodyRewrite.covered, 0, "body edits never invalidate judged failed-trigger evidence");
   assert.equal(Object.keys(ledger.entries).length, 1);
+
+  const descriptionFixed = { ...rewrittenBody, description: phrasing };
+  const afterDescriptionFix = pruneGapLedger(ledger, {
+    memoryFile: memoryFile(),
+    memoryPath: MEMORY_PATH,
+    maxAge: "all",
+    skills: [descriptionFixed],
+  });
+  assert.equal(afterDescriptionFix.covered, 1, "a covering description retires the resolved failed trigger");
+  assert.deepEqual(ledger.entries, {});
 });
 
 test("a missing skill suppresses its citation while body edits preserve judged citations", () => {

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -398,7 +398,7 @@ test("failed-trigger evidence survives unchanged skill coverage and retires afte
   assert.deepEqual(ledger.entries, {});
 });
 
-test("a missing cited skill remains ordinary gap evidence", () => {
+test("an unavailable or non-covering cited skill remains ordinary gap evidence", () => {
   const phrasing = "Run pnpm lint before committing changes.";
   const citedSkill = {
     name: "lint-ritual",
@@ -409,14 +409,24 @@ test("a missing cited skill remains ordinary gap evidence", () => {
   const ledger = { version: 1, entries: {} };
   recordGapObservations(
     ledger,
-    [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])],
+    [
+      record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }]),
+      record("s2", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }]),
+    ],
     { skills: [citedSkill] },
   );
 
-  const observations = ledgerGapObservations(ledger, MEMORY_PATH, []);
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0].coveredBySkill, undefined);
+  const missing = ledgerGapObservations(ledger, MEMORY_PATH, []);
+  assert.equal(missing.length, 2);
+  assert.ok(missing.every((observation) => observation.coveredBySkill === undefined));
+
+  const noLongerCovered = ledgerGapObservations(ledger, MEMORY_PATH, [
+    { ...citedSkill, body: "- Run the formatter before committing.\n" },
+  ]);
+  assert.equal(noLongerCovered.length, 2);
+  assert.ok(noLongerCovered.every((observation) => observation.coveredBySkill === undefined));
   assert.equal(Object.values(ledger.entries)[0].sessions.s1.coveredBySkill, "lint-ritual");
+  assert.equal(Object.values(ledger.entries)[0].sessions.s2.coveredBySkill, "lint-ritual");
 });
 
 test("a skill's description line alone can cover a gap", () => {

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -278,6 +278,25 @@ test("mergeGapEntries unions sessions without double-counting and keeps the shor
   assert.deepEqual(Object.keys(entries[0].sessions).sort(), ["s1", "s2", "shared"], "a session never counts twice");
 });
 
+test("mergeGapEntries preserves absorbed citations for duplicate sessions", () => {
+  const targetId = "a".repeat(16);
+  const absorbedId = "b".repeat(16);
+  const ledger = ledgerWith(
+    { id: targetId, text: "Check the database contract before changing queries.", sessions: ["s1", "s2"] },
+    { id: absorbedId, text: "Read schema docs before SQL edits.", sessions: ["s1", "s2"] },
+  );
+  ledger.entries[absorbedId].sessions.s1.coveredBySkill = "db-schema";
+  ledger.entries[absorbedId].sessions.s2.coveredBySkill = "db-schema";
+
+  mergeGapEntries(ledger, [[targetId, absorbedId]]);
+  const observations = ledgerGapObservations(ledger, MEMORY_PATH, [{ name: "db-schema" }]);
+  const summary = foldEvidence([], { gapObservations: observations, minGapEvidence: 2 });
+
+  assert.equal(observations.length, 2, "each session remains one observation");
+  assert.equal(summary.gaps[0].failedTriggerSkill, "db-schema");
+  assert.equal(summary.gaps[0].failedTriggerSessions, 2);
+});
+
 test("merged gap identities remain durable as the canonical phrasing changes", () => {
   const first = "Always inspect the database schema documentation before composing a production SQL query.";
   const absorbed = "Consult schema before SQL.";

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -138,6 +138,24 @@ function age(h, days) {
   h.state.writeGapLedger(ledger);
 }
 
+test("a later uncited observation preserves the session's failed-trigger citation", () => {
+  const phrasing = "Wrap migrations in a transaction.";
+  const citedThenUncited = (id) =>
+    record(id, [
+      { proposedInstruction: phrasing, coveredBySkill: "db-schema" },
+      { proposedInstruction: phrasing },
+    ]);
+  const ledger = { version: 1, entries: {} };
+
+  recordGapObservations(ledger, [citedThenUncited("s1"), citedThenUncited("s2")]);
+  const observations = ledgerGapObservations(ledger, MEMORY_PATH, [{ name: "db-schema" }]);
+  const summary = foldEvidence([], { gapObservations: observations, minGapEvidence: 2 });
+
+  assert.equal(observations.length, 2);
+  assert.equal(summary.gaps[0].failedTriggerSkill, "db-schema");
+  assert.equal(summary.gaps[0].failedTriggerSessions, 2);
+});
+
 test("a sighting older than gapLedgerMaxAge expires instead of resurfacing indefinitely", async () => {
   const h = harness({ gapLedgerMaxAge: "90d" });
   await run(h, [record("claude-s1", [GAP])]);

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -359,7 +359,7 @@ test("failed-trigger evidence survives unchanged skill coverage and retires afte
 
   const entry = Object.values(ledger.entries)[0];
   assert.equal(Object.values(entry.sessions)[0].coveredBySkill, "lint-ritual");
-  assert.equal(ledgerGapObservations(ledger, MEMORY_PATH)[0].coveredBySkill, "lint-ritual");
+  assert.equal(ledgerGapObservations(ledger, MEMORY_PATH, [citedSkill])[0].coveredBySkill, "lint-ritual");
 
   const unchanged = pruneGapLedger(ledger, {
     memoryFile: memoryFile(),
@@ -370,20 +370,53 @@ test("failed-trigger evidence survives unchanged skill coverage and retires afte
   assert.equal(unchanged.covered, 0, "the cited pre-existing body is evidence of a failed trigger");
   assert.equal(Object.keys(ledger.entries).length, 1);
 
-  const fixedSkill = { ...citedSkill, body: `# Fixed trigger\n\n- ${phrasing}\n` };
+  const unrelatedEdit = { ...citedSkill, body: `# Notes\n\nUnrelated details changed.\n\n- ${phrasing}\n` };
   recordGapObservations(
     ledger,
     [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])],
-    { skills: [fixedSkill] },
+    { skills: [unrelatedEdit] },
   );
+  const afterUnrelatedEdit = pruneGapLedger(ledger, {
+    memoryFile: memoryFile(),
+    memoryPath: MEMORY_PATH,
+    maxAge: "all",
+    skills: [unrelatedEdit],
+  });
+  assert.equal(afterUnrelatedEdit.covered, 0, "an unrelated body edit preserves the failed-trigger evidence");
+
+  const fixedSkill = {
+    ...unrelatedEdit,
+    body: "# Notes\n\nUnrelated details changed.\n\n- Run pnpm lint before committing changes every time.\n",
+  };
   const stats = pruneGapLedger(ledger, {
     memoryFile: memoryFile(),
     memoryPath: MEMORY_PATH,
     maxAge: "all",
     skills: [fixedSkill],
   });
-  assert.equal(stats.covered, 1, "changed skill content that resolves the gap retires it");
+  assert.equal(stats.covered, 1, "changed covering content that resolves the gap retires it");
   assert.deepEqual(ledger.entries, {});
+});
+
+test("a missing cited skill remains ordinary gap evidence", () => {
+  const phrasing = "Run pnpm lint before committing changes.";
+  const citedSkill = {
+    name: "lint-ritual",
+    path: ".agents/skills/lint-ritual/SKILL.md",
+    description: "Load before committing.",
+    body: `- ${phrasing}\n`,
+  };
+  const ledger = { version: 1, entries: {} };
+  recordGapObservations(
+    ledger,
+    [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])],
+    { skills: [citedSkill] },
+  );
+
+  const observations = ledgerGapObservations(ledger, MEMORY_PATH, []);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0].coveredBySkill, undefined);
+  assert.equal(Object.values(ledger.entries)[0].sessions.s1.coveredBySkill, "lint-ritual");
 });
 
 test("a skill's description line alone can cover a gap", () => {

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -141,10 +141,7 @@ function age(h, days) {
 test("a later uncited observation preserves the session's failed-trigger citation", () => {
   const phrasing = "Wrap migrations in a transaction.";
   const citedThenUncited = (id) =>
-    record(id, [
-      { proposedInstruction: phrasing, coveredBySkill: "db-schema" },
-      { proposedInstruction: phrasing },
-    ]);
+    record(id, [{ proposedInstruction: phrasing, coveredBySkill: "db-schema" }, { proposedInstruction: phrasing }]);
   const ledger = { version: 1, entries: {} };
 
   recordGapObservations(ledger, [citedThenUncited("s1"), citedThenUncited("s2")]);
@@ -388,11 +385,9 @@ test("failed-trigger evidence survives skill body edits", () => {
     body: `- ${phrasing}\n`,
   };
   const ledger = { version: 1, entries: {} };
-  recordGapObservations(
-    ledger,
-    [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])],
-    { skills: [citedSkill] },
-  );
+  recordGapObservations(ledger, [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])], {
+    skills: [citedSkill],
+  });
 
   const entry = Object.values(ledger.entries)[0];
   assert.equal(Object.values(entry.sessions)[0].coveredBySkill, "lint-ritual");
@@ -408,11 +403,9 @@ test("failed-trigger evidence survives skill body edits", () => {
   assert.equal(Object.keys(ledger.entries).length, 1);
 
   const unrelatedEdit = { ...citedSkill, body: `# Notes\n\nUnrelated details changed.\n\n- ${phrasing}\n` };
-  recordGapObservations(
-    ledger,
-    [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])],
-    { skills: [unrelatedEdit] },
-  );
+  recordGapObservations(ledger, [record("s1", [{ proposedInstruction: phrasing, coveredBySkill: "lint-ritual" }])], {
+    skills: [unrelatedEdit],
+  });
   const afterUnrelatedEdit = pruneGapLedger(ledger, {
     memoryFile: memoryFile(),
     memoryPath: MEMORY_PATH,

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -156,6 +156,14 @@ test("the run hash is the memory surface: skill identity and descriptions move i
   assert.notEqual(v1.hash, noSkills.hash, "the skill layer is part of the judged surface");
   assert.equal(v1.skills.length, 1, "the loaded skills ride along with the hash they are part of");
 
+  const humanSkill = path.join(repo.root, ".claude/skills/review/SKILL.md");
+  fs.mkdirSync(path.dirname(humanSkill), { recursive: true });
+  fs.writeFileSync(humanSkill, skill("review trigger", "- review body", "review"));
+  const withHumanSkill = primaryMemoryFile(repo, config);
+  assert.equal(withHumanSkill.skills.length, 2, "a real Claude skill root joins the same project memory surface");
+  assert.notEqual(withHumanSkill.hash, v1.hash);
+  fs.rmSync(path.join(repo.root, ".claude"), { recursive: true });
+
   fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skill("old trigger", "- body v2 changed"));
   const v2 = primaryMemoryFile(repo, config);
   assert.equal(v2.hash, v1.hash, "a body edit invalidates nothing - evidence is never judged against bodies");

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -18,7 +18,11 @@ const SEPARATE_CLAUDE = "# Claude notes\n\n- Prefer bun over npm.\n";
 
 function repoWith(files) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-memres-"));
-  for (const [name, text] of Object.entries(files)) fs.writeFileSync(path.join(dir, name), text);
+  for (const [name, text] of Object.entries(files)) {
+    const absolute = path.join(dir, name);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, text);
+  }
   return { root: dir, realRoot: dir, name: path.basename(dir), worktrees: [dir], remotes: [] };
 }
 
@@ -140,4 +144,23 @@ test("no memory file: primaryMemoryFile fails with a pointer to bootstrap", () =
   const repo = repoWith({});
   assert.throws(() => primaryMemoryFile(repo, loadConfig(repo.root)), /no memory file found/);
   assert.equal(resolveMemoryFiles(repo.root, ["AGENTS.md", "CLAUDE.md"]).primary, null);
+});
+
+test("the run hash is the memory surface: skill descriptions move it, bodies do not", () => {
+  const skill = (description, body) => `---\nname: db\ndescription: ${description}\n---\n\n${body}\n`;
+  const repo = repoWith({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": skill("old trigger", "- body v1") });
+  const config = loadConfig(repo.root);
+
+  const noSkills = primaryMemoryFile(repoWith({ "AGENTS.md": AGENTS }), config);
+  const v1 = primaryMemoryFile(repo, config);
+  assert.notEqual(v1.hash, noSkills.hash, "the skill layer is part of the judged surface");
+  assert.equal(v1.skills.length, 1, "the loaded skills ride along with the hash they are part of");
+
+  fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skill("old trigger", "- body v2 changed"));
+  const v2 = primaryMemoryFile(repo, config);
+  assert.equal(v2.hash, v1.hash, "a body edit invalidates nothing - evidence is never judged against bodies");
+
+  fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skill("new trigger", "- body v2 changed"));
+  const v3 = primaryMemoryFile(repo, config);
+  assert.notEqual(v3.hash, v1.hash, "a description edit invalidates evidence like a memory-file edit does");
 });

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -164,7 +164,10 @@ test("the run hash is the memory surface: skill identity and descriptions move i
   const v3 = primaryMemoryFile(repo, config);
   assert.notEqual(v3.hash, v1.hash, "a description edit invalidates evidence like a memory-file edit does");
 
-  fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skill("new trigger", "- body v2 changed", "database"));
+  fs.writeFileSync(
+    path.join(repo.root, ".agents/skills/db/SKILL.md"),
+    skill("new trigger", "- body v2 changed", "database"),
+  );
   const v4 = primaryMemoryFile(repo, config);
   assert.notEqual(v4.hash, v3.hash, "a rendered skill rename invalidates evidence carrying the old name");
 });

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -146,8 +146,8 @@ test("no memory file: primaryMemoryFile fails with a pointer to bootstrap", () =
   assert.equal(resolveMemoryFiles(repo.root, ["AGENTS.md", "CLAUDE.md"]).primary, null);
 });
 
-test("the run hash is the memory surface: skill descriptions move it, bodies do not", () => {
-  const skill = (description, body) => `---\nname: db\ndescription: ${description}\n---\n\n${body}\n`;
+test("the run hash is the memory surface: skill identity and descriptions move it, bodies do not", () => {
+  const skill = (description, body, name = "db") => `---\nname: ${name}\ndescription: ${description}\n---\n\n${body}\n`;
   const repo = repoWith({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": skill("old trigger", "- body v1") });
   const config = loadConfig(repo.root);
 
@@ -163,4 +163,8 @@ test("the run hash is the memory surface: skill descriptions move it, bodies do 
   fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skill("new trigger", "- body v2 changed"));
   const v3 = primaryMemoryFile(repo, config);
   assert.notEqual(v3.hash, v1.hash, "a description edit invalidates evidence like a memory-file edit does");
+
+  fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skill("new trigger", "- body v2 changed", "database"));
+  const v4 = primaryMemoryFile(repo, config);
+  assert.notEqual(v4.hash, v3.hash, "a rendered skill rename invalidates evidence carrying the old name");
 });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -590,6 +590,7 @@ test("apply refuses an accepted subset that exceeds the memory cap before writin
     config: config({ budgetTokens: cap }),
   });
   assert.deepEqual(violations, [], "the complete proposal is valid because the removal pays for the addition");
+  proposal.config.skillsDir = "configured-but-missing";
 
   const results = applyDecisions({
     proposal,

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1685,6 +1685,20 @@ test("a skill file that changed after the proposal refuses the apply; unchanged,
   assert.equal(fs.readFileSync(skillOnDisk, "utf8"), concurrent, "the concurrent version is kept");
   assert.equal(refused.rejectionsRecorded, false);
 
+  const staleRejection = build();
+  const rejectedSkill = path.join(staleRejection.repo.root, ".agents/skills/db/SKILL.md");
+  fs.writeFileSync(rejectedSkill, concurrent);
+  const rejected = applyDecisions({
+    proposal: staleRejection.proposal,
+    decisions: { e1: "rejected" },
+    repo: staleRejection.repo,
+    state: staleRejection.state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.match(rejected.failed[0].error, /\.agents\/skills\/db\/SKILL\.md changed after this proposal was made/);
+  assert.equal(rejected.rejectionsRecorded, false);
+  assert.equal(Object.keys(staleRejection.state.readRejections().entries).length, 0);
+
   // Untouched, the same edit applies and the description lands on disk.
   const fresh = build();
   const applied = applyDecisions({

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1573,7 +1573,7 @@ test("description bloat with an unchanged memory file trips the always-loaded ca
   );
 });
 
-test("apply labels the first skill description as part of the always-loaded surface", () => {
+test("apply measures a legacy skill rewrite missing descriptionDelta", () => {
   const skill = "---\nname: db\ndescription: \n---\n\nbody\n";
   const built = gate({
     files: { ".agents/skills/db/SKILL.md": skill },
@@ -1584,6 +1584,7 @@ test("apply labels the first skill description as part of the always-loaded surf
     annotation: { edits: [claim(["H1"], { title: "add the trigger" })] },
   });
   assert.deepEqual(built.violations, []);
+  delete built.proposal.edits[0].descriptionDelta;
 
   const results = applyDecisions({
     proposal: built.proposal,
@@ -1610,6 +1611,7 @@ test("post-apply warnings label a newly created skill description as always-load
   });
   assert.deepEqual(built.violations, []);
   assert.ok(built.proposal.budget.delta < 0);
+  delete built.proposal.edits[0].descriptionDelta;
 
   const results = applyDecisions({
     proposal: built.proposal,

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1077,7 +1077,9 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
         deltaTokens: -20,
         descriptionDelta: 5,
         hunks: [],
-        skills: [{ name: "setup", path: ".agents/skills/setup/SKILL.md", description: "Load for setup.", body: "body" }],
+        skills: [
+          { name: "setup", path: ".agents/skills/setup/SKILL.md", description: "Load for setup.", body: "body" },
+        ],
         evidence: [],
       },
       {
@@ -1631,8 +1633,7 @@ test("a skill-only shrink reports the remaining always-loaded overage", () => {
   const skill = `---\nname: db\ndescription: ${oldDescription}\n---\n\nbody\n`;
   const built = gate({
     files: { ".agents/skills/db/SKILL.md": skill },
-    edit: (root) =>
-      writeIn(root, ".agents/skills/db/SKILL.md", (text) => text.replace(oldDescription, newDescription)),
+    edit: (root) => writeIn(root, ".agents/skills/db/SKILL.md", (text) => text.replace(oldDescription, newDescription)),
     annotation: { edits: [claim(["H1"], { title: "trim the trigger" })] },
     config: config({ budgetTokens: 100 }),
   });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import vm from "node:vm";
 
 import {
   applyEdit,
@@ -1035,6 +1036,80 @@ test("renderApplySurface writes one valid document through the real template", (
   assert.deepEqual(extractInjectedPayload(html), { ...payload, toolVersion: "0.1.0" });
 });
 
+test("the apply surface separates memory, description, and on-trigger deltas", () => {
+  class Node {
+    constructor(text = "") {
+      this.textContent = text;
+      this.children = [];
+      this.style = {};
+    }
+    appendChild(child) {
+      this.children.push(child);
+      return child;
+    }
+    setAttribute() {}
+    addEventListener() {}
+  }
+  const nodes = new Map();
+  const document = {
+    createElement: () => new Node(),
+    createTextNode: (text) => new Node(String(text)),
+    getElementById: (id) => {
+      if (!nodes.has(id)) nodes.set(id, new Node());
+      return nodes.get(id);
+    },
+  };
+  const textOf = (node) => node.textContent + node.children.map(textOf).join("");
+  const proposal = {
+    generatedAt: "2026-08-01T00:00:00.000Z",
+    repo: { name: "demo" },
+    memoryFile: { path: "AGENTS.md" },
+    stats: { harnessCounts: {}, transcripts: 2, positive: 0, negative: 0, gapClusters: 0, skillExtractions: 1 },
+    config: { maxEditsPerRun: 5, minGapEvidence: 2 },
+    budget: { current: 100, projected: 82, capTokens: 200, descriptionTokens: 0, mode: "cap" },
+    edits: [
+      {
+        id: "e1",
+        kind: "extract",
+        title: "extract setup",
+        file: "AGENTS.md",
+        targetsMemoryFile: true,
+        deltaTokens: -20,
+        descriptionDelta: 5,
+        hunks: [],
+        skills: [{ name: "setup", path: ".agents/skills/setup/SKILL.md", description: "Load for setup.", body: "body" }],
+        evidence: [],
+      },
+      {
+        id: "e2",
+        kind: "rewrite",
+        title: "tighten trigger",
+        file: ".agents/skills/db/SKILL.md",
+        targetsMemoryFile: false,
+        deltaTokens: -3,
+        descriptionDelta: -2,
+        hunks: [],
+        evidence: [],
+      },
+    ],
+  };
+  const repo = makeRepo();
+  const target = renderApplySurface(proposal, new State(repo.root), "0.1.0");
+  const html = fs.readFileSync(target, "utf8");
+  const window = {};
+  window.window = window;
+  for (const match of html.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
+    vm.runInNewContext(match[1], { window, document });
+  }
+
+  const cards = nodes.get("edits").children;
+  assert.match(textOf(cards[0]), /Δ memory -20 tok/);
+  assert.match(textOf(cards[0]), /Δ description \(always-loaded\) \+5 tok/);
+  assert.match(textOf(cards[1]), /Δ on trigger -1 tok/);
+  assert.match(textOf(cards[1]), /Δ description \(always-loaded\) -2 tok/);
+  assert.equal(nodes.get("gauge-title").textContent, "Always-loaded budget · AGENTS.md + skill descriptions");
+});
+
 test("the decision vector from the review surface is parsed back into decisions", () => {
   const ids = ["e1", "e2", "e3"];
   assert.deepEqual(parseDecisions("BACKPASS_DECISIONS e1=accepted e2=rejected e3=accepted", ids), {
@@ -1545,6 +1620,35 @@ test("post-apply warnings label a newly created skill description as always-load
     dryRun: true,
   });
   assert.deepEqual(results.failed, []);
+  assert.match(results.warnings[0], /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/);
+});
+
+test("a skill-only shrink reports the remaining always-loaded overage", () => {
+  const oldDescription = "trigger ".repeat(60).trim();
+  const newDescription = "trigger ".repeat(50).trim();
+  const skill = `---\nname: db\ndescription: ${oldDescription}\n---\n\nbody\n`;
+  const built = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) =>
+      writeIn(root, ".agents/skills/db/SKILL.md", (text) => text.replace(oldDescription, newDescription)),
+    annotation: { edits: [claim(["H1"], { title: "trim the trigger" })] },
+    config: config({ budgetTokens: 100 }),
+  });
+  assert.deepEqual(built.violations, []);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: { e1: "accepted" },
+    repo: built.repo,
+    state: built.state,
+    config: { budgetTokens: 100 },
+    dryRun: true,
+  });
+  assert.deepEqual(results.failed, []);
+  assert.equal(results.written.length, 1);
+  assert.equal(results.written[0].file, ".agents/skills/db/SKILL.md");
+  assert.ok(results.written[0].budget.delta < 0);
+  assert.ok(results.written[0].budget.projected > 100);
   assert.match(results.warnings[0], /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/);
 });
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1498,6 +1498,56 @@ test("description bloat with an unchanged memory file trips the always-loaded ca
   );
 });
 
+test("apply labels the first skill description as part of the always-loaded surface", () => {
+  const skill = "---\nname: db\ndescription: \n---\n\nbody\n";
+  const built = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) =>
+      writeIn(root, ".agents/skills/db/SKILL.md", (text) =>
+        text.replace("description: \n", "description: Load before touching the database.\n"),
+      ),
+    annotation: { edits: [claim(["H1"], { title: "add the trigger" })] },
+  });
+  assert.deepEqual(built.violations, []);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: { e1: "accepted" },
+    repo: built.repo,
+    state: built.state,
+    config: { budgetTokens: estimateTokens(MEMORY_TEXT) },
+  });
+  assert.match(results.failed[0].error, /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/);
+  assert.equal(fs.readFileSync(path.join(built.repo.root, ".agents/skills/db/SKILL.md"), "utf8"), skill);
+});
+
+test("post-apply warnings label a newly created skill description as always-loaded", () => {
+  const skillText =
+    "---\nname: release-signing\ndescription: Release.\n---\n\n- Use Node 18 via nvm before running any script.\n";
+  const built = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text.replace("- Use Node 18 via nvm before running any script.", "- Use the release skill."),
+      );
+      writeIn(root, ".agents/skills/release-signing/SKILL.md", skillText);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract release setup" })] },
+  });
+  assert.deepEqual(built.violations, []);
+  assert.ok(built.proposal.budget.delta < 0);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: { e1: "accepted" },
+    repo: built.repo,
+    state: built.state,
+    config: { budgetTokens: built.proposal.budget.projected - 1 },
+    dryRun: true,
+  });
+  assert.deepEqual(results.failed, []);
+  assert.match(results.warnings[0], /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/);
+});
+
 test("a skill file that changed after the proposal refuses the apply; unchanged, the edit lands", () => {
   const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
   const build = () =>

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -444,7 +444,16 @@ test("a skill's description can be rewritten in place; deletions and stray files
   assert.deepEqual(rewritten.violations, []);
   assert.equal(rewritten.proposal.edits[0].file, ".agents/skills/db/SKILL.md");
   assert.equal(rewritten.proposal.edits[0].targetsMemoryFile, false);
-  assert.equal(rewritten.proposal.budget.delta, 0, "skill files are not always-loaded");
+  // Only the description line of a skill is always-loaded: the budget moves by the
+  // measured description delta, never by the body text around it.
+  const descDelta = estimateTokens("Load before touching the database.") - estimateTokens("old trigger");
+  assert.equal(rewritten.proposal.edits[0].descriptionDelta, descDelta);
+  assert.equal(rewritten.proposal.budget.delta, descDelta, "the description line is the skill's always-loaded cost");
+  assert.deepEqual(
+    rewritten.proposal.targetFiles.map((t) => t.file),
+    [".agents/skills/db/SKILL.md"],
+    "the proposal fingerprints every non-memory file its edits target",
+  );
 
   const deleted = gate({
     files: { ".agents/skills/db/SKILL.md": skill },
@@ -556,7 +565,9 @@ test("applying decisions writes accepted edits, skips rejected ones, and remembe
 
 test("apply refuses an accepted subset that exceeds the memory cap before writing any file", () => {
   const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
-  const cap = estimateTokens(MEMORY_TEXT);
+  // The cap covers the always-loaded surface: the memory file plus the skill's
+  // description line, per the one-cap budget model.
+  const cap = estimateTokens(MEMORY_TEXT) + estimateTokens("old trigger");
   const { proposal, violations, repo, state } = gate({
     files: { ".agents/skills/db/SKILL.md": skill },
     edit: (root) => {
@@ -588,7 +599,10 @@ test("apply refuses an accepted subset that exceeds the memory cap before writin
     config: { budgetTokens: cap },
   });
 
-  assert.match(results.failed[0].error, /accepted edits leave AGENTS\.md .* over the .* budget/);
+  assert.match(
+    results.failed[0].error,
+    /accepted edits leave the always-loaded surface \(AGENTS\.md \+ skill descriptions\) .* over the .* budget/,
+  );
   assert.equal(results.rejectionsRecorded, false);
   assert.deepEqual(results.written, []);
   assert.deepEqual(results.skills, []);
@@ -1442,5 +1456,90 @@ test("a mixed removal reaching EOF without a trailing newline stays one merged h
   assert.ok(
     staged.violations.some((violation) => /do not carry/.test(violation)),
     "the merged hunk still cannot smuggle the deletion through the extract gate",
+  );
+});
+
+test("a pure deletion inside a skill file is a removal with no possible evidence: refused", () => {
+  const skill =
+    "---\nname: db\ndescription: Load before touching the database.\n---\n\n- Always run migrations in a transaction.\n- Never drop a column without a backfill plan.\n";
+  const { violations } = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) =>
+      writeIn(root, ".agents/skills/db/SKILL.md", (t) =>
+        t.replace("- Never drop a column without a backfill plan.\n", ""),
+      ),
+    annotation: {
+      edits: [claim(["H1"], { kind: "remove", title: "drop the backfill rule", transcripts: 9 })],
+    },
+  });
+  assert.ok(
+    violations.some((v) =>
+      /deletes "- Never drop a column without a backfill plan\." from \.agents\/skills\/db\/SKILL\.md/.test(v),
+    ),
+    `expected the skill-deletion floor, got ${JSON.stringify(violations)}`,
+  );
+  assert.ok(violations.some((v) => /no evidence can attribute to skill files/.test(v)));
+});
+
+test("description bloat with an unchanged memory file trips the always-loaded cap", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const bloated = "Load this skill ".repeat(40).trim(); // ~160 tok of description
+  const cap = estimateTokens(MEMORY_TEXT) + estimateTokens("old trigger") + 20;
+  const { violations } = gate({
+    files: { ".agents/skills/db/SKILL.md": skill },
+    edit: (root) => writeIn(root, ".agents/skills/db/SKILL.md", (t) => t.replace("old trigger", bloated)),
+    annotation: { edits: [claim(["H1"], { title: "inflate the trigger" })] },
+    config: config({ budgetTokens: cap }),
+  });
+  assert.ok(
+    violations.some((v) => /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/.test(v) && /over the/.test(v)),
+    `expected the surface cap violation, got ${JSON.stringify(violations)}`,
+  );
+});
+
+test("a skill file that changed after the proposal refuses the apply; unchanged, the edit lands", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const build = () =>
+    gate({
+      files: { ".agents/skills/db/SKILL.md": skill },
+      edit: (root) =>
+        writeIn(root, ".agents/skills/db/SKILL.md", (t) =>
+          t.replace("old trigger", "Load before touching the database."),
+        ),
+      annotation: { edits: [claim(["H1"], { title: "fix the trigger" })] },
+    });
+
+  // Concurrent skill edit between propose and apply: the file no longer matches the
+  // image the hunks were cut from, so nothing anywhere is written.
+  const stale = build();
+  assert.deepEqual(stale.violations, []);
+  const skillOnDisk = path.join(stale.repo.root, ".agents/skills/db/SKILL.md");
+  const concurrent = skill.replace("body", "body, hand-edited meanwhile");
+  fs.writeFileSync(skillOnDisk, concurrent);
+  const refused = applyDecisions({
+    proposal: stale.proposal,
+    decisions: { e1: "accepted" },
+    repo: stale.repo,
+    state: stale.state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.match(refused.failed[0].error, /\.agents\/skills\/db\/SKILL\.md changed after this proposal was made/);
+  assert.deepEqual(refused.written, []);
+  assert.equal(fs.readFileSync(skillOnDisk, "utf8"), concurrent, "the concurrent version is kept");
+  assert.equal(refused.rejectionsRecorded, false);
+
+  // Untouched, the same edit applies and the description lands on disk.
+  const fresh = build();
+  const applied = applyDecisions({
+    proposal: fresh.proposal,
+    decisions: { e1: "accepted" },
+    repo: fresh.repo,
+    state: fresh.state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.deepEqual(applied.failed, []);
+  assert.match(
+    fs.readFileSync(path.join(fresh.repo.root, ".agents/skills/db/SKILL.md"), "utf8"),
+    /description: Load before touching the database\./,
   );
 });

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -9,6 +9,7 @@ import {
   CLAUDE_SKILLS_LINK,
   CLAUDE_SKILLS_LINK_TARGET,
   ensureSkillsLayout,
+  loadProjectSkills,
   loadSkills,
   parseFrontmatter,
   renderSkillFile,
@@ -90,6 +91,28 @@ test("resolveOverflowTarget prefers .agents/skills and never auto-picks bare ski
   assert.equal(resolveOverflowTarget(bare, "skills").dir, "skills");
   // ...but one that does not exist falls back to the canonical dir.
   assert.equal(resolveOverflowTarget(bare, "nope/skills").dir, CANONICAL_SKILLS_DIR);
+});
+
+test("project skill discovery includes separate canonical and Claude roots without double-counting symlinks", () => {
+  const root = tmpRepo();
+  const canonical = path.join(root, CANONICAL_SKILLS_DIR, "generated", "SKILL.md");
+  const claude = path.join(root, CLAUDE_SKILLS_LINK, "hand-written", "SKILL.md");
+  fs.mkdirSync(path.dirname(canonical), { recursive: true });
+  fs.mkdirSync(path.dirname(claude), { recursive: true });
+  fs.writeFileSync(canonical, "---\nname: generated\ndescription: generated trigger\n---\n\nbody\n");
+  fs.writeFileSync(claude, "---\nname: hand-written\ndescription: human trigger\n---\n\nbody\n");
+
+  assert.deepEqual(
+    loadProjectSkills(root).map((skill) => skill.path),
+    [".agents/skills/generated/SKILL.md", ".claude/skills/hand-written/SKILL.md"],
+  );
+
+  fs.rmSync(path.join(root, CLAUDE_SKILLS_LINK), { recursive: true });
+  fs.symlinkSync(CLAUDE_SKILLS_LINK_TARGET, path.join(root, CLAUDE_SKILLS_LINK), "dir");
+  assert.deepEqual(
+    loadProjectSkills(root).map((skill) => skill.name),
+    ["generated"],
+  );
 });
 
 test("ensureSkillsLayout creates the dir and symlink when none exists and is idempotent", () => {

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cmdStatus } from "../src/commands/status.js";
+import { loadConfig } from "../src/config.js";
+import { State } from "../src/state.js";
+import { estimateTokens } from "../src/tokens.js";
+import { makeRepo } from "./helpers/staging.js";
+
+const MEMORY = "# Rules\n\n- Keep changes focused.\n";
+const DESCRIPTION = "Load before changing database queries.";
+const SKILL = `---\nname: database\ndescription: ${DESCRIPTION}\n---\n\n# Database\n\nRead the schema first.\n`;
+
+async function captureStatus(repo, json) {
+  const config = loadConfig(repo.root, {
+    memoryFiles: ["AGENTS.md"],
+    skillsDir: ".agents/skills",
+    budgetTokens: estimateTokens(MEMORY),
+  });
+  config.state = new State(repo.root).ensure();
+  config.agents = {
+    pinned: () => ({ agent: "test", model: null, reason: "test" }),
+    ladder: () => [],
+  };
+
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    await cmdStatus({ repo, config, flags: { json } });
+  } finally {
+    console.log = original;
+  }
+  return lines;
+}
+
+test("status reports one always-loaded budget over memory and skill descriptions", async () => {
+  const repo = makeRepo({
+    "AGENTS.md": MEMORY,
+    ".agents/skills/database/SKILL.md": SKILL,
+  });
+  const expected = estimateTokens(MEMORY) + estimateTokens(DESCRIPTION);
+
+  const structured = JSON.parse((await captureStatus(repo, true)).join("\n"));
+  assert.equal(structured.budgets.length, 1);
+  assert.equal(structured.budgets[0].current, expected);
+  assert.equal(structured.budgets[0].projected, expected);
+  assert.equal(structured.budgets[0].label, "AGENTS.md + skill descriptions");
+  assert.equal(structured.budgets[0].over, estimateTokens(DESCRIPTION));
+
+  const text = (await captureStatus(repo, false)).join("\n");
+  assert.match(text, new RegExp(`AGENTS\\.md \\+ skill descriptions.*${expected} /`));
+  assert.equal((text.match(/AGENTS\.md \+ skill descriptions/g) || []).length, 1);
+});

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -175,7 +175,10 @@ test("fold and synthesis events settle the tail stages", () => {
 // ---------- full frames ----------
 
 const DISCOVERY_SCRIPT = [
-  ["memory", { path: "AGENTS.md", tokens: 2412, budget: 5000, units: 63 }],
+  [
+    "memory",
+    { path: "AGENTS.md", label: "AGENTS.md + skill descriptions", tokens: 2412, budget: 5000, units: 63 },
+  ],
   ["discover:start", { harnesses: ["claude", "codex", "opencode", "grok", "pi"] }],
   ["discover:harness:start", { harness: "claude" }],
   ["discover:harness:done", { harness: "claude", scanned: 214, cached: 131, matched: 38, tiers: { 1: 36, 2: 2 } }],
@@ -195,6 +198,7 @@ test("discovery frame: header gauge, rail, per-harness rows, plain-language labe
 
   assert.ok(text.includes("∇ backpass v1.1.0"));
   assert.ok(text.includes("eddies-wallet · 3 worktrees · since 30d"));
+  assert.ok(text.includes("AGENTS.md + skill descriptions"));
   assert.ok(text.includes("2,412 / 5,000 tok"));
   assert.ok(text.includes("63 instructions · budget 48%"));
   assert.ok(text.includes("sessions from this repo so far"));

--- a/test/tui-render.test.js
+++ b/test/tui-render.test.js
@@ -175,10 +175,7 @@ test("fold and synthesis events settle the tail stages", () => {
 // ---------- full frames ----------
 
 const DISCOVERY_SCRIPT = [
-  [
-    "memory",
-    { path: "AGENTS.md", label: "AGENTS.md + skill descriptions", tokens: 2412, budget: 5000, units: 63 },
-  ],
+  ["memory", { path: "AGENTS.md", label: "AGENTS.md + skill descriptions", tokens: 2412, budget: 5000, units: 63 }],
   ["discover:start", { harnesses: ["claude", "codex", "opencode", "grok", "pi"] }],
   ["discover:harness:start", { harness: "claude" }],
   ["discover:harness:done", { harness: "claude", scanned: 214, cached: 131, matched: 38, tiers: { 1: 36, 2: 2 } }],


### PR DESCRIPTION
## Intent

Extend backpass to treat project-level skills as improvable memory via existing chokepoints only: step 1 close the deletion hole (the removal-evidence floor extends to all indexed files, so pure deletions inside skill files are refused at zero harm evidence - previously they passed ungated); step 2 skill-file freshness at apply (the proposal fingerprints every non-memory edit-target file in proposal.targetFiles, the writer hash-checks each before composing, mirroring memoryFileSnapshot); step 3 failed-triggers-as-data (skill names+descriptions rendered into the analysis prompt, an optional coveredBySkill gap field kept by sanitizeEvidence, per-skill failed-trigger clusters counted through the gap ledger across sessions and rendered to synthesis as failedTriggerSkill/failedTriggerSessions, isCovered extends to skill content so gaps resolved by a skill retire instead of aging out, and skill description text joins the evidence key as a memory-surface hash - a description edit invalidates cached evidence, a body edit never does, a repo without skills keeps its old hash); step 4 skill descriptions enter the always-loaded budget gate (buildProposal, the apply subset gate, the synthesis prompt framing, the adaptive edit cap, and the status/run/apply-surface displays all measure memory file + description lines; bodies stay free until triggered; each edit carries a measured descriptionDelta). Captain decision B: scope is ALL project skills, generated and human-authored alike - deliberately not restricted to backpass-generated ones. Captain decision C: a SINGLE always-loaded cap over memory + descriptions, with the accepted one-time budgetTokens re-tune for repos already carrying many skills (called out in the README) - deliberately no separate description allowance and no delta-only gating. Also includes the captain-approved one-line VISION.md amendment (memory file -> memory surface: the memory file and the project's skills) and matching AGENTS.md sharp-edge updates. Explicitly NOT in scope, by the captain's ruling: step 5 body-level evidence and the corpus probe, step 6 promote edit kind, split/merge/retire gates, and any parallel skill subsystem - every change extends an existing chokepoint. Existing test expectation changes are deliberate semantic updates: the skill-description rewrite test now expects the measured descriptionDelta in the budget, the apply subset-cap test caps the surface (memory + description), and the stale-evidence CLI test expects the 'memory surface' wording. All new proofs are behavioral through real CLI/module interfaces and fixtures (sanitize/fold/ledger/proposal unit tests plus an end-to-end analyze-reuse CLI test for cache invalidation); no source-text tests.

## What Changed

- Include project skill descriptions in analysis, evidence freshness, failed-trigger corroboration, and gap coverage.
- Enforce deletion evidence and file-freshness gates for proposed skill edits.
- Apply one always-loaded budget across the memory file and skill descriptions, with measured description deltas reflected throughout proposal, apply, status, and review surfaces.

## Risk Assessment

🚨 High: A common human-authored project skill layout remains outside every newly added memory-surface chokepoint, contradicting an explicit required scope.

## Testing

Targeted tests covered deletion gating, target freshness, failed-trigger citation retention and retirement, surface budgeting, displays, and cache semantics. The end-to-end CLI evidence confirms status counts skill descriptions, body-only edits reuse evidence, and description edits invalidate and reanalyze it. All checks passed and the worktree remained clean.

<details>
<summary>Evidence: Project skills as memory CLI transcript</summary>

Source: [Project skills as memory CLI transcript](https://github.com/kunchenguid/backpass/blob/8551e227bb7f446aaf5bbd7612e92cc0681d1d27/.no-mistakes/evidence/fm/backpass-project-skills-as-memory-s1/project-skills-memory-cli.txt)

```text
$ backpass status --json
{
  "repo": "repo",
  "budgets": [
    {
      "path": "AGENTS.md",
      "label": "AGENTS.md + skill descriptions",
      "capTokens": 5000,
      "current": 19,
      "projected": 19,
      "delta": 0,
      "withinBudget": true,
      "over": 0,
      "utilization": 0.0038,
      "instructions": 1,
      "pointerTo": null,
      "separate": false
    }
  ],
  "evidence": {
    "ok": 0,
    "failed": 0,
    "skipped": 0
  },
  "scanCacheEntries": 0,
  "summary": null,
  "proposal": null,
  "rejections": 0,
  "skills": 1
}

$ backpass analyze ... # initial skill description + body
{"total":1,"cached":0,"analyzed":1,"skipped":0,"failed":0,"usage":[{"agent":"pi","usage":null}],"staleMemoryHash":0}
$ backpass analyze ... # after body-only edit
{"total":1,"cached":1,"analyzed":0,"skipped":0,"failed":0,"usage":[],"staleMemoryHash":0}
$ backpass analyze ... # after description edit
{"total":1,"cached":0,"analyzed":1,"skipped":0,"failed":0,"usage":[{"agent":"pi","usage":null}],"staleMemoryHash":1}
stderr:
· 1 transcript(s) have evidence from a previous memory surface (sha256:34e1f201a9ed0eb3 -> sha256:14ed65aee7553ea4); that evidence is stale, not missing, and reuse resumes once this pass re-judges it against the current memory file and skill descriptions
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"82825b40d1f17b63fc08a1e06e129976b85825b9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/gap-ledger.js:189` - Failed-trigger sightings can be deleted in the same fold that records them. If analysis reports `coveredBySkill: &#34;db&#34;` because the existing db skill body contains the proposed instruction, `recordGapObservations` adds the sighting and this coverage check immediately matches that same body and removes the ledger entry. It can therefore never corroborate across sessions. Preserve failed-trigger entries when coverage comes from the cited skill&#39;s pre-existing body, while still retiring gaps genuinely resolved by memory or skill changes.
- 🚨 `src/fold.js:134` - The required criterion says failed-trigger citations are corroborated per skill across sessions before synthesis is told to fix a trigger, but `failedTriggerOf` emits the most-cited skill without applying `minGapEvidence` to that skill. A two-session gap where only one session cites `db`, or each session cites a different skill, still produces a `FAILED TRIGGER` instruction backed by one citation. Require the winning skill itself to meet the corroboration floor.
- 🚨 `src/apply/writer.js:227` - Apply loads descriptions from the raw configured `skillsDir`, while analysis and synthesis use `resolveOverflowTarget`. With a configured custom directory that does not exist, proposal construction falls back to `.agents/skills` and counts its descriptions, but apply loads zero descriptions and can incorrectly pass the cap or shrink gate. Resolve the effective directory through the same chokepoint before loading skills.
- 🚨 `src/commands/status.js:29` - The required criterion says the status display measures memory plus description lines, but `budgets` still contains bare memory-file values and is returned unchanged by `status --json`. Text mode also prints that bare value under `BUDGET (always-loaded)` before a separate combined row. Make the primary status budget, including its JSON contract, represent the single always-loaded surface.
- ⚠️ `src/memory.js:162` - The analysis prompt includes skill names and records those names in `coveredBySkill`, but the evidence hash includes only path and description. Renaming a skill without changing its path or description reuses cached evidence carrying the old name, which can later direct synthesis toward a nonexistent skill. Include the rendered skill name in the judged-surface fingerprint while continuing to exclude body content.

🔧 Fix: Fix skill coverage, budgeting, and evidence freshness
5 issues (4 errors, 1 warning) still open:

- 🚨 `src/fold.js:134` - Intent requires per-skill failed-trigger corroboration across sessions, but the threshold is applied only to the whole gap cluster. Two sessions can form a cluster while only one cites `db`, yet `failedTriggerOf` still emits `FAILED TRIGGER` with one supporting session. Require the selected skill&#39;s own citation count to meet `minGapEvidence`.
- 🚨 `src/commands/status.js:29` - Intent requires status displays to measure memory plus description lines, but `budgets` still reports bare memory-file values in JSON and text mode labels those values as always-loaded before printing a second combined row. Make the primary status budget contract represent the single always-loaded surface.
- 🚨 `src/commands/analyze.js:59` - Intent requires the run display to measure memory plus description lines, but the live TUI `memory` event still receives only `file.tokens`; `src/tui/render.js` uses that value for its budget gauge throughout the run. Emit the always-loaded surface token count and an accurate label.
- 🚨 `src/gap-ledger.js:230` - The failed-trigger snapshot hashes the entire skill, so an unrelated body edit makes the cited skill appear changed and causes `pruneGapLedger` to retire the gap if the original covering instruction remains. Concrete path: record a failed trigger, edit an unrelated paragraph in that skill, reuse cached evidence as allowed for body edits, then fold; the changed whole-skill hash permits coverage and deletes the cross-run evidence. Compare the trigger description and relevant covering content rather than unrelated body bytes.
- ⚠️ `src/gap-ledger.js:264` - Failed-trigger names are emitted without checking that they resolve to a current skill. Two model responses can cite a hallucinated name, or a previously cited skill can later be deleted, and synthesis is then instructed to edit a nonexistent skill. Preserve the gap as ordinary evidence but expose `failedTriggerSkill` only for names present in the current skill index.

🔧 Fix: Preserve failed-trigger evidence across unrelated skill edits
3 errors still open:

- 🚨 `src/fold.js:134` - The required per-skill corroboration is still absent. A gap cluster can reach `minGapEvidence` with two sessions while only one cites `db`, yet `failedTriggerOf` emits `FAILED TRIGGER` backed by that single citation. Require the selected skill&#39;s citation count to meet the corroboration floor.
- 🚨 `src/commands/status.js:29` - The required status display still reports bare memory-file budgets through the primary `budgets` JSON contract and labels those values as always-loaded in text mode. The separately appended combined row does not correct the wrong primary values. Make `budgets` measure memory plus skill descriptions.
- 🚨 `src/commands/analyze.js:59` - The required run display still sends only `file.tokens` to the live TUI. `src/tui/render.js` uses this value for the budget gauge, so TTY runs omit skill-description tokens even though the gate includes them. Emit the always-loaded surface count and corresponding label.

🔧 Fix: Enforce corroborated triggers and unified surface budgets
2 issues (1 error, 1 warning) still open:

- 🚨 `src/gap-ledger.js:267` - A cached failed-trigger citation remains active after the named skill stops covering the gap. Concrete path: two sessions cite `db`, their coverage hashes are recorded, then a human removes or rewrites the covering body unit. Body edits intentionally preserve the evidence cache, `pruneGapLedger` keeps the unresolved gap, and this projection checks only that `db` still exists, so `foldEvidence` still instructs synthesis to fix `db`&#39;s description even though its body no longer contains the knowledge. Preserve the ordinary gap, but suppress `coveredBySkill` when recorded coverage hashes no longer occur in the current named skill.
- ⚠️ `src/apply/writer.js:45` - Apply labels the budget from current description tokens only. When an accepted extraction or skill edit adds the repository&#39;s first description tokens, the projection includes them but cap errors still claim bare `AGENTS.md` exceeded the budget. The post-apply warning at line 471 has the same issue and can claim the file itself is over when only the projected memory surface is over. Select the surface label using current plus accepted or landed `descriptionDelta`.

🔧 Fix: Validate current skill coverage and surface labels
3 issues (2 errors, 1 warning) still open:

- 🚨 `src/gap-ledger.js:230` - The body-hash machinery contradicts the required judged-citation model and the explicit rule that body edits never invalidate cached evidence. A model can cite a semantically covering skill whose wording is below the lexical 0.6 threshold; `matchingCoverageHashes` then records no hashes and lines 273-276 immediately discard the citation. Likewise, changing an unrelated continuation within the matched body unit changes its hash and suppresses previously corroborated failed-trigger evidence. This also introduces the explicitly excluded body-level evidence behavior. Revert this machinery to the minimal failed-trigger fix rather than making judged citations contingent on lexical body-unit hashes.
- 🚨 `templates/apply.html:989` - The required apply surface still presents the wrong per-edit budget semantics. A skill description rewrite is labeled using the entire skill-file delta as &#34;not always-loaded&#34; even when `descriptionDelta` is nonzero, while an extraction card omits its new description cost. The gauge title also omits skill descriptions when the accepted extraction creates the first one. Render the measured memory delta and description delta separately, consistent with the terminal surface and the single always-loaded cap.
- ⚠️ `src/apply/writer.js:450` - A skill-only shrink never receives a post-apply budget result or over-budget warning because budget calculation is attached only to a planned memory-file write. For example, reducing a skill description from a 5,100-token surface to 5,090 tokens succeeds but returns no warning that the surface remains over the 5,000-token cap. Compute the landed surface result independently of whether the memory file was among the written files.

🔧 Fix: Restore judged triggers and unify apply surface budgets
2 issues (1 error, 1 warning) still open:

- 🚨 `src/gap-ledger.js:222` - The latest fix blanket-excludes every unit from a cited skill from coverage forever. Concrete path: two sessions cite `db`, synthesis improves `db`&#39;s description, then future pruning still sets `isFailedTrigger` for every `db` description/body unit, so the resolved gap remains in the ledger and continues producing failed-trigger evidence until expiry. This contradicts the required criterion that &#34;isCovered extends to skill content so gaps resolved by a skill retire instead of aging out.&#34; Reconsider this fix at the failed-trigger/pruning boundary; distinguishing original cited coverage from a later resolution requires authorization because body edits must also remain non-invalidating.
- ⚠️ `src/fold.js:182` - Failed-trigger counts silently depend on observation order when one session contributes multiple observations that cluster together. If each of two sessions first has an uncited phrasing and later a `coveredBySkill: &#34;db&#34;` phrasing, the later items are discarded because those session IDs already exist, leaving a two-session gap with zero trigger citations. Preserve citation information per distinct session while deduplicating the cluster&#39;s session count.

🔧 Fix: Retire fixed triggers and preserve duplicate citations
2 issues (1 error, 1 warning) still open:

- 🚨 `src/apply/writer.js:45` - The apply gate trusts persisted `descriptionDelta` values instead of measuring the accepted skill changes it composes. A proposal created by the previous version can rewrite a short skill description to a large one without this field; after upgrading, apply adds zero description tokens at lines 45 and 447, so the accepted subset can exceed the new single always-loaded cap without failing or warning. Recompute description deltas from the composed skill texts and created skills at the apply preflight boundary, retaining legacy proposal compatibility without bypassing the cap.
- ⚠️ `src/gap-ledger.js:296` - The duplicate-citation fix still loses citations on the production ledger path. If one session reports two paraphrases below the lexical threshold, only one cites `db`, and consolidation later judges the two ledger entries identical, `mergeGapEntries` keeps the target session observation and discards the absorbed observation&#39;s `coveredBySkill`. Repeating this in two sessions yields a corroborated gap with zero failed-trigger citations after `ledgerGapObservations`, despite `fold.js` now preserving duplicates presented directly to it. Preserve citation information when duplicate session observations are recorded or merged, before the ledger flattens them.

🔧 Fix: Measure legacy apply budgets and preserve merged citations
2 issues (1 error, 1 warning) still open:

- 🚨 `src/apply/writer.js:245` - Freshness checks cover only accepted skill edits. If a target skill changes after proposal creation and the reviewer rejects its edit, the hash is never checked, yet the stale rejection is persisted and can suppress a future valid proposal with the same hunk. Validate every decided non-memory target before recording rejections, matching the memory-file snapshot gate.
- ⚠️ `src/gap-ledger.js:149` - Recording multiple observations from one session can still erase a failed-trigger citation before consolidation. If two same-gap observations occur in order cited then uncited, the second assignment replaces the session object without `coveredBySkill`; repeating this in two sessions yields a corroborated gap with no failed-trigger signal. Preserve a prior session citation when its replacement lacks one.

🔧 Fix: Validate rejected targets and preserve prior trigger citations
1 error still open:

- 🚨 `src/commands/analyze.js:42` - The required scope is &#34;ALL project skills, generated and human-authored alike,&#34; but this new read path loads only the single directory selected by `resolveOverflowTarget`. Concrete path: with a human-authored `.claude/skills/db/SKILL.md` real directory and default configuration, `resolveOverflowTarget` warns and returns `.agents/skills`; analysis therefore sees no skills, the surface hash and budget omit the description, and failed-trigger detection cannot cite it. Supporting multiple project skill roots changes deliberate skill-discovery behavior, so confirm the intended roots with the user rather than silently narrowing the stated requirement.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/analyze-reuse.test.js test/fold.test.js test/gap-ledger.test.js test/proposal.test.js test/status.test.js`
- `node --test test/analyze-progress.test.js test/distill.test.js test/memory-resolution.test.js test/tui-render.test.js`
- <code>Manual CLI flow in a temporary git repository: ran `backpass status --json`, analyzed once, edited only a skill body and reanalyzed, then edited the skill description and reanalyzed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
