### PR TITLE
fix(prompts): classify orchestrator repo gaps as project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,8 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   orchestrated the task, not by this repo) are counted in
   `totals.orchestrationGapSightings` and excluded from clustering, so they can
   never reach a proposal - there is deliberately no orchestrator-memory write path.
+  When this repository IS that orchestrating tool, those mistakes are `project`
+  (`src/prompts/analysis.md`).
   A gap may also carry `coveredBySkill`: the analysis (shown every skill's name and
   trigger line) judged an existing skill's content to cover the mistake - a failed
   trigger. The fold counts those citations per skill onto the cluster

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ caused damage), `non-compliance` (the agent ignored it), or `irrelevant` - becau
 argue for opposite fates: harm argues against an instruction, non-compliance argues for
 reinforcing it. Every gap carries a domain - `orchestration` when the mistake was caused
 not by this repository but by an external agent harness or tooling that orchestrated the
-task, `project` for every other mistake - and the
+task, `project` for every other mistake (including when this repository is the
+orchestrating tool) - and the
 analysis is shown the ledger's open gaps so it can cite an existing gap id instead of
 coining a paraphrase of it.
 

--- a/src/prompts/analysis.md
+++ b/src/prompts/analysis.md
@@ -67,8 +67,9 @@ Rules, in order of importance:
    not caused by this repository, but by an external agent harness or tooling that
    orchestrated the task (a task brief, a supervisor's process, the harness itself - by
    way of illustration only, not a list to match against); every other gap is `project`.
-   Ask the causal question, not which category the wording resembles. Orchestration gaps
-   are counted but never proposed into this repository's memory file.
+   Ask the causal question, not which category the wording resembles. If this
+   repository IS the orchestrating tool, mistakes in how it orchestrated are `project`.
+   Orchestration gaps are counted but never proposed into this repository's memory file.
 5. **Do not confabulate influence.** Only call something positive when the trace shows
    the agent doing the specific thing the instruction asks for. An outcome that would
    have happened anyway is not evidence.

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -17,7 +17,8 @@ import { renderEvidenceForPrompt } from "../src/fold.js";
  * `backpass propose` does, asserting both halves of the contract a user depends on:
  * the analysis prompt actually handed to the model states the causal test for
  * `orchestration` (the mistake was caused by the harness around the session, not by this
- * repository), and the mechanics behind it are unchanged - orchestration sightings are
+ * repository - except when this repository IS that tool, in which case those mistakes
+ * are `project`), and the mechanics behind it are unchanged - orchestration sightings are
  * recorded and counted but never corroborate, while a gap with no domain at all is still
  * treated as `project`.
  */
@@ -27,6 +28,9 @@ const CLI = path.join(ROOT, "bin", "backpass.js");
 
 const ORCHESTRATION_GAP = "Stop after the report on scout tasks.";
 const UNLABELLED_GAP = "Always run lint before pushing.";
+// Same mistake as ORCHESTRATION_GAP, judged `project` because this repo IS the
+// orchestrating tool (firstmate-class). Fold must cluster it, not exclude it.
+const ORCHESTRATOR_REPO_GAP = ORCHESTRATION_GAP;
 
 const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-domain-bin-"));
 const fakePi = path.join(binDir, "pi");
@@ -72,6 +76,43 @@ process.exit(0);
 );
 fs.chmodSync(fakeAcpx, 0o755);
 
+// The same sighting as the orchestration gap, but the model applied the
+// repo-aware causal test: this repository IS the orchestrating tool, so the
+// mistake is `project` and must reach a cluster.
+const orchRepoBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-domain-orch-bin-"));
+const fakePiOrchRepo = path.join(orchRepoBinDir, "pi");
+const fakeAcpxOrchRepo = path.join(orchRepoBinDir, "acpx");
+fs.writeFileSync(fakePiOrchRepo, `#!${process.execPath}\nprocess.exit(0);\n`);
+fs.chmodSync(fakePiOrchRepo, 0o755);
+fs.writeFileSync(
+  fakeAcpxOrchRepo,
+  `#!${process.execPath}
+const argv = process.argv.slice(2);
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write(JSON.stringify({ agents: {} }) + "\\n");
+  process.exit(0);
+}
+if (argv.includes("--file")) {
+  process.stdout.write(JSON.stringify({
+    positive: [],
+    negative: [],
+    gaps: [
+      {
+        mistake: "kept working after the brief said to report and stop",
+        proposedInstruction: ${JSON.stringify(ORCHESTRATOR_REPO_GAP)},
+        recurrenceRisk: "high",
+        domain: "project",
+        quote: "opened a PR during a scout task",
+      },
+    ],
+  }) + "\\n");
+  process.exit(0);
+}
+process.exit(0);
+`,
+);
+fs.chmodSync(fakeAcpxOrchRepo, 0o755);
+
 function git(args, cwd) {
   spawnSync("git", args, { cwd, stdio: "ignore" });
 }
