### PR TITLE
fix: enable synthesis harness write access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,
   `anchoredHunks`) and the agent annotates the measured changes by id, initially in the
-  same session. Write-capable spawn flags are in `src/harness-invoke.js` (`writeAccess`):
-  Codex code-mode and Grok `--always-approve` / `--permission-mode bypassPermissions`.
-  The model never supplies `find` text - every hunk is cut from the raw
+  same session. Synthesis sessions request `writeAccess`; analysis remains read-only.
+  `src/harness-invoke.js` owns the per-harness write-capability contract. The model never
+  supplies `find` text - every hunk is cut from the raw
   file, widened until unique, so a hunk can only go stale by the file itself changing after
   the proposal, which apply refuses rather than part-applies. Never pass
   `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   gets `--approve-all` with `cwd` = `.backpass/synthesis/` (`prepareWorkspace`), which holds
   only the memory file and the skills dir; backpass measures the copy (`measureWorkspace`,
   `anchoredHunks`) and the agent annotates the measured changes by id, initially in the
-  same session. The model never supplies `find` text - every hunk is cut from the raw
+  same session. Write-capable spawn flags are in `src/harness-invoke.js` (`writeAccess`):
+  Codex code-mode and Grok `--always-approve` / `--permission-mode bypassPermissions`.
+  The model never supplies `find` text - every hunk is cut from the raw
   file, widened until unique, so a hunk can only go stale by the file itself changing after
   the proposal, which apply refuses rather than part-applies. Never pass
   `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that

--- a/README.md
+++ b/README.md
@@ -273,8 +273,9 @@ for different things:
   attempt and can trigger a re-prompt. Only a parseable, gate-rejected answer writes a
   rejected proposal, stamped with the attempt that produced it.
 
-When a run does fail, the advice it prints comes from the condition it ended on. Run
-`backpass propose` again to start a fresh synthesis.
+When a run does fail, the advice it prints comes from the condition it ended on. If the
+rejected proposal included notes, the failure prints those too instead of hiding useful
+diagnostic context. Run `backpass propose` again to start a fresh synthesis.
 
 Token deltas shown to you are measured by backpass from the actual text - never taken from
 the model's own arithmetic.
