### PR TITLE
feat: add existing-skill extracts and memory moves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,9 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   separately measured skills must stay separate edits. An extract may create `SKILL.md`
   or extend an existing one when the staged file still has every prior line plus every
   line the memory hunks remove (`normalizeRecoveryLine`). A `move` is the same verbatim
-  carry inside the memory file: removed lines must reappear in the same edit's added
-  lines, so repositioning does not hit the harm floor. Edits carry `skills: []` for
+  carry inside the memory file: normalized removed and added line multisets must match
+  exactly, so repositioning cannot smuggle additions and does not hit the harm floor.
+  Edits carry `skills: []` for
   created files; read them through `editSkills` (`src/skills.js`), which also understands
   the pre-0.1.8 single `skill`. Writer apply splits a multi-file extract by hunk `file`
   (`filesOfEdit` / `sliceEditForFile` in `src/proposal.js`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,18 +105,25 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   stronger-model/budget/max-edits line.
 - **An extract is one measured memory change plus the skill(s) it pays for.** `anchoredHunks`
   merges adjacent removals, so extracting neighbouring sections yields one change and N
-  created skills - one honest accept/reject decision, since a merged change cannot be
-  half-accepted. `buildProposal` allows N skills only when they share ONE hunk; separately
-  measured skills must stay separate edits. Edits carry `skills: []`; read them through
-  `editSkills` (`src/skills.js`), which also understands the pre-0.1.8 single `skill`.
+  skills - one honest accept/reject decision, since a merged change cannot be
+  half-accepted. `buildProposal` allows N skills only when they share ONE memory hunk;
+  separately measured skills must stay separate edits. An extract may create `SKILL.md`
+  or extend an existing one when the staged file still has every prior line plus every
+  line the memory hunks remove (`normalizeRecoveryLine`). A `move` is the same verbatim
+  carry inside the memory file: removed lines must reappear in the same edit's added
+  lines, so repositioning does not hit the harm floor. Edits carry `skills: []` for
+  created files; read them through `editSkills` (`src/skills.js`), which also understands
+  the pre-0.1.8 single `skill`. Writer apply splits a multi-file extract by hunk `file`
+  (`filesOfEdit` / `sliceEditForFile` in `src/proposal.js`).
 - **Extraction and deletion never share one decision.** `measureWorkspace` splits a pure
   removal that mixes skill-carried and vanishing text at that boundary (`splitRemovalHunk`;
   a split that cannot anchor uniquely keeps the merged hunk instead of guessing). In
-  `buildProposal`, an extract's skills must carry every line its hunks remove
+  `buildProposal`, an extract's skills must carry every line its memory hunks remove
   (dash-and-whitespace-folded, `normalizeRecoveryLine`), and any other edit whose hunk only
   deletes memory-file text is a removal whatever its kind: each deleted unit needs
   `minGapEvidence` distinct sessions of `class: "harm"` negatives (`harmSessions` in the
-  fold). The same floor covers skill files, where no evidence can attribute at all, so a
+  fold). Extract and move skip that floor because the text never leaves the always-loaded
+  surface. The same floor covers skill files, where no evidence can attribute at all, so a
   pure deletion inside a skill file is refused outright - skill content is rewritten or
   extracted, never dropped. Non-compliance never satisfies the floor; the >= 20%-relevance
   placement table stays prompt guidance by the captain's explicit decision - do not harden it.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ out of the proposal entirely.
 ### 5. Gradient descent - native edits
 
 A high-reasoning synthesis run turns the aggregated gradients into concrete edits: ADD,
-REMOVE, REWRITE, or EXTRACT→SKILL. The agent does not describe edits for backpass to
+REMOVE, REWRITE, EXTRACT→SKILL, or MOVE. The agent does not describe edits for backpass to
 splice in - it makes them, with its harness's own file tools, in a **staging copy** of the
 memory file and project skills under `.backpass/synthesis/` (the repo itself is read-only
 to it, for grounding). backpass then diffs the copy against the original and shows the agent the
@@ -241,12 +241,16 @@ Then mechanical gates run, and they are not negotiable:
   `minGapEvidence` distinct sessions - non-compliance never counts, because a rule that
   was skipped needs reinforcement, not deletion. A pure deletion in a skill file is also
   a removal, but no evidence can attribute harm to skill-file text, so it is refused.
-- an extraction preserves every line it removes in the skills it creates; a deletion is
-  never part of an extract
+- an extraction preserves every line it removes in the skills it creates or extends, and
+  an existing skill must still contain every line it already had; a deletion is never part
+  of an extract
+- a move preserves every line it removes by re-adding it verbatim elsewhere in the memory
+  file, so repositioning is not a harm-gated deletion
 - every edit carries a verbatim quote
 - the post-edit always-loaded surface must fit the budget, measured from the staged files
 
-An extraction is the created `SKILL.md` plus the memory-file change that pays for it.
+An extraction is the `SKILL.md` (created, or an existing skill file that still carries
+every prior line plus the extracted ones) plus the memory-file change that pays for it.
 Neighbouring removals are merged into one measured change, and a merged change cannot be
 accepted in halves - so when several sections leave together, their skills arrive as one
 extract with several skills, which is one honest accept/reject decision. Skills whose

--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Then mechanical gates run, and they are not negotiable:
 - an extraction preserves every line it removes in the skills it creates or extends, and
   an existing skill must still contain every line it already had; a deletion is never part
   of an extract
-- a move preserves every line it removes by re-adding it verbatim elsewhere in the memory
-  file, so repositioning is not a harm-gated deletion
+- a move's normalized removed and added line multisets match exactly, so it repositions
+  text one-for-one without smuggling additions or triggering the harm floor
 - every edit carries a verbatim quote
 - the post-edit always-loaded surface must fit the budget, measured from the staged files
 

