### PR TITLE
feat: report cross-surface skill duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   hash on stderr, so a full reanalysis without `--force` after a memory edit reads as "the
   file changed," not as a
   broken cache - the cache-hit path itself (unchanged file, no `--force`) is unaffected.
+- **Cross-surface duplication is report-only.** `crossSurfaceDuplicates` (`src/overlap.js`)
+  flags memory-file units whose text substantially overlaps a skill description or body
+  (Dice >= 0.6, same bar as gap coverage). Fold stamps it on the instruction row and
+  `backpass status` lists it so a shrink can drop the memory-file copy; nothing is deleted
+  automatically. Relevance still accrues to the memory-file alias until that copy is gone.
 - **Gap corroboration is counted across runs through `.backpass/gap-ledger.json`**
   (`src/gap-ledger.js`, wired in `foldForRun`): one sighting per (gap, transcript id), so a
   session never counts twice and a gap seen once per run still graduates at `minGapEvidence`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 - **Cross-surface duplication is report-only.** `crossSurfaceDuplicates` (`src/overlap.js`)
   flags memory-file units whose text substantially overlaps a skill description or body
   (Dice >= 0.6, same bar as gap coverage). Fold stamps it on the instruction row and
-  `backpass status` lists it so a shrink can drop the memory-file copy; nothing is deleted
-  automatically. Relevance still accrues to the memory-file alias until that copy is gone.
+  `backpass status` lists it. Description overlap duplicates always-loaded tokens and can
+  guide a shrink to drop the memory-file copy. Body overlap is only placement evidence: a
+  skill body loads on trigger, so its memory copy may be the only always-loaded coverage.
+  Nothing is deleted automatically. Relevance still accrues to the memory-file alias until
+  that copy is gone.
 - **Gap corroboration is counted across runs through `.backpass/gap-ledger.json`**
   (`src/gap-ledger.js`, wired in `foldForRun`): one sighting per (gap, transcript id), so a
   session never counts twice and a gap seen once per run still graduates at `minGapEvidence`.

--- a/README.md
+++ b/README.md
@@ -185,9 +185,12 @@ replaced with fresh judgments.
 
 Evidence is grouped by instruction, giving each one a positive/negative count, a count of
 distinct sessions with harm-class negatives, and a **relevance** figure: the share of
-analyzed sessions in which it mattered at all. Duplicate gaps across sessions are
-clustered, and clusters seen in fewer than `minGapEvidence` sessions (default 2) are
-dropped. One bad session never rewrites the weights.
+analyzed sessions in which it mattered at all. The fold also reports memory-file units
+that substantially overlap a project skill. An overlap with a skill description duplicates
+always-loaded tokens and points the shrink at the memory-file copy; an overlap with a
+triggered skill body is placement evidence only, since the memory copy may be the only
+always-loaded coverage. Neither kind is deleted automatically. Duplicate gaps across
+sessions are clustered, and clusters seen in fewer than `minGapEvidence` sessions (default 2) are dropped. One bad session never rewrites the weights.
 
 Whether two sightings are one gap is a judgment call, not a word-overlap score - models
 paraphrase, and a paraphrase that fails a lexical match would hide real recurrence.