@@ -449,7 +450,8 @@ Bare model ids are resolved against what each adapter advertises (`openai-codex/
 on pi, `openai/gpt-5.6-luna` on opencode, `gpt-5.6-luna` on codex), so nothing is hardcoded
 per harness. Ladders are ordinary config - reorder or shorten them under `"ladders"`.
 
-Pinning an agent skips its ladder entirely:
+Pinning an agent skips its ladder entirely. If that harness fails, backpass reports an
+actionable error and keeps the pin rather than falling through or printing a raw stack:
 
 ```sh
 backpass \

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -342,8 +342,8 @@ export async function execOneShot({
  *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
  *   close: () => Promise<void> }>}
  */
-export async function openSession({ agent, model = null, effort = null, sessionName, cwd }) {
-  const invocation = prepareHarnessInvocation({ agent, model, effort });
+export async function openSession({ agent, model = null, effort = null, sessionName, cwd, writeAccess = false }) {
+  const invocation = prepareHarnessInvocation({ agent, model, effort, writeAccess });
   const notes = [...invocation.notes];
   const acpxAgentArgs = invocationAgentArgs(invocation, agent);
   const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
@@ -400,6 +400,21 @@ export async function openSession({ agent, model = null, effort = null, sessionN
   };
 
   try {
+    if (invocation.sessionMode) {
+      const setMode = await run([...acpxAgentArgs, "-s", sessionName, "set-mode", invocation.sessionMode], runOpts);
+      if (setMode.code !== 0) {
+        const detail = firstLine(setMode.stderr) || `exit ${setMode.code}`;
+        if (invocation.sessionModeRequired) {
+          throw new AcpxError(
+            `acpx ${agent} could not enable write session mode=${invocation.sessionMode}: ${detail}`,
+            setMode,
+          );
+        }
+        notes.push(
+          `${agent} did not accept session mode ${invocation.sessionMode}; continuing with the adapter default`,
+        );
+      }
+    }
     if (effort && invocation.setEffortKey) {
       const set = await run([...acpxAgentArgs, "-s", sessionName, "set", invocation.setEffortKey, effort], runOpts);
       if (set.code !== 0) {

--- a/src/agents.js
+++ b/src/agents.js
@@ -363,7 +363,10 @@ export class AgentResolver {
         return await fn(pick);
       } catch (err) {
         const verdict = err instanceof AcpxError ? classifyAcpxFailure(err) : null;
-        if (!verdict || !(await this.demote(role, pick, verdict, err.message))) throw err;
+        if (verdict && !(await this.demote(role, pick, verdict, err.message))) {
+          throw pinnedFailureError(role, pick, verdict, err);
+        }
+        if (!verdict) throw err;
       }
     }
   }
@@ -373,6 +376,20 @@ function describeTrail(trail) {
   const losers = trail.filter((t) => t.verdict !== "ok");
   if (!losers.length) return "first candidate in the ladder";
   return `after skipping ${losers.map((t) => `${t.agent}/${t.model} (${VERDICT_LABELS[t.verdict] || t.verdict})`).join(", ")}`;
+}
+
+function pinnedFailureError(role, pick, verdict, err) {
+  const label = VERDICT_LABELS[verdict] || verdict;
+  const model = pick.model ? ` (${pick.model})` : "";
+  const pin = `or pin a different harness: backpass --${role}-agent <agent>`;
+  let hint = pin;
+  if (verdict === "unauthenticated" && LOGIN_HINTS[pick.agent]) {
+    hint = `run: ${LOGIN_HINTS[pick.agent]}; ${pin}`;
+  } else if (verdict === "unreachable") {
+    hint = `install the ${pick.agent} CLI; ${pin}`;
+  }
+  const detail = err?.message ? ` (${String(err.message).split("\n")[0]})` : "";
+  return new UserError(`pinned ${role} agent ${pick.agent}${model} is ${label}${detail}`, hint);
 }
 
 function exhaustedError(role, trail) {

--- a/src/agents.js
+++ b/src/agents.js
@@ -362,11 +362,11 @@ export class AgentResolver {
       try {
         return await fn(pick);
       } catch (err) {
-        const verdict = err instanceof AcpxError ? classifyAcpxFailure(err) : null;
-        if (verdict && !(await this.demote(role, pick, verdict, err.message))) {
-          throw pinnedFailureError(role, pick, verdict, err);
-        }
+        const isAcpxError = err instanceof AcpxError;
+        const verdict = isAcpxError ? classifyAcpxFailure(err) : null;
+        if (isAcpxError && pick.pinned) throw pinnedFailureError(role, pick, verdict, err);
         if (!verdict) throw err;
+        await this.demote(role, pick, verdict, err.message);
       }
     }
   }
@@ -379,17 +379,19 @@ function describeTrail(trail) {
 }
 
 function pinnedFailureError(role, pick, verdict, err) {
-  const label = VERDICT_LABELS[verdict] || verdict;
+  const label = verdict ? VERDICT_LABELS[verdict] || verdict : "failed unexpectedly";
   const model = pick.model ? ` (${pick.model})` : "";
   const pin = `or pin a different harness: backpass --${role}-agent <agent>`;
-  let hint = pin;
+  let hint = `check the ${pick.agent}/acpx failure above and retry; ${pin}`;
   if (verdict === "unauthenticated" && LOGIN_HINTS[pick.agent]) {
     hint = `run: ${LOGIN_HINTS[pick.agent]}; ${pin}`;
   } else if (verdict === "unreachable") {
     hint = `install the ${pick.agent} CLI; ${pin}`;
+  } else if (verdict) {
+    hint = pin;
   }
   const detail = err?.message ? ` (${String(err.message).split("\n")[0]})` : "";
-  return new UserError(`pinned ${role} agent ${pick.agent}${model} is ${label}${detail}`, hint);
+  return new UserError(`pinned ${role} agent ${pick.agent}${model} ${label}${detail}`, hint);
 }
 
 function exhaustedError(role, trail) {

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -202,6 +202,17 @@ export function printSynthesisFailure(err, state) {
     info(color.dim(`  it is from annotation attempt ${err.saved.attempt}, not the turn above, and it lists:`));
     for (const violation of err.saved.violations) info(color.dim(`    - ${violation}`));
   }
+  const notes = rejectedProposalNotes(err, state);
+  if (notes.length) {
+    info(color.dim("  the rejected proposal noted:"));
+    for (const note of notes) info(`    ${note}`);
+  }
+}
+
+function rejectedProposalNotes(err, state) {
+  if (Array.isArray(err.saved?.notes) && err.saved.notes.length) return err.saved.notes.map(String);
+  const proposal = state?.readProposal?.();
+  return Array.isArray(proposal?.notes) ? proposal.notes.map(String).filter(Boolean) : [];
 }
 
 export async function cmdPropose(ctx) {

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -3,7 +3,7 @@ import { foldEvidence } from "../fold.js";
 import { ledgerGapObservations, pruneGapLedger, recordGapObservations } from "../gap-ledger.js";
 import { synthesizeProposal } from "../synthesize.js";
 import { ProposalViolation } from "../proposal.js";
-import { UserError, color, info, json, out } from "../logger.js";
+import { UserError, color, info, json, out, terminalSafe } from "../logger.js";
 import { budgetBar, formatTokens } from "../tokens.js";
 import { emitProgress } from "../progress.js";
 import { primaryMemoryFile } from "./analyze.js";
@@ -142,7 +142,7 @@ export function printProposal(proposal, { applied = false, analysisUsage = [] } 
     );
   }
 
-  for (const note of proposal.notes || []) out(color.dim(`  note: ${note}`));
+  for (const note of proposal.notes || []) out(color.dim(`  note: ${terminalSafe(note)}`));
 
   printUsage({ tier1: analysisUsage, tier2: proposal.usage || [] });
   if (applied) return;
@@ -205,7 +205,7 @@ export function printSynthesisFailure(err, state) {
   const notes = rejectedProposalNotes(err, state);
   if (notes.length) {
     info(color.dim("  the rejected proposal noted:"));
-    for (const note of notes) info(`    ${note}`);
+    for (const note of notes) info(`    ${terminalSafe(note)}`);
   }
 }
 

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -25,7 +25,7 @@ import { UserError } from "./logger.js";
  * this spawn, never by rewriting `~/.codex/config.toml` or other harness defaults.
  *   codex     `INITIAL_AGENT_MODE=agent`, `CODEX_CONFIG` `features.code_mode_host=true`,
  *             `CODEX_PATH` wrapper `--enable code_mode_host`, ACP `set-mode agent`
- *   grok      process `--always-approve --permission-mode bypassPermissions`
+ *   grok      process `--always-approve --permission-mode bypassPermissions --sandbox workspace`
  *   pi        no extra flags (the adapter always exposes write/edit; modes are thinking)
  *   claude    acpx `--approve-all` on the prompt (client-side permission) is the contract
  *   opencode  no proven process overlay; `--approve-all` remains the client-side gate
@@ -177,7 +177,11 @@ function grokInvocation({ requestedModel, requestedEffort, writeAccess = false, 
     );
   }
   const extra = [];
-  if (writeAccess) extra.push("--always-approve", "--permission-mode", "bypassPermissions");
+  if (writeAccess) {
+    // Permission bypass prevents edit prompts; the OS sandbox still confines approved
+    // file and command tools to the staging cwd rather than granting host-wide writes.
+    extra.push("--always-approve", "--permission-mode", "bypassPermissions", "--sandbox", "workspace");
+  }
   if (requestedModel) extra.push("-m", requestedModel);
   if (requestedEffort) extra.push("--reasoning-effort", requestedEffort);
   extra.push("agent", "stdio");

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -218,15 +218,16 @@ function applyCodexWriteAccess(invocation, { cleanups }) {
   invocation.sessionMode = "agent";
   invocation.sessionModeRequired = true;
 
-  const real = invocation.env.CODEX_PATH || process.env.CODEX_PATH || resolveOnPath("codex");
-  if (!real || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(real))) return;
+  const real = process.env.CODEX_PATH || null;
   const { wrapperPath, dir } = writeArgvWrapper({
     realCommand: real,
+    bundledPackageBin: real ? null : ["@openai", "codex", "bin", "codex.js"],
     extraArgs: ["--enable", "code_mode_host"],
     binName: "codex",
   });
   cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
   invocation.env.CODEX_PATH = wrapperPath;
+  invocation.requiredBuiltinAgent = "codex";
 }
 
 function mergeCodexConfig(...layers) {
@@ -267,17 +268,19 @@ function mergeCodexConfig(...layers) {
  * Write a node wrapper that prepends `extraArgs` and execs `realCommand` with
  * inherited stdio. Args are JSON-encoded so values with spaces or `$()` stay literal.
  *
- * @param {{ realCommand: string, extraArgs: string[], binName: string }} options
+ * @param {{ realCommand: string | null, bundledPackageBin?: string[] | null, extraArgs: string[], binName: string }} options
  */
-function writeArgvWrapper({ realCommand, extraArgs, binName }) {
+function writeArgvWrapper({ realCommand, bundledPackageBin = null, extraArgs, binName }) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-wrap-"));
   const scriptPath = path.join(dir, `${binName}.cjs`);
-  const payload = JSON.stringify({ real: realCommand, extra: extraArgs });
+  const payload = JSON.stringify({ real: realCommand, bundledPackageBin, extra: extraArgs });
   fs.writeFileSync(
     scriptPath,
     `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
 const { spawn } = require("node:child_process");
-const { real, extra } = ${payload};
+const { real, bundledPackageBin, extra } = ${payload};
 const signals = ["SIGTERM", "SIGINT", "SIGHUP"];
 let child = null;
 let pendingSignal = null;
@@ -300,7 +303,24 @@ const forwardSignal = (signal) => {
 };
 const signalHandlers = new Map(signals.map((signal) => [signal, () => forwardSignal(signal)]));
 for (const [signal, handler] of signalHandlers) process.on(signal, handler);
-child = spawn(real, extra.concat(process.argv.slice(2)), { stdio: "inherit" });
+let command = real;
+let args = extra.concat(process.argv.slice(2));
+if (bundledPackageBin) {
+  const pathEntries = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+  const packageBin = pathEntries
+    .map((entry) => path.resolve(entry.replace(/^"|"$/g, ""), "..", ...bundledPackageBin))
+    .find((candidate) => {
+      try { return fs.statSync(candidate).isFile(); } catch { return false; }
+    });
+  if (!packageBin) {
+    console.error("could not locate the Codex executable bundled with the acpx adapter");
+    process.exit(1);
+  }
+  command = process.execPath;
+  args = [packageBin, ...args];
+}
+const shell = process.platform === "win32" && /\\.(?:cmd|bat)$/i.test(command);
+child = spawn(command, args, { stdio: "inherit", shell });
 if (pendingSignal) forwardSignal(pendingSignal);
 child.on("error", (err) => {
   console.error(err.message);

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -255,7 +255,13 @@ function mergeCodexConfig(...layers) {
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
     for (const [key, value] of Object.entries(parsed)) {
       if (key === "features" && value && typeof value === "object" && !Array.isArray(value)) {
-        merged.features = { ...(merged.features || {}), ...value };
+        const currentFeatures = merged.features;
+        merged.features = {
+          ...(currentFeatures && typeof currentFeatures === "object" && !Array.isArray(currentFeatures)
+            ? currentFeatures
+            : {}),
+          ...value,
+        };
       } else {
         merged[key] = value;
       }

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -21,6 +21,15 @@ import { UserError } from "./logger.js";
  *   codex     acpx `--model` at `sessions new`; ACP `set reasoning_effort`
  *   opencode  acpx `--model` at `sessions new`; no effort overlay (report, never pretend)
  *
+ * Synthesis also requests `writeAccess`: native file-write / code-mode must be on for
+ * this spawn, never by rewriting `~/.codex/config.toml` or other harness defaults.
+ *   codex     `INITIAL_AGENT_MODE=agent`, `CODEX_CONFIG` `features.code_mode_host=true`,
+ *             `CODEX_PATH` wrapper `--enable code_mode_host`, ACP `set-mode agent`
+ *   grok      process `--always-approve --permission-mode bypassPermissions`
+ *   pi        no extra flags (the adapter always exposes write/edit; modes are thinking)
+ *   claude    acpx `--approve-all` on the prompt (client-side permission) is the contract
+ *   opencode  no proven process overlay; `--approve-all` remains the client-side gate
+ *
  * No overlay requested means no wrapper, no `--model`, no `set` - same spawn as before.
  * A requested overlay with no proven invocation-scoped mechanism throws rather than
  * writing persistent defaults or silently ignoring the request. OpenCode effort is the
@@ -35,6 +44,8 @@ const SESSION_LOCAL_EFFORT_KEYS = { codex: "reasoning_effort", claude: "effort" 
  *   env: Record<string, string> | undefined,
  *   acpxModel: string | null,
  *   setEffortKey: string | null,
+ *   sessionMode: string | null,
+ *   sessionModeRequired: boolean,
  *   acpxAgentCommand: string | null,
  *   requiredBuiltinAgent: string | null,
  *   notes: string[],
@@ -43,10 +54,10 @@ const SESSION_LOCAL_EFFORT_KEYS = { codex: "reasoning_effort", claude: "effort" 
  */
 
 /**
- * @param {{ agent: string, model?: string | null, effort?: string | null }} options
+ * @param {{ agent: string, model?: string | null, effort?: string | null, writeAccess?: boolean }} options
  * @returns {HarnessInvocation}
  */
-export function prepareHarnessInvocation({ agent, model = null, effort = null }) {
+export function prepareHarnessInvocation({ agent, model = null, effort = null, writeAccess = false }) {
   const notes = [];
   const cleanups = [];
   const dispose = () => {
@@ -61,55 +72,62 @@ export function prepareHarnessInvocation({ agent, model = null, effort = null })
 
   const requestedModel = typeof model === "string" && model.trim() ? model.trim() : null;
   const requestedEffort = typeof effort === "string" && effort.trim() ? effort.trim() : null;
+  const overlay = Boolean(requestedModel || requestedEffort);
 
-  if (!requestedModel && !requestedEffort) {
-    return {
-      env: undefined,
-      acpxModel: null,
-      setEffortKey: null,
-      acpxAgentCommand: null,
-      requiredBuiltinAgent: null,
-      notes,
-      dispose,
-    };
-  }
+  if (!overlay && !writeAccess) return baseInvocation({ notes, dispose });
 
   try {
-    if (agent === "pi") return piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose });
-    if (agent === "grok") return grokInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose });
-    if (agent === "claude" || agent === "codex") {
-      return {
-        env: undefined,
+    let invocation;
+    if (agent === "pi") {
+      invocation = overlay
+        ? piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose })
+        : baseInvocation({ notes, dispose });
+    } else if (agent === "grok") {
+      invocation = grokInvocation({ requestedModel, requestedEffort, writeAccess, notes, cleanups, dispose });
+    } else if (agent === "claude" || agent === "codex") {
+      invocation = {
+        ...baseInvocation({ notes, dispose }),
         acpxModel: requestedModel,
         setEffortKey: requestedEffort ? SESSION_LOCAL_EFFORT_KEYS[agent] : null,
-        acpxAgentCommand: null,
-        requiredBuiltinAgent: agent,
-        notes,
-        dispose,
+        requiredBuiltinAgent: overlay ? agent : null,
       };
-    }
-    if (agent === "opencode") {
+    } else if (agent === "opencode") {
       if (requestedEffort) {
         notes.push(`${agent} does not advertise a reasoning-effort option; ran without effort=${requestedEffort}`);
       }
-      return {
-        env: undefined,
+      invocation = {
+        ...baseInvocation({ notes, dispose }),
         acpxModel: requestedModel,
-        setEffortKey: null,
-        acpxAgentCommand: null,
-        requiredBuiltinAgent: agent,
-        notes,
-        dispose,
+        requiredBuiltinAgent: overlay ? agent : null,
       };
+    } else if (overlay) {
+      throw new UserError(
+        `${agent} has no proven invocation-scoped way to apply ${describeOverride(requestedModel, requestedEffort)} without writing persistent harness defaults`,
+        "pin pi, claude, codex, grok, or opencode, or omit the model and effort override",
+      );
+    } else {
+      invocation = baseInvocation({ notes, dispose });
     }
-    throw new UserError(
-      `${agent} has no proven invocation-scoped way to apply ${describeOverride(requestedModel, requestedEffort)} without writing persistent harness defaults`,
-      "pin pi, claude, codex, grok, or opencode, or omit the model and effort override",
-    );
+    if (writeAccess && agent === "codex") applyCodexWriteAccess(invocation, { cleanups });
+    return invocation;
   } catch (err) {
     dispose();
     throw err;
   }
+}
+
+function baseInvocation({ notes, dispose }) {
+  return {
+    env: undefined,
+    acpxModel: null,
+    setEffortKey: null,
+    sessionMode: null,
+    sessionModeRequired: false,
+    acpxAgentCommand: null,
+    requiredBuiltinAgent: null,
+    notes,
+    dispose,
+  };
 }
 
 function describeOverride(model, effort) {
@@ -142,6 +160,8 @@ function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispos
     env: { PI_ACP_PI_COMMAND: wrapperPath },
     acpxModel: null,
     setEffortKey: null,
+    sessionMode: null,
+    sessionModeRequired: false,
     acpxAgentCommand: null,
     requiredBuiltinAgent: "pi",
     notes,
@@ -149,21 +169,22 @@ function piInvocation({ requestedModel, requestedEffort, notes, cleanups, dispos
   };
 }
 
-function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, dispose }) {
+function grokInvocation({ requestedModel, requestedEffort, writeAccess = false, notes, cleanups, dispose }) {
   if (process.platform === "win32") {
     throw new UserError(
-      `cannot apply ${describeOverride(requestedModel, requestedEffort)} through acpx --agent on Windows`,
+      `cannot apply ${describeOverride(requestedModel, requestedEffort) || "file-write flags"} through acpx --agent on Windows`,
       "pin pi, claude, codex, or opencode, or omit the model and effort override",
     );
   }
   const extra = [];
+  if (writeAccess) extra.push("--always-approve", "--permission-mode", "bypassPermissions");
   if (requestedModel) extra.push("-m", requestedModel);
   if (requestedEffort) extra.push("--reasoning-effort", requestedEffort);
   extra.push("agent", "stdio");
   const real = resolveOnPath("grok");
   if (!real) {
     throw new UserError(
-      `cannot apply ${describeOverride(requestedModel, requestedEffort)} as grok process flags because grok was not found on PATH`,
+      `cannot apply ${describeOverride(requestedModel, requestedEffort) || "file-write flags"} as grok process flags because grok was not found on PATH`,
       "install the grok CLI, or pin a different agent / omit the model and effort override",
     );
   }
@@ -173,11 +194,64 @@ function grokInvocation({ requestedModel, requestedEffort, notes, cleanups, disp
     env: undefined,
     acpxModel: null,
     setEffortKey: null,
+    sessionMode: null,
+    sessionModeRequired: false,
     acpxAgentCommand: nodeCommand,
     requiredBuiltinAgent: null,
     notes,
     dispose,
   };
+}
+
+/**
+ * Codex 0.147+ fails closed when `features.code_mode_host` is off: every file/exec tool
+ * returns "code-mode host is disabled". The adapter honors invocation env
+ * (`INITIAL_AGENT_MODE`, `CODEX_CONFIG`) and a `CODEX_PATH` wrapper; ACP `set-mode agent`
+ * is the session-local follow-through. None of this writes `~/.codex/config.toml`.
+ */
+function applyCodexWriteAccess(invocation, { cleanups }) {
+  invocation.env = { ...(invocation.env || {}) };
+  invocation.env.INITIAL_AGENT_MODE = "agent";
+  invocation.env.CODEX_CONFIG = mergeCodexConfig(process.env.CODEX_CONFIG, invocation.env.CODEX_CONFIG, {
+    features: { code_mode_host: true },
+  });
+  invocation.sessionMode = "agent";
+  invocation.sessionModeRequired = true;
+
+  const real = invocation.env.CODEX_PATH || process.env.CODEX_PATH || resolveOnPath("codex");
+  if (!real || (process.platform === "win32" && /\.(?:cmd|bat)$/i.test(real))) return;
+  const { wrapperPath, dir } = writeArgvWrapper({
+    realCommand: real,
+    extraArgs: ["--enable", "code_mode_host"],
+    binName: "codex",
+  });
+  cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  invocation.env.CODEX_PATH = wrapperPath;
+}
+
+function mergeCodexConfig(...layers) {
+  /** @type {Record<string, unknown>} */
+  const merged = {};
+  for (const layer of layers) {
+    if (!layer) continue;
+    let parsed = layer;
+    if (typeof layer === "string") {
+      try {
+        parsed = JSON.parse(layer);
+      } catch {
+        continue;
+      }
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    for (const [key, value] of Object.entries(parsed)) {
+      if (key === "features" && value && typeof value === "object" && !Array.isArray(value)) {
+        merged.features = { ...(merged.features || {}), ...value };
+      } else {
+        merged[key] = value;
+      }
+    }
+  }
+  return JSON.stringify(merged);
 }
 
 /**

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -239,7 +239,16 @@ function mergeCodexConfig(...layers) {
       try {
         parsed = JSON.parse(layer);
       } catch {
-        continue;
+        throw new UserError(
+          "cannot enable Codex file-write access because CODEX_CONFIG is not valid JSON",
+          "unset CODEX_CONFIG or set it to a valid JSON object",
+        );
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new UserError(
+          "cannot enable Codex file-write access because CODEX_CONFIG is not a JSON object",
+          "unset CODEX_CONFIG or set it to a valid JSON object",
+        );
       }
     }
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;

--- a/src/logger.js
+++ b/src/logger.js
@@ -20,6 +20,12 @@ export function setQuiet(value) {
   quiet = Boolean(value);
 }
 
+/** Make untrusted text safe to place inside one terminal diagnostic line. */
+export function terminalSafe(value) {
+  // eslint-disable-next-line no-control-regex -- terminal control bytes are the attack surface
+  return String(value).replace(/[\u0000-\u001f\u007f-\u009f]/g, " ");
+}
+
 /**
  * While the live progress view owns stderr, progress lines are diverted here,
  * buffered, and replayed verbatim on teardown - so scrollback after a TUI run

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -61,7 +61,7 @@ export class ProposalViolation extends Error {
    * @param {string} message
    * @param {string[]} violations
    * @param {{ reason?: string, attempts?: number,
-   *   saved?: { attempt: number, violations: string[] } | null, proposalPath?: string | null }} [detail]
+   *   saved?: { attempt: number, violations: string[], notes?: string[] } | null, proposalPath?: string | null }} [detail]
    */
   constructor(message, violations, detail = {}) {
     super(message);

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -272,7 +272,7 @@ async function annotateLoop({
   let violationsToShow = [];
   let justRemeasured = false;
   let owePreface = startFresh;
-  /** @type {{ attempt: number, violations: string[] } | null} */
+  /** @type {{ attempt: number, violations: string[], notes?: string[] } | null} */
   let saved = null;
   /** @type {{ reason: string, violations: string[] }} */
   let terminal;
@@ -370,7 +370,7 @@ async function annotateLoop({
     // Keep the rejected proposal so a loud failure is still inspectable. It records which
     // attempt produced it, so a later empty turn cannot be reported as its author.
     state.writeProposal(proposal);
-    saved = { attempt: attempts, violations };
+    saved = { attempt: attempts, violations, notes: proposal.notes };
     if (attempts >= ANNOTATE_TURNS) {
       terminal = { reason: "gates", violations };
       break;
@@ -494,6 +494,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       effort: current.effort,
       sessionName,
       cwd: workspace.root,
+      writeAccess: true,
     });
     try {
       return await holder.session.prompt({
@@ -519,6 +520,7 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       effort: chosen.effort,
       sessionName: `${sessionName}-r${(serial += 1)}`,
       cwd: workspace.root,
+      writeAccess: true,
     });
 
   try {

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -301,12 +301,18 @@ test("explicit config or CLI flags pin the role and skip the ladder entirely", a
   );
   assert.deepEqual(calls, [], "nothing was probed");
 
-  // A pinned agent is the user's decision: an auth failure surfaces, it does not fall through.
+  // A pinned agent is the user's decision: an auth failure surfaces as a UserError, it does not fall through.
   await assert.rejects(
     resolver.withFallthrough("synthesis", async () => {
       throw authRequired("claude");
     }),
-    AcpxError,
+    (err) => {
+      assert.ok(err instanceof UserError);
+      assert.match(err.message, /pinned synthesis agent claude/);
+      assert.match(err.message, /not logged in/);
+      assert.match(err.hint, /claude auth login/);
+      return true;
+    },
   );
 });
 

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -314,6 +314,20 @@ test("explicit config or CLI flags pin the role and skip the ladder entirely", a
       return true;
     },
   );
+
+  await assert.rejects(
+    resolver.withFallthrough("synthesis", async () => {
+      throw new AcpxError("acpx claude could not enable write session mode=agent: unsupported command");
+    }),
+    (err) => {
+      assert.ok(err instanceof UserError);
+      assert.match(err.message, /pinned synthesis agent claude/);
+      assert.match(err.message, /failed unexpectedly/);
+      assert.match(err.message, /unsupported command/);
+      assert.match(err.hint, /check the claude\/acpx failure above and retry/);
+      return true;
+    },
+  );
 });
 
 test("--no-auto-agent pins the pre-ladder defaults", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -692,6 +692,30 @@ test("a write-access Codex session enables code-mode on the spawn, not by rewrit
   assert.deepEqual(jsonl(codexLog)[0], ["--enable", "code_mode_host"]);
 });
 
+test("a write-access Codex session rejects malformed CODEX_CONFIG before invoking acpx", async () => {
+  resetLogsAndSettings();
+  process.env.CODEX_CONFIG = "{not-json";
+  try {
+    await assert.rejects(
+      openSession({
+        agent: "codex",
+        sessionName: "bp-codex-invalid-config",
+        cwd: workDir,
+        writeAccess: true,
+      }),
+      {
+        name: "UserError",
+        message: /CODEX_CONFIG is not valid JSON/,
+        hint: /unset CODEX_CONFIG or set it to a valid JSON object/,
+      },
+    );
+  } finally {
+    delete process.env.CODEX_CONFIG;
+  }
+
+  assert.deepEqual(acpxCalls(), []);
+});
+
 test("a write-access Grok session launches with native file-write permission flags", async () => {
   resetLogsAndSettings();
   const session = await openSession({

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -761,8 +761,14 @@ test("a write-access Grok session launches with native file-write permission fla
   await session.close();
   const spawned = jsonl(grokLog);
   assert.ok(spawned.length >= 1);
-  assert.deepEqual(spawned[0].slice(0, 3), ["--always-approve", "--permission-mode", "bypassPermissions"]);
-  assert.deepEqual(spawned[0].slice(3, 7), ["-m", "grok-4.6", "--reasoning-effort", "high"]);
+  assert.deepEqual(spawned[0].slice(0, 5), [
+    "--always-approve",
+    "--permission-mode",
+    "bypassPermissions",
+    "--sandbox",
+    "workspace",
+  ]);
+  assert.deepEqual(spawned[0].slice(5, 9), ["-m", "grok-4.6", "--reasoning-effort", "high"]);
 });
 
 test("a write-access Pi session does not invent a permission overlay", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -29,10 +29,12 @@ const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-bin-"));
 const fakeAcpx = path.join(binDir, "acpx");
 const fakePi = path.join(binDir, "pi");
 const fakeGrok = path.join(binDir, "grok");
+const fakeCodex = path.join(binDir, "codex");
 const settingsPath = path.join(fakeHome, ".pi", "agent", "settings.json");
 const acpxLog = path.join(binDir, "acpx.log");
 const piLog = path.join(binDir, "pi.log");
 const grokLog = path.join(binDir, "grok.log");
+const codexLog = path.join(binDir, "codex.log");
 const workDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-harness-cwd-")));
 
 const ORIGINAL_SETTINGS = `{
@@ -76,6 +78,16 @@ process.exit(0);
 fs.chmodSync(fakeGrok, 0o755);
 
 fs.writeFileSync(
+  fakeCodex,
+  `#!${process.execPath}
+const fs = require("node:fs");
+fs.appendFileSync(process.env.FAKE_CODEX_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+process.exit(0);
+`,
+);
+fs.chmodSync(fakeCodex, 0o755);
+
+fs.writeFileSync(
   fakeAcpx,
   `#!${process.execPath}
 const fs = require("node:fs");
@@ -85,6 +97,9 @@ fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify({
   argv,
   cwd: process.cwd(),
   PI_ACP_PI_COMMAND: process.env.PI_ACP_PI_COMMAND || null,
+  INITIAL_AGENT_MODE: process.env.INITIAL_AGENT_MODE || null,
+  CODEX_CONFIG: process.env.CODEX_CONFIG || null,
+  CODEX_PATH: process.env.CODEX_PATH || null,
 }) + "\\n");
 const settings = process.env.FAKE_HARNESS_SETTINGS;
 if (argv.includes("config") && argv.includes("show")) {
@@ -93,6 +108,7 @@ if (argv.includes("config") && argv.includes("show")) {
   process.stdout.write(JSON.stringify({ agents }) + "\\n");
   process.exit(0);
 }
+if (argv.includes("set-mode")) process.exit(0);
 const setAt = argv.indexOf("set");
 if (setAt >= 0) {
   const key = argv[setAt + 1];
@@ -105,6 +121,11 @@ function spawnWrappedPi() {
   const wrap = process.env.PI_ACP_PI_COMMAND;
   if (!wrap) return;
   spawnSync(wrap, ["--mode", "rpc", "--no-themes"], { stdio: "ignore", env: process.env });
+}
+function spawnWrappedCodex() {
+  const wrap = process.env.CODEX_PATH;
+  if (!wrap) return;
+  spawnSync(wrap, [], { stdio: "ignore", env: process.env });
 }
 function splitAgentCommand(value) {
   const parts = [];
@@ -152,6 +173,7 @@ if (argv.includes("sessions") && argv.includes("new")) {
     process.exit(2);
   }
   spawnWrappedPi();
+  spawnWrappedCodex();
   spawnOverriddenAgent();
   process.exit(0);
 }
@@ -172,13 +194,18 @@ fs.chmodSync(fakeAcpx, 0o755);
 
 process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH || ""}`;
 process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+delete process.env.CODEX_PATH;
+delete process.env.INITIAL_AGENT_MODE;
+delete process.env.CODEX_CONFIG;
 process.env.FAKE_ACPX_LOG = acpxLog;
 process.env.FAKE_PI_LOG = piLog;
 process.env.FAKE_GROK_LOG = grokLog;
+process.env.FAKE_CODEX_LOG = codexLog;
 process.env.FAKE_HARNESS_SETTINGS = settingsPath;
 fs.writeFileSync(acpxLog, "");
 fs.writeFileSync(piLog, "");
 fs.writeFileSync(grokLog, "");
+fs.writeFileSync(codexLog, "");
 
 const { execOneShot, openSession, sessionPrompt } = await import("../src/acpx.js");
 const { prepareHarnessInvocation } = await import("../src/harness-invoke.js");
@@ -191,6 +218,7 @@ function resetLogsAndSettings() {
   fs.writeFileSync(acpxLog, "");
   fs.writeFileSync(piLog, "");
   fs.writeFileSync(grokLog, "");
+  fs.writeFileSync(codexLog, "");
 }
 
 function settingsBytes() {
@@ -560,6 +588,9 @@ test("Codex session passes --model at create and ACP set reasoning_effort, never
   const created = calls.find((c) => c.argv.includes("new"));
   assert.equal(created.argv[created.argv.indexOf("--model") + 1], "gpt-5.6-sol");
   assert.deepEqual(setCalls(calls).map(setKey), ["reasoning_effort"]);
+  assert.equal(created.INITIAL_AGENT_MODE, null);
+  assert.ok(!calls.some((c) => c.argv.includes("set-mode")));
+  assert.deepEqual(jsonl(codexLog), []);
 });
 
 test("OpenCode session passes --model at create, skips effort, and does not persist", async () => {
@@ -628,6 +659,72 @@ test("Grok session forces an acpx raw-command override with process model and ef
   assert.ok(spawned.length >= 1);
   assert.deepEqual(spawned[0].slice(0, 4), ["-m", "grok-4.6", "--reasoning-effort", "high"]);
   assert.deepEqual(spawned[0].slice(4), ["agent", "stdio"]);
+});
+
+test("a write-access Codex session enables code-mode on the spawn, not by rewriting config.toml", async () => {
+  resetLogsAndSettings();
+  process.env.CODEX_CONFIG = JSON.stringify({ features: { foo: true }, model: "keep-me" });
+  try {
+    const session = await openSession({
+      agent: "codex",
+      model: "gpt-5.6-sol",
+      effort: "high",
+      sessionName: "bp-codex-write",
+      cwd: workDir,
+      writeAccess: true,
+    });
+    await session.close();
+  } finally {
+    delete process.env.CODEX_CONFIG;
+  }
+
+  const calls = acpxCalls();
+  const created = calls.find((c) => c.argv.includes("new"));
+  assert.equal(created.INITIAL_AGENT_MODE, "agent");
+  const config = JSON.parse(created.CODEX_CONFIG);
+  assert.equal(config.features.code_mode_host, true);
+  assert.equal(config.features.foo, true);
+  assert.equal(config.model, "keep-me");
+  assert.ok(created.CODEX_PATH);
+  assert.notEqual(created.CODEX_PATH, fakeCodex);
+  assert.ok(calls.some((c) => c.argv.includes("set-mode") && c.argv.includes("agent")));
+  assert.deepEqual(setCalls(calls).map(setKey), ["reasoning_effort"]);
+  assert.deepEqual(jsonl(codexLog)[0], ["--enable", "code_mode_host"]);
+});
+
+test("a write-access Grok session launches with native file-write permission flags", async () => {
+  resetLogsAndSettings();
+  const session = await openSession({
+    agent: "grok",
+    model: "grok-4.6",
+    effort: "high",
+    sessionName: "bp-grok-write",
+    cwd: workDir,
+    writeAccess: true,
+  });
+  await session.close();
+  const spawned = jsonl(grokLog);
+  assert.ok(spawned.length >= 1);
+  assert.deepEqual(spawned[0].slice(0, 3), ["--always-approve", "--permission-mode", "bypassPermissions"]);
+  assert.deepEqual(spawned[0].slice(3, 7), ["-m", "grok-4.6", "--reasoning-effort", "high"]);
+});
+
+test("a write-access Pi session does not invent a permission overlay", async () => {
+  resetLogsAndSettings();
+  const session = await openSession({
+    agent: "pi",
+    model: "openai-codex/gpt-5.6-sol",
+    effort: "high",
+    sessionName: "bp-pi-write",
+    cwd: workDir,
+    writeAccess: true,
+  });
+  await session.close();
+  const spawned = jsonl(piLog);
+  assert.deepEqual(spawned[0].slice(0, 4), ["--model", "openai-codex/gpt-5.6-sol", "--thinking", "high"]);
+  assert.ok(!spawned[0].includes("--tools"));
+  const calls = acpxCalls();
+  assert.ok(!calls.some((c) => c.argv.includes("set-mode")));
 });
 
 test("Pi and Grok retain process effort when session fallback uses exec", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -30,6 +30,9 @@ const fakeAcpx = path.join(binDir, "acpx");
 const fakePi = path.join(binDir, "pi");
 const fakeGrok = path.join(binDir, "grok");
 const fakeCodex = path.join(binDir, "codex");
+const adapterModules = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-codex-adapter-"));
+const adapterBin = path.join(adapterModules, ".bin");
+const bundledCodex = path.join(adapterModules, "@openai", "codex", "bin", "codex.js");
 const settingsPath = path.join(fakeHome, ".pi", "agent", "settings.json");
 const acpxLog = path.join(binDir, "acpx.log");
 const piLog = path.join(binDir, "pi.log");
@@ -77,20 +80,23 @@ process.exit(0);
 );
 fs.chmodSync(fakeGrok, 0o755);
 
-fs.writeFileSync(
-  fakeCodex,
-  `#!${process.execPath}
+const codexScript = `#!${process.execPath}
 const fs = require("node:fs");
 fs.appendFileSync(process.env.FAKE_CODEX_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
 process.exit(0);
-`,
-);
+`;
+fs.writeFileSync(fakeCodex, codexScript);
 fs.chmodSync(fakeCodex, 0o755);
+fs.mkdirSync(path.dirname(bundledCodex), { recursive: true });
+fs.mkdirSync(adapterBin, { recursive: true });
+fs.writeFileSync(bundledCodex, codexScript);
+fs.chmodSync(bundledCodex, 0o755);
 
 fs.writeFileSync(
   fakeAcpx,
   `#!${process.execPath}
 const fs = require("node:fs");
+const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const argv = process.argv.slice(2);
 fs.appendFileSync(process.env.FAKE_ACPX_LOG, JSON.stringify({
@@ -125,7 +131,11 @@ function spawnWrappedPi() {
 function spawnWrappedCodex() {
   const wrap = process.env.CODEX_PATH;
   if (!wrap) return;
-  spawnSync(wrap, [], { stdio: "ignore", env: process.env });
+  const env = { ...process.env };
+  if (env.FAKE_CODEX_ADAPTER_BIN) {
+    env.PATH = env.FAKE_CODEX_ADAPTER_BIN + path.delimiter + (env.PATH || "");
+  }
+  spawnSync(wrap, ["app-server"], { stdio: "ignore", env });
 }
 function splitAgentCommand(value) {
   const parts = [];
@@ -201,6 +211,7 @@ process.env.FAKE_ACPX_LOG = acpxLog;
 process.env.FAKE_PI_LOG = piLog;
 process.env.FAKE_GROK_LOG = grokLog;
 process.env.FAKE_CODEX_LOG = codexLog;
+process.env.FAKE_CODEX_ADAPTER_BIN = adapterBin;
 process.env.FAKE_HARNESS_SETTINGS = settingsPath;
 fs.writeFileSync(acpxLog, "");
 fs.writeFileSync(piLog, "");
@@ -689,7 +700,28 @@ test("a write-access Codex session enables code-mode on the spawn, not by rewrit
   assert.notEqual(created.CODEX_PATH, fakeCodex);
   assert.ok(calls.some((c) => c.argv.includes("set-mode") && c.argv.includes("agent")));
   assert.deepEqual(setCalls(calls).map(setKey), ["reasoning_effort"]);
-  assert.deepEqual(jsonl(codexLog)[0], ["--enable", "code_mode_host"]);
+  assert.deepEqual(jsonl(codexLog)[0], ["--enable", "code_mode_host", "app-server"]);
+});
+
+test("write-access Codex wraps the adapter's bundled executable when codex is absent from PATH", async () => {
+  resetLogsAndSettings();
+  const originalPath = process.env.PATH;
+  const nodeOnlyBin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-node-only-"));
+  fs.symlinkSync(process.execPath, path.join(nodeOnlyBin, "node"));
+  process.env.PATH = nodeOnlyBin;
+  try {
+    const session = await openSession({
+      agent: "codex",
+      sessionName: "bp-codex-bundled",
+      cwd: workDir,
+      writeAccess: true,
+    });
+    await session.close();
+  } finally {
+    process.env.PATH = originalPath;
+  }
+
+  assert.deepEqual(jsonl(codexLog), [["--enable", "code_mode_host", "app-server"]]);
 });
 
 test("a write-access Codex session rejects malformed CODEX_CONFIG before invoking acpx", async () => {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -300,6 +300,28 @@ test("a rejected proposal's notes are printed with the failure", () => {
   assert.match(run.stderr, /code-mode host is disabled/);
 });
 
+test("rejected proposal notes cannot inject terminal controls", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        {
+          reply: {
+            edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })],
+            notes: ["permission failure\u001b]52;c;dGVzdA==\u0007\nforged diagnostic"],
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(run.status, 1, `the run should fail:\n${run.output}`);
+  assert.match(run.stderr, /permission failure.*forged diagnostic/);
+  // eslint-disable-next-line no-control-regex -- these terminal controls are the malicious input
+  assert.doesNotMatch(run.stderr, /\u001b|\u0007/);
+});
+
 test("a failed synthesis invalidates an older applicable proposal", () => {
   const dir = makeCliRepo({ memory: MEMORY });
   const succeeded = runCli(dir, ["propose", ...PIN], {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -278,6 +278,28 @@ test("a run that ends on an empty turn says so, and never reads an older proposa
   assert.ok(staged[".agents/skills/incident-response/SKILL.md"]);
 });
 
+test("a rejected proposal's notes are printed with the failure", () => {
+  const dir = makeCliRepo({ memory: MEMORY });
+  const run = runCli(dir, ["propose", ...PIN], {
+    script: {
+      edit: EDIT_TURN,
+      annotations: [
+        {
+          reply: {
+            edits: [extract(["H1", "H2", "H3"], "extract two playbooks", { evidence: [] })],
+            notes: ["Code Mode is unavailable because code-mode host is disabled."],
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(run.status, 1, `the run should fail:\n${run.output}`);
+  assert.match(run.stderr, /carries no verbatim evidence quote/);
+  assert.match(run.stderr, /the rejected proposal noted:/);
+  assert.match(run.stderr, /code-mode host is disabled/);
+});
+
 test("a failed synthesis invalidates an older applicable proposal", () => {
   const dir = makeCliRepo({ memory: MEMORY });
   const succeeded = runCli(dir, ["propose", ...PIN], {


### PR DESCRIPTION
## Intent

Fix backpass synthesis-harness file-permission failures at the root. Two firstmate synthesis runs were burned when the harness silently could not edit files ("code-mode host is disabled"); the error blamed the budget gate and the model's own note naming the real cause was hidden.

CAPTAIN DIRECTION (authoritative): do NOT add a writable-staging preflight/sentinel probe. Instead FIX THE INVOCATION: launch each synthesis harness backpass invokes (codex, pi, and any others) with file-write/edit ("code-mode") permission enabled so "code-mode host disabled" cannot happen by construction.

KEEP the still-valuable half: when a rejected proposal has notes, PRINT them with the failure, and route pinned-agent failures through the same friendly-hint path as ladder failures instead of a raw stack trace.

Cover behaviorally: the harness is invoked with the correct file-write args; a failure surfaces the rejected-proposal notes rather than hiding them.

Implementation choices already made (do not reverse without a captain decision): synthesis sessions pass writeAccess=true; analysis stays read-only. Codex gets invocation-scoped INITIAL_AGENT_MODE=agent, CODEX_CONFIG features.code_mode_host=true, a CODEX_PATH wrapper with --enable code_mode_host, and ACP set-mode agent - none of this writes ~/.codex/config.toml. Grok gets --always-approve and --permission-mode bypassPermissions on the process wrapper. Pi gets no extra flags because write/edit tools are already on and Pi ACP modes are thinking levels. Claude/OpenCode keep acpx --approve-all as the client-side permission contract. Do not add a sentinel file probe.

## What Changed

- Launch synthesis sessions with invocation-scoped write permissions, including Codex code-mode configuration and Grok approval flags, while keeping analysis read-only and persistent harness defaults untouched.
- Surface rejected proposal notes in synthesis failures and convert pinned-agent failures into actionable user errors instead of raw stack traces.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the required invocation and error-reporting behavior, and includes behavioral coverage for the identified failure paths.

## Testing

No baseline commands were supplied. Targeted behavioral tests verified synthesis-only Codex, Grok, and Pi write-access invocation behavior, read-only Codex behavior, friendly pinned-agent errors, and rejected-proposal note output. A manual CLI run confirmed users see the hidden code-mode note alongside the synthesis failure.

<details>
<summary>Evidence: End-to-end rejected proposal notes shown by backpass CLI</summary>

Source: [End-to-end rejected proposal notes shown by backpass CLI](https://github.com/kunchenguid/backpass/blob/fe924382c2db99e7d9e5bb370070c224b8c7a1df/.no-mistakes/evidence/fm/backpass-harness-write-permissions-r1/rejected-proposal-notes-cli.txt)

```text
$ backpass propose --synthesis-agent claude --synthesis-model fake-model
exit status: 1
· synthesizing with claude (fake-model) effort=high
warn synthesis violated 1 gate(s); re-prompting with the exact violations
warn synthesis violated 1 gate(s); re-prompting with the exact violations

  x edit e1 ("extract release checklist") carries no verbatim evidence quote

  the rejected proposal was saved to /private/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/backpass-cli-vUmQGZ/.backpass/proposal.json
  the rejected proposal noted:
    Code Mode is unavailable because code-mode host is disabled.
error synthesis could not produce a valid proposal after 2 re-prompt(s) (1 violation(s))
  the gates above are what the next synthesis must satisfy; run `backpass propose` again
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fe6a16bba9b4ff5e58015e2799bddbce1290b3a1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `src/harness-invoke.js:222` - Intent requires that Codex get a `CODEX_PATH` wrapper with `--enable code_mode_host`, but this branch silently skips the wrapper when `codex` is absent from PATH or is a Windows cmd/bat executable. acpx can use its bundled Codex without a PATH binary, so this path is reachable. Either ensure the required wrapper can always target the adapter&#39;s Codex executable or ask the captain to authorize relying only on the other overlays.
- 🚨 `src/agents.js:369` - Intent requires routing pinned-agent failures through the friendly-hint path instead of a raw stack trace, but only classifiable ACP failures are wrapped. For example, a pinned Codex session whose `set-mode agent` call is unsupported throws an unclassified `AcpxError`; this line rethrows it and the CLI prints its stack. Convert pinned unclassified `AcpxError`s to an actionable `UserError` without falling through, or obtain captain approval to narrow the requirement.
- ⚠️ `src/harness-invoke.js:241` - A nonempty malformed `CODEX_CONFIG` is now silently discarded and replaced with the generated feature config. Before this change the adapter would reject the malformed override, but synthesis can now run with the user&#39;s intended model/provider settings missing and no warning. Reject malformed existing JSON with an actionable error rather than continuing.

🔧 Fix: Reject malformed Codex invocation configuration
2 errors still open:

- 🚨 `src/harness-invoke.js:222` - Intent requires Codex to get a `CODEX_PATH` wrapper with `--enable code_mode_host`, but this return silently omits it when no `codex` executable is on PATH or on Windows when it is a cmd/bat file. acpx may still launch its bundled Codex, leaving the authorized failure reachable. Ensure the required wrapper always targets the adapter&#39;s executable, or obtain captain approval to rely only on the remaining overlays.
- 🚨 `src/agents.js:369` - Intent requires pinned-agent failures to use the friendly-hint path instead of a raw stack trace, but unclassified `AcpxError`s are still rethrown. For example, a pinned Codex invocation whose newly required `set-mode agent` command is unsupported reaches this line and the CLI prints a stack. Convert pinned unclassified `AcpxError`s to an actionable `UserError`, or obtain captain approval to narrow the requirement.

🔧 Fix: Enforce bundled Codex writes and friendly pinned failures
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='write-access Codex|write-access Grok|write-access Pi|explicit config or CLI flags pin|rejected proposal.s notes' test/harness-invoke.test.js test/agents.test.js test/synthesis-cli.test.js`
- `node --test --test-name-pattern='Codex session passes --model at create' test/harness-invoke.test.js`
- <code>Manual end-to-end `backpass propose` run with a fake synthesis harness that returned a gate-rejected proposal containing a code-mode failure note; captured the CLI exit status and stderr.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