--- a/src/apply/terminal.js
+++ b/src/apply/terminal.js
@@ -13,7 +13,11 @@ import { formatTokens } from "../tokens.js";
 /** Measured edits carry display lines per hunk; a legacy edit shows its find/replace. */
 export function diffLinesOf(edit) {
   if (Array.isArray(edit.hunks)) {
-    return edit.hunks.flatMap((hunk, i) => [...(i > 0 ? [{ type: "gap", text: "" }] : []), ...(hunk.lines || [])]);
+    return edit.hunks.flatMap((hunk, i) => [
+      ...(i > 0 ? [{ type: "gap", text: "" }] : []),
+      { type: "file", text: `--- ${hunk.file || edit.file} ---` },
+      ...(hunk.lines || []),
+    ]);
   }
   return [
     ...(edit.find || "")
@@ -33,6 +37,7 @@ function renderDiff(edit) {
     if (line.type === "del") lines.push(color.red(`  - ${line.text}`));
     else if (line.type === "ins") lines.push(color.green(`  + ${line.text}`));
     else if (line.type === "gap") lines.push(color.dim("  ..."));
+    else if (line.type === "file") lines.push(color.dim(`  ${line.text}`));
     else lines.push(color.dim(`    ${line.text}`));
   }
   return lines.join("\n");
@@ -55,7 +60,11 @@ export function renderEdit(edit, index, total) {
   out.push("");
   out.push(`${color.bold(`[${index + 1}/${total}] ${kind}`)}  ${color.dim(deltaText)}`);
   out.push(`  ${edit.title}`);
-  out.push(`  ${color.dim(`file: ${edit.file}`)}`);
+  const hunkFiles = Array.isArray(edit.hunks)
+    ? [...new Set(edit.hunks.map((hunk) => hunk.file || edit.file).filter(Boolean))]
+    : [];
+  const files = hunkFiles.length ? hunkFiles : [edit.file].filter(Boolean);
+  out.push(`  ${color.dim(`${files.length === 1 ? "file" : "files"}: ${files.join(", ")}`)}`);
   if (edit.rationale) out.push(`  ${color.dim(edit.rationale)}`);
   out.push("");
   out.push(renderDiff(edit));

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import { applyEdit } from "../proposal.js";
+import { applyEdit, filesOfEdit, sliceEditForFile } from "../proposal.js";
 import { memoryTextHash } from "../memory.js";
 import { budgetGateKind, budgetStatus, estimateTokens, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
@@ -242,32 +242,37 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   const expectedTargetHashes = new Map((proposal.targetFiles ?? []).map((t) => [t.file, t.hash]));
   const checkedTargets = new Set();
   for (const edit of [...accepted, ...rejected]) {
-    const relative = edit.file;
-    if (!relative || relative === proposal.memoryFile?.path || checkedTargets.has(relative)) continue;
-    checkedTargets.add(relative);
-    const expected = expectedTargetHashes.get(relative);
-    if (!expected) continue;
-    const absolute = path.join(repo.root, relative);
-    if (!fs.existsSync(absolute)) {
-      results.failed.push({ file: relative, error: "file does not exist" });
-      continue;
-    }
-    const observed = memoryTextHash(fs.readFileSync(absolute, "utf8"));
-    if (observed !== expected) {
-      results.failed.push({
-        file: relative,
-        error:
-          `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
-          `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
-          `against the current repository.`,
-      });
+    for (const relative of filesOfEdit(edit)) {
+      if (!relative || relative === proposal.memoryFile?.path || checkedTargets.has(relative)) continue;
+      checkedTargets.add(relative);
+      const expected = expectedTargetHashes.get(relative);
+      if (!expected) continue;
+      const absolute = path.join(repo.root, relative);
+      if (!fs.existsSync(absolute)) {
+        results.failed.push({ file: relative, error: "file does not exist" });
+        continue;
+      }
+      const observed = memoryTextHash(fs.readFileSync(absolute, "utf8"));
+      if (observed !== expected) {
+        results.failed.push({
+          file: relative,
+          error:
+            `${relative} changed after this proposal was made (${expected} -> ${observed}), so its edits ` +
+            `no longer describe the file on disk; nothing was written. Run \`backpass\` to re-propose ` +
+            `against the current repository.`,
+        });
+      }
     }
   }
   if (results.failed.length) return results;
 
   for (const edit of accepted) {
-    if (!byFile.has(edit.file)) byFile.set(edit.file, []);
-    byFile.get(edit.file).push(edit);
+    for (const relative of filesOfEdit(edit)) {
+      const slice = sliceEditForFile(edit, relative);
+      if (!slice) continue;
+      if (!byFile.has(relative)) byFile.set(relative, []);
+      byFile.get(relative).push(slice);
+    }
   }
 
   // Compose first, write later. Each file's accepted edits are applied to one immutable

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -32,8 +32,9 @@ Return ONE JSON object and nothing else. No prose, no markdown fence.
 Hard rules - a violation fails the whole proposal:
 
 1. **Every measured change belongs to exactly one edit.** Group the changes that make up
-   one decision (an extraction is the new `SKILL.md` plus the removal it pays for); do
-   not leave a change out. If a change should not ship, revert it in the file first.
+   one decision (an extraction is its created or extended `SKILL.md` plus the removal it
+   pays for); do not leave a change out. If a change should not ship, revert it in the
+   file first.
 2. **At most {{MAX_EDITS}} edits** - the learning rate. Regroup or revert if you are over.
 3. **Every edit carries at least one verbatim quote in `evidence`**, with its source.
 4. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
@@ -57,9 +58,9 @@ Hard rules - a violation fails the whole proposal:
    own extract. Any other kind must not include a created file. An extract may span
    {{MEMORY_PATH}} and the skill file it extends; every other kind changes one file only.
 7. `kind: "move"` is an edit whose changes are all on {{MEMORY_PATH}} and whose **removed
-   lines reappear verbatim** in the same edit's added lines (repositioning a rule, not
-   deleting it). Group the deletion and the re-add as one decision. Text that does not
-   reappear is a removal and needs its own `remove` edit.
+   and added lines match one-for-one** (repositioning a rule, not deleting or adding one).
+   Group the deletion and the re-add as one decision. Any unmatched removal needs its own
+   `remove` edit, and any unmatched addition needs its normal evidence.
 8. **Budget:** {{BUDGET_RULE}}
 
 If you still need to change the files, do that first and then answer; backpass

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -14,7 +14,7 @@ Return ONE JSON object and nothing else. No prose, no markdown fence.
   "edits": [
     {
       "changes": ["H1"],
-      "kind": "add" | "remove" | "rewrite" | "extract",
+      "kind": "add" | "remove" | "rewrite" | "extract" | "move",
       "title": "one line a human can decide on",
       "rationale": "why the evidence supports this",
       "instructions": ["AG-017"],
@@ -42,19 +42,25 @@ Hard rules - a violation fails the whole proposal:
 5. **Removing an instruction outright needs harm evidence from at least
    {{MIN_GAP_EVIDENCE}} distinct sessions** (`harm-sessions` in the evidence). Only
    `harm` negatives argue against an instruction; `non-compliance` never justifies a
-   deletion. A change that only deletes text and is not part of an extract is a removal
-   whatever its `kind` says - if it lacks the evidence, revert it in the file first.
+   deletion. A change that only deletes text and is not part of an extract or a move is a
+   removal whatever its `kind` says - if it lacks the evidence, revert it in the file first.
    Text deleted from an existing skill file can never carry that evidence (skills have
    no instruction ids), so revert any skill-file deletion.
-6. `kind: "extract"` is an edit whose changes are one or more created `SKILL.md` files
-   plus the change(s) to {{MEMORY_PATH}} that pay for them. **The skills must carry every
-   line those changes remove** - a deletion is never part of an extract; give it its own
-   `remove` edit. One skill per extract is the normal shape. Several skills belong in ONE
-   extract exactly when their removals landed in a **single** measured change: adjacent
-   removals are merged into one change, and a merged change cannot be accepted in halves.
-   If each skill has its own measured change, give each its own extract. Any other kind
-   must not include a created file, and an edit changes one file only.
-7. **Budget:** {{BUDGET_RULE}}
+6. `kind: "extract"` is an edit whose changes are one or more `SKILL.md` files (created,
+   or an existing skill file you extended) plus the change(s) to {{MEMORY_PATH}} that pay
+   for them. **The skills must carry every line those changes remove**, and an existing
+   skill must still contain every line it already had - a deletion is never part of an
+   extract; give it its own `remove` edit. One skill per extract is the normal shape.
+   Several skills belong in ONE extract exactly when their removals landed in a **single**
+   measured change: adjacent removals are merged into one change, and a merged change
+   cannot be accepted in halves. If each skill has its own measured change, give each its
+   own extract. Any other kind must not include a created file. An extract may span
+   {{MEMORY_PATH}} and the skill file it extends; every other kind changes one file only.
+7. `kind: "move"` is an edit whose changes are all on {{MEMORY_PATH}} and whose **removed
+   lines reappear verbatim** in the same edit's added lines (repositioning a rule, not
+   deleting it). Group the deletion and the re-add as one decision. Text that does not
+   reappear is a removal and needs its own `remove` edit.
+8. **Budget:** {{BUDGET_RULE}}
 
 If you still need to change the files, do that first and then answer; backpass
 re-measures after this reply and shows you the new ids if anything moved. Re-measuring

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -39,7 +39,8 @@ refers to instructions by these ids.
 {{SKILL_INDEX}}
 
 To extract a section into a skill, create `./{{SKILLS_DIR}}/<skill-name>/SKILL.md` with
-this exact shape, then remove the extracted detail from `./{{MEMORY_PATH}}`
+this exact shape, or append the extracted lines to an existing SKILL.md that should own
+them, then remove the extracted detail from `./{{MEMORY_PATH}}`
 (optionally leaving a one-line pointer):
 
 ```
@@ -76,18 +77,24 @@ analyzed sessions in which an instruction drew any evidence at all.
    Only `harm` negatives - following the instruction caused damage - argue against an
    instruction. `non-compliance` means it failed to steer: reinforce it, reposition it,
    or improve its trigger, never delete it for being ignored. Text you delete that does
-   not land in a created skill is a removal, whatever the edit is called - including
-   text deleted from an existing skill file, where no evidence can attribute at all, so
-   no skill-file deletion clears the floor: rewrite skill content, never remove it.
-4. **An extraction preserves every line it removes** in the SKILL.md it creates. A
-   deletion is never part of an extract: it is its own `remove` edit, decided on its
-   own evidence.
-5. **Every edit must be backed by at least one verbatim quote** from the evidence. You
+   not land in a skill (created or extended) and does not reappear verbatim elsewhere in
+   this file is a removal, whatever the edit is called - including text deleted from an
+   existing skill file, where no evidence can attribute at all, so no skill-file deletion
+   clears the floor: rewrite skill content, never remove it.
+4. **An extraction preserves every line it removes** in the SKILL.md it creates or
+   extends. Extending an existing skill keeps every line that file already had, then adds
+   the extracted lines. A deletion is never part of an extract: it is its own `remove`
+   edit, decided on its own evidence.
+5. **A move preserves every line it removes** by re-adding it verbatim elsewhere in
+   `./{{MEMORY_PATH}}`. Group the deletion and the re-add as one change. Do not duplicate
+   a rule in order to "move" it.
+6. **Every edit must be backed by at least one verbatim quote** from the evidence. You
    will attach the quotes in the next step, so only make changes you can back.
-6. **Budget:** {{BUDGET_RULE}}
-7. You can extract a long, narrow, crisply-triggered section instead of deleting it:
-   extraction frees the same always-loaded tokens and loses nothing.
-8. Change only `./{{MEMORY_PATH}}` and files under `./{{SKILLS_DIR}}/`. Never delete a
+7. **Budget:** {{BUDGET_RULE}}
+8. You can extract a long, narrow, crisply-triggered section instead of deleting it:
+   extraction frees the same always-loaded tokens and loses nothing. You can extract into
+   an existing skill when that file is the right home, instead of creating a new one.
+9. Change only `./{{MEMORY_PATH}}` and files under `./{{SKILLS_DIR}}/`. Never delete a
    file. Do not create notes, scripts, or scratch files.
 
 ## Where an instruction belongs

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -85,9 +85,9 @@ analyzed sessions in which an instruction drew any evidence at all.
    extends. Extending an existing skill keeps every line that file already had, then adds
    the extracted lines. A deletion is never part of an extract: it is its own `remove`
    edit, decided on its own evidence.
-5. **A move preserves every line it removes** by re-adding it verbatim elsewhere in
-   `./{{MEMORY_PATH}}`. Group the deletion and the re-add as one change. Do not duplicate
-   a rule in order to "move" it.
+5. **A move's removed and added lines match one-for-one** in `./{{MEMORY_PATH}}`.
+   Group the deletion and the re-add as one change. Do not duplicate, rewrite, or add a
+   rule in order to "move" it.
 6. **Every edit must be backed by at least one verbatim quote** from the evidence. You
    will attach the quotes in the next step, so only make changes you can back.
 7. **Budget:** {{BUDGET_RULE}}

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -12,7 +12,8 @@ import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./w
  * The synthesis agent edits a staging copy of the memory file and project skills natively
  * (`src/workspace.js`); backpass measures the result as anchored hunks (`src/diff.js`)
  * and the agent annotates them - kind, title, rationale, evidence - by id. An edit is
- * therefore a group of measured changes against one file:
+ * therefore a group of measured changes, normally against one file (an extract also
+ * includes its destination skill files):
  *
  *   add      only inserts text                  (gated like a new instruction)
  *   remove   only deletes text
@@ -20,8 +21,8 @@ import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./w
  *   extract  memory-file change(s) + the SKILL.md file(s) they pay for
  *            (created, or an existing skill that still has every prior line plus
  *            every line the memory hunks remove)
- *   move     memory-file change(s) whose removed lines reappear verbatim in the
- *            same edit's added lines - repositioning, not deletion
+ *   move     memory-file change(s) whose normalized removed and added line
+ *            multisets match exactly - repositioning, not deletion or addition
  *
  * Each hunk carries a `find`/`replace` pair copied out of the original file by
  * construction; `find` occurs exactly once there. That is what the writer applies later,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -169,10 +169,17 @@ function createdDescriptionCost(edit) {
   return editSkills(edit).reduce((sum, skill) => sum + estimateTokens(skill.description || ""), 0);
 }
 
-function addedLineCounts(hunks) {
+function changedLineCounts(hunks, type) {
   return recoveredLineCounts(
-    hunks.flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text)),
+    hunks.flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === type).map((line) => line.text)),
   );
+}
+
+function firstLineCountMismatch(left, right) {
+  for (const line of new Set([...left.keys(), ...right.keys()])) {
+    if ((left.get(line) || 0) !== (right.get(line) || 0)) return line;
+  }
+  return null;
 }
 
 /** Overlapping count: a run of identical lines must not pass as unique. */
@@ -369,6 +376,18 @@ export function buildProposal(rawResult, context) {
         );
         continue;
       }
+      const hasMemoryRemoval = memoryHunks.some((hunk) => hunk.removed > 0);
+      if (!hasMemoryRemoval) {
+        if (edit.transcripts < config.minGapEvidence) {
+          violations.push(
+            `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
+              `${config.minGapEvidence} are required`,
+          );
+        } else {
+          violations.push(`edit ${edit.id}: kind "extract" must remove text from ${memoryFile.path}`);
+        }
+        continue;
+      }
       const notSkill = destFiles.find((file) => !isSkillFilePath(file, skillsDir));
       if (notSkill) {
         violations.push(
@@ -426,6 +445,16 @@ export function buildProposal(rawResult, context) {
       // in its own remove edit, where the removal-evidence floor below can judge it.
       const destTexts = [...created.map((c) => c.text), ...destFiles.map((file) => measured.texts?.get(file) ?? "")];
       const carried = recoveredLineCounts(destTexts);
+      for (const file of destFiles) {
+        unrecoveredRemovedLines(
+          {
+            lines: String(measured.originals?.get(file) ?? "")
+              .split("\n")
+              .map((text) => ({ type: "del", text })),
+          },
+          carried,
+        );
+      }
       const missing = memoryHunks.flatMap((h) => unrecoveredRemovedLines(h, carried));
       if (missing.length) {
         violations.push(
@@ -456,12 +485,14 @@ export function buildProposal(rawResult, context) {
         );
         continue;
       }
-      const missing = memoryHunks.flatMap((hunk) => unrecoveredRemovedLines(hunk, addedLineCounts(memoryHunks)));
-      if (missing.length) {
+      const removed = changedLineCounts(memoryHunks, "del");
+      const added = changedLineCounts(memoryHunks, "ins");
+      const mismatch = firstLineCountMismatch(removed, added);
+      if (mismatch) {
         violations.push(
-          `edit ${edit.id} ("${edit.title}") removes text that does not reappear verbatim in the same edit ` +
-            `(first: "${missing[0].trim().slice(0, 80)}"); a move preserves every line it removes - ` +
-            `revert that text, or make its deletion a separate "remove" edit`,
+          `edit ${edit.id} ("${edit.title}") removes text that does not reappear verbatim one-for-one in the same edit ` +
+            `(first mismatch: "${mismatch.slice(0, 80)}"); a move's removed and added lines must match exactly - ` +
+            `revert that text, or use a different edit kind`,
         );
         continue;
       }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -684,7 +684,7 @@ export function buildProposal(rawResult, context) {
         if (e.kind !== "extract") return n;
         const createdSkills = editSkills(e).length;
         const extended = new Set(filesOfEdit(e).filter((file) => file !== memoryFile.path)).size;
-        return n + Math.max(createdSkills, extended);
+        return n + createdSkills + extended;
       }, 0),
     },
     edits: accepted,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -17,7 +17,11 @@ import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./w
  *   add      only inserts text                  (gated like a new instruction)
  *   remove   only deletes text
  *   rewrite  replaces text
- *   extract  memory-file change(s) + the created SKILL.md file(s) they pay for
+ *   extract  memory-file change(s) + the SKILL.md file(s) they pay for
+ *            (created, or an existing skill that still has every prior line plus
+ *            every line the memory hunks remove)
+ *   move     memory-file change(s) whose removed lines reappear verbatim in the
+ *            same edit's added lines - repositioning, not deletion
  *
  * Each hunk carries a `find`/`replace` pair copied out of the original file by
  * construction; `find` occurs exactly once there. That is what the writer applies later,
@@ -25,7 +29,28 @@ import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./w
  * rather than guessed at - a memory file is not something to fuzzy-patch.
  */
 
-export const EDIT_KINDS = ["add", "remove", "rewrite", "extract"];
+export const EDIT_KINDS = ["add", "remove", "rewrite", "extract", "move"];
+
+/** Kinds whose deletions stay on the always-loaded surface, so the harm floor does not apply. */
+function preservesAlwaysLoaded(kind) {
+  return kind === "extract" || kind === "move";
+}
+
+/** Every file an edit's hunks touch. Created skills are not hunks; they live on `edit.skills`. */
+export function filesOfEdit(edit) {
+  if (Array.isArray(edit.hunks) && edit.hunks.length) {
+    return [...new Set(edit.hunks.map((hunk) => hunk.file || edit.file).filter(Boolean))];
+  }
+  return edit.file ? [edit.file] : [];
+}
+
+/** The subset of an edit that applies to one file, or null when that file is not a target. */
+export function sliceEditForFile(edit, file) {
+  if (!Array.isArray(edit.hunks)) return edit.file === file ? edit : null;
+  const hunks = edit.hunks.filter((hunk) => (hunk.file || edit.file) === file);
+  if (!hunks.length) return null;
+  return { ...edit, file, hunks };
+}
 
 /**
  * The per-run edit cap is adaptive (design section 6). Near or under budget it is the
@@ -133,14 +158,21 @@ function unitsRemovedBy(hunk, memoryFile) {
  * an existing skill pays (or earns) the change to its `description:` line. Everything
  * else in a skill file is body - loaded on trigger, never billed here.
  */
-function descriptionDeltaOf(edit, before, next, skillsDir) {
-  if (edit.kind === "extract") {
-    return editSkills(edit).reduce((sum, skill) => sum + estimateTokens(skill.description || ""), 0);
-  }
-  if (edit.targetsMemoryFile || !edit.file || !skillsDir || !isSkillFilePath(edit.file, skillsDir)) return 0;
-  const beforeDescription = parseFrontmatter(before).description || "";
-  const nextDescription = parseFrontmatter(next).description || "";
-  return estimateTokens(nextDescription) - estimateTokens(beforeDescription);
+function descriptionLineDelta(before, next) {
+  return (
+    estimateTokens(parseFrontmatter(next).description || "") -
+    estimateTokens(parseFrontmatter(before).description || "")
+  );
+}
+
+function createdDescriptionCost(edit) {
+  return editSkills(edit).reduce((sum, skill) => sum + estimateTokens(skill.description || ""), 0);
+}
+
+function addedLineCounts(hunks) {
+  return recoveredLineCounts(
+    hunks.flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text)),
+  );
 }
 
 /** Overlapping count: a run of identical lines must not pass as unique. */
@@ -320,18 +352,27 @@ export function buildProposal(rawResult, context) {
       violations.push(`edit ${edit.id} ("${edit.title}") names no measured change`);
       continue;
     }
-    if (files.length > 1) {
-      violations.push(`edit ${edit.id} ("${edit.title}") changes ${files.join(" and ")}; an edit changes one file`);
-      continue;
-    }
     if (!edit.evidence.length) {
       violations.push(`edit ${edit.id} ("${edit.title}") carries no verbatim evidence quote`);
       continue;
     }
+
+    const skillsDir = config.skillDirs || config.skillsDir;
+    const memoryHunks = hunks.filter((hunk) => hunk.file === memoryFile.path);
+    const otherHunks = hunks.filter((hunk) => hunk.file !== memoryFile.path);
+    const destFiles = [...new Set(otherHunks.map((hunk) => hunk.file))];
+
     if (edit.kind === "extract") {
-      if (!created.length || !hunks.length || files[0] !== memoryFile.path) {
+      if (!memoryHunks.length || (!created.length && !destFiles.length)) {
         violations.push(
-          `edit ${edit.id}: kind "extract" must group created SKILL.md file(s) with change(s) to ${memoryFile.path}`,
+          `edit ${edit.id}: kind "extract" must group SKILL.md file(s) (created or extended) with change(s) to ${memoryFile.path}`,
+        );
+        continue;
+      }
+      const notSkill = destFiles.find((file) => !isSkillFilePath(file, skillsDir));
+      if (notSkill) {
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") changes ${notSkill}; an extract only extends a skill file alongside ${memoryFile.path}`,
         );
         continue;
       }
@@ -339,10 +380,12 @@ export function buildProposal(rawResult, context) {
       // single measured change - a merged change cannot be accepted in halves, so that
       // grouping is the measurement's, not the model's. Skills whose removals were measured
       // separately stay separately decidable.
-      if (created.length > 1 && hunks.length > 1) {
+      const skillCount = created.length + destFiles.length;
+      if (skillCount > 1 && memoryHunks.length > 1) {
+        const grouped = destFiles.length ? `${skillCount} skills` : `${created.length} created skills`;
         violations.push(
-          `edit ${edit.id}: groups ${created.length} created skills against ${hunks.length} separate changes to ` +
-            `${memoryFile.path} (${hunks.map((h) => h.id).join(", ")}); give each skill its own extract, or group ` +
+          `edit ${edit.id}: groups ${grouped} against ${memoryHunks.length} separate changes to ` +
+            `${memoryFile.path} (${memoryHunks.map((h) => h.id).join(", ")}); give each skill its own extract, or group ` +
             `several skills only when they share one measured change`,
         );
         continue;
@@ -352,14 +395,41 @@ export function buildProposal(rawResult, context) {
         violations.push(`edit ${edit.id}: ${unusable.file} needs YAML frontmatter with \`name:\` and \`description:\``);
         continue;
       }
-      // An extraction moves text; it never doubles as a deletion. Every line its hunks
-      // remove must land in the skills it creates - a real deletion goes in its own
-      // remove edit, where the removal-evidence floor below can judge it on its own.
-      const carried = recoveredLineCounts(created.map((c) => c.text));
-      const missing = hunks.flatMap((h) => unrecoveredRemovedLines(h, carried));
+      // Extending an existing skill must not drop what was already there: the staged file
+      // still contains every prior line, then the extracted lines on top of that.
+      let droppedPrior = null;
+      for (const file of destFiles) {
+        const original = measured.originals?.get(file) ?? "";
+        const staged = measured.texts?.get(file) ?? "";
+        const missingPrior = unrecoveredRemovedLines(
+          {
+            lines: String(original)
+              .split("\n")
+              .map((text) => ({ type: "del", text })),
+          },
+          recoveredLineCounts([staged]),
+        );
+        if (missingPrior.length) {
+          droppedPrior = missingPrior[0];
+          break;
+        }
+      }
+      if (droppedPrior) {
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") drops text the existing skill already had ` +
+            `(first: "${droppedPrior.trim().slice(0, 80)}"); extending a skill keeps every line it had`,
+        );
+        continue;
+      }
+      // An extraction moves text; it never doubles as a deletion. Every line its memory
+      // hunks remove must land in the skills it creates or extends - a real deletion goes
+      // in its own remove edit, where the removal-evidence floor below can judge it.
+      const destTexts = [...created.map((c) => c.text), ...destFiles.map((file) => measured.texts?.get(file) ?? "")];
+      const carried = recoveredLineCounts(destTexts);
+      const missing = memoryHunks.flatMap((h) => unrecoveredRemovedLines(h, carried));
       if (missing.length) {
         violations.push(
-          `edit ${edit.id} ("${edit.title}") removes text its created skill(s) do not carry ` +
+          `edit ${edit.id} ("${edit.title}") removes text its skill(s) do not carry ` +
             `(first: "${missing[0].trim().slice(0, 80)}"); an extraction preserves every line it removes - ` +
             `revert that text, or make its deletion a separate "remove" edit`,
         );
@@ -368,11 +438,38 @@ export function buildProposal(rawResult, context) {
     } else if (created.length) {
       violations.push(`edit ${edit.id}: only kind "extract" may include a created file (${created[0].id})`);
       continue;
+    } else if (files.length > 1) {
+      violations.push(`edit ${edit.id} ("${edit.title}") changes ${files.join(" and ")}; an edit changes one file`);
+      continue;
+    }
+
+    if (edit.kind === "move") {
+      if (!memoryHunks.length || destFiles.length || files[0] !== memoryFile.path) {
+        violations.push(`edit ${edit.id}: kind "move" must be change(s) to ${memoryFile.path} only`);
+        continue;
+      }
+      const hasRemoval = memoryHunks.some((hunk) => hunk.removed);
+      const hasAddition = memoryHunks.some((hunk) => hunk.added);
+      if (!hasRemoval || !hasAddition) {
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") is not a move: a move both removes text and re-adds it verbatim elsewhere in ${memoryFile.path}`,
+        );
+        continue;
+      }
+      const missing = memoryHunks.flatMap((hunk) => unrecoveredRemovedLines(hunk, addedLineCounts(memoryHunks)));
+      if (missing.length) {
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") removes text that does not reappear verbatim in the same edit ` +
+            `(first: "${missing[0].trim().slice(0, 80)}"); a move preserves every line it removes - ` +
+            `revert that text, or make its deletion a separate "remove" edit`,
+        );
+        continue;
+      }
     }
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    if (edit.kind !== "extract" && onlyAdds && edit.transcripts < config.minGapEvidence) {
+    if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
@@ -381,12 +478,12 @@ export function buildProposal(rawResult, context) {
     }
 
     // A removal is measured the same way: a hunk that only deletes text, outside an
-    // extraction, deletes instructions - whatever the edit's kind says. Deleting an
-    // instruction needs the same corroboration adding one does, and only negatives the
+    // extraction or move, deletes instructions - whatever the edit's kind says. Deleting
+    // an instruction needs the same corroboration adding one does, and only negatives the
     // analysis classified as `harm` (following the rule caused damage) count toward it.
     // Non-compliance is the rule failing to steer; it never justifies deletion. This is
     // the removal-evidence floor; the >= 20%-relevance placement table stays guidance.
-    if (edit.kind !== "extract" && files[0] === memoryFile.path) {
+    if (!preservesAlwaysLoaded(edit.kind) && files[0] === memoryFile.path) {
       const rows = new Map((summary?.instructions ?? []).map((row) => [row.instruction, row]));
       const unsupported = [];
       for (const hunk of hunks) {
@@ -412,7 +509,7 @@ export function buildProposal(rawResult, context) {
     // skill-file text at all - there are no instruction ids for it - so no pure
     // deletion there can reach the harm bar, whatever the edit is called. Rewrites
     // (a hunk that also adds text) stay possible; only vanishing text is refused.
-    if (edit.kind !== "extract" && files[0] !== memoryFile.path) {
+    if (!preservesAlwaysLoaded(edit.kind) && files[0] !== memoryFile.path) {
       const deleted = hunks
         .filter((hunk) => hunk.removed && !hunk.added)
         .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "del").map((line) => line.text))
@@ -427,7 +524,7 @@ export function buildProposal(rawResult, context) {
       }
     }
 
-    const file = files[0];
+    const file = memoryHunks.length ? memoryFile.path : files[0];
     const proposed = {
       id: edit.id,
       kind: edit.kind,
@@ -440,6 +537,7 @@ export function buildProposal(rawResult, context) {
       skills: created.map((c) => c.skill),
       hunks: hunks.map((h) => ({
         id: h.id,
+        file: h.file,
         find: h.find,
         replace: h.replace,
         oldStart: h.oldStart,
@@ -464,11 +562,27 @@ export function buildProposal(rawResult, context) {
   // free-until-triggered and never enter it.
   const running = new Map();
   for (const edit of accepted) {
-    const before =
-      running.get(edit.file) ?? (edit.targetsMemoryFile ? memoryFile.text : (measured.originals?.get(edit.file) ?? ""));
-    let next;
+    const targets = filesOfEdit(edit);
+    let memoryDelta = 0;
+    let otherDelta = 0;
+    let descriptionDelta = edit.kind === "extract" ? createdDescriptionCost(edit) : 0;
     try {
-      next = applyEdit(before, edit);
+      for (const target of targets) {
+        const slice = sliceEditForFile(edit, target);
+        const before =
+          running.get(target) ??
+          (target === memoryFile.path ? memoryFile.text : (measured.originals?.get(target) ?? ""));
+        const next = applyEdit(before, slice);
+        running.set(target, next);
+        const delta = estimateTokens(next) - estimateTokens(before);
+        if (target === memoryFile.path) memoryDelta += delta;
+        else {
+          otherDelta += delta;
+          if (isSkillFilePath(target, config.skillDirs || config.skillsDir)) {
+            descriptionDelta += descriptionLineDelta(before, next);
+          }
+        }
+      }
     } catch (err) {
       violations.push(err.message);
       edit.applicable = false;
@@ -477,9 +591,8 @@ export function buildProposal(rawResult, context) {
       continue;
     }
     edit.applicable = true;
-    edit.deltaTokens = estimateTokens(next) - estimateTokens(before);
-    edit.descriptionDelta = descriptionDeltaOf(edit, before, next, config.skillDirs || config.skillsDir);
-    running.set(edit.file, next);
+    edit.deltaTokens = edit.targetsMemoryFile ? memoryDelta : otherDelta;
+    edit.descriptionDelta = descriptionDelta;
   }
 
   const projectedText = running.get(memoryFile.path) ?? memoryFile.text;
@@ -531,7 +644,9 @@ export function buildProposal(rawResult, context) {
   // image its hunks were cut from. The writer re-checks these before composing, the
   // same freshness contract `memoryFileSnapshot` gives the memory file - a skill file
   // that changed after the proposal must refuse the apply, never be patched blind.
-  const targetFiles = [...new Set(accepted.filter((edit) => !edit.targetsMemoryFile).map((edit) => edit.file))]
+  const targetFiles = [
+    ...new Set(accepted.flatMap((edit) => filesOfEdit(edit).filter((file) => file !== memoryFile.path))),
+  ]
     .filter((file) => measured.originals?.has(file))
     .map((file) => ({ file, hash: memoryTextHash(measured.originals.get(file)) }));
 
@@ -565,7 +680,12 @@ export function buildProposal(rawResult, context) {
       gapSightings: summary?.totals?.gapSightings ?? null,
       orchestrationGapSightings: summary?.totals?.orchestrationGapSightings ?? null,
       droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,
-      skillExtractions: accepted.reduce((n, e) => n + editSkills(e).length, 0),
+      skillExtractions: accepted.reduce((n, e) => {
+        if (e.kind !== "extract") return n;
+        const createdSkills = editSkills(e).length;
+        const extended = new Set(filesOfEdit(e).filter((file) => file !== memoryFile.path)).size;
+        return n + Math.max(createdSkills, extended);
+      }, 0),
     },
     edits: accepted,
     verdicts: Array.isArray(rawResult?.verdicts) ? rawResult.verdicts : [],
@@ -597,7 +717,8 @@ export function projectWithDecisions(memoryText, edits, acceptedIds, capTokens, 
   let text = memoryText;
   for (const edit of chosen) {
     try {
-      text = applyEdit(text, edit);
+      const slice = sliceEditForFile(edit, edit.file) ?? edit;
+      text = applyEdit(text, slice);
     } catch {
       // Skip an edit that no longer applies; the writer reports it.
     }

--- a/src/skills.js
+++ b/src/skills.js
@@ -188,7 +188,9 @@ export function editSkills(edit) {
 export function extractionBudgetEffect(edit) {
   const skills = editSkills(edit);
   if (edit.kind !== "extract" || !skills.length) return null;
-  const pairs = Array.isArray(edit.hunks) ? edit.hunks : [edit];
+  const pairs = (Array.isArray(edit.hunks) ? edit.hunks : [edit]).filter(
+    (part) => !part.file || !edit.file || part.file === edit.file,
+  );
   const removedFromMemory = pairs.reduce((sum, p) => sum + estimateTokens(p.find) - estimateTokens(p.replace), 0);
   const descriptionCost = skills.reduce((sum, skill) => sum + estimateTokens(skill.description), 0);
   return {

--- a/src/state.js
+++ b/src/state.js
@@ -227,9 +227,19 @@ export function isEvidenceFresh(evidence, transcript, memoryHash) {
  * backed by strictly more transcripts than when it was turned down.
  */
 export function rejectionKey(edit) {
-  const body = Array.isArray(edit.hunks)
-    ? edit.hunks.map((h) => `${h.find}\u0000${h.replace}`).join("\u0001")
-    : `${edit.find || ""}\u0000${edit.replace || ""}`;
+  let body;
+  if (Array.isArray(edit.hunks)) {
+    const files = new Set(edit.hunks.map((hunk) => hunk.file || edit.file).filter(Boolean));
+    body = edit.hunks
+      .map((hunk) =>
+        files.size > 1
+          ? `${hunk.file || edit.file}\u0000${hunk.find}\u0000${hunk.replace}`
+          : `${hunk.find}\u0000${hunk.replace}`,
+      )
+      .join("\u0001");
+  } else {
+    body = `${edit.find || ""}\u0000${edit.replace || ""}`;
+  }
   return sha256([edit.kind, edit.file, body].join(" ")).slice(0, 16);
 }
 

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -247,12 +247,20 @@ export function measureWorkspace(workspace) {
     changes.push({ kind: "created", file: relative, text, skill: parseSkillFile(relative, text) });
   }
 
-  // With the created files known, split any memory-file removal that mixes extracted
-  // text (recovered in a created file) with deleted text, so the deletion is its own
+  // Split any memory-file removal that mixes extracted text (recovered in a created
+  // skill or in a modified existing one) with deleted text, so the deletion is its own
   // measured change and stays independently decidable.
   const createdTexts = changes.filter((c) => c.kind === "created").map((c) => c.text);
-  if (createdTexts.length) {
-    const recovered = recoveredLineCounts(createdTexts);
+  const extendedSkillFiles = [
+    ...new Set(
+      changes
+        .filter((c) => c.kind === "hunk" && c.file !== memoryPath && isSkillFilePath(c.file, skillDirs))
+        .map((c) => c.file),
+    ),
+  ];
+  const recoveredTexts = [...createdTexts, ...extendedSkillFiles.map((file) => texts.get(file) ?? "")];
+  if (recoveredTexts.length) {
+    const recovered = recoveredLineCounts(recoveredTexts);
     const oldText = originals.get(memoryPath) ?? "";
     const oldLines = oldText.split("\n");
     const measured = [];

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -123,9 +123,10 @@ export function recoveredLineCounts(texts) {
 
 /**
  * Split one pure-removal memory-file hunk at the boundary between text that lands in a
- * created skill and text that vanishes. Adjacent removals merge into one measured change
- * (`anchoredHunks`), so without this split an extraction and an unrelated deletion that
- * happen to sit next to each other in the file fuse into a single accept/reject decision.
+ * created or extended skill and text that vanishes. Adjacent removals merge into one
+ * measured change (`anchoredHunks`), so without this split an extraction and an unrelated
+ * deletion that happen to sit next to each other in the file fuse into a single
+ * accept/reject decision.
  * The boundary is a decision boundary, and it falls on instruction-unit edges because a
  * skill carries whole sections.
  *

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -491,6 +491,12 @@
         padding: 1px 8px;
         border-top: 1px dashed var(--line-soft);
       }
+      .diff .file {
+        display: block;
+        color: var(--blue);
+        padding: 1px 8px;
+        font-weight: 650;
+      }
 
       .evidence {
         border-top: 1px dashed var(--line-soft);
@@ -997,7 +1003,8 @@
           card.appendChild(head);
 
           var body = el("div", "edit-body");
-          if (!edit.targetsMemoryFile) body.appendChild(el("div", "target", "target: " + edit.file));
+          var files = editFiles(edit);
+          body.appendChild(el("div", "target", (files.length === 1 ? "file: " : "files: ") + files.join(", ")));
           if (edit.rationale) body.appendChild(el("p", "rationale", edit.rationale));
 
           // An extract creates one skill, or several when their removals were measured as
@@ -1078,6 +1085,16 @@
           return line.length > 0;
         }
 
+        function editFiles(edit) {
+          if (!Array.isArray(edit.hunks)) return edit.file ? [edit.file] : [];
+          var files = edit.hunks.reduce(function (files, hunk) {
+            var file = hunk.file || edit.file;
+            if (file && files.indexOf(file) === -1) files.push(file);
+            return files;
+          }, []);
+          return files.length ? files : edit.file ? [edit.file] : [];
+        }
+
         // The skills one extract creates. A proposal saved before an extract could carry
         // several (merged removals) has a single `skill`; both shapes read the same way.
         function editSkills(edit) {
@@ -1096,6 +1113,7 @@
             var out = [];
             edit.hunks.forEach(function (hunk, i) {
               if (i > 0) out.push({ type: "gap", text: "\u2026" });
+              out.push({ type: "file", text: "--- " + (hunk.file || edit.file) + " ---" });
               (hunk.lines || []).forEach(function (line) {
                 out.push(line);
               });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -563,6 +563,53 @@ test("an extract may extend an existing SKILL.md when the staged file keeps prio
   );
 });
 
+test("an extended extraction requires prior skill lines plus separately carried memory lines", () => {
+  const extracted = "- Use Node 18 via nvm before running any script.";
+  const skill = skillFile("node-setup", `${extracted}\n`);
+  const reusedPriorCopy = gate({
+    files: { ".agents/skills/node-setup/SKILL.md": skill },
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) => text.replace(extracted, "- See the node-setup skill."));
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", (text) => `${text}- Added unrelated guidance.\n`);
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract node setup" })] },
+  });
+
+  assert.ok(
+    reusedPriorCopy.violations.some((violation) => /removes text its skill\(s\) do not carry/.test(violation)),
+    reusedPriorCopy.violations.join("\n"),
+  );
+});
+
+test("an extract cannot bypass addition evidence without removing memory text", () => {
+  const skill = skillFile("node-setup", "- Keep this setup guidance.\n");
+  const files = { ".agents/skills/node-setup/SKILL.md": skill };
+  const addOnly = (root) => {
+    writeIn(root, "AGENTS.md", (text) => `${text}- Unsupported new memory rule.\n`);
+    writeIn(root, ".agents/skills/node-setup/SKILL.md", (text) => `${text}- More skill guidance.\n`);
+  };
+
+  const unsupported = gate({
+    files,
+    edit: addOnly,
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "add setup guidance", transcripts: 1 })] },
+  });
+  assert.ok(
+    unsupported.violations.some((violation) => /adds a new instruction backed by 1 session/.test(violation)),
+    unsupported.violations.join("\n"),
+  );
+
+  const corroborated = gate({
+    files,
+    edit: addOnly,
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "add setup guidance" })] },
+  });
+  assert.ok(
+    corroborated.violations.some((violation) => /kind "extract" must remove text/.test(violation)),
+    corroborated.violations.join("\n"),
+  );
+});
+
 test("a move repositions verbatim memory-file text without the harm floor", () => {
   const text = `${MEMORY_TEXT}\n## Later\n\n- Keep this nearby.\n`;
   const node = "- Use Node 18 via nvm before running any script.";
@@ -622,6 +669,49 @@ test("a move repositions verbatim memory-file text without the harm floor", () =
   assert.ok(
     fake.violations.some((v) => /does not reappear verbatim/.test(v)),
     fake.violations.join("\n"),
+  );
+
+  const extraAddition = gate({
+    text,
+    edit: memoryEdit((t) =>
+      t
+        .replace(`${node}\n`, "")
+        .replace("- Keep this nearby.", `- Keep this nearby.\n${node}\n- Unsupported extra rule.`),
+    ),
+    annotation: { edits: [claim(["H1", "H2"], { kind: "move", title: "move and smuggle an addition" })] },
+    context: { summary: noHarmRows() },
+  });
+  assert.ok(
+    extraAddition.violations.some((v) => /removed and added lines must match exactly/.test(v)),
+    extraAddition.violations.join("\n"),
+  );
+
+  const duplicateText = [
+    MEMORY_TEXT,
+    "## Middle",
+    "",
+    node,
+    "",
+    "## Spacer",
+    "",
+    "- Leave enough unique context between copies.",
+    "",
+    "## Destination",
+    "",
+    "- Keep this last.",
+    "",
+  ].join("\n");
+  const doubleRemoval = gate({
+    text: duplicateText,
+    edit: memoryEdit((t) => t.replaceAll(`${node}\n`, "").replace("- Keep this last.", `- Keep this last.\n${node}`)),
+    annotation: {
+      edits: [claim(["H1", "H2", "H3"], { kind: "move", title: "collapse two copies into one" })],
+    },
+    context: { summary: noHarmRows() },
+  });
+  assert.ok(
+    doubleRemoval.violations.some((v) => /removed and added lines must match exactly/.test(v)),
+    doubleRemoval.violations.join("\n"),
   );
 });
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -479,6 +479,20 @@ test("an extract may extend an existing SKILL.md when the staged file keeps prio
     [".agents/skills/node-setup/SKILL.md"],
   );
 
+  const mixed = gate({
+    files,
+    edit: (root) => {
+      extend(root);
+      writeIn(root, ".agents/skills/release-signing/SKILL.md", skillFile("release-signing"));
+    },
+    annotation: {
+      edits: [claim(["H1", "H2", "H3"], { kind: "extract", title: "extend setup and add signing" })],
+    },
+    context: { summary: noHarmRows() },
+  });
+  assert.deepEqual(mixed.violations, [], mixed.violations.join("\n"));
+  assert.equal(mixed.proposal.stats.skillExtractions, 2, "created and extended destinations both count");
+
   const applied = applyDecisions({
     proposal: good.proposal,
     decisions: { e1: "accepted" },
@@ -679,6 +693,43 @@ test("a previously rejected edit is suppressed until new evidence arrives", () =
     context: { rejections, isSuppressed: isSuppressedByRejection },
   });
   assert.equal(revived.proposal.edits.length, 1, "materially new evidence revives the edit");
+});
+
+test("rejection suppression distinguishes multi-file extraction destinations", () => {
+  const sharedSkill = skillFile("setup", "- Keep the existing setup step.\n");
+  const files = {
+    ".agents/skills/setup-a/SKILL.md": sharedSkill,
+    ".agents/skills/setup-b/SKILL.md": sharedSkill,
+  };
+  const extracted = "- Use Node 18 via nvm before running any script.";
+  const extractTo = (destination) => (root) => {
+    writeIn(root, "AGENTS.md", (text) => text.replace(extracted, "- See the setup skill."));
+    writeIn(root, destination, (text) => `${text}${extracted}\n`);
+  };
+  const annotation = {
+    edits: [claim(["H1", "H2"], { kind: "extract", title: "extract setup" })],
+  };
+
+  const first = gate({ files, edit: extractTo(".agents/skills/setup-a/SKILL.md"), annotation });
+  assert.deepEqual(first.violations, [], first.violations.join("\n"));
+  const rejections = recordRejection(first.proposal.edits[0], { version: 1, entries: {} });
+
+  const sameDestination = gate({
+    files,
+    edit: extractTo(".agents/skills/setup-a/SKILL.md"),
+    annotation,
+    context: { rejections, isSuppressed: isSuppressedByRejection },
+  });
+  assert.equal(sameDestination.proposal.edits.length, 0);
+
+  const otherDestination = gate({
+    files,
+    edit: extractTo(".agents/skills/setup-b/SKILL.md"),
+    annotation,
+    context: { rejections, isSuppressed: isSuppressedByRejection },
+  });
+  assert.deepEqual(otherDestination.violations, [], otherDestination.violations.join("\n"));
+  assert.equal(otherDestination.proposal.edits.length, 1, "a different destination is a materially different edit");
 });
 
 test("projectWithDecisions tracks the budget for the subset the human accepted", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -364,7 +364,7 @@ test("an extract is the created SKILL.md file(s) grouped with the memory change 
     edit: extractEdit,
     annotation: { edits: [claim(["H1"], { kind: "extract", title: "x" }), claim(["H2"], { kind: "add", title: "y" })] },
   });
-  assert.ok(split.violations.some((v) => /kind "extract" must group created SKILL\.md file\(s\)/.test(v)));
+  assert.ok(split.violations.some((v) => /kind "extract" must group SKILL\.md file\(s\)/.test(v)));
   assert.ok(split.violations.some((v) => /only kind "extract" may include a created file \(H2\)/.test(v)));
 
   const headless = gate({
@@ -430,6 +430,184 @@ test("skills whose removals were measured as one change may share an extract; se
     `expected a split demand, got ${JSON.stringify(separate.violations)}`,
   );
   assert.ok(separate.violations.some((v) => /give each skill its own extract/.test(v)));
+});
+
+const noHarmRows = () => ({
+  analyzedSessions: 4,
+  totals: { positive: 0, negative: 4, gapClusters: 0 },
+  instructions: Array.from({ length: 20 }, (_, i) => ({
+    instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+    positive: 0,
+    negative: 4,
+    harmSessions: 0,
+    sessions: 4,
+    relevance: 1,
+    quotes: [],
+  })),
+});
+
+test("an extract may extend an existing SKILL.md when the staged file keeps prior lines and carries the removal", () => {
+  const existing = skillFile("node-setup", "- Prefer nvm over a system node.\n");
+  const extracted = "- Use Node 18 via nvm before running any script.";
+  const extend = (root) => {
+    writeIn(root, "AGENTS.md", (t) => t.replace(extracted, "- See the node-setup skill."));
+    writeIn(root, ".agents/skills/node-setup/SKILL.md", (t) =>
+      t.replace("- Prefer nvm over a system node.\n", `- Prefer nvm over a system node.\n${extracted}\n`),
+    );
+  };
+  const files = { ".agents/skills/node-setup/SKILL.md": existing };
+
+  const good = gate({
+    files,
+    edit: extend,
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "fold the node pin into node-setup" })] },
+    context: { summary: noHarmRows() },
+  });
+  assert.deepEqual(good.violations, [], good.violations.join("\n"));
+  assert.equal(good.proposal.edits.length, 1);
+  assert.equal(good.proposal.edits[0].kind, "extract");
+  assert.equal(good.proposal.edits[0].hunks.length, 2, "memory removal and skill extension are one decision");
+  assert.equal(
+    good.proposal.edits[0].skills.length,
+    0,
+    "the skill already exists; apply patches it, it does not create it",
+  );
+  assert.equal(good.proposal.stats.skillExtractions, 1);
+  assert.deepEqual(
+    good.proposal.targetFiles.map((t) => t.file),
+    [".agents/skills/node-setup/SKILL.md"],
+  );
+
+  const applied = applyDecisions({
+    proposal: good.proposal,
+    decisions: { e1: "accepted" },
+    repo: good.repo,
+    state: good.state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.equal(applied.failed.length, 0, JSON.stringify(applied.failed));
+  const skill = fs.readFileSync(path.join(good.repo.root, ".agents/skills/node-setup/SKILL.md"), "utf8");
+  assert.ok(skill.includes("- Prefer nvm over a system node."), "prior skill lines stay");
+  assert.ok(skill.includes(extracted), "extracted lines land in the existing skill");
+  const memory = fs.readFileSync(path.join(good.repo.root, "AGENTS.md"), "utf8");
+  assert.ok(memory.includes("- See the node-setup skill."));
+  assert.ok(!memory.includes(extracted));
+
+  const split = gate({
+    files,
+    edit: extend,
+    annotation: { edits: [claim(["H1", "H2"], { kind: "rewrite", title: "fold the node pin into node-setup" })] },
+    context: { summary: noHarmRows() },
+  });
+  assert.ok(
+    split.violations.some((v) => /an edit changes one file/.test(v)),
+    `grouping the two files as a rewrite must fail, got ${JSON.stringify(split.violations)}`,
+  );
+
+  const cut = (root) => {
+    writeIn(root, "AGENTS.md", (t) => t.replace(`${extracted}\n`, ""));
+    writeIn(root, ".agents/skills/node-setup/SKILL.md", (t) =>
+      t.replace("- Prefer nvm over a system node.\n", `- Prefer nvm over a system node.\n${extracted}\n`),
+    );
+  };
+  const asRemove = gate({
+    files,
+    edit: cut,
+    annotation: {
+      edits: [
+        claim(["H1"], { kind: "remove", title: "drop the node pin" }),
+        claim(["H2"], { kind: "rewrite", title: "append to node-setup" }),
+      ],
+    },
+    context: { summary: noHarmRows() },
+  });
+  assert.ok(
+    asRemove.violations.some((v) => /harm-class negative evidence/.test(v)),
+    `a bare memory deletion still needs harm, got ${JSON.stringify(asRemove.violations)}`,
+  );
+  const asExtract = gate({
+    files,
+    edit: cut,
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "fold the node pin into node-setup" })] },
+    context: { summary: noHarmRows() },
+  });
+  assert.deepEqual(asExtract.violations, [], asExtract.violations.join("\n"));
+
+  const droppedPrior = gate({
+    files,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) => t.replace(extracted, "- See the node-setup skill."));
+      writeIn(root, ".agents/skills/node-setup/SKILL.md", skillFile("node-setup", `${extracted}\n`));
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "replace the skill body" })] },
+    context: { summary: noHarmRows() },
+  });
+  assert.ok(
+    droppedPrior.violations.some((v) => /drops text the existing skill already had/.test(v)),
+    droppedPrior.violations.join("\n"),
+  );
+});
+
+test("a move repositions verbatim memory-file text without the harm floor", () => {
+  const text = `${MEMORY_TEXT}\n## Later\n\n- Keep this nearby.\n`;
+  const node = "- Use Node 18 via nvm before running any script.";
+  const relocate = memoryEdit((t) =>
+    t.replace(`${node}\n`, "").replace("- Keep this nearby.", `- Keep this nearby.\n${node}`),
+  );
+
+  const split = gate({
+    text,
+    edit: relocate,
+    annotation: {
+      edits: [
+        claim(["H1"], { kind: "remove", title: "drop the node pin" }),
+        claim(["H2"], { kind: "add", title: "put it later" }),
+      ],
+    },
+    context: { summary: noHarmRows() },
+  });
+  assert.ok(
+    split.violations.some((v) => /harm-class negative evidence/.test(v)),
+    `the deletion half of a move must hit the harm floor, got ${JSON.stringify(split.violations)}`,
+  );
+
+  const moved = gate({
+    text,
+    edit: relocate,
+    annotation: { edits: [claim(["H1", "H2"], { kind: "move", title: "park the node pin later" })] },
+    context: { summary: noHarmRows() },
+  });
+  assert.deepEqual(moved.violations, [], moved.violations.join("\n"));
+  assert.equal(moved.proposal.edits.length, 1);
+  assert.equal(moved.proposal.edits[0].kind, "move");
+  assert.equal(moved.proposal.edits[0].hunks.length, 2, "deletion and re-add are one decision");
+
+  const applied = applyDecisions({
+    proposal: moved.proposal,
+    decisions: { e1: "accepted" },
+    repo: moved.repo,
+    state: moved.state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.equal(applied.failed.length, 0, JSON.stringify(applied.failed));
+  const next = fs.readFileSync(path.join(moved.repo.root, "AGENTS.md"), "utf8");
+  const first = next.indexOf(node);
+  assert.ok(first !== -1);
+  assert.equal(next.indexOf(node, first + 1), -1, "the line appears once, not duplicated");
+  assert.ok(first > next.indexOf("## Later"), "the line moved below Later");
+
+  const fake = gate({
+    text,
+    edit: memoryEdit((t) =>
+      t.replace(`${node}\n`, "").replace("- Keep this nearby.", "- Keep this nearby.\n- Use Node 22 instead."),
+    ),
+    annotation: { edits: [claim(["H1", "H2"], { kind: "move", title: "rewrite disguised as move" })] },
+    context: { summary: noHarmRows() },
+  });
+  assert.ok(
+    fake.violations.some((v) => /does not reappear verbatim/.test(v)),
+    fake.violations.join("\n"),
+  );
 });
 
 test("a skill's description can be rewritten in place; deletions and stray files are refused or ignored", () => {
@@ -1484,9 +1662,7 @@ test("an extract cannot smuggle the adjacent deletion: its skills must carry eve
     context: { summary: betaRows({ harmSessions: 0 }) },
   });
   assert.ok(
-    violations.some(
-      (v) => /removes text its created skill\(s\) do not carry/.test(v) && /separate "remove" edit/.test(v),
-    ),
+    violations.some((v) => /removes text its skill\(s\) do not carry/.test(v) && /separate "remove" edit/.test(v)),
     violations.join("\n"),
   );
 });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -17,6 +17,7 @@ import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
 import { injectPayload, parseDecisions, renderApplySurface } from "../src/apply/lavish.js";
+import { renderEdit } from "../src/apply/terminal.js";
 import { extractJson, parseTokenLine, stripAcpxNoise } from "../src/acpx.js";
 import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
 
@@ -1254,10 +1255,14 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
         targetsMemoryFile: true,
         deltaTokens: -20,
         descriptionDelta: 5,
-        hunks: [],
-        skills: [
-          { name: "setup", path: ".agents/skills/setup/SKILL.md", description: "Load for setup.", body: "body" },
+        hunks: [
+          { file: "AGENTS.md", lines: [{ type: "del", text: "- setup details" }] },
+          {
+            file: ".agents/skills/setup/SKILL.md",
+            lines: [{ type: "ins", text: "- setup details" }],
+          },
         ],
+        skills: [],
         evidence: [],
       },
       {
@@ -1285,9 +1290,42 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
   const cards = nodes.get("edits").children;
   assert.match(textOf(cards[0]), /Δ memory -20 tok/);
   assert.match(textOf(cards[0]), /Δ description \(always-loaded\) \+5 tok/);
+  assert.match(textOf(cards[0]), /files: AGENTS\.md, \.agents\/skills\/setup\/SKILL\.md/);
+  const fileBoundaries = (function collect(node) {
+    return [node, ...node.children.flatMap(collect)];
+  })(cards[0])
+    .filter((node) => node.className === "file")
+    .map((node) => node.textContent);
+  assert.deepEqual(fileBoundaries, ["--- AGENTS.md ---", "--- .agents/skills/setup/SKILL.md ---"]);
   assert.match(textOf(cards[1]), /Δ on trigger -1 tok/);
   assert.match(textOf(cards[1]), /Δ description \(always-loaded\) -2 tok/);
+  assert.match(textOf(cards[1]), /file: \.agents\/skills\/db\/SKILL\.md/);
   assert.equal(nodes.get("gauge-title").textContent, "Always-loaded budget · AGENTS.md + skill descriptions");
+});
+
+test("terminal review labels every file in a multi-file extraction", () => {
+  const output = renderEdit(
+    {
+      kind: "extract",
+      title: "extract setup",
+      file: "AGENTS.md",
+      targetsMemoryFile: true,
+      hunks: [
+        { file: "AGENTS.md", lines: [{ type: "del", text: "- setup details" }] },
+        {
+          file: ".agents/skills/setup/SKILL.md",
+          lines: [{ type: "ins", text: "- setup details" }],
+        },
+      ],
+      skills: [],
+    },
+    0,
+    1,
+  );
+
+  assert.match(output, /files: AGENTS\.md, \.agents\/skills\/setup\/SKILL\.md/);
+  assert.match(output, /--- AGENTS\.md ---/);
+  assert.match(output, /--- \.agents\/skills\/setup\/SKILL\.md ---/);
 });
 
 test("the decision vector from the review surface is parsed back into decisions", () => {

--- a/test/synthesis-cli.test.js
+++ b/test/synthesis-cli.test.js
@@ -318,7 +318,7 @@ test("skills whose removals merged into one change ship as one decision, and app
   // Extraction is offered as an available option, not urged: the deciding model must not
   // read the prompt as pushing it toward a skill when the evidence does not ask for one.
   assert.match(editPrompt, /You can extract a long, narrow, crisply-triggered section instead of deleting it/);
-  assert.ok(!/Prefer extracting/.test(editPrompt), "hard rule 7 states permission, never preference");
+  assert.ok(!/Prefer extracting/.test(editPrompt), "hard rule 8 states permission, never preference");
   assert.ok(
     !/nearly pure budget profit/.test(editPrompt),
     "the placement table's follow-up states the mechanics, it does not re-add the nudge",


### PR DESCRIPTION
## Intent

Add the two natural edit shapes backpass currently forces its model to route around with worse edits. Today (a) moving content into an EXISTING skill file fails because an extract must CREATE the SKILL.md (the deletion counts as a bare removal needing harm evidence), and (b) REPOSITIONING text within the memory file fails because the deletion half of a move fails the harm floor even though the text is re-added verbatim - producing a duplicated rule instead of a move, and a 739-token block left in place with a "duplicates an existing skill" note. Fix, gated on MECHANICAL (verbatim-identity) checks, NOT the harm floor, since no content leaves the always-loaded surface: (a) EXTEND-EXTRACT: allow an extraction to target an existing SKILL.md when the staged skill file still contains every line it previously had PLUS every line the memory-file hunk removes (reuse the existing verbatim-carry checker normalizeRecoveryLine, which today just refuses non-created targets); (b) MOVE: an edit kind whose removed memory-file text reappears verbatim elsewhere in the staged memory file, gated on verbatim identity like extraction. Both must keep "one honest accept/reject decision" intact. Cover both shapes behaviorally through the real gate. Stay strictly scoped to this improvement only.

## What Changed

- Allow extraction edits to extend existing skills when they preserve all prior skill content and carry every removed memory line.
- Add memory-file move edits gated by one-for-one normalized identity between removed and re-added lines.
- Support multi-file extraction decisions throughout measurement, proposal validation, review, and atomic apply.

## Risk Assessment

✅ Low: The mechanical gates now enforce combined extraction carry, actual memory removal for extracts, and bijective normalized move identity, with multi-file review and apply paths consistently updated.

## Testing

The focused behavioral tests passed, including the three strengthened mechanical gates, and manual end-to-end verification showed an existing skill extended without losing prior content and a memory rule repositioned exactly once with both files persisted correctly.

<details>
<summary>Evidence: EXTEND-EXTRACT and MOVE end-to-end CLI review and persisted results</summary>

Source: [EXTEND-EXTRACT and MOVE end-to-end CLI review and persisted results](https://github.com/kunchenguid/backpass/blob/2239fddd235de0ccd8f8bd2a96ec7742f6878155/.no-mistakes/evidence/fm/backpass-edit-shapes-extract-move-r1/edit-shapes-e2e.txt)

```text
=== EXTEND-EXTRACT: end-user review and accepted result ===

[1/1] EXTRACT -> SKILL  -6 tok
  Move Node setup details into the existing skill
  files: AGENTS.md, .agents/skills/node-setup/SKILL.md

  --- AGENTS.md ---
  - - Use Node 18 via nvm before running any script.
  + - See the node-setup skill.
  ...
  --- .agents/skills/node-setup/SKILL.md ---
    - Prefer nvm over a system Node.
  + - Use Node 18 via nvm before running any script.

  evidence (3 transcript(s)):
    - "The layout caused the rule to be missed."
      claude · demo · turn 3

Persisted AGENTS.md:
# Demo instructions

## Rules

- Keep PR links complete.
- See the node-setup skill.

## Later

- Keep this nearby.

Persisted existing .agents/skills/node-setup/SKILL.md:
---
name: node-setup
description: Load when configuring Node.
---

- Prefer nvm over a system Node.
- Use Node 18 via nvm before running any script.

=== MOVE: end-user review and accepted result ===

[1/1] MOVE  0 tok
  Reposition the Node rule under Later
  file: AGENTS.md

  --- AGENTS.md ---
  - - Use Node 18 via nvm before running any script.
  ...
  --- AGENTS.md ---
    - Keep this nearby.
  + - Use Node 18 via nvm before running any script.

  evidence (3 transcript(s)):
    - "The layout caused the rule to be missed."
      claude · demo · turn 3

Persisted AGENTS.md (rule occurs exactly once):
# Demo instructions

## Rules

- Keep PR links complete.

## Later

- Keep this nearby.
- Use Node 18 via nvm before running any script.

Verified occurrence count: 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ee8fbc2d2552b0a3d3bffb93cbe9751f015cf02f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `src/proposal.js:459` - The required MOVE gate is not true verbatim identity. It rebuilds the full added-line count for every hunk, so two distant removals of the same line can both be justified by one inserted copy. It also never rejects unmatched inserted lines, allowing a move to add a new instruction without the normal evidence floor. This contradicts the criterion that MOVE is repositioning whose removed text reappears verbatim. Use one shared count across all removals and reject unmatched nonblank additions so removed and added normalized multisets match.
- 🚨 `src/proposal.js:427` - The existing-skill retention and extraction checks each start from a fresh count of the staged file. If the original skill already contains line A, the memory removes another A, and the skill makes any unrelated edit, the same staged occurrence satisfies both checks. The proposal passes without the required prior contents PLUS every removed line. Validate the staged multiset against the combined counts of the original skill and removed memory text.
- 🚨 `templates/apply.html:1000` - An extract into an existing skill has targetsMemoryFile=true and skills=[], so the browser card shows no target or skill preview, then interleaves memory and skill hunks without file labels. The terminal renderer similarly labels the entire edit as AGENTS.md. A reviewer cannot tell which additions land in the existing skill before accepting the combined decision. Render file boundaries from each hunk.file in both review surfaces.

🔧 Fix: Label multi-file extraction review boundaries
4 issues (2 errors, 2 warnings) still open:

- 🚨 `src/proposal.js:459` - The required MOVE &#34;verbatim-identity&#34; gate is not bijective. It recreates the complete addition count for each hunk, so two distant removals of the same line can both consume one inserted copy. It also permits unmatched inserted lines, allowing a move to add an instruction while bypassing the addition evidence floor. Use one shared count and require the normalized removed and added multisets to match.
- 🚨 `src/proposal.js:427` - This contradicts the required EXTEND-EXTRACT invariant that the staged skill contain every prior line &#34;PLUS every line the memory-file hunk removes.&#34; Prior retention and extraction carry are checked against separate fresh counts. If both files already contain line A, memory removes A, and the skill makes an unrelated edit while retaining its existing A, that single staged occurrence satisfies both checks. Validate staged counts against the combined multiset of prior skill lines and removed memory lines.
- ⚠️ `src/proposal.js:687` - An allowed extract containing one created skill and one extended skill reports one skill extraction because Math.max(1, 1) is used, although the review surface labels this statistic as a count of skill extractions. Add the created and extended destination counts instead.
- ⚠️ `src/state.js:231` - The rejection key hashes each hunk&#39;s text but not its file. With the new multi-file extract shape, rejecting an extraction into skill A suppresses a later extraction of the same memory text into skill B when the skills have identical source text and receive the same insertion. Include the per-hunk target path for multi-file edits while preserving legacy single-file key compatibility.

🔧 Fix: Fix extraction counts and rejection identity
3 errors still open:

- 🚨 `src/proposal.js:459` - The required MOVE verbatim-identity gate is not bijective. It rebuilds the complete addition count for each removal hunk, so two separate removals of the same line can both consume one inserted copy. It also permits unmatched inserted lines, allowing a move to add an instruction without the normal evidence floor. This contradicts the required repositioning-only behavior. Use one shared count and require normalized removed and added multisets to match.
- 🚨 `src/proposal.js:410` - The required EXTEND-EXTRACT invariant says the staged skill must contain every prior line PLUS every removed memory line, but retention and extraction use separate fresh counts. If both files contain line A, memory removes A, and the staged skill retains its existing A while making an unrelated edit, that single occurrence satisfies both checks. Validate staged counts against the combined multiset of prior skill lines and removed memory lines.
- 🚨 `src/proposal.js:366` - The newly allowed existing-skill extract shape does not require any memory removal. A staging change that only appends a new memory instruction and modifies an existing skill can be labeled extract; the carry check is vacuous and line 472 exempts it from minGapEvidence. This violates the contract that an addition is a new instruction regardless of kind. Require an extract to remove memory text, or apply the addition floor whenever all memory hunks only add.

🔧 Fix: Enforce bijective move and extraction gates
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff against `7b1a915aa757a632b8ae053eca773ab79158c17b` for proposal gating, multi-file apply, and review rendering changes.</code>
- `node --test --test-name-pattern='extract may extend|extended extraction requires|extract cannot bypass|move repositions|terminal review labels|apply surface separates' test/proposal.test.js`
- `Ran an end-to-end Node scenario through workspace measurement, the real proposal gate, terminal review rendering, acceptance, and persisted-file verification for EXTEND-EXTRACT and MOVE.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