@@ -405,7 +408,7 @@ pointer-aware:
 | `backpass analyze` | calculate loss: the tier-1 pass over pending transcripts                                 |
 | `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
 | `backpass apply`   | review and write the accepted edits                                                      |
-| `backpass status`  | cache state, failed transcripts, budget bars                                             |
+| `backpass status`  | cache state, failed transcripts, budget bars, and cross-surface overlaps                 |
 | `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
 
 Run `backpass --help` for the full flag list.

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -54,6 +54,7 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = []) {
     minGapEvidence,
     memoryFile,
     gapObservations: ledgerGapObservations(ledger, memoryFile.path, skills),
+    skills,
   });
   summary.consolidation = consolidation;
   return summary;

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -100,9 +100,7 @@ export async function cmdStatus(ctx) {
     for (const hit of duplicates) {
       const where = hit.memoryPath && hit.memoryPath !== resolved.primary?.path ? ` ${hit.memoryPath}` : "";
       const placement =
-        hit.surface === "description"
-          ? " · duplicated always loaded"
-          : " · body loads on trigger; weigh placement";
+        hit.surface === "description" ? " · duplicated always loaded" : " · body loads on trigger; weigh placement";
       out(
         `  ${hit.instruction}${where} restates ${hit.skill} ${hit.surface}` +
           ` · ${formatTokens(hit.tokens)} tok · similarity ${hit.score.toFixed(2)}${placement}`,

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -9,6 +9,7 @@ import {
   resolveProjectSkillDirs,
   skillDescriptionTokens,
 } from "../skills.js";
+import { crossSurfaceDuplicates } from "../overlap.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 import { table } from "./scan.js";
 import { DEFAULT_EFFORT } from "../config.js";
@@ -33,6 +34,10 @@ export async function cmdStatus(ctx) {
   const skills = loadProjectSkills(repo.root, overflow.dir);
   const descriptionTokens = skillDescriptionTokens(skills);
 
+  const duplicates = files
+    .filter((file) => !resolved.pointers.includes(file))
+    .flatMap((file) => crossSurfaceDuplicates(file, skills));
+
   const budgets = files.map((file) => {
     const includesSkills = file === resolved.primary && skills.length > 0;
     return {
@@ -51,6 +56,7 @@ export async function cmdStatus(ctx) {
     json({
       repo: repo.name,
       budgets,
+      crossSurfaceDuplicates: duplicates,
       evidence: counts,
       scanCacheEntries: Object.keys(cache.entries).length,
       summary: summary ? { analyzedSessions: summary.analyzedSessions, totals: summary.totals } : null,
@@ -87,6 +93,17 @@ export async function cmdStatus(ctx) {
           `${formatTokens(descriptionTokens)} tok always loaded`,
       ),
     );
+  }
+  if (duplicates.length) {
+    out("");
+    out(color.dim("CROSS-SURFACE (report-only)"));
+    for (const hit of duplicates) {
+      const where = hit.memoryPath && hit.memoryPath !== resolved.primary?.path ? ` ${hit.memoryPath}` : "";
+      out(
+        `  ${hit.instruction}${where} restates ${hit.skill} ${hit.surface}` +
+          ` · ${formatTokens(hit.tokens)} tok · similarity ${hit.score.toFixed(2)}`,
+      );
+    }
   }
   out("");
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -99,9 +99,13 @@ export async function cmdStatus(ctx) {
     out(color.dim("CROSS-SURFACE (report-only)"));
     for (const hit of duplicates) {
       const where = hit.memoryPath && hit.memoryPath !== resolved.primary?.path ? ` ${hit.memoryPath}` : "";
+      const placement =
+        hit.surface === "description"
+          ? " · duplicated always loaded"
+          : " · body loads on trigger; weigh placement";
       out(
         `  ${hit.instruction}${where} restates ${hit.skill} ${hit.surface}` +
-          ` · ${formatTokens(hit.tokens)} tok · similarity ${hit.score.toFixed(2)}`,
+          ` · ${formatTokens(hit.tokens)} tok · similarity ${hit.score.toFixed(2)}${placement}`,
       );
     }
   }

--- a/src/fold.js
+++ b/src/fold.js
@@ -23,8 +23,9 @@ import { crossSurfaceDuplicates } from "./overlap.js";
  *     clusters are built from those instead of this run's records, so a gap seen once now
  *     and once on a later run graduates. Without a ledger the records alone are used.
  *  4. Memory-file units whose text substantially overlaps a skill description or body are
- *     flagged (`crossSurfaceDuplicates` in `src/overlap.js`). Report-only: the shrink sees
- *     the duplicated always-loaded tokens; nothing is deleted here.
+ *     flagged (`crossSurfaceDuplicates` in `src/overlap.js`). Description overlap exposes
+ *     duplicated always-loaded tokens; body overlap is placement evidence because skill
+ *     bodies load only on trigger. Both are report-only: nothing is deleted here.
  */
 
 /**

--- a/src/fold.js
+++ b/src/fold.js
@@ -1,11 +1,12 @@
 import { similarity } from "./memory.js";
 import { GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
+import { crossSurfaceDuplicates } from "./overlap.js";
 
 /**
  * Stage 2 of the pipeline (design section 3): fold per-transcript evidence into one
  * compact summary. Entirely deterministic - no model involved.
  *
- * Three things happen here that the synthesis pass depends on:
+ * Four things happen here that the synthesis pass depends on:
  *
  *  1. Evidence is grouped by instruction id, giving per-instruction positive/negative
  *     counts and, crucially, `relevance` = sessions where the instruction drew any
@@ -21,13 +22,19 @@ import { GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
  *     caller passes `gapObservations` (the pruned gap ledger, `src/gap-ledger.js`) the
  *     clusters are built from those instead of this run's records, so a gap seen once now
  *     and once on a later run graduates. Without a ledger the records alone are used.
+ *  4. Memory-file units whose text substantially overlaps a skill description or body are
+ *     flagged (`crossSurfaceDuplicates` in `src/overlap.js`). Report-only: the shrink sees
+ *     the duplicated always-loaded tokens; nothing is deleted here.
  */
 
 /**
  * @param {object[]} evidenceRecords
- * @param {{ minGapEvidence?: number, memoryFile?: object|null, gapObservations?: object[]|null }} [options]
+ * @param {{ minGapEvidence?: number, memoryFile?: object|null, gapObservations?: object[]|null, skills?: object[] }} [options]
  */
-export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile = null, gapObservations = null } = {}) {
+export function foldEvidence(
+  evidenceRecords,
+  { minGapEvidence = 2, memoryFile = null, gapObservations = null, skills = [] } = {},
+) {
   const usable = evidenceRecords.filter((e) => e && e.status === "ok");
   const analyzedSessions = usable.length;
 
@@ -107,9 +114,13 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
     for (const unit of memoryFile.units) touch(unit.id);
   }
 
+  const duplicates = crossSurfaceDuplicates(memoryFile, skills);
+  const overlapById = new Map(duplicates.map((hit) => [hit.instruction, hit]));
+
   const instructionRows = [...instructions.values()]
     .map((entry) => {
       const unit = memoryFile?.units.find((u) => u.id === entry.instruction) || null;
+      const skillOverlap = overlapById.get(entry.instruction);
       return {
         instruction: entry.instruction,
         positive: entry.positive,
@@ -121,6 +132,7 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
         section: unit?.section ?? null,
         known: Boolean(unit),
         quotes: entry.quotes.slice(0, 6),
+        ...(skillOverlap ? { skillOverlap } : {}),
       };
     })
     .sort((a, b) => b.negative - a.negative || b.sessions - a.sessions || a.instruction.localeCompare(b.instruction));
@@ -153,9 +165,11 @@ export function foldEvidence(evidenceRecords, { minGapEvidence = 2, memoryFile =
       droppedGapSingletons,
       orchestrationGapSightings,
       usedRawTranscript: usedRawCount,
+      crossSurfaceDuplicates: duplicates.length,
     },
     instructions: instructionRows,
     gaps,
+    crossSurfaceDuplicates: duplicates,
   };
 }
 
@@ -252,6 +266,14 @@ export function renderEvidenceForPrompt(summary) {
       `- [${row.instruction}] +${row.positive} -${row.negative}${harm} sessions=${row.sessions} relevance=${relevance}${cost}` +
         (row.known ? "" : " (id not found in current file - stale reference)"),
     );
+    if (row.skillOverlap) {
+      const overlap = row.skillOverlap;
+      lines.push(
+        `    CROSS-SURFACE: restates skill "${overlap.skill}" ${overlap.surface} ` +
+          `(similarity ${overlap.score.toFixed(2)}) - duplicated always-loaded tokens; ` +
+          `drop the memory-file copy, do not treat it as a second instruction`,
+      );
+    }
     for (const quote of row.quotes.slice(0, 3)) {
       const sign = quote.polarity === "negative" ? "-" : "+";
       const cls = quote.polarity === "negative" ? ` [${quote.class ?? "unclassified"}]` : "";

--- a/src/fold.js
+++ b/src/fold.js
@@ -268,11 +268,20 @@ export function renderEvidenceForPrompt(summary) {
     );
     if (row.skillOverlap) {
       const overlap = row.skillOverlap;
-      lines.push(
+      const match =
         `    CROSS-SURFACE: restates skill "${overlap.skill}" ${overlap.surface} ` +
-          `(similarity ${overlap.score.toFixed(2)}) - duplicated always-loaded tokens; ` +
-          `drop the memory-file copy, do not treat it as a second instruction`,
-      );
+        `(similarity ${overlap.score.toFixed(2)})`;
+      if (overlap.surface === "description") {
+        lines.push(
+          `${match} - duplicated always-loaded tokens; ` +
+            `drop the memory-file copy, do not treat it as a second instruction`,
+        );
+      } else {
+        lines.push(
+          `${match} - triggered skill-body overlap (report-only); weigh relevance and trigger suitability, ` +
+            `do not infer the memory-file copy should be dropped`,
+        );
+      }
     }
     for (const quote of row.quotes.slice(0, 3)) {
       const sign = quote.polarity === "negative" ? "-" : "+";

--- a/src/memory.js
+++ b/src/memory.js
@@ -177,7 +177,7 @@ export function renderInstructionIndex(file) {
     .join("\n\n");
 }
 
-function bigrams(text) {
+export function similarityFeatures(text) {
   const words = normalizeForHash(text).split(" ").filter(Boolean);
   if (words.length < 2) return new Set(words);
   const out = new Set();
@@ -185,14 +185,16 @@ function bigrams(text) {
   return out;
 }
 
+export function featureSimilarity(a, b) {
+  if (!a.size || !b.size) return a.size === b.size ? 1 : 0;
+  let shared = 0;
+  for (const feature of a) if (b.has(feature)) shared += 1;
+  return (2 * shared) / (a.size + b.size);
+}
+
 /** Sorensen-Dice similarity over word bigrams, used for re-anchoring. */
 export function similarity(a, b) {
-  const A = bigrams(a);
-  const B = bigrams(b);
-  if (!A.size || !B.size) return A.size === B.size ? 1 : 0;
-  let shared = 0;
-  for (const g of A) if (B.has(g)) shared += 1;
-  return (2 * shared) / (A.size + B.size);
+  return featureSimilarity(similarityFeatures(a), similarityFeatures(b));
 }
 
 /**

--- a/src/overlap.js
+++ b/src/overlap.js
@@ -1,4 +1,4 @@
-import { parseMemoryUnits, similarity } from "./memory.js";
+import { featureSimilarity, parseMemoryUnits, similarityFeatures } from "./memory.js";
 
 /**
  * Cross-surface duplication (always-loaded memory file vs skills).
@@ -35,18 +35,26 @@ function normalizeIndexLabel(text) {
     .trim();
 }
 
-function overlapScore(unitText, candidate) {
-  const unitVariants = textVariants(unitText);
-  const unmarked = unitVariants.at(-1);
-  const indexed = /^(.*?)(?:::|:|\s+-\s+)([\s\S]+)$/.exec(unmarked);
-  if (indexed && normalizeIndexLabel(indexed[1]) === normalizeIndexLabel(candidate.skill)) {
-    unitVariants.push(indexed[2].trim());
-  }
+function preparedUnit(text) {
+  const variants = textVariants(text);
+  const indexed = /^(.*?)(?:::|:|\s+-\s+)([\s\S]+)$/.exec(variants.at(-1));
+  return {
+    features: variants.map(similarityFeatures),
+    indexLabel: indexed ? normalizeIndexLabel(indexed[1]) : null,
+    indexedFeatures: indexed ? similarityFeatures(indexed[2].trim()) : null,
+  };
+}
 
+function overlapScore(unit, candidate) {
   let best = 0;
-  for (const unitVariant of unitVariants) {
-    for (const candidateVariant of textVariants(candidate.text)) {
-      best = Math.max(best, similarity(unitVariant, candidateVariant));
+  for (const unitFeatures of unit.features) {
+    for (const candidateFeatures of candidate.features) {
+      best = Math.max(best, featureSimilarity(unitFeatures, candidateFeatures));
+    }
+  }
+  if (unit.indexLabel === candidate.skillLabel) {
+    for (const candidateFeatures of candidate.features) {
+      best = Math.max(best, featureSimilarity(unit.indexedFeatures, candidateFeatures));
     }
   }
   return best;
@@ -85,15 +93,18 @@ export function crossSurfaceDuplicates(memoryFile, skills = [], threshold = CROS
       skill: skill.name,
       path: skill.path,
       ...entry,
+      skillLabel: normalizeIndexLabel(skill.name),
+      features: textVariants(entry.text).map(similarityFeatures),
     })),
   );
   if (!catalog.length) return [];
 
   const hits = [];
   for (const unit of units) {
+    const prepared = preparedUnit(unit.text);
     let best = null;
     for (const candidate of catalog) {
-      const score = overlapScore(unit.text, candidate);
+      const score = overlapScore(prepared, candidate);
       if (score < threshold) continue;
       if (!best || score > best.score) {
         best = {

--- a/src/overlap.js
+++ b/src/overlap.js
@@ -1,0 +1,81 @@
+import { parseMemoryUnits, similarity } from "./memory.js";
+
+/**
+ * Cross-surface duplication (always-loaded memory file vs skills).
+ *
+ * A skill's description is already always-loaded; an index line or restated procedure
+ * in the memory file pays those tokens twice, and relevance credit still lands on the
+ * memory-file alias. This pass flags the overlap so a shrink can drop the copy. It
+ * never deletes: detection and report only.
+ *
+ * The score is the same Sorensen-Dice word-bigram `similarity` used to re-anchor
+ * instructions and to decide gap coverage. The bar matches `GAP_COVERED_THRESHOLD`
+ * (0.6): substantial overlap, not a shared stopword.
+ */
+
+/** Same bar as gap coverage / re-anchor: enough to call the texts the same unit. */
+export const CROSS_SURFACE_OVERLAP_THRESHOLD = 0.6;
+
+/**
+ * Surfaces a memory-file unit can duplicate: the skill's always-loaded description,
+ * the full body, and each body unit (so a restated paragraph still matches).
+ */
+function skillSurfaces(skill) {
+  const surfaces = [];
+  const description = String(skill?.description || "").trim();
+  if (description) {
+    surfaces.push({ surface: "description", text: description });
+  }
+  const body = String(skill?.body || "").trim();
+  if (body) {
+    surfaces.push({ surface: "body", text: body });
+    for (const unit of parseMemoryUnits(body)) {
+      if (unit.text.trim()) surfaces.push({ surface: "body", text: unit.text });
+    }
+  }
+  return surfaces;
+}
+
+/**
+ * Memory-file units whose normalized text substantially overlaps a skill description
+ * or body. One best hit per unit (highest score); report-only.
+ *
+ * @param {{ path?: string, units?: object[] }|null} memoryFile
+ * @param {object[]} [skills]
+ * @param {number} [threshold]
+ */
+export function crossSurfaceDuplicates(memoryFile, skills = [], threshold = CROSS_SURFACE_OVERLAP_THRESHOLD) {
+  const units = memoryFile?.units || [];
+  if (!units.length || !skills.length) return [];
+
+  const catalog = skills.flatMap((skill) =>
+    skillSurfaces(skill).map((entry) => ({
+      skill: skill.name,
+      path: skill.path,
+      ...entry,
+    })),
+  );
+  if (!catalog.length) return [];
+
+  const hits = [];
+  for (const unit of units) {
+    let best = null;
+    for (const candidate of catalog) {
+      const score = similarity(unit.text, candidate.text);
+      if (score < threshold) continue;
+      if (!best || score > best.score) {
+        best = {
+          instruction: unit.id,
+          tokens: unit.tokens,
+          skill: candidate.skill,
+          path: candidate.path,
+          surface: candidate.surface,
+          score,
+          ...(memoryFile.path ? { memoryPath: memoryFile.path } : {}),
+        };
+      }
+    }
+    if (best) hits.push(best);
+  }
+  return hits;
+}

--- a/src/overlap.js
+++ b/src/overlap.js
@@ -78,7 +78,8 @@ function skillSurfaces(skill) {
 
 /**
  * Memory-file units whose normalized text substantially overlaps a skill description
- * or body. One best hit per unit (highest score); report-only.
+ * or body. One preferred hit per unit: a qualifying description match wins over body
+ * matches, then the highest score wins within that surface; report-only.
  *
  * @param {{ path?: string, units?: object[] }|null} memoryFile
  * @param {object[]} [skills]
@@ -106,7 +107,11 @@ export function crossSurfaceDuplicates(memoryFile, skills = [], threshold = CROS
     for (const candidate of catalog) {
       const score = overlapScore(prepared, candidate);
       if (score < threshold) continue;
-      if (!best || score > best.score) {
+      if (
+        !best ||
+        (candidate.surface === "description" && best.surface !== "description") ||
+        (candidate.surface === best.surface && score > best.score)
+      ) {
         best = {
           instruction: unit.id,
           tokens: unit.tokens,

--- a/src/overlap.js
+++ b/src/overlap.js
@@ -3,10 +3,11 @@ import { featureSimilarity, parseMemoryUnits, similarityFeatures } from "./memor
 /**
  * Cross-surface duplication (always-loaded memory file vs skills).
  *
- * A skill's description is already always-loaded; an index line or restated procedure
- * in the memory file pays those tokens twice, and relevance credit still lands on the
- * memory-file alias. This pass flags the overlap so a shrink can drop the copy. It
- * never deletes: detection and report only.
+ * A skill's description is already always-loaded, so a matching memory-file unit pays
+ * those tokens twice while relevance credit still lands on the memory-file alias. A
+ * skill-body match is different: the body loads only on trigger, so the memory unit may
+ * be the only always-loaded coverage. This pass reports both for placement decisions and
+ * never deletes; only description matches point a shrink at the memory-file copy.
  *
  * The score is the same Sorensen-Dice word-bigram `similarity` used to re-anchor
  * instructions and to decide gap coverage. The bar matches `GAP_COVERED_THRESHOLD`
@@ -17,8 +18,8 @@ import { featureSimilarity, parseMemoryUnits, similarityFeatures } from "./memor
 export const CROSS_SURFACE_OVERLAP_THRESHOLD = 0.6;
 
 /**
- * Surfaces a memory-file unit can duplicate: the skill's always-loaded description,
- * the full body, and each body unit (so a restated paragraph still matches).
+ * Skill surfaces a memory-file unit can overlap: the always-loaded description, the
+ * full triggered body, and each body unit (so a restated paragraph still matches).
  */
 function textVariants(text) {
   const original = String(text || "").trim();

--- a/src/overlap.js
+++ b/src/overlap.js
@@ -20,6 +20,38 @@ export const CROSS_SURFACE_OVERLAP_THRESHOLD = 0.6;
  * Surfaces a memory-file unit can duplicate: the skill's always-loaded description,
  * the full body, and each body unit (so a restated paragraph still matches).
  */
+function textVariants(text) {
+  const original = String(text || "").trim();
+  if (!original) return [];
+  const withoutListMarker = original.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, "").trim();
+  return withoutListMarker === original ? [original] : [original, withoutListMarker];
+}
+
+function normalizeIndexLabel(text) {
+  return text
+    .toLowerCase()
+    .replace(/[`*_~[\]()]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function overlapScore(unitText, candidate) {
+  const unitVariants = textVariants(unitText);
+  const unmarked = unitVariants.at(-1);
+  const indexed = /^(.*?)(?:::|:|\s+-\s+)([\s\S]+)$/.exec(unmarked);
+  if (indexed && normalizeIndexLabel(indexed[1]) === normalizeIndexLabel(candidate.skill)) {
+    unitVariants.push(indexed[2].trim());
+  }
+
+  let best = 0;
+  for (const unitVariant of unitVariants) {
+    for (const candidateVariant of textVariants(candidate.text)) {
+      best = Math.max(best, similarity(unitVariant, candidateVariant));
+    }
+  }
+  return best;
+}
+
 function skillSurfaces(skill) {
   const surfaces = [];
   const description = String(skill?.description || "").trim();
@@ -61,7 +93,7 @@ export function crossSurfaceDuplicates(memoryFile, skills = [], threshold = CROS
   for (const unit of units) {
     let best = null;
     for (const candidate of catalog) {
-      const score = similarity(unit.text, candidate.text);
+      const score = overlapScore(unit.text, candidate);
       if (score < threshold) continue;
       if (!best || score > best.score) {
         best = {

--- a/test/overlap.test.js
+++ b/test/overlap.test.js
@@ -35,6 +35,20 @@ test("a memory unit that restates a skill description is flagged", () => {
   );
 });
 
+test("a short skill index entry is compared without its structural prefix", () => {
+  const memoryFile = {
+    path: "AGENTS.md",
+    units: parseMemoryUnits("# Skills\n\n- deploy: Run deployments.\n"),
+  };
+  const hits = crossSurfaceDuplicates(memoryFile, [
+    skill({ name: "deploy", description: "Run deployments.", body: "Deployment details." }),
+  ]);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].instruction, "AG-001");
+  assert.equal(hits[0].surface, "description");
+  assert.equal(hits[0].score, 1);
+});
+
 test("a memory unit that restates a skill body paragraph is flagged against the body", () => {
   const body = "Always wrap migrations in a transaction before applying them.";
   const memoryFile = {

--- a/test/overlap.test.js
+++ b/test/overlap.test.js
@@ -61,6 +61,24 @@ test("a memory unit that restates a skill body paragraph is flagged against the 
   assert.equal(hits[0].skill, "database");
 });
 
+test("fold renders body overlap without always-loaded drop advice", () => {
+  const body = "Always wrap migrations in a transaction before applying them.";
+  const memoryFile = {
+    path: "AGENTS.md",
+    units: parseMemoryUnits(`# Rules\n\n- ${body}\n`),
+  };
+  const summary = foldEvidence([], {
+    memoryFile,
+    skills: [skill({ description: "Database skill.", body })],
+  });
+
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.match(rendered, /triggered skill-body overlap \(report-only\)/);
+  assert.match(rendered, /weigh relevance and trigger suitability/);
+  assert.doesNotMatch(rendered, /duplicated always-loaded tokens/);
+  assert.doesNotMatch(rendered, /drop the memory-file copy/);
+});
+
 test("empty skills or empty memory produce no flags", () => {
   const memoryFile = { path: "AGENTS.md", units: parseMemoryUnits("# T\n\n- Keep changes focused.\n") };
   assert.deepEqual(crossSurfaceDuplicates(memoryFile, []), []);

--- a/test/overlap.test.js
+++ b/test/overlap.test.js
@@ -49,6 +49,26 @@ test("a short skill index entry is compared without its structural prefix", () =
   assert.equal(hits[0].score, 1);
 });
 
+test("a qualifying description match takes precedence over a stronger body match", () => {
+  const memoryText = "Run deployments safely";
+  const memoryFile = {
+    path: "AGENTS.md",
+    units: parseMemoryUnits(`# Skills\n\n- ${memoryText}\n`),
+  };
+  const hits = crossSurfaceDuplicates(memoryFile, [
+    skill({
+      name: "deploy",
+      description: "Run deployments safely in production.",
+      body: memoryText,
+    }),
+  ]);
+
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].surface, "description");
+  assert.ok(hits[0].score >= CROSS_SURFACE_OVERLAP_THRESHOLD);
+  assert.ok(hits[0].score < 1);
+});
+
 test("a memory unit that restates a skill body paragraph is flagged against the body", () => {
   const body = "Always wrap migrations in a transaction before applying them.";
   const memoryFile = {

--- a/test/overlap.test.js
+++ b/test/overlap.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { parseMemoryUnits } from "../src/memory.js";
+import { CROSS_SURFACE_OVERLAP_THRESHOLD, crossSurfaceDuplicates } from "../src/overlap.js";
+
+const DESCRIPTION = "Load before changing database queries.";
+
+function skill(overrides = {}) {
+  return {
+    name: "database",
+    path: ".agents/skills/database/SKILL.md",
+    description: DESCRIPTION,
+    body: "Read the schema first.",
+    ...overrides,
+  };
+}
+
+test("a memory unit that restates a skill description is flagged", () => {
+  const memoryFile = {
+    path: "AGENTS.md",
+    units: parseMemoryUnits(`# Rules\n\n- ${DESCRIPTION}\n- Keep changes focused.\n`),
+  };
+  const hits = crossSurfaceDuplicates(memoryFile, [skill()]);
+  assert.equal(hits.length, 1, "only the restated description is a duplicate");
+  assert.equal(hits[0].instruction, "AG-001");
+  assert.equal(hits[0].skill, "database");
+  assert.equal(hits[0].surface, "description");
+  assert.ok(hits[0].score >= CROSS_SURFACE_OVERLAP_THRESHOLD);
+  assert.equal(
+    hits.some((hit) => hit.instruction === "AG-002"),
+    false,
+    "an unrelated unit is not a duplicate",
+  );
+});
+
+test("a memory unit that restates a skill body paragraph is flagged against the body", () => {
+  const body = "Always wrap migrations in a transaction before applying them.";
+  const memoryFile = {
+    path: "AGENTS.md",
+    units: parseMemoryUnits(`# Rules\n\n- ${body}\n`),
+  };
+  const hits = crossSurfaceDuplicates(memoryFile, [skill({ description: "Database skill.", body })]);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].surface, "body");
+  assert.equal(hits[0].skill, "database");
+});
+
+test("empty skills or empty memory produce no flags", () => {
+  const memoryFile = { path: "AGENTS.md", units: parseMemoryUnits("# T\n\n- Keep changes focused.\n") };
+  assert.deepEqual(crossSurfaceDuplicates(memoryFile, []), []);
+  assert.deepEqual(crossSurfaceDuplicates(null, [skill()]), []);
+  assert.deepEqual(crossSurfaceDuplicates(memoryFile, [skill({ description: "", body: "" })]), []);
+});
+
+test("fold stamps the flag on the instruction row and renders it for synthesis", () => {
+  const memoryFile = {
+    path: "AGENTS.md",
+    units: parseMemoryUnits(`# Rules\n\n- ${DESCRIPTION}\n- Keep changes focused.\n`),
+  };
+  const summary = foldEvidence(
+    [
+      {
+        status: "ok",
+        transcript: { id: "s1", harness: "claude" },
+        positive: [{ instruction: "AG-001", quote: "opened the schema" }],
+        negative: [],
+        gaps: [],
+      },
+    ],
+    { memoryFile, skills: [skill()] },
+  );
+
+  const row = summary.instructions.find((item) => item.instruction === "AG-001");
+  assert.equal(row.skillOverlap.skill, "database");
+  assert.equal(row.skillOverlap.surface, "description");
+  assert.equal(summary.totals.crossSurfaceDuplicates, 1);
+  assert.equal(summary.crossSurfaceDuplicates.length, 1);
+
+  const unrelated = summary.instructions.find((item) => item.instruction === "AG-002");
+  assert.equal(unrelated.skillOverlap, undefined);
+
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.match(rendered, /CROSS-SURFACE: restates skill "database" description/);
+  assert.match(rendered, /drop the memory-file copy/);
+});

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -68,5 +68,21 @@ test("status reports a memory unit that restates a skill description", async () 
 
   const text = (await captureStatus(repo, false)).join("\n");
   assert.match(text, /CROSS-SURFACE \(report-only\)/);
-  assert.match(text, /AG-001 restates database description/);
+  assert.match(text, /AG-001 restates database description.*duplicated always loaded/);
+});
+
+test("status identifies body overlap as triggered placement evidence", async () => {
+  const body = "Always wrap migrations in a transaction before applying them.";
+  const repo = makeRepo({
+    "AGENTS.md": `# Rules\n\n- ${body}\n`,
+    ".agents/skills/database/SKILL.md": `---\nname: database\ndescription: Database skill.\n---\n\n${body}\n`,
+  });
+
+  const structured = JSON.parse((await captureStatus(repo, true)).join("\n"));
+  assert.equal(structured.crossSurfaceDuplicates.length, 1);
+  assert.equal(structured.crossSurfaceDuplicates[0].surface, "body");
+
+  const text = (await captureStatus(repo, false)).join("\n");
+  assert.match(text, /AG-001 restates database body.*body loads on trigger; weigh placement/);
+  assert.doesNotMatch(text, /duplicated always loaded/);
 });

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -51,4 +51,22 @@ test("status reports one always-loaded budget over memory and skill descriptions
   const text = (await captureStatus(repo, false)).join("\n");
   assert.match(text, new RegExp(`AGENTS\\.md \\+ skill descriptions.*${expected} /`));
   assert.equal((text.match(/AGENTS\.md \+ skill descriptions/g) || []).length, 1);
+  assert.equal(structured.crossSurfaceDuplicates.length, 0);
+});
+
+test("status reports a memory unit that restates a skill description", async () => {
+  const repo = makeRepo({
+    "AGENTS.md": `# Rules\n\n- ${DESCRIPTION}\n- Keep changes focused.\n`,
+    ".agents/skills/database/SKILL.md": SKILL,
+  });
+
+  const structured = JSON.parse((await captureStatus(repo, true)).join("\n"));
+  assert.equal(structured.crossSurfaceDuplicates.length, 1);
+  assert.equal(structured.crossSurfaceDuplicates[0].instruction, "AG-001");
+  assert.equal(structured.crossSurfaceDuplicates[0].skill, "database");
+  assert.equal(structured.crossSurfaceDuplicates[0].surface, "description");
+
+  const text = (await captureStatus(repo, false)).join("\n");
+  assert.match(text, /CROSS-SURFACE \(report-only\)/);
+  assert.match(text, /AG-001 restates database description/);
 });


### PR DESCRIPTION
## Intent

Add a cross-surface duplication pass to backpass's accounting. Today the two always-loaded surfaces overlap invisibly: firstmate's section-13 index lines duplicate the skills' own always-loaded descriptions, both are counted, and relevance credit accrues to the memory-file copy (the synthesis model noticed "AG-026 duplicates quota-array-dispatch" itself; the pipeline has no concept of it). Fix: at fold or status time, flag memory-file units whose normalized text substantially overlaps an existing skill's description or body. Even a REPORT-ONLY flag is enough to point the shrink at the easy duplicated tokens. Keep it a detection/report addition, not an automatic deletion. Cover behaviorally: a memory unit that restates a skill description is flagged.

## What Changed

- Detect memory units that substantially overlap skill descriptions or bodies using normalized similarity scoring.
- Surface report-only overlap details in fold summaries, synthesis evidence, and text and JSON status output.
- Document and behaviorally test description duplication, body placement evidence, and short skill index matching.

## Risk Assessment

✅ Low: The report-only detection is well bounded, behaviorally covered, and the prior fixes correctly distinguish description overlap from triggered body overlap.

## Testing

Targeted tests and an end-to-end CLI demo confirmed description overlaps are reported as duplicated always-loaded content, body overlaps are report-only placement evidence without drop advice, unrelated memory remains unflagged, and status does not modify AGENTS.md.

<details>
<summary>Evidence: End-to-end human-readable status report</summary>

```text
cross-surface-status-demo ~/.no-mistakes/evidence/01M18JJYKBBG3YG421ZC51VAHA/cross-surface-status-demo

BUDGET (always-loaded)
  AGENTS.md + skill descriptions [................................] 45 / 5,000 tok · 3 instructions
  overflow: 1 skill(s) in .agents/skills · 38 tok on trigger, 10 tok always loaded

CROSS-SURFACE (report-only)
  AG-001 restates database description · 10 tok · similarity 1.00 · duplicated always loaded
  AG-002 restates database body · 16 tok · similarity 1.00 · body loads on trigger; weigh placement

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  none yet - run `backpass`

MODELS
  analysis        auto - 7 candidates, none probed yet (effort medium)
  synthesis       auto - 7 candidates, none probed yet (effort high)

VERIFICATION
  AGENTS.md unchanged after report: yes
```
</details>
<details>
<summary>Evidence: End-to-end structured JSON status response</summary>

```text
{
  "repo": "cross-surface-status-demo",
  "budgets": [
    {
      "path": "AGENTS.md",
      "label": "AGENTS.md + skill descriptions",
      "capTokens": 5000,
      "current": 45,
      "projected": 45,
      "delta": 0,
      "withinBudget": true,
      "over": 0,
      "utilization": 0.009,
      "instructions": 3,
      "pointerTo": null,
      "separate": false
    }
  ],
  "crossSurfaceDuplicates": [
    {
      "instruction": "AG-001",
      "tokens": 10,
      "skill": "database",
      "path": ".agents/skills/database/SKILL.md",
      "surface": "description",
      "score": 1,
      "memoryPath": "AGENTS.md"
    },
    {
      "instruction": "AG-002",
      "tokens": 16,
      "skill": "database",
      "path": ".agents/skills/database/SKILL.md",
      "surface": "body",
      "score": 1,
      "memoryPath": "AGENTS.md"
    }
  ],
  "evidence": {
    "ok": 0,
    "failed": 0,
    "skipped": 0
  },
  "scanCacheEntries": 0,
  "summary": null,
  "proposal": null,
  "rejections": 0,
  "skills": 1
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"23920d5e93eece13c190b4dcc06299a9484598e4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (5) ✅</summary>

- 🚨 `src/overlap.js:66` - The shared similarity function retains Markdown list markers and index prefixes, so exact restatements of short descriptions can be missed. For example, memory unit `- deploy: Run deployments.` versus skill description `Run deployments.` scores 0.5 and is not flagged. Normalize cross-surface structural prefixes or compare against an appropriate contained span before applying the threshold.

🔧 Fix: Detect short skill index duplicates
2 warnings still open:

- ⚠️ `src/fold.js:273` - Every body match is called &#34;duplicated always-loaded tokens&#34; and unconditionally tells synthesis to drop the memory copy, but skill bodies are loaded only when triggered. A broadly relevant memory rule that also appears in a narrowly triggered skill body will receive advice contrary to the placement policy. Distinguish description duplication from body overlap and let relevance and trigger suitability govern body matches.
- ⚠️ `src/overlap.js:93` - Each memory unit repeatedly normalizes and builds bigrams for every full skill body and body unit. With U memory units and B total skill-body bytes, status and fold do O(U*B) text processing, so a large skill catalog can make the otherwise immediate status command slow. Precompute normalized candidate representations once at the shared overlap boundary.

🔧 Fix: Precompute cross-surface similarity features
1 warning still open:

- ⚠️ `src/fold.js:273` - Body matches are labeled as &#34;duplicated always-loaded tokens&#34; and tell synthesis to drop the memory copy, but skill bodies load only when triggered. A broadly relevant ambient rule duplicated in a narrowly triggered body can therefore receive advice contrary to the placement policy. Distinguish description matches from body matches and let relevance and trigger suitability govern the latter.

🔧 Fix: Distinguish description and body overlap guidance
2 issues (1 error, 1 warning) still open:

- 🚨 `src/overlap.js:109` - Selecting only the highest-scoring candidate lets a body match suppress a qualifying description match. For example, if memory text exactly matches a skill body while the description contains that text plus a short suffix, the body scores 1 and wins even though the description also exceeds 0.6. Status and fold then label this only as triggered body overlap and hide the genuine always-loaded duplication. Prefer qualifying description matches over body matches, or preserve both surfaces.
- ⚠️ `AGENTS.md:165` - The accepted requirement says body overlap must not advise dropping the memory copy, but this new instruction describes description or body overlap and then says status lists it &#34;so a shrink can drop the memory-file copy.&#34; This can steer future agents contrary to the corrected runtime guidance. Authorization is needed to revise the project instruction to distinguish description overlap from report-only body overlap.

🔧 Fix: Prefer qualifying description overlap matches
1 warning still open:

- ⚠️ `AGENTS.md:165` - This instruction groups description and body overlaps together and says a shrink can drop the memory-file copy. Skill bodies load only when triggered, so this can steer future agents contrary to the corrected runtime behavior. Revise it to reserve drop advice for description overlap and describe body overlap as report-only placement evidence.

🔧 Fix: Clarify cross-surface overlap placement guidance
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec node --test test/overlap.test.js test/status.test.js`
- <code>Ran `backpass status` and `backpass status --json` in a representative Git repository containing both description and body overlaps</code>
- <code>Verified `AGENTS.md` remained unchanged after status reporting with `git diff --quiet -- AGENTS.md`</code>
- `git diff --check d8cbdb68ca20a9ad6626810e0c24a576e43223c7..a4eb58cfcf4daa60c5d7b7a2a427b4260f7c8d91`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