@@ -104,7 +145,7 @@ function writeSession(home, id, cwd) {
   );
 }
 
-function runAnalyze(dir, home) {
+function runAnalyze(dir, home, { pathBin = binDir, acpx = fakeAcpx } = {}) {
   const args = ["analyze", "--harness", "pi", "--since", "all", "--analysis-agent", "pi", "--jobs", "1", "--json"];
   const result = spawnSync(process.execPath, [CLI, ...args], {
     cwd: dir,
@@ -112,8 +153,8 @@ function runAnalyze(dir, home) {
       ...process.env,
       HOME: home,
       USERPROFILE: home,
-      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
-      BACKPASS_ACPX_BIN: fakeAcpx,
+      PATH: `${pathBin}${path.delimiter}${process.env.PATH}`,
+      BACKPASS_ACPX_BIN: acpx,
       NO_COLOR: "1",
     },
     encoding: "utf8",
@@ -122,12 +163,12 @@ function runAnalyze(dir, home) {
   return { ...result, output: `${result.stdout}${result.stderr}` };
 }
 
-function analyzedRepo() {
+function analyzedRepo(analyzeOpts) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-domain-home-"));
   const dir = initRepo();
   writeSession(home, "session-a", dir);
   writeSession(home, "session-b", dir);
-  const run = runAnalyze(dir, home);
+  const run = runAnalyze(dir, home, analyzeOpts);
   assert.equal(run.status, 0, run.output);
   return dir;
 }
@@ -151,6 +192,11 @@ test("the analysis prompt the model receives asks what caused the gap, not which
       "the old enumeration no longer stands in for the definition",
     );
     assert.match(prompt, /Orchestration gaps\s+are counted but never proposed into this repository's memory file/);
+    assert.match(
+      prompt,
+      /If this\s+repository IS the orchestrating tool,\s+mistakes in how it orchestrated are `project`/,
+      "an orchestrator repo must not starve its own subject-matter gaps",
+    );
   }
 });
 
@@ -179,4 +225,27 @@ test("an orchestration gap is counted but never corroborates, while a gap with n
   const ledger = state.readGapLedger();
   const domains = Object.values(ledger.entries).map((entry) => Object.values(entry.sessions)[0].domain);
   assert.deepEqual(domains.sort(), ["orchestration", "project"], "the ledger keeps the judged domain of each sighting");
+});
+
+test("a firstmate-class orchestrator-repo sighting judged project corroborates instead of being excluded", async () => {
+  const dir = analyzedRepo({ pathBin: orchRepoBinDir, acpx: fakeAcpxOrchRepo });
+  const state = new State(dir).ensure();
+  const resolved = resolveMemoryFiles(dir, ["AGENTS.md", "CLAUDE.md"]);
+  const summary = await foldForRun(
+    { config: { state, minGapEvidence: 2, gapLedgerMaxAge: "90d" } },
+    resolved.primary,
+    resolved.hash,
+  );
+
+  assert.equal(summary.analyzedSessions, 2);
+  assert.equal(summary.totals.orchestrationGapSightings, 0, "the causal test kept this repo's own mistakes as project");
+  assert.deepEqual(summary.gaps.map((gap) => gap.proposedInstruction), [ORCHESTRATOR_REPO_GAP]);
+
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.ok(rendered.includes(ORCHESTRATOR_REPO_GAP), "the sighting reaches the synthesis prompt");
+  assert.ok(!/orchestration-domain sighting\(s\).*excluded/.test(rendered));
+
+  const ledger = state.readGapLedger();
+  const domains = Object.values(ledger.entries).map((entry) => Object.values(entry.sessions)[0].domain);
+  assert.deepEqual(domains, ["project"]);
 });

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -239,7 +239,10 @@ test("a firstmate-class orchestrator-repo sighting judged project corroborates i
 
   assert.equal(summary.analyzedSessions, 2);
   assert.equal(summary.totals.orchestrationGapSightings, 0, "the causal test kept this repo's own mistakes as project");
-  assert.deepEqual(summary.gaps.map((gap) => gap.proposedInstruction), [ORCHESTRATOR_REPO_GAP]);
+  assert.deepEqual(
+    summary.gaps.map((gap) => gap.proposedInstruction),
+    [ORCHESTRATOR_REPO_GAP],
+  );
 
   const rendered = renderEvidenceForPrompt(summary);
   assert.ok(rendered.includes(ORCHESTRATOR_REPO_GAP), "the sighting reaches the synthesis prompt");


### PR DESCRIPTION
## Intent

Make backpass's domain rubric repo-aware so orchestrator repos are not starved. Today for an orchestrator repo like firstmate, "caused by the orchestrating tooling" and "this repo's subject matter" coincide, so the rubric wrongly excluded 15 of 23 sightings and produced 0 clusters from 94 sessions. Fix: add one sentence to the analysis prompt so the causal test lands correctly for firstmate-class repos, e.g. "If this repository IS the orchestrating tool, mistakes in how it orchestrated are `project`." Keep it a minimal prompt change. Cover behaviorally where an executable contract exists (e.g. a representative orchestrator-repo sighting is classified `project` rather than excluded). Stay strictly scoped to this improvement. Do not self-merge.

## What Changed

- Update the analysis rubric so mistakes made by a repository that is itself the orchestrating tool are classified as `project` gaps.
- Add CLI-level coverage proving orchestrator-repo gaps corroborate and reach synthesis instead of being excluded.
- Document the repo-aware domain classification behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped, clarifies the emitted analysis rubric, and adds executable coverage for prompt delivery and downstream project-domain handling.

## Testing

Reviewed the focused diff, ran the gap-domain CLI tests, and exercised the persisted analysis-to-fold path end to end. Two orchestrator-repo sightings remained `project`, produced zero excluded orchestration sightings, and formed a proposal-eligible two-session cluster. The worktree remained clean.

<details>
<summary>Evidence: Orchestrator-repository end-to-end evidence</summary>

Source: [Orchestrator-repository end-to-end evidence](https://github.com/kunchenguid/backpass/blob/d782714ab43161aace2817ad1f0ee76baa0bb067/.no-mistakes/evidence/fm/backpass-repo-aware-rubric-r1/orchestrator-repo-e2e.json)

```text
{
  "scenario": "A firstmate-class repository is itself the orchestrating tool; two sessions report the same orchestration-subject-matter mistake.",
  "persistedAnalysisEvidence": [
    {
      "session": "pi-session-b",
      "gaps": [
        {
          "mistake": "kept working after the brief said to report and stop",
          "proposedInstruction": "Stop after the report on scout tasks.",
          "domain": "project",
          "quote": "opened a PR during a scout task"
        }
      ]
    },
    {
      "session": "pi-session-a",
      "gaps": [
        {
          "mistake": "kept working after the brief said to report and stop",
          "proposedInstruction": "Stop after the report on scout tasks.",
          "domain": "project",
          "quote": "opened a PR during a scout task"
        }
      ]
    }
  ],
  "aggregateResult": {
    "analyzedSessions": 2,
    "orchestrationGapSightingsExcluded": 0,
    "proposalEligibleGaps": [
      {
        "proposedInstruction": "Stop after the report on scout tasks.",
        "sessions": 2,
        "quotes": [
          {
            "text": "opened a PR during a scout task",
            "effect": "kept working after the brief said to report and stop",
            "source": "pi · b · 2026-08-30"
          },
          {
            "text": "opened a PR during a scout task",
            "effect": "kept working after the brief said to report and stop",
            "source": "pi · a · 2026-08-30"
          }
        ]
      }
    ]
  },
  "synthesisPromptEvidence": "Sessions analyzed: 2\nTotals: 0 positive, 0 negative, 1 gap clusters (0 singletons dropped below threshold)\n\n### Per-instruction evidence\nA negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.\n- [AG-001] +0 -0 sessions=0 relevance=0.0% cost=10tok\n\n### Gap clusters (mistakes no current instruction covers)\n- sessions=2 risk=high :: Stop after the report on scout tasks.\n    \"opened a PR during a scout task\" (pi · b · 2026-08-30)\n    \"opened a PR during a scout task\" (pi · a · 2026-08-30)"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d70d03167ccc69b61b691a53a93206580089340d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/gap-domain-cli.test.js`
- <code>Generated `orchestrator-repo-e2e.json` by folding persisted evidence from the executable CLI fixture through `foldForRun` and `renderEvidenceForPrompt`.</code>
- <code>`git status --short` confirmed testing left the worktree clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
