### PR TITLE
fix: retry transient harness capability probes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   `AgentResolver.withFallthrough`, which demotes a candidate on a classifiable failure
   (`classifyAcpxFailure`). Effortful calls go through `sessionPrompt` so the overlay in
   `src/harness-invoke.js` can apply. Verdicts cache in `.backpass/agent-probe-cache.json`.
+  A probe miss retries once with backoff (`probeAndRecord` in `src/agents.js`); a timeout,
+  a bare `exit N`, or an empty advertised-model list is never written as a negative cache
+  hit, so a busy harness cannot poison the next run.
 - **The Lavish apply surface is chatty and its output is YAML-quoted.** `lavish-axi poll`
   can return feedback that is not a decision vector (a comment, a queued layout report) any
   number of times before the real one; `pollDecisions` in `src/apply/lavish.js` announces

--- a/README.md
+++ b/README.md
@@ -438,8 +438,8 @@ wins:
 | synthesis | high   | `gpt-5.6-sol` via pi, opencode, codex  | `claude-opus-5` via claude   | `grok-4.6` via pi, opencode, grok |
 
 Each candidate is checked with a ~1.5s zero-token acpx probe (claude via `claude auth status`,
-because its adapter accepts sessions while logged out); a busy-harness miss retries once,
-and a probe timeout is not cached. Other verdicts are cached in
+because its adapter accepts sessions while logged out). A potentially transient busy-harness
+miss retries once and is not cached; durable verdicts are cached in
 `.backpass/agent-probe-cache.json` for 12h (30min for negatives) and re-probed with `--force`.
 The probe is a filter, not a promise: if the chosen harness answers `AUTH_REQUIRED` or rejects
 the model mid-run, backpass falls through to the next candidate and says so. When a whole

