### PR TITLE
fix: select OpenCode variants via session-local ACP effort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,8 +238,7 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   `set thought_level` (those rewrite `~/.pi/agent/settings.json`) and never edit-then-restore
   harness defaults. `src/harness-invoke.js` owns the harness overlay mechanisms and
   `src/acpx.js` owns verification and fallback. An unproven overlay must stop rather than
-  pretend; OpenCode effort alone is skipped with a report note. Preserve the current spawn
-  when no override is requested.
+  pretend. Preserve the current spawn when no override is requested.
 - **Agent auto-pick is probe-then-verify, never probe-only.** `src/agents.js` walks each
   role's ladder with a zero-token probe, but the claude adapter cannot be pre-verified by
   acpx (sessions succeed while logged out), so every real call runs under

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ backpass \
 `--no-auto-agent` pins the pre-ladder defaults (codex / claude). Model and effort
 overrides are scoped to that Backpass invocation, so they never rewrite your harness
 defaults. If an adapter has no proven overlay, backpass stops rather than pretending it
-applied, except OpenCode effort which is skipped with a report note.
+applied.
 
 ### Configuration
 

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -37,9 +37,9 @@ export function acpxAgentName(agent) {
  * `set` is session-local. Pi is absent: ACP `set thought_level` rewrites
  * `~/.pi/agent/settings.json`, so Pi effort is process `--thinking` instead
  * (`src/harness-invoke.js`). Grok uses process `--reasoning-effort`. OpenCode
- * has no overlay; effort is skipped with a report note, never silently.
+ * uses ACP `set effort`, which is session-local variant state.
  */
-export const EFFORT_OPTION_KEYS = { codex: "reasoning_effort", claude: "effort" };
+export const EFFORT_OPTION_KEYS = { codex: "reasoning_effort", claude: "effort", opencode: "effort" };
 
 export function effortOptionKey(agent) {
   return EFFORT_OPTION_KEYS[agent] || null;
@@ -335,8 +335,7 @@ export async function execOneShot({
  * effort for every harness, so an effortful call still goes through a session when
  * the overlay needs one. Synthesis also needs more than one turn in the same context:
  * the agent edits the staging copy, then annotates the changes backpass measured.
- * OpenCode alone skips its unsupported effort overlay with a report line. Every other
- * requested overlay without a proven mechanism stops rather than pretending it applied.
+ * A requested overlay without a proven mechanism stops rather than pretending it applied.
  *
  * Resolves to the handle, or throws an `AcpxError` (`unsupported: true` when the adapter
  * has no session support; `sessionPrompt` only falls back when it can preserve the requested overlays).
@@ -486,7 +485,7 @@ function subtractUsage(current, previous) {
  * One prompt through a short-lived named session: open, prompt, close. The analysis
  * pass uses this whenever an effort is configured. Without session support, it falls
  * back to one-shot `exec` only when that preserves the requested overlays; otherwise it
- * stops with actionable guidance. OpenCode effort remains the explicit reported skip.
+ * stops with actionable guidance.
  */
 export async function sessionPrompt({
   agent,
@@ -505,20 +504,17 @@ export async function sessionPrompt({
     session = await openSession({ agent, model, effort, sessionName, cwd });
   } catch (err) {
     if (!(err instanceof AcpxError) || !err.unsupported) throw err;
-    if (effort && (agent === "claude" || agent === "codex")) {
+    if (effort && effortOptionKey(agent)) {
       throw new UserError(
         `${agent} cannot apply invocation-scoped effort=${effort} because its acpx adapter does not support sessions`,
         "upgrade acpx or omit the effort override",
       );
     }
     const notes = [`session unsupported for ${agent}; fell back to exec one-shot`];
-    if (effort && agent === "opencode") {
-      notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${effort}`);
-    }
     const fallback = await execOneShot({
       agent,
       model,
-      effort: agent === "opencode" ? null : effort,
+      effort,
       promptFile,
       cwd,
       timeoutSeconds,

--- a/src/agents.js
+++ b/src/agents.js
@@ -353,11 +353,10 @@ export class AgentResolver {
    */
   async resolve(role) {
     if (this.picks[role]) return this.picks[role];
-    const effort = this.config[role].effort || DEFAULT_EFFORT[role];
 
     const pinned = this.pinned(role);
     if (pinned) {
-      this.picks[role] = { ...pinned, effort };
+      this.picks[role] = { ...pinned, effort: resolvedEffort(role, pinned.agent, this.config) };
       return this.picks[role];
     }
 
@@ -377,7 +376,7 @@ export class AgentResolver {
           agent: candidate.agent,
           model: entry.resolvedModel || candidate.model,
           ladderModel: candidate.model,
-          effort,
+          effort: resolvedEffort(role, candidate.agent, this.config),
           pinned: false,
           reason: describeTrail(trail),
         };
@@ -391,7 +390,7 @@ export class AgentResolver {
   announce(role, pick, trail) {
     const losers = trail.filter((t) => t.verdict !== "ok");
     const cached = trail.at(-1)?.cached ? color.dim(" (cached)") : "";
-    info(`${color.cyan("·")} ${role}: ${pick.agent} (${pick.model}) effort=${pick.effort}${cached}`);
+    info(`${color.cyan("·")} ${role}: ${pick.agent} (${pick.model}) effort=${pick.effort || "unset"}${cached}`);
     for (const t of losers) {
       info(color.dim(`    skipped ${t.agent}/${t.model}: ${VERDICT_LABELS[t.verdict] || t.verdict}`));
     }
@@ -436,6 +435,14 @@ export class AgentResolver {
       }
     }
   }
+}
+
+/** OpenCode variants are per-model, so role defaults do not become an overlay. */
+export function resolvedEffort(role, agent, config) {
+  const configured = config[role].effort;
+  if (typeof configured === "string" && configured.trim()) return configured.trim();
+  if (agent === "opencode") return null;
+  return DEFAULT_EFFORT[role];
 }
 
 function describeTrail(trail) {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -12,7 +12,6 @@ import {
 import { crossSurfaceDuplicates } from "../overlap.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 import { table } from "./scan.js";
-import { DEFAULT_EFFORT } from "../config.js";
 import { candidateKey, isProbeEntryFresh, resolvedEffort } from "../agents.js";
 
 export async function cmdStatus(ctx) {
@@ -175,8 +174,10 @@ function describeRole(config, role) {
       return `${candidate.agent}/${entry.resolvedModel || candidate.model} (effort ${formatEffort(resolvedEffort(role, candidate.agent, config))}, auto - probed ${entry.checkedAt.slice(0, 16).replace("T", " ")})`;
     }
   }
+  const configured =
+    typeof config[role].effort === "string" && config[role].effort.trim() ? config[role].effort.trim() : null;
   return color.dim(
-    `auto - ${config.agents.ladder(role).length} candidates, none probed yet (effort ${config[role].effort || DEFAULT_EFFORT[role]})`,
+    `auto - ${config.agents.ladder(role).length} candidates, none probed yet (effort ${formatEffort(configured)})`,
   );
 }
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -176,9 +176,8 @@ function describeRole(config, role) {
   }
   const configured =
     typeof config[role].effort === "string" && config[role].effort.trim() ? config[role].effort.trim() : null;
-  return color.dim(
-    `auto - ${config.agents.ladder(role).length} candidates, none probed yet (effort ${formatEffort(configured)})`,
-  );
+  const count = `auto - ${config.agents.ladder(role).length} candidates, none probed yet`;
+  return color.dim(configured ? `${count} (effort ${configured})` : count);
 }
 
 function formatEffort(effort) {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -13,7 +13,7 @@ import { crossSurfaceDuplicates } from "../overlap.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 import { table } from "./scan.js";
 import { DEFAULT_EFFORT } from "../config.js";
-import { candidateKey, isProbeEntryFresh } from "../agents.js";
+import { candidateKey, isProbeEntryFresh, resolvedEffort } from "../agents.js";
 
 export async function cmdStatus(ctx) {
   const { repo, config } = ctx;
@@ -164,17 +164,22 @@ export async function cmdStatus(ctx) {
  */
 function describeRole(config, role) {
   const pinned = config.agents.pinned(role);
-  const effort = config[role].effort || DEFAULT_EFFORT[role];
   if (pinned) {
-    return `${pinned.agent}${pinned.model ? `/${pinned.model}` : ""} (effort ${effort}, ${pinned.reason})`;
+    return `${pinned.agent}${pinned.model ? `/${pinned.model}` : ""} (effort ${formatEffort(resolvedEffort(role, pinned.agent, config))}, ${pinned.reason})`;
   }
   const cache = config.state.readProbeCache();
   for (const candidate of config.agents.ladder(role)) {
     const entry = cache.entries[candidateKey(candidate)];
     if (!isProbeEntryFresh(entry)) continue;
     if (entry.verdict === "ok") {
-      return `${candidate.agent}/${entry.resolvedModel || candidate.model} (effort ${effort}, auto - probed ${entry.checkedAt.slice(0, 16).replace("T", " ")})`;
+      return `${candidate.agent}/${entry.resolvedModel || candidate.model} (effort ${formatEffort(resolvedEffort(role, candidate.agent, config))}, auto - probed ${entry.checkedAt.slice(0, 16).replace("T", " ")})`;
     }
   }
-  return color.dim(`auto - ${config.agents.ladder(role).length} candidates, none probed yet (effort ${effort})`);
+  return color.dim(
+    `auto - ${config.agents.ladder(role).length} candidates, none probed yet (effort ${config[role].effort || DEFAULT_EFFORT[role]})`,
+  );
+}
+
+function formatEffort(effort) {
+  return effort || "unset";
 }

--- a/src/config.js
+++ b/src/config.js
@@ -63,7 +63,8 @@ export const DEFAULT_CONFIG = {
   seed: null,
   /**
    * `agent: null` means auto-pick from `ladders[role]`; `effort: null` means
-   * `DEFAULT_EFFORT[role]`. Setting `agent` pins the role and skips the ladder.
+   * `DEFAULT_EFFORT[role]`, except OpenCode which omits the overlay until effort
+   * is set. Setting `agent` pins the role and skips the ladder.
    */
   analysis: { agent: null, model: null, effort: null },
   synthesis: { agent: null, model: null, effort: null },

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -19,7 +19,7 @@ import { UserError } from "./logger.js";
  *   grok      process argv via acpx `--agent` wrapper: `-m`, `--reasoning-effort`
  *   claude    acpx `--model` at `sessions new` (session/new `_meta`); ACP `set effort`
  *   codex     acpx `--model` at `sessions new`; ACP `set reasoning_effort`
- *   opencode  acpx `--model` at `sessions new`; no effort overlay (report, never pretend)
+ *   opencode  acpx `--model` at `sessions new`; ACP `set effort` (session-local variant)
  *
  * Synthesis also requests `writeAccess`: native file-write / code-mode must be on for
  * this spawn, never by rewriting `~/.codex/config.toml` or other harness defaults.
@@ -32,12 +32,11 @@ import { UserError } from "./logger.js";
  *
  * No overlay requested means no wrapper, no `--model`, no `set` - same spawn as before.
  * A requested overlay with no proven invocation-scoped mechanism throws rather than
- * writing persistent defaults or silently ignoring the request. OpenCode effort is the
- * sole explicit exception: it is skipped with a report note.
+ * writing persistent defaults or silently ignoring the request.
  */
 
 /** ACP session-config ids used only when that `set` is session-local, not a persist path. */
-const SESSION_LOCAL_EFFORT_KEYS = { codex: "reasoning_effort", claude: "effort" };
+const SESSION_LOCAL_EFFORT_KEYS = { codex: "reasoning_effort", claude: "effort", opencode: "effort" };
 
 /**
  * @typedef {{
@@ -84,20 +83,11 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null, w
         : baseInvocation({ notes, dispose });
     } else if (agent === "grok") {
       invocation = grokInvocation({ requestedModel, requestedEffort, writeAccess, notes, cleanups, dispose });
-    } else if (agent === "claude" || agent === "codex") {
+    } else if (agent === "claude" || agent === "codex" || agent === "opencode") {
       invocation = {
         ...baseInvocation({ notes, dispose }),
         acpxModel: requestedModel,
         setEffortKey: requestedEffort ? SESSION_LOCAL_EFFORT_KEYS[agent] : null,
-        requiredBuiltinAgent: overlay ? agent : null,
-      };
-    } else if (agent === "opencode") {
-      if (requestedEffort) {
-        notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${requestedEffort}`);
-      }
-      invocation = {
-        ...baseInvocation({ notes, dispose }),
-        acpxModel: requestedModel,
         requiredBuiltinAgent: overlay ? agent : null,
       };
     } else if (overlay) {

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -386,6 +386,24 @@ test("explicit config or CLI flags pin the role and skip the ladder entirely", a
     { agent: synthesis.agent, model: synthesis.model, effort: synthesis.effort, pinned: synthesis.pinned },
     { agent: "claude", model: "claude-opus-5", effort: "max", pinned: true },
   );
+  const opencodeConfig = loadConfig(tmpRepo({ analysis: { agent: "opencode", model: "xai/grok-4.6" } }), {
+    synthesis: { agent: "opencode", model: "xai/grok-4.6", effort: "xhigh" },
+  });
+  const { resolver: opencodeResolver, calls: opencodeCalls } = resolverWith({}, { config: opencodeConfig });
+  const opencodeAnalysis = await opencodeResolver.resolve("analysis");
+  assert.deepEqual(
+    {
+      agent: opencodeAnalysis.agent,
+      model: opencodeAnalysis.model,
+      effort: opencodeAnalysis.effort,
+      pinned: opencodeAnalysis.pinned,
+    },
+    { agent: "opencode", model: "xai/grok-4.6", effort: null, pinned: true },
+  );
+  const opencodeSynthesis = await opencodeResolver.resolve("synthesis");
+  assert.equal(opencodeSynthesis.effort, "xhigh");
+  assert.deepEqual(opencodeCalls, [], "pinned OpenCode skips the ladder");
+
   assert.deepEqual(calls, [], "nothing was probed");
 
   // A pinned agent is the user's decision: an auth failure surfaces as a UserError, it does not fall through.
@@ -660,6 +678,7 @@ test("acpx failure classification and the per-adapter tables", () => {
   assert.equal(acpxAgentName("codex"), "codex");
   assert.equal(effortOptionKey("codex"), "reasoning_effort");
   assert.equal(effortOptionKey("claude"), "effort");
+  assert.equal(effortOptionKey("opencode"), "effort");
   assert.equal(effortOptionKey("pi"), null, "Pi effort is process --thinking, not ACP set");
   assert.equal(effortOptionKey("grok"), null);
 });

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -604,7 +604,24 @@ test("Codex session passes --model at create and ACP set reasoning_effort, never
   assert.deepEqual(jsonl(codexLog), []);
 });
 
-test("OpenCode session passes --model at create, skips effort, and does not persist", async () => {
+test("OpenCode session with no effort passes --model at create and does not set effort", async () => {
+  resetLogsAndSettings();
+  const before = Buffer.from(settingsBytes());
+  const session = await openSession({
+    agent: "opencode",
+    model: "gpt-5.6-sol",
+    sessionName: "bp-opencode-model-only",
+    cwd: workDir,
+  });
+  await session.close();
+  assert.equal(settingsBytes().compare(before), 0);
+  const calls = acpxCalls();
+  const created = calls.find((c) => c.argv.includes("new"));
+  assert.equal(created.argv[created.argv.indexOf("--model") + 1], "gpt-5.6-sol");
+  assert.deepEqual(setCalls(calls).map(setKey), []);
+});
+
+test("OpenCode session passes --model at create and ACP set effort, never set model", async () => {
   resetLogsAndSettings();
   const before = Buffer.from(settingsBytes());
   const session = await openSession({
@@ -614,13 +631,13 @@ test("OpenCode session passes --model at create, skips effort, and does not pers
     sessionName: "bp-opencode",
     cwd: workDir,
   });
-  assert.match(session.notes.join("\n"), /does not advertise a reasoning-effort option/);
   await session.close();
   assert.equal(settingsBytes().compare(before), 0);
   const calls = acpxCalls();
   const created = calls.find((c) => c.argv.includes("new"));
   assert.equal(created.argv[created.argv.indexOf("--model") + 1], "gpt-5.6-sol");
-  assert.deepEqual(setCalls(calls).map(setKey), []);
+  assert.deepEqual(setCalls(calls).map(setKey), ["effort"]);
+  assert.ok(!setCalls(calls).some((c) => setKey(c) === "model"));
 });
 
 test("configured replacement adapters are rejected for positional built-ins", async () => {
@@ -813,30 +830,8 @@ test("Pi and Grok retain process effort when session fallback uses exec", async 
   }
 });
 
-test("OpenCode session fallback keeps its authorized effort omission visible", async () => {
-  resetLogsAndSettings();
-  process.env.FAKE_SESSIONS_UNSUPPORTED = "1";
-  let result;
-  try {
-    result = await sessionPrompt({
-      agent: "opencode",
-      model: "safe-model",
-      effort: "high",
-      sessionName: "bp-opencode-fallback",
-      promptFile,
-      cwd: workDir,
-      timeoutSeconds: 5,
-    });
-  } finally {
-    delete process.env.FAKE_SESSIONS_UNSUPPORTED;
-  }
-  assert.match(result.notes.join("\n"), /ran without effort=high/);
-  const exec = acpxCalls().find((c) => c.argv.includes("exec"));
-  assert.equal(exec.argv[exec.argv.indexOf("--model") + 1], "safe-model");
-});
-
-test("Claude and Codex stop when effort cannot be applied without a session", async () => {
-  for (const agent of ["claude", "codex"]) {
+test("Claude, Codex, and OpenCode stop when effort cannot be applied without a session", async () => {
+  for (const agent of ["claude", "codex", "opencode"]) {
     resetLogsAndSettings();
     process.env.FAKE_SESSIONS_UNSUPPORTED = "1";
     try {
@@ -891,7 +886,7 @@ test("the Backpass CLI uses verified overlays for every positional harness", () 
   const cases = [
     { agent: "claude", model: "claude-opus-5", effortKey: "effort" },
     { agent: "codex", model: "gpt-5.6-sol", effortKey: "reasoning_effort" },
-    { agent: "opencode", model: "openai/gpt-5.6-sol", effortKey: null },
+    { agent: "opencode", model: "openai/gpt-5.6-sol", effortKey: "effort" },
   ];
   for (const { agent, model, effortKey } of cases) {
     resetLogsAndSettings();
@@ -926,7 +921,7 @@ test("the Backpass CLI applies Grok model and effort as process arguments", () =
 });
 
 test("the Backpass CLI preserves safe process fallbacks and rejects unsafe ones", () => {
-  for (const agent of ["pi", "grok", "opencode"]) {
+  for (const agent of ["pi", "grok"]) {
     resetLogsAndSettings();
     const before = Buffer.from(settingsBytes());
     const repo = makeCliRepo(`${agent}-fallback`);
@@ -936,12 +931,11 @@ test("the Backpass CLI preserves safe process fallbacks and rejects unsafe ones"
     assert.ok(acpxCalls().some((call) => call.argv.includes("exec")));
     if (agent === "pi") assert.ok(jsonl(piLog)[0].includes("--thinking"));
     if (agent === "grok") assert.ok(jsonl(grokLog)[0].includes("--reasoning-effort"));
-    if (agent === "opencode") assert.match(result.stderr, /ran without effort=high/);
     assert.equal(settingsBytes().compare(before), 0);
     assertBareDefaults(before);
   }
 
-  for (const agent of ["claude", "codex"]) {
+  for (const agent of ["claude", "codex", "opencode"]) {
     resetLogsAndSettings();
     const before = Buffer.from(settingsBytes());
     const repo = makeCliRepo(`${agent}-unsafe-fallback`);


### PR DESCRIPTION
## Intent

Fix [#66](https://github.com/kunchenguid/backpass/issues/66): Backpass can pin an OpenCode model but could not select an OpenCode variant. Keep the PR #49 rule: overlay only when it is invocation-scoped and proven. Do not write `opencode.json` or last-used defaults.

## What Changed

OpenCode ACP advertises session config option `effort` (category `thought_level`). `setSessionConfigOption` stores the value as in-memory ACP session variant state, then the next prompt uses it. That is the same class of overlay Claude already uses.

- `src/harness-invoke.js` / `src/acpx.js`: OpenCode now uses `acpx --model` at `sessions new` and `acpx set effort` on that session. Missing session support fails closed, like Claude/Codex.
- `src/agents.js`: role defaults (`medium` / `high`) are **not** sent to OpenCode. Variant keys are per-model (`xhigh`, `max`, â€¦). Overlay applies only when `analysis.effort` / `synthesis.effort` (or the CLI flags) is set. Unconfigured OpenCode stays on the model default variant.
- `src/commands/status.js`: known OpenCode picks print `effort unset` unless effort is configured.
- Tests cover explicit `set effort`, model-only (no set), pinned OpenCode with/without effort, and session-unsupported failure.

## Risk Assessment

Low. Opt-in overlay: no effort request means the same spawn as before (model-only `--model`, no `set`). Persistent OpenCode config is not written. A rejected `set effort` (unknown variant for that model) fails loudly instead of pretending it applied.

## Verification

- `pnpm run lint` and `pnpm run typecheck` passed.
- `node --test test/agents.test.js`: 14 passed; the remaining failure is the pre-existing Windows `claude auth status` shebang probe.
- `prepareHarnessInvocation({ agent: "opencode", model: "xai/grok-4.6", effort: "xhigh" })` returns `setEffortKey: "effort"`; model-only returns `setEffortKey: null`.
- Independent reviews: GLM then Grok. First pass caught role-default abort on models whose variant map rejects `medium`/`high` (issue example: `openrouter/z-ai/glm-5.3-flash` is `low|high|max`). That is now opt-in. Second pass: no remaining medium/high findings; status display was aligned with `resolvedEffort`.

Fixes #66

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3599d744f7cf2a25cb3d7b8bd65daf8df45778b5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"completed"},{"step":"ci","status":"completed"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ Rebased onto current `main` (write-access overlays and later commits). Conflict in `src/harness-invoke.js` resolved by treating OpenCode like Claude/Codex for session-local `set effort` while keeping the current write-access invocation shape.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No blocking issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ `pnpm run lint`, `pnpm run typecheck`, and the test suite completed in the no-mistakes worktree.
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
