### PR TITLE
feat(discovery): cwdAliases — tier-1 association for sessions whose cwd is not a git repo

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -73,6 +73,10 @@ export const DEFAULT_CONFIG = {
     harnesses: ALL_HARNESSES,
     since: "30d",
     worktreeGlobs: [],
+    /** Map a session cwd (absolute path) to a path in this repo ("." for the
+     *  root) so non-repo cwds - a bare $HOME, a scratch dir - associate at
+     *  tier 1. The alias target must resolve into a worktree of this repo. */
+    cwdAliases: {},
     minUserTurns: 2,
     includeCursorIde: false,
   },

--- a/src/discovery/association.js
+++ b/src/discovery/association.js
@@ -53,7 +53,24 @@ export function globToRegExp(glob) {
 
 export function associate({ cwd, remotes = [], gitRoot = null }, repo, options = {}) {
   const globs = options.worktreeGlobs || [];
+  const aliases = options.cwdAliases || {};
   const candidates = [cwd, gitRoot].filter(Boolean);
+
+  // Tier 1 - explicit cwd alias: sessions whose cwd is not a git repo at all
+  // (e.g. a bare $HOME) can be pinned to this repo by config. The alias only
+  // holds when its target actually resolves into one of the repo's worktrees,
+  // so a stale alias can never capture another repo's sessions.
+  for (const candidate of candidates) {
+    const target = aliases[candidate] ?? aliases[realpathOrResolve(candidate)];
+    if (target == null) continue;
+    const base = repo.realRoot || repo.root;
+    const resolved = realpathOrResolve(path.isAbsolute(target) ? target : path.resolve(base, target));
+    for (const worktree of repo.worktrees) {
+      if (resolved === worktree || isUnder(resolved, worktree)) {
+        return { tier: 1, confidence: "alias", reason: `cwd alias ${candidate} -> ${target}` };
+      }
+    }
+  }
 
   // Tier 1 - live path under a known worktree.
   for (const candidate of candidates) {

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -129,6 +129,7 @@ async function discoverDirect(adapter, { repo, config, cutoffMs, strict, stats }
     stats.scanned += 1;
     const association = associate({ cwd: row.cwd, remotes: row.remotes || [], gitRoot: row.gitRoot }, repo, {
       worktreeGlobs: config.discovery.worktreeGlobs,
+      cwdAliases: config.discovery.cwdAliases,
     });
     if (!passesStrict(association, strict)) {
       stats.skipped += 1;
@@ -183,7 +184,7 @@ function discoverFiles(adapter, { repo, config, cutoffMs, strict, stats, cache, 
     const association = associate(
       { cwd: descriptor.cwd, remotes: descriptor.remotes || [], gitRoot: descriptor.gitRoot },
       repo,
-      { worktreeGlobs: config.discovery.worktreeGlobs },
+      { worktreeGlobs: config.discovery.worktreeGlobs, cwdAliases: config.discovery.cwdAliases },
     );
     if (!passesStrict(association, strict)) {
       stats.skipped += 1;

--- a/test/association.test.js
+++ b/test/association.test.js
@@ -91,3 +91,40 @@ test("globToRegExp treats * as one segment and ** as many", () => {
   assert.ok(!globToRegExp("/a/*/c").test("/a/b/x/c"));
   assert.ok(globToRegExp("/a/**/c").test("/a/b/x/c"));
 });
+
+test("tier 1 alias: cwdAliases maps a non-repo cwd onto the repo root", () => {
+  const { repo, live } = makeRepo();
+  try {
+    const alias = { "/Users/someone": "." };
+    const res = associate({ cwd: "/Users/someone", remotes: [] }, repo, { cwdAliases: alias });
+    assert.ok(res, "alias cwd should associate");
+    assert.equal(res.tier, 1);
+    assert.equal(res.confidence, "alias");
+  } finally {
+    fs.rmSync(live, { recursive: true, force: true });
+  }
+});
+
+test("cwdAliases target outside the repo does not associate", () => {
+  const { repo, live } = makeRepo();
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-outside-"));
+  try {
+    const res = associate({ cwd: "/Users/someone", remotes: [] }, repo, {
+      cwdAliases: { "/Users/someone": outside },
+    });
+    assert.equal(res, null);
+  } finally {
+    fs.rmSync(outside, { recursive: true, force: true });
+    fs.rmSync(live, { recursive: true, force: true });
+  }
+});
+
+test("cwdAliases absent leaves existing behaviour unchanged", () => {
+  const { repo, live } = makeRepo();
+  try {
+    const res = associate({ cwd: "/Users/someone", remotes: [] }, repo, {});
+    assert.equal(res, null);
+  } finally {
+    fs.rmSync(live, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem
A large share of real agent sessions run with a cwd that is not a git repo at all — a bare $HOME, a notes dir, a scratch folder. In our fleet, 225 of 312 recent Claude sessions had cwd=$HOME. These sessions never associate: tiers 1–2 need a live worktree or a recorded remote, and tier 3 only considers paths that no longer exist (`worktreeGlobs` doesn't help for live-but-non-repo paths). The forward passes happen; the backward pass never sees them.

## Change
`discovery.cwdAliases` — an object mapping an absolute session cwd to a path in the repo (`"."` for the root):

```json
{ "discovery": { "cwdAliases": { "/Users/me": "." } } }
```

- Checked first in `associate()` as tier 1, confidence `"alias"`.
- The alias only holds when its target resolves into one of the repo's worktrees — a stale alias can never capture another repo's sessions.
- Both the raw cwd and its realpath are matched; relative targets resolve against `repo.realRoot || repo.root`.
- Default `{}`: zero behaviour change unless configured.

## Tests
3 new cases in `test/association.test.js` (RED-first): alias→tier-1/alias; alias target outside the repo → no association; absent aliases → unchanged behaviour. `npm test`: 362 tests, +3 pass over baseline, no new failures (the 19 failures on my machine are pre-existing agent-ladder/probe environment tests, identical on unmodified main).