--- a/README.md
+++ b/README.md
@@ -438,7 +438,8 @@ wins:
 | synthesis | high   | `gpt-5.6-sol` via pi, opencode, codex  | `claude-opus-5` via claude   | `grok-4.6` via pi, opencode, grok |
 
 Each candidate is checked with a ~1.5s zero-token acpx probe (claude via `claude auth status`,
-because its adapter accepts sessions while logged out); verdicts are cached in
+because its adapter accepts sessions while logged out); a busy-harness miss retries once,
+and a probe timeout is not cached. Other verdicts are cached in
 `.backpass/agent-probe-cache.json` for 12h (30min for negatives) and re-probed with `--force`.
 The probe is a filter, not a promise: if the chosen harness answers `AUTH_REQUIRED` or rejects
 the model mid-run, backpass falls through to the next candidate and says so. When a whole

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -232,7 +232,7 @@ export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
  * checks `claude auth status` before ever calling this.
  *
  * @returns {Promise<{ verdict: "ok" | "unauthenticated" | "model-unavailable" | "unreachable" | "timeout",
- *   detail: string, availableModels: string[] }>}
+ *   detail: string, availableModels: string[], transient?: boolean }>}
  */
 export async function probeSession({ agent, sessionName, cwd = undefined, timeoutMs = 20_000 }) {
   const acpxAgent = acpxAgentName(agent);
@@ -246,8 +246,13 @@ export async function probeSession({ agent, sessionName, cwd = undefined, timeou
     };
   }
   if (created.code !== 0) {
-    const verdict = classifyAcpxFailure(created) || "unreachable";
-    return { verdict, detail: firstLine(created.stderr) || `exit ${created.code}`, availableModels: [] };
+    const classified = classifyAcpxFailure(created);
+    return {
+      verdict: classified || "unreachable",
+      detail: firstLine(created.stderr) || `exit ${created.code}`,
+      availableModels: [],
+      ...(!classified ? { transient: true } : {}),
+    };
   }
 
   try {

--- a/src/agents.js
+++ b/src/agents.js
@@ -24,8 +24,8 @@ import { runCapture } from "./subprocess.js";
  *
  * A busy harness (another backpass run, a wedged ACP session) looks like a probe
  * timeout, a bare `exit 1`, or an empty advertised-model list. Those retry once with
- * backoff before the walk demotes. A timeout is never written to the on-disk cache:
- * a transient miss must not become a 30-minute "model not advertised" for the next run.
+ * backoff before the walk demotes and are never written to the on-disk cache: a
+ * transient miss must not become a 30-minute negative verdict for the next run.
  */
 
 const OK_TTL_MS = 12 * 60 * 60 * 1000;

--- a/src/agents.js
+++ b/src/agents.js
@@ -21,6 +21,11 @@ import { runCapture } from "./subprocess.js";
  *
  * Verdicts are cached in `.backpass/agent-probe-cache.json` (12h for ok, 30min for
  * negatives, invalidated on an acpx version change) and memoized for the run.
+ *
+ * A busy harness (another backpass run, a wedged ACP session) looks like a probe
+ * timeout, a bare `exit 1`, or an empty advertised-model list. Those retry once with
+ * backoff before the walk demotes. A timeout is never written to the on-disk cache:
+ * a transient miss must not become a 30-minute "model not advertised" for the next run.
  */
 
 const OK_TTL_MS = 12 * 60 * 60 * 1000;
@@ -28,6 +33,7 @@ const NEGATIVE_TTL_MS = 30 * 60 * 1000;
 const NATIVE_TIMEOUT_MS = 5_000;
 const PROBE_TIMEOUT_MS = 20_000;
 const PROBE_TIMEOUT_BY_AGENT = { opencode: 10_000 };
+const PROBE_RETRY_BACKOFF_MS = 1_000;
 
 /** Adapters whose model list is open-ended: any id is forwarded, none can be verified. */
 const TRUSTING_MODEL_AGENTS = new Set(["claude"]);
@@ -176,9 +182,30 @@ export async function probeCandidate(candidate, options = {}) {
  */
 export function isProbeEntryFresh(entry, { now = Date.now() } = {}) {
   if (!entry || !entry.checkedAt) return false;
+  if (isTransientProbeResult(entry)) return false;
   const age = now - Date.parse(entry.checkedAt);
   if (!Number.isFinite(age) || age < 0) return false;
   return age < (entry.verdict === "ok" ? OK_TTL_MS : NEGATIVE_TTL_MS);
+}
+
+/**
+ * Probe misses that are often the harness being busy, not a durable capability gap.
+ * One retry, then skip for this run; never persist them as a negative cache hit.
+ */
+export function isTransientProbeResult(result) {
+  if (!result) return false;
+  if (result.verdict === "timeout") return true;
+  if (result.verdict === "model-unavailable" && /advertised no models/i.test(result.detail || "")) {
+    return true;
+  }
+  if (result.verdict === "unreachable" && /^exit \d+\b/i.test((result.detail || "").trim())) {
+    return true;
+  }
+  return false;
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function hintFor(agent, verdict) {
@@ -199,7 +226,8 @@ export class AgentResolver {
   /**
    * @param {object} config
    * @param {{ state?: { readProbeCache: Function, writeProbeCache: Function }, cwd?: string,
-   *   bypassCache?: boolean, probeCandidate?: Function, acpxVersion?: Function, now?: () => number }} [deps]
+   *   bypassCache?: boolean, probeCandidate?: Function, acpxVersion?: Function, now?: () => number,
+   *   sleep?: (ms: number) => Promise<void>, probeRetryBackoffMs?: number }} [deps]
    */
   constructor(config, deps = {}) {
     this.config = config;
@@ -209,6 +237,8 @@ export class AgentResolver {
     this.probeCandidate = deps.probeCandidate || probeCandidate;
     this.acpxVersion = deps.acpxVersion || acpxVersion;
     this.now = deps.now || (() => Date.now());
+    this.sleep = deps.sleep || defaultSleep;
+    this.probeRetryBackoffMs = deps.probeRetryBackoffMs ?? PROBE_RETRY_BACKOFF_MS;
     /** In-process memo for the run: key -> { verdict, detail, resolvedModel, checkedAt }. */
     this.memo = new Map();
     /** Probes in flight, so parallel analysis workers never double-probe a candidate. */
@@ -251,16 +281,30 @@ export class AgentResolver {
     }
 
     this.probeCount += 1;
-    const sessionName = `backpass-probe-${process.pid}-${this.probeCount}`;
-    const result = await this.probeCandidate(candidate, { cwd: this.cwd, sessionName });
+    let result = await this.probeCandidate(candidate, {
+      cwd: this.cwd,
+      sessionName: `backpass-probe-${process.pid}-${this.probeCount}`,
+    });
+    if (isTransientProbeResult(result)) {
+      await this.sleep(this.probeRetryBackoffMs);
+      this.probeCount += 1;
+      result = await this.probeCandidate(candidate, {
+        cwd: this.cwd,
+        sessionName: `backpass-probe-${process.pid}-${this.probeCount}`,
+      });
+    }
     const entry = {
       verdict: result.verdict,
       detail: result.detail || "",
       resolvedModel: result.resolvedModel || null,
       checkedAt: new Date(this.now()).toISOString(),
     };
-    cache.entries[key] = entry;
     this.memo.set(key, entry);
+    if (isTransientProbeResult(entry)) {
+      delete cache.entries[key];
+    } else {
+      cache.entries[key] = entry;
+    }
     this.saveCache();
     return entry;
   }

--- a/src/agents.js
+++ b/src/agents.js
@@ -59,10 +59,13 @@ const LOGIN_HINTS = {
  * the acpx probe decides). See the module header for why this table exists at all.
  */
 const NATIVE_PROBES = {
-  async claude({ model }) {
-    const result = await runCapture("claude", ["auth", "status"], { timeoutMs: NATIVE_TIMEOUT_MS });
+  async claude({ model }, capture) {
+    const result = await capture("claude", ["auth", "status"], { timeoutMs: NATIVE_TIMEOUT_MS });
     if (result.spawnError?.code === "ENOENT") {
       return { verdict: "unreachable", detail: "claude CLI not found on PATH", resolvedModel: model };
+    }
+    if (result.timedOut) {
+      return { verdict: "timeout", detail: "claude auth status timed out" };
     }
     let parsed = null;
     try {
@@ -79,16 +82,20 @@ const NATIVE_PROBES = {
     }
     return null;
   },
-  async opencode({ model }) {
-    const result = await runCapture("opencode", ["models"], { timeoutMs: NATIVE_TIMEOUT_MS });
+  async opencode({ model }, capture) {
+    const result = await capture("opencode", ["models"], { timeoutMs: NATIVE_TIMEOUT_MS });
     if (result.spawnError?.code === "ENOENT") {
       return { verdict: "unreachable", detail: "opencode CLI not found on PATH" };
     }
-    if (result.timedOut || result.code !== 0) return null;
+    if (result.timedOut) return { verdict: "timeout", detail: "opencode models timed out" };
+    if (result.code !== 0) return null;
     const advertised = result.stdout
       .split("\n")
       .map((l) => l.trim())
       .filter(Boolean);
+    if (!advertised.length) {
+      return { verdict: "model-unavailable", detail: "`opencode models` advertised no models" };
+    }
     const resolved = resolveModelId(model, advertised);
     if (!resolved.id) {
       return {
@@ -141,15 +148,16 @@ export function candidateKey({ agent, model }) {
  * @param {{ agent: string, model: string }} candidate
  * @param {{ cwd?: string, sessionName?: string,
  *   probeSession?: (args: { agent: string, sessionName: string, cwd?: string, timeoutMs?: number }) =>
- *     Promise<{ verdict: string, detail: string, availableModels?: string[] }> }} [options]
+ *     Promise<{ verdict: string, detail: string, availableModels?: string[] }>,
+ *   runCapture?: typeof runCapture }} [options]
  * @returns {Promise<{ verdict: string, detail: string, resolvedModel: string | null }>}
  */
 export async function probeCandidate(candidate, options = {}) {
-  const { cwd, sessionName, probeSession: probe = probeSession } = options;
+  const { cwd, sessionName, probeSession: probe = probeSession, runCapture: capture = runCapture } = options;
   const { agent, model } = candidate;
   const native = NATIVE_PROBES[agent];
   if (native) {
-    const early = await native(candidate);
+    const early = await native(candidate, capture);
     if (early) return { resolvedModel: null, ...early };
   }
 
@@ -198,7 +206,10 @@ export function isTransientProbeResult(result) {
   if (result.verdict === "model-unavailable" && /advertised no models/i.test(result.detail || "")) {
     return true;
   }
-  if (result.verdict === "unreachable" && /^exit \d+\b/i.test((result.detail || "").trim())) {
+  if (
+    result.verdict === "unreachable" &&
+    /^(?:claude auth status )?exit (?:\d+|null)\b/i.test((result.detail || "").trim())
+  ) {
     return true;
   }
   return false;

--- a/src/agents.js
+++ b/src/agents.js
@@ -78,7 +78,11 @@ const NATIVE_PROBES = {
       return null;
     }
     if (result.code !== 0) {
-      return { verdict: "unreachable", detail: firstLine(result.stderr) || `claude auth status exit ${result.code}` };
+      return {
+        verdict: "unreachable",
+        detail: firstLine(result.stderr) || `claude auth status exit ${result.code}`,
+        transient: true,
+      };
     }
     return null;
   },
@@ -148,9 +152,9 @@ export function candidateKey({ agent, model }) {
  * @param {{ agent: string, model: string }} candidate
  * @param {{ cwd?: string, sessionName?: string,
  *   probeSession?: (args: { agent: string, sessionName: string, cwd?: string, timeoutMs?: number }) =>
- *     Promise<{ verdict: string, detail: string, availableModels?: string[] }>,
+ *     Promise<{ verdict: string, detail: string, availableModels?: string[], transient?: boolean }>,
  *   runCapture?: typeof runCapture }} [options]
- * @returns {Promise<{ verdict: string, detail: string, resolvedModel: string | null }>}
+ * @returns {Promise<{ verdict: string, detail: string, resolvedModel: string | null, transient?: boolean }>}
  */
 export async function probeCandidate(candidate, options = {}) {
   const { cwd, sessionName, probeSession: probe = probeSession, runCapture: capture = runCapture } = options;
@@ -167,7 +171,14 @@ export async function probeCandidate(candidate, options = {}) {
     cwd,
     timeoutMs: PROBE_TIMEOUT_BY_AGENT[agent] || PROBE_TIMEOUT_MS,
   });
-  if (result.verdict !== "ok") return { verdict: result.verdict, detail: result.detail, resolvedModel: null };
+  if (result.verdict !== "ok") {
+    return {
+      verdict: result.verdict,
+      detail: result.detail,
+      resolvedModel: null,
+      ...(result.transient ? { transient: true } : {}),
+    };
+  }
 
   if (TRUSTING_MODEL_AGENTS.has(agent)) {
     return { verdict: "ok", detail: "model accepted on faith; the first real call verifies it", resolvedModel: model };
@@ -202,7 +213,7 @@ export function isProbeEntryFresh(entry, { now = Date.now() } = {}) {
  */
 export function isTransientProbeResult(result) {
   if (!result) return false;
-  if (result.verdict === "timeout") return true;
+  if (result.transient || result.verdict === "timeout") return true;
   if (result.verdict === "model-unavailable" && /advertised no models/i.test(result.detail || "")) {
     return true;
   }

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -204,6 +204,61 @@ test("claude is decided by `claude auth status`, not by the acpx session probe",
   }
 });
 
+test("native probe transients retry without caching while unsupported models demote", async () => {
+  function nativeResolver(agent, nativeResults) {
+    const config = loadConfig(tmpRepo());
+    config.ladders.analysis = [{ model: "gpt-5.6-luna", agents: [agent, "codex"] }];
+    const state = memoryState();
+    const results = [...nativeResults];
+    let nativeCalls = 0;
+    const resolver = new AgentResolver(config, {
+      state,
+      acpxVersion: async () => "0.13.0",
+      sleep: async () => {},
+      probeCandidate: (candidate, options) =>
+        probeCandidate(candidate, {
+          ...options,
+          runCapture: async () => {
+            nativeCalls += 1;
+            return results.length > 1 ? results.shift() : results[0];
+          },
+          probeSession: async () => ({
+            verdict: "ok",
+            detail: "",
+            availableModels: ["openai-codex/gpt-5.6-luna"],
+          }),
+        }),
+    });
+    return { resolver, state, nativeCalls: () => nativeCalls };
+  }
+
+  const emptyThenReady = nativeResolver("opencode", [
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "openai-codex/gpt-5.6-luna\n", stderr: "" },
+  ]);
+  assert.equal((await emptyThenReady.resolver.resolve("analysis")).agent, "opencode");
+  assert.equal(emptyThenReady.nativeCalls(), 2);
+
+  const empty = nativeResolver("opencode", [{ code: 0, stdout: "", stderr: "" }]);
+  assert.equal((await empty.resolver.resolve("analysis")).agent, "codex");
+  assert.equal(empty.nativeCalls(), 2);
+  assert.equal(empty.state.cache.entries["opencode|gpt-5.6-luna"], undefined);
+
+  const timedOut = nativeResolver("claude", [
+    { code: null, stdout: "", stderr: "", timedOut: true },
+  ]);
+  assert.equal((await timedOut.resolver.resolve("analysis")).agent, "codex");
+  assert.equal(timedOut.nativeCalls(), 2);
+  assert.equal(timedOut.state.cache.entries["claude|gpt-5.6-luna"], undefined);
+
+  const unsupported = nativeResolver("opencode", [
+    { code: 0, stdout: "anthropic/claude-opus-5\n", stderr: "" },
+  ]);
+  assert.equal((await unsupported.resolver.resolve("analysis")).agent, "codex");
+  assert.equal(unsupported.nativeCalls(), 1);
+  assert.equal(unsupported.state.cache.entries["opencode|gpt-5.6-luna"].verdict, "model-unavailable");
+});
+
 test("non-claude candidates resolve the bare id against the advertised list", async () => {
   const piLike = async () => ({
     verdict: "ok",
@@ -425,6 +480,15 @@ test("probe verdicts are cached with TTLs and invalidated on an acpx version cha
     }),
     false,
     "a cached timeout is never treated as a durable negative",
+  );
+  assert.equal(
+    isProbeEntryFresh({
+      verdict: "unreachable",
+      detail: "claude auth status exit null",
+      checkedAt: new Date(now).toISOString(),
+    }),
+    false,
+    "a legacy native timeout is never treated as a durable negative",
   );
 });
 

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -55,7 +55,8 @@ function scriptedProbe(verdicts) {
 /**
  * @param {Record<string, any>} verdicts
  * @param {{ config?: any, state?: ReturnType<typeof memoryState>, now?: () => number,
- *   bypassCache?: boolean, acpxVersion?: () => Promise<string | null> }} [options]
+ *   bypassCache?: boolean, acpxVersion?: () => Promise<string | null>,
+ *   sleep?: (ms: number) => Promise<void> }} [options]
  */
 function resolverWith(
   verdicts,
@@ -244,16 +245,12 @@ test("native probe transients retry without caching while unsupported models dem
   assert.equal(empty.nativeCalls(), 2);
   assert.equal(empty.state.cache.entries["opencode|gpt-5.6-luna"], undefined);
 
-  const timedOut = nativeResolver("claude", [
-    { code: null, stdout: "", stderr: "", timedOut: true },
-  ]);
+  const timedOut = nativeResolver("claude", [{ code: null, stdout: "", stderr: "", timedOut: true }]);
   assert.equal((await timedOut.resolver.resolve("analysis")).agent, "codex");
   assert.equal(timedOut.nativeCalls(), 2);
   assert.equal(timedOut.state.cache.entries["claude|gpt-5.6-luna"], undefined);
 
-  const unsupported = nativeResolver("opencode", [
-    { code: 0, stdout: "anthropic/claude-opus-5\n", stderr: "" },
-  ]);
+  const unsupported = nativeResolver("opencode", [{ code: 0, stdout: "anthropic/claude-opus-5\n", stderr: "" }]);
   assert.equal((await unsupported.resolver.resolve("analysis")).agent, "codex");
   assert.equal(unsupported.nativeCalls(), 1);
   assert.equal(unsupported.state.cache.entries["opencode|gpt-5.6-luna"].verdict, "model-unavailable");

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -36,9 +36,15 @@ function memoryState(initial = { version: 1, acpxVersion: "0.13.0", entries: {} 
  */
 function scriptedProbe(verdicts) {
   const calls = [];
+  const queues = Object.create(null);
   const probe = async (candidate) => {
     calls.push(candidateKey(candidate));
-    const v = verdicts[candidateKey(candidate)];
+    const key = candidateKey(candidate);
+    let v = verdicts[key];
+    if (Array.isArray(v)) {
+      if (!queues[key]) queues[key] = [...v];
+      v = queues[key].length > 1 ? queues[key].shift() : queues[key][0];
+    }
     if (!v) return { verdict: "unreachable", detail: "not installed", resolvedModel: null };
     if (typeof v === "string") return { verdict: v, detail: "", resolvedModel: null };
     return { verdict: "ok", detail: "", resolvedModel: candidate.model, ...v };
@@ -51,12 +57,16 @@ function scriptedProbe(verdicts) {
  * @param {{ config?: any, state?: ReturnType<typeof memoryState>, now?: () => number,
  *   bypassCache?: boolean, acpxVersion?: () => Promise<string | null> }} [options]
  */
-function resolverWith(verdicts, { config = loadConfig(tmpRepo()), state = memoryState(), ...deps } = {}) {
+function resolverWith(
+  verdicts,
+  { config = loadConfig(tmpRepo()), state = memoryState(), sleep = async () => {}, ...deps } = {},
+) {
   const { probe, calls } = scriptedProbe(verdicts);
   const resolver = new AgentResolver(config, {
     state,
     probeCandidate: probe,
     acpxVersion: async () => "0.13.0",
+    sleep,
     ...deps,
   });
   return { resolver, calls, state };
@@ -126,6 +136,7 @@ test("ordered selection picks the first available+authed candidate per role", as
       "pi|gpt-5.6-luna",
       "opencode|gpt-5.6-luna",
       "codex|gpt-5.6-luna",
+      "pi|gpt-5.6-sol",
       "pi|gpt-5.6-sol",
       "opencode|gpt-5.6-sol",
       "codex|gpt-5.6-sol",
@@ -407,6 +418,103 @@ test("probe verdicts are cached with TTLs and invalidated on an acpx version cha
 
   assert.equal(isProbeEntryFresh(null), false);
   assert.equal(isProbeEntryFresh({ verdict: "ok", checkedAt: "garbage" }), false);
+  assert.equal(
+    isProbeEntryFresh({
+      verdict: "timeout",
+      checkedAt: new Date(now).toISOString(),
+    }),
+    false,
+    "a cached timeout is never treated as a durable negative",
+  );
+});
+
+test("a transient probe timeout retries once and does not poison the cache", async () => {
+  const delays = [];
+  const state = memoryState();
+  const first = resolverWith(
+    {
+      "pi|gpt-5.6-luna": ["timeout", { resolvedModel: "openai-codex/gpt-5.6-luna" }],
+    },
+    {
+      state,
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+    },
+  );
+
+  const pick = await first.resolver.resolve("analysis");
+  assert.equal(pick.agent, "pi");
+  assert.deepEqual(first.calls, ["pi|gpt-5.6-luna", "pi|gpt-5.6-luna"]);
+  assert.deepEqual(delays, [1000], "the retry waits one backoff interval");
+  assert.equal(state.cache.entries["pi|gpt-5.6-luna"].verdict, "ok");
+
+  const poisoned = memoryState();
+  const miss = resolverWith(
+    {
+      "pi|gpt-5.6-luna": "timeout",
+      "opencode|gpt-5.6-luna": { resolvedModel: "openai/gpt-5.6-luna" },
+    },
+    { state: poisoned },
+  );
+  assert.equal((await miss.resolver.resolve("analysis")).agent, "opencode");
+  assert.equal(miss.calls.filter((c) => c === "pi|gpt-5.6-luna").length, 2, "timeout retries once then falls through");
+  assert.equal(poisoned.cache.entries["pi|gpt-5.6-luna"], undefined, "the timeout is not persisted");
+
+  const replay = resolverWith(
+    {
+      "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" },
+    },
+    { state: poisoned },
+  );
+  assert.equal((await replay.resolver.resolve("analysis")).agent, "pi", "the next run is free to re-probe");
+  assert.deepEqual(replay.calls, ["pi|gpt-5.6-luna"]);
+
+  const busyExit = resolverWith({
+    "pi|gpt-5.6-luna": [
+      { verdict: "unreachable", detail: "exit 1", resolvedModel: null },
+      { resolvedModel: "openai-codex/gpt-5.6-luna" },
+    ],
+  });
+  assert.equal((await busyExit.resolver.resolve("analysis")).agent, "pi");
+  assert.deepEqual(busyExit.calls, ["pi|gpt-5.6-luna", "pi|gpt-5.6-luna"]);
+});
+
+test("a busy empty advertised-model list retries; a genuine unsupported model still demotes", async () => {
+  const emptyThenOk = resolverWith({
+    "pi|gpt-5.6-luna": [
+      { verdict: "model-unavailable", detail: "adapter advertised no models", resolvedModel: null },
+      { resolvedModel: "openai-codex/gpt-5.6-luna" },
+    ],
+  });
+  assert.equal((await emptyThenOk.resolver.resolve("analysis")).agent, "pi");
+  assert.deepEqual(emptyThenOk.calls, ["pi|gpt-5.6-luna", "pi|gpt-5.6-luna"]);
+
+  const { resolver, calls, state } = resolverWith({
+    "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" },
+    "opencode|gpt-5.6-luna": "model-unavailable",
+    "codex|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" },
+  });
+  const attempts = [];
+  const result = await resolver.withFallthrough("analysis", async (pick) => {
+    attempts.push(`${pick.agent}/${pick.model}`);
+    if (pick.agent === "pi") {
+      throw new AcpxError('Cannot apply --model "gpt-5.6-luna": the ACP agent did not advertise that model.', {
+        stderr: 'Cannot apply --model "gpt-5.6-luna": the ACP agent did not advertise that model.',
+        code: 1,
+      });
+    }
+    return "evidence";
+  });
+  assert.equal(result, "evidence");
+  assert.deepEqual(attempts, ["pi/openai-codex/gpt-5.6-luna", "codex/gpt-5.6-luna"]);
+  assert.equal(
+    calls.filter((c) => c === "opencode|gpt-5.6-luna").length,
+    1,
+    "a listed-but-missing model is not retried",
+  );
+  assert.equal(state.cache.entries["pi|gpt-5.6-luna"].verdict, "model-unavailable");
+  assert.equal((await resolver.resolve("analysis")).agent, "codex");
 });
 
 test("bare model ids resolve by segment equality, never by prefix", () => {

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -9,7 +9,7 @@ import {
   probeCandidate,
   resolveModelId,
 } from "../src/agents.js";
-import { AcpxError, acpxAgentName, classifyAcpxFailure, effortOptionKey } from "../src/acpx.js";
+import { AcpxError, acpxAgentName, classifyAcpxFailure, effortOptionKey, probeSession } from "../src/acpx.js";
 import { DEFAULT_LADDERS, loadConfig } from "../src/config.js";
 import { UserError, setQuiet } from "../src/logger.js";
 
@@ -205,6 +205,23 @@ test("claude is decided by `claude auth status`, not by the acpx session probe",
   }
 });
 
+test("an unclassified acpx probe exit remains transient when stderr has detail", async () => {
+  const bin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fake-acpx-"));
+  const script = path.join(bin, "acpx");
+  fs.writeFileSync(script, "#!/bin/sh\necho 'another session is already running' >&2\nexit 1\n");
+  fs.chmodSync(script, 0o755);
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${bin}${path.delimiter}${oldPath}`;
+  try {
+    const result = await probeSession({ agent: "pi", sessionName: "busy-probe" });
+    assert.equal(result.verdict, "unreachable");
+    assert.equal(result.detail, "another session is already running");
+    assert.equal(result.transient, true);
+  } finally {
+    process.env.PATH = oldPath;
+  }
+});
+
 test("native probe transients retry without caching while unsupported models demote", async () => {
   function nativeResolver(agent, nativeResults) {
     const config = loadConfig(tmpRepo());
@@ -249,6 +266,13 @@ test("native probe transients retry without caching while unsupported models dem
   assert.equal((await timedOut.resolver.resolve("analysis")).agent, "codex");
   assert.equal(timedOut.nativeCalls(), 2);
   assert.equal(timedOut.state.cache.entries["claude|gpt-5.6-luna"], undefined);
+
+  const stderrThenReady = nativeResolver("claude", [
+    { code: 1, stdout: "", stderr: "another session is already running\n" },
+    { code: 0, stdout: '{"loggedIn":true}\n', stderr: "" },
+  ]);
+  assert.equal((await stderrThenReady.resolver.resolve("analysis")).agent, "claude");
+  assert.equal(stderrThenReady.nativeCalls(), 2);
 
   const unsupported = nativeResolver("opencode", [{ code: 0, stdout: "anthropic/claude-opus-5\n", stderr: "" }]);
   assert.equal((await unsupported.resolver.resolve("analysis")).agent, "codex");
@@ -533,7 +557,12 @@ test("a transient probe timeout retries once and does not poison the cache", asy
 
   const busyExit = resolverWith({
     "pi|gpt-5.6-luna": [
-      { verdict: "unreachable", detail: "exit 1", resolvedModel: null },
+      {
+        verdict: "unreachable",
+        detail: "another session is already running",
+        resolvedModel: null,
+        transient: true,
+      },
       { resolvedModel: "openai-codex/gpt-5.6-luna" },
     ],
   });


### PR DESCRIPTION
## Intent

Make backpass's harness capability probe robust under concurrency. Today a probe answered "model not advertised" purely because the harness was busy serving another backpass run, and a plain exit 1 on a pinned session minutes later - transient failures got turned into permanent negative verdicts. Fix: one retry with backoff before demoting or failing a probe, and do NOT cache a negative probe verdict that came from a timeout (cache-poisoning protection). Keep it scoped to the probe path. Cover behaviorally: a transient/timeout probe failure retries and does not poison the cache; a genuine unsupported result still demotes. Do not self-merge.

## What Changed

- Retry timeouts, bare exits, and empty advertised-model results once with backoff.
- Keep transient failures out of the probe cache while preserving durable unsupported-model demotion.
- Document the behavior and add behavioral coverage for retries, cache safety, and genuine unsupported results.

## Risk Assessment

✅ Low: The change is scoped to capability probing, retries recognized transient failures once, avoids persisting transient negatives, and preserves demotion for genuine unsupported results.

## Testing

No baseline command was supplied. Focused behavioral tests and a persisted-cache integration check confirmed transient probes retry once, timeout negatives do not poison later runs, concurrent workers share probe work, and genuinely unsupported models still demote and cache correctly.

<details>
<summary>Evidence: Probe retry, fallback, and cache behavior</summary>

Source: [Probe retry, fallback, and cache behavior](https://github.com/kunchenguid/backpass/blob/7838862be36c17d1e8b42f93bcc743ed245fa8d0/.no-mistakes/evidence/fm/backpass-probe-concurrency-retry-r1/probe-concurrency-behavior.json)

```text
{
  "transient_then_recovered": {
    "probe_sequence": [
      "busy",
      "busy"
    ],
    "selected": "busy/provider/wanted",
    "persisted_verdict": "ok"
  },
  "repeated_timeout": {
    "probe_sequence": [
      "busy",
      "busy",
      "fallback"
    ],
    "selected_this_run": "fallback",
    "transient_negative_persisted": false,
    "next_run_probe_sequence": [
      "busy"
    ],
    "selected_next_run": "busy"
  },
  "genuine_unsupported": {
    "probe_sequence": [
      "busy",
      "fallback"
    ],
    "selected": "fallback",
    "persisted_verdict": "model-unavailable"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8f0e47b5a6d91e4c1bf65c96199b4f89958e2df5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/agents.js:198` - The required &#34;transient/timeout probe failure retries and does not poison the cache&#34; invariant remains broken for native probes. If `opencode models` exits 0 with empty stdout, `NATIVE_PROBES.opencode` returns `model-unavailable` with detail `absent from ...`, which this classifier does not recognize, so it is neither retried nor excluded from the cache. Likewise, a timed-out `claude auth status` becomes `unreachable` with detail `claude auth status exit null` and is cached. Normalize native timeout and empty-list outcomes into transient results at the probe boundary, then behaviorally cover those native paths. Because this contradicts an explicit required criterion, the remedy requires user review.

🔧 Fix: Handle native probe transients without cache poisoning
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='native probe transients|transient probe timeout|busy empty advertised-model|parallel workers' test/agents.test.js`
- `node --test --test-name-pattern='probe verdicts are cached with TTLs|native probe transients retry without caching while unsupported models demote|a transient probe timeout retries once and does not poison the cache|a busy empty advertised-model list retries; a genuine unsupported model still demotes' test/agents.test.js`
- `Executed an AgentResolver integration scenario with persisted State covering transient recovery, repeated timeout fallback and next-run re-probe, and genuine unsupported demotion.`
- <code>`git status --short` confirmed testing left the worktree clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
