### PR TITLE
fix(discovery): find sessions in sibling clones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 
 ## Sharp edges
 
+- **Sibling clones are a live-path tier, not a recorded-remote one.** `git worktree
+list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches the
+  parent of each worktree (and `discovery.cloneRoots`) for other checkouts that share a
+  remote, read-only, so Claude sessions whose cwd is a sibling clone still attach
+  (tier 1.5). A second full clone with no overlapping remote is never associated.
 - **Transcript formats are undocumented and drift.** File adapters in
   `src/discovery/adapters/` are pinned by golden fixtures in `test/fixtures/`; SQLite
   adapters (opencode, hermes) build tiny temp databases in tests. When a harness changes

--- a/README.md
+++ b/README.md
@@ -104,14 +104,20 @@ and reads each JSONL file once.
 Hermes collection includes CLI and ACP sessions only. Gateway, cron, and WhatsApp sessions
 are excluded because their recorded cwd belongs to the shared gateway process, not a project.
 
-Association runs in three tiers:
+Association runs in four tiers:
 
 1. **Tier 1 - deterministic.** The session's cwd is (or sits inside) one of this repo's
    worktrees.
-2. **Tier 2 - deterministic, survives deletion.** A git remote recorded in the transcript
+2. **Tier 1.5 - deterministic, sibling clone.** The cwd is a live local clone (or one of
+   its worktrees) that shares a git remote with this repo. This clone's `git worktree
+list` cannot see a second checkout, and Claude records no remote, so without this
+   tier a sibling clone's interactive history is invisible. Backpass searches the parent
+   of each of this repo's worktrees, plus any `discovery.cloneRoots` you configure, and
+   only reads git identity there. `--strict` keeps this tier.
+3. **Tier 2 - deterministic, survives deletion.** A git remote recorded in the transcript
    matches one of the repo's remotes. This is how codex and grok stay attributable long
    after the worktree is gone.
-3. **Tier 3 - best-effort.** A dead path whose last segment is the repo's directory name,
+4. **Tier 3 - best-effort.** A dead path whose last segment is the repo's directory name,
    or one matching a glob you configured. Labelled as such, and excluded by `--strict`.
 
 Collection is incremental. Codex alone can hold 10,000+ rollouts, so verdicts are cached in
@@ -496,6 +502,7 @@ CLI flags on top:
     "harnesses": ["claude", "codex", "pi", "opencode", "grok", "cursor", "hermes"],
     "since": "30d",
     "worktreeGlobs": [],
+    "cloneRoots": [],
     "minUserTurns": 2
   },
   "jobs": 4

--- a/README.md
+++ b/README.md
@@ -109,11 +109,13 @@ Association runs in four tiers:
 1. **Tier 1 - deterministic.** The session's cwd is (or sits inside) one of this repo's
    worktrees.
 2. **Tier 1.5 - deterministic, sibling clone.** The cwd is a live local clone (or one of
-   its worktrees) that shares a git remote with this repo. This clone's `git worktree
-list` cannot see a second checkout, and Claude records no remote, so without this
-   tier a sibling clone's interactive history is invisible. Backpass searches the parent
+   its worktrees) that shares a git remote with this repo. `git worktree list` only sees
+   worktrees from one clone, and Claude records no remote, so without this tier a sibling
+   clone's interactive history is invisible. Backpass searches the parent
    of each of this repo's worktrees, plus any `discovery.cloneRoots` you configure, and
-   only reads git identity there. `--strict` keeps this tier.
+   only reads git identity there. Each clone root may be a checkout or a directory whose
+   immediate children are checkouts; relative paths resolve from the repo root. `--strict`
+   keeps this tier.
 3. **Tier 2 - deterministic, survives deletion.** A git remote recorded in the transcript
    matches one of the repo's remotes. This is how codex and grok stay attributable long
    after the worktree is gone.

--- a/src/cli.js
+++ b/src/cli.js
@@ -84,7 +84,7 @@ COLLECT SAMPLES
   --since <dur>            only sessions newer than this (30d, 12h, 2w, all)  [30d]
   --harness <a,b>          limit to these harnesses
                            (claude, codex, pi, opencode, grok, cursor, hermes)
-  --strict                 deterministic associations only (tiers 1 and 2)
+  --strict                 deterministic associations only (tiers 1, 1.5, and 2)
   --include-cursor-ide     also scan the Cursor IDE store (best-effort, v1.1 preview)
   --limit <n>              analyze at most N transcripts this run (newest first)
   --max-transcripts <n>    cap per run; past it a recency-weighted sticky sample

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { UserError, fail, setQuiet } from "./logger.js";
 import { loadConfig, parseMaxTranscripts } from "./config.js";
-import { resolveRepo } from "./repo.js";
+import { attachSiblingClones, resolveRepo } from "./repo.js";
 import { State } from "./state.js";
 import { AgentResolver } from "./agents.js";
 
@@ -233,6 +233,7 @@ export async function main(argv) {
   try {
     const repo = resolveRepo(process.cwd());
     const config = loadConfig(repo.root, overridesFrom(values));
+    attachSiblingClones(repo, config.discovery.cloneRoots);
     config.state = new State(repo.root).ensure();
     config.agents = new AgentResolver(config, {
       state: config.state,

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { UserError, fail, setQuiet } from "./logger.js";
 import { loadConfig, parseMaxTranscripts } from "./config.js";
-import { attachSiblingClones, resolveRepo } from "./repo.js";
+import { resolveRepo } from "./repo.js";
 import { State } from "./state.js";
 import { AgentResolver } from "./agents.js";
 
@@ -233,7 +233,6 @@ export async function main(argv) {
   try {
     const repo = resolveRepo(process.cwd());
     const config = loadConfig(repo.root, overridesFrom(values));
-    attachSiblingClones(repo, config.discovery.cloneRoots);
     config.state = new State(repo.root).ensure();
     config.agents = new AgentResolver(config, {
       state: config.state,

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -1,9 +1,11 @@
 import { discoverTranscripts } from "../discovery/index.js";
 import { color, info, json, out } from "../logger.js";
+import { attachSiblingClones } from "../repo.js";
 
 /** Shared by every command that needs the transcript set. */
 export async function discoverForRun(ctx) {
   const { repo, config, strict } = ctx;
+  attachSiblingClones(repo, config.discovery.cloneRoots);
   const result = await discoverTranscripts({ repo, config, strict });
   if (ctx.limit && result.transcripts.length > ctx.limit) {
     result.truncated = result.transcripts.length - ctx.limit;

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -47,11 +47,12 @@ export async function cmdScan(ctx) {
   if (selfTotal) out(color.dim(`  SELF = backpass's own loss / gradient-descent sessions, excluded from the corpus`));
   out("");
 
-  const byTier = { 1: 0, 2: 0, 3: 0 };
+  const byTier = { 1: 0, 1.5: 0, 2: 0, 3: 0 };
   for (const t of transcripts) byTier[t.association.tier] += 1;
   out(
     `${transcripts.length} transcript(s) associated with this repo · ` +
-      `tier1 ${byTier[1]} (exact) · tier2 ${byTier[2]} (remote) · tier3 ${byTier[3]} (best-effort)`,
+      `tier1 ${byTier[1]} (exact) · tier1.5 ${byTier[1.5]} (sibling clone) · ` +
+      `tier2 ${byTier[2]} (remote) · tier3 ${byTier[3]} (best-effort)`,
   );
   if (byTier[3] && !ctx.strict) out(color.dim("  re-run with --strict to exclude the best-effort tier"));
   if (truncated) out(color.dim(`  --limit ${ctx.limit} is hiding ${truncated} more transcript(s)`));

--- a/src/config.js
+++ b/src/config.js
@@ -73,6 +73,12 @@ export const DEFAULT_CONFIG = {
     harnesses: ALL_HARNESSES,
     since: "30d",
     worktreeGlobs: [],
+    /**
+     * Extra directories to search for local clones that share this repo's remotes
+     * (sibling of the current checkout is searched automatically). Each entry is a
+     * checkout or a parent of checkouts. Discovery only reads git identity there.
+     */
+    cloneRoots: [],
     minUserTurns: 2,
     includeCursorIde: false,
   },
@@ -208,6 +214,9 @@ function validate(config) {
   }
   config.discovery.harnesses = config.discovery.harnesses.filter((h) => known.has(h));
   parseSince(config.discovery.since);
+  if (!Array.isArray(config.discovery.cloneRoots) || config.discovery.cloneRoots.some((p) => typeof p !== "string")) {
+    throw new UserError("config.discovery.cloneRoots must be an array of paths");
+  }
   return config;
 }
 

--- a/src/discovery/adapters/claude.js
+++ b/src/discovery/adapters/claude.js
@@ -18,7 +18,8 @@ import {
  * Every message line carries `cwd`, `gitBranch`, `sessionId` and `version`. The
  * directory name is a lossy munge of the cwd (slashes and dots both become dashes),
  * so it is only used to narrow the search - the per-line `cwd` is the authority.
- * No git remote is recorded, so a deleted worktree can only reach tier 3.
+ * No git remote is recorded, so a deleted worktree can only reach tier 3. A live
+ * sibling clone that shares this repo's remotes is associated at tier 1.5.
  *
  * `CLAUDE_CONFIG_DIR` relocates the whole config dir, and it is commonly set per
  * invocation (a shell alias for a work profile), which splits a machine's sessions across

--- a/src/discovery/association.js
+++ b/src/discovery/association.js
@@ -4,13 +4,17 @@ import path from "node:path";
 import { normalizeRemote } from "../repo.js";
 
 /**
- * Three-tier repo/worktree association (design section 2.1).
+ * Association tiers (design section 2.1, plus sibling clones).
  *
- *   tier 1  deterministic  - transcript cwd is (or sits under) a live worktree path
- *   tier 2  deterministic  - a recorded git remote matches one of the repo's remotes;
- *                            survives worktree deletion (codex, grok)
- *   tier 3  best-effort    - dead cwd whose last segment is the repo dir name, or that
- *                            matches a user-supplied worktree glob; excluded by --strict
+ *   tier 1    deterministic  - transcript cwd is (or sits under) a live worktree path
+ *   tier 1.5  deterministic  - live cwd under a local clone that shares a git remote
+ *                              (sibling worktrees `git worktree list` cannot see).
+ *                              Survives `--strict`. Claude records no remote, so this
+ *                              is how a second clone's interactive history attaches.
+ *   tier 2    deterministic  - a recorded git remote matches one of the repo's remotes;
+ *                              survives worktree deletion (codex, grok)
+ *   tier 3    best-effort    - dead cwd whose last segment is the repo dir name, or that
+ *                              matches a user-supplied worktree glob; excluded by --strict
  *
  * Returns null when the transcript belongs to some other repo.
  */
@@ -55,7 +59,7 @@ export function associate({ cwd, remotes = [], gitRoot = null }, repo, options =
   const globs = options.worktreeGlobs || [];
   const candidates = [cwd, gitRoot].filter(Boolean);
 
-  // Tier 1 - live path under a known worktree.
+  // Tier 1 - live path under a known worktree of this clone.
   for (const candidate of candidates) {
     const real = realpathOrResolve(candidate);
     for (const worktree of repo.worktrees) {
@@ -64,6 +68,20 @@ export function associate({ cwd, remotes = [], gitRoot = null }, repo, options =
       }
       if (isUnder(real, worktree)) {
         return { tier: 1, confidence: "nested", reason: `cwd is inside worktree ${worktree}` };
+      }
+    }
+  }
+
+  // Tier 1.5 - live path under a sibling clone that shares a remote.
+  const siblingWorktrees = repo.siblingWorktrees || [];
+  for (const candidate of candidates) {
+    const real = realpathOrResolve(candidate);
+    for (const worktree of siblingWorktrees) {
+      if (real === worktree) {
+        return { tier: 1.5, confidence: "sibling", reason: `cwd is sibling clone ${worktree}` };
+      }
+      if (isUnder(real, worktree)) {
+        return { tier: 1.5, confidence: "sibling", reason: `cwd is inside sibling clone ${worktree}` };
       }
     }
   }

--- a/src/repo.js
+++ b/src/repo.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import { UserError } from "./logger.js";
 
@@ -51,6 +52,25 @@ function listWorktrees(root) {
   return [...new Set(paths)];
 }
 
+function remoteIdentity(remote, root) {
+  const value = String(remote || "").trim();
+  if (!value) return null;
+
+  if (/^file:\/\//i.test(value)) {
+    try {
+      return normalizeRemote(realpathOrSelf(fileURLToPath(value)));
+    } catch {
+      return normalizeRemote(value);
+    }
+  }
+  if (/^[a-z][a-z+.-]*:\/\//i.test(value) || /^(?:[^/@\s]+@)?[^/:\s]+:.+/.test(value)) {
+    return normalizeRemote(value);
+  }
+
+  const expanded = expandUserPath(value);
+  return normalizeRemote(realpathOrSelf(path.isAbsolute(expanded) ? expanded : path.resolve(root, expanded)));
+}
+
 function listRemotes(root) {
   let raw;
   try {
@@ -61,7 +81,7 @@ function listRemotes(root) {
   const out = new Set();
   for (const line of raw.split("\n")) {
     const url = line.split(/\s+/)[1];
-    const norm = normalizeRemote(url);
+    const norm = remoteIdentity(url, root);
     if (norm) out.add(norm);
   }
   return [...out];
@@ -99,9 +119,9 @@ function remotesOverlap(ours, theirs) {
  * immediate children of those directories. Matching is remote identity, not directory
  * name. Fail-soft: an unreadable path is skipped.
  *
- * @param {{ remotes?: string[], worktrees?: string[], cloneRoots?: string[] }} [opts]
+ * @param {{ remotes?: string[], worktrees?: string[], cloneRoots?: string[], repoRoot?: string }} [opts]
  */
-export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [] } = {}) {
+export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [], repoRoot } = {}) {
   if (!remotes?.length) return [];
   const known = new Set(worktrees || []);
   const found = [];
@@ -131,7 +151,7 @@ export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [] 
   for (const extra of cloneRoots) {
     const expanded = expandUserPath(extra);
     if (!expanded) continue;
-    searchRoots.add(path.resolve(expanded));
+    searchRoots.add(path.resolve(repoRoot || worktrees?.[0] || ".", expanded));
   }
 
   for (const root of searchRoots) {
@@ -154,7 +174,7 @@ export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [] 
 /**
  * Fill `repo.siblingWorktrees` from local clones that share this repo's remotes.
  *
- * @param {{ remotes: string[], worktrees: string[], siblingWorktrees?: string[] }} repo
+ * @param {{ root: string, remotes: string[], worktrees: string[], siblingWorktrees?: string[] }} repo
  * @param {string[]} [cloneRoots]
  */
 export function attachSiblingClones(repo, cloneRoots = []) {
@@ -162,6 +182,7 @@ export function attachSiblingClones(repo, cloneRoots = []) {
     remotes: repo.remotes,
     worktrees: repo.worktrees,
     cloneRoots,
+    repoRoot: repo.root,
   });
   return repo;
 }

--- a/src/repo.js
+++ b/src/repo.js
@@ -67,6 +67,105 @@ function listRemotes(root) {
   return [...out];
 }
 
+function expandUserPath(p) {
+  if (p === "~") return process.env.HOME || "";
+  if (typeof p === "string" && p.startsWith("~/")) {
+    return path.join(process.env.HOME || "", p.slice(2));
+  }
+  return p;
+}
+
+function isGitCheckout(dir) {
+  try {
+    return fs.existsSync(path.join(dir, ".git"));
+  } catch {
+    return false;
+  }
+}
+
+function remotesOverlap(ours, theirs) {
+  if (!ours.length || !theirs.length) return false;
+  const set = new Set(ours);
+  return theirs.some((remote) => set.has(remote));
+}
+
+/**
+ * Local checkouts that share a remote with this repo, plus their worktrees.
+ *
+ * Claude (and other harnesses that record cwd but no remote) only reach tier 1 when
+ * the cwd is a known live path. `git worktree list` cannot see a sibling clone's
+ * separate `.git`, so those sessions were invisible. Search is bounded and read-only:
+ * the parent of each of this repo's worktrees, each configured extra root, and the
+ * immediate children of those directories. Matching is remote identity, not directory
+ * name. Fail-soft: an unreadable path is skipped.
+ *
+ * @param {{ remotes?: string[], worktrees?: string[], cloneRoots?: string[] }} [opts]
+ */
+export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [] } = {}) {
+  if (!remotes?.length) return [];
+  const known = new Set(worktrees || []);
+  const found = [];
+
+  const consider = (dir) => {
+    let real;
+    try {
+      real = realpathOrSelf(dir);
+    } catch {
+      return;
+    }
+    if (known.has(real) || !isGitCheckout(real)) return;
+    const theirs = listRemotes(real);
+    if (!remotesOverlap(remotes, theirs)) return;
+    for (const wt of listWorktrees(real)) {
+      if (known.has(wt)) continue;
+      known.add(wt);
+      found.push(wt);
+    }
+  };
+
+  const searchRoots = new Set();
+  for (const wt of worktrees || []) {
+    const parent = path.dirname(wt);
+    if (parent && parent !== wt) searchRoots.add(parent);
+  }
+  for (const extra of cloneRoots) {
+    const expanded = expandUserPath(extra);
+    if (!expanded) continue;
+    searchRoots.add(path.resolve(expanded));
+  }
+
+  for (const root of searchRoots) {
+    consider(root);
+    let entries;
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      consider(path.join(root, entry.name));
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Fill `repo.siblingWorktrees` from local clones that share this repo's remotes.
+ *
+ * @param {{ remotes: string[], worktrees: string[], siblingWorktrees?: string[] }} repo
+ * @param {string[]} [cloneRoots]
+ */
+export function attachSiblingClones(repo, cloneRoots = []) {
+  repo.siblingWorktrees = listSiblingCloneWorktrees({
+    remotes: repo.remotes,
+    worktrees: repo.worktrees,
+    cloneRoots,
+  });
+  return repo;
+}
+
 /**
  * Ensure `line` is present in this repo's *local* git exclude file
  * (`.git/info/exclude`) - never a tracked file the user owns. The path is
@@ -114,5 +213,6 @@ export function resolveRepo(cwd = process.cwd()) {
     name: path.basename(realRoot),
     worktrees: listWorktrees(root),
     remotes: listRemotes(root),
+    siblingWorktrees: [],
   };
 }

--- a/src/repo.js
+++ b/src/repo.js
@@ -60,8 +60,7 @@ function networkRemoteIdentity(remote) {
     try {
       const parsed = new URL(remote);
       const defaultPorts = { "http:": "80", "https:": "443", "ssh:": "22" };
-      const port =
-        parsed.port && parsed.port !== defaultPorts[parsed.protocol.toLowerCase()] ? `:${parsed.port}` : "";
+      const port = parsed.port && parsed.port !== defaultPorts[parsed.protocol.toLowerCase()] ? `:${parsed.port}` : "";
       host = `${parsed.hostname.toLowerCase()}${port}`;
       repositoryPath = `${parsed.pathname}${parsed.search}${parsed.hash}`;
     } catch {
@@ -101,9 +100,7 @@ function cloneRemoteIdentity(remote, root) {
 function listRemoteUrls(root) {
   let names;
   try {
-    names = git(["remote"], root)
-      .split("\n")
-      .filter(Boolean);
+    names = git(["remote"], root).split("\n").filter(Boolean);
   } catch {
     return [];
   }
@@ -131,7 +128,13 @@ function listRemotes(root) {
 }
 
 function listCloneRemotes(root) {
-  return [...new Set(listRemoteUrls(root).map((remote) => cloneRemoteIdentity(remote, root)).filter(Boolean))];
+  return [
+    ...new Set(
+      listRemoteUrls(root)
+        .map((remote) => cloneRemoteIdentity(remote, root))
+        .filter(Boolean),
+    ),
+  ];
 }
 
 function expandUserPath(p) {

--- a/src/repo.js
+++ b/src/repo.js
@@ -99,16 +99,31 @@ function cloneRemoteIdentity(remote, root) {
 }
 
 function listRemoteUrls(root) {
-  let raw;
+  let names;
   try {
-    raw = git(["remote", "-v"], root);
+    names = git(["remote"], root)
+      .split("\n")
+      .filter(Boolean);
   } catch {
     return [];
   }
-  return raw
-    .split("\n")
-    .map((line) => line.split(/\s+/)[1])
-    .filter(Boolean);
+
+  const urls = new Set();
+  for (const name of names) {
+    for (const args of [
+      ["remote", "get-url", "--all", name],
+      ["remote", "get-url", "--push", "--all", name],
+    ]) {
+      try {
+        for (const url of git(args, root).split("\n")) {
+          if (url) urls.add(url);
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return [...urls];
 }
 
 function listRemotes(root) {

--- a/src/repo.js
+++ b/src/repo.js
@@ -52,6 +52,29 @@ function listWorktrees(root) {
   return [...new Set(paths)];
 }
 
+function networkRemoteIdentity(remote) {
+  let host;
+  let repositoryPath;
+
+  if (/^[a-z][a-z+.-]*:\/\//i.test(remote)) {
+    try {
+      const parsed = new URL(remote);
+      host = `${parsed.hostname.toLowerCase()}${parsed.port ? `:${parsed.port}` : ""}`;
+      repositoryPath = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    } catch {
+      return null;
+    }
+  } else {
+    const match = remote.match(/^(?:[^/@\s]+@)?([^/:\s]+):(.+)$/);
+    if (!match) return null;
+    host = match[1].toLowerCase();
+    repositoryPath = match[2];
+  }
+
+  repositoryPath = repositoryPath.replace(/^\/+|\/+$/g, "").replace(/\.git$/i, "");
+  return host && repositoryPath ? `remote:${host}/${repositoryPath}` : null;
+}
+
 function cloneRemoteIdentity(remote, root) {
   const value = String(remote || "").trim();
   if (!value) return null;
@@ -64,8 +87,7 @@ function cloneRemoteIdentity(remote, root) {
     }
   }
   if (/^[a-z][a-z+.-]*:\/\//i.test(value) || /^(?:[^/@\s]+@)?[^/:\s]+:.+/.test(value)) {
-    const normalized = normalizeRemote(value);
-    return normalized ? `remote:${normalized}` : null;
+    return networkRemoteIdentity(value);
   }
 
   const expanded = expandUserPath(value);
@@ -126,10 +148,10 @@ function remotesOverlap(ours, theirs) {
  * immediate children of those directories. Matching is remote identity, not directory
  * name. Fail-soft: an unreadable path is skipped.
  *
- * @param {{ remotes?: string[], worktrees?: string[], cloneRoots?: string[], repoRoot?: string }} [opts]
+ * @param {{ cloneRemotes?: string[], worktrees?: string[], cloneRoots?: string[], repoRoot?: string }} [opts]
  */
-export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [], repoRoot } = {}) {
-  if (!remotes?.length) return [];
+export function listSiblingCloneWorktrees({ cloneRemotes, worktrees, cloneRoots = [], repoRoot } = {}) {
+  if (!cloneRemotes?.length) return [];
   const known = new Set(worktrees || []);
   const found = [];
 
@@ -142,7 +164,7 @@ export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [],
     }
     if (known.has(real) || !isGitCheckout(real)) return;
     const theirs = listCloneRemotes(real);
-    if (!remotesOverlap(remotes, theirs)) return;
+    if (!remotesOverlap(cloneRemotes, theirs)) return;
     for (const wt of listWorktrees(real)) {
       if (known.has(wt)) continue;
       known.add(wt);
@@ -186,7 +208,7 @@ export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [],
  */
 export function attachSiblingClones(repo, cloneRoots = []) {
   repo.siblingWorktrees = listSiblingCloneWorktrees({
-    remotes: repo.cloneRemotes,
+    cloneRemotes: repo.cloneRemotes,
     worktrees: repo.worktrees,
     cloneRoots,
     repoRoot: repo.root,

--- a/src/repo.js
+++ b/src/repo.js
@@ -59,7 +59,7 @@ function networkRemoteIdentity(remote) {
   if (/^[a-z][a-z+.-]*:\/\//i.test(remote)) {
     try {
       const parsed = new URL(remote);
-      const defaultPorts = { "http:": "80", "https:": "443", "ssh:": "22" };
+      const defaultPorts = { "git:": "9418", "http:": "80", "https:": "443", "ssh:": "22" };
       const port = parsed.port && parsed.port !== defaultPorts[parsed.protocol.toLowerCase()] ? `:${parsed.port}` : "";
       host = `${parsed.hostname.toLowerCase()}${port}`;
       repositoryPath = `${parsed.pathname}${parsed.search}${parsed.hash}`;

--- a/src/repo.js
+++ b/src/repo.js
@@ -59,7 +59,10 @@ function networkRemoteIdentity(remote) {
   if (/^[a-z][a-z+.-]*:\/\//i.test(remote)) {
     try {
       const parsed = new URL(remote);
-      host = `${parsed.hostname.toLowerCase()}${parsed.port ? `:${parsed.port}` : ""}`;
+      const defaultPorts = { "http:": "80", "https:": "443", "ssh:": "22" };
+      const port =
+        parsed.port && parsed.port !== defaultPorts[parsed.protocol.toLowerCase()] ? `:${parsed.port}` : "";
+      host = `${parsed.hostname.toLowerCase()}${port}`;
       repositoryPath = `${parsed.pathname}${parsed.search}${parsed.hash}`;
     } catch {
       return null;

--- a/src/repo.js
+++ b/src/repo.js
@@ -52,39 +52,46 @@ function listWorktrees(root) {
   return [...new Set(paths)];
 }
 
-function remoteIdentity(remote, root) {
+function cloneRemoteIdentity(remote, root) {
   const value = String(remote || "").trim();
   if (!value) return null;
 
   if (/^file:\/\//i.test(value)) {
     try {
-      return normalizeRemote(realpathOrSelf(fileURLToPath(value)));
+      return `local:${realpathOrSelf(fileURLToPath(value))}`;
     } catch {
-      return normalizeRemote(value);
+      return null;
     }
   }
   if (/^[a-z][a-z+.-]*:\/\//i.test(value) || /^(?:[^/@\s]+@)?[^/:\s]+:.+/.test(value)) {
-    return normalizeRemote(value);
+    const normalized = normalizeRemote(value);
+    return normalized ? `remote:${normalized}` : null;
   }
 
   const expanded = expandUserPath(value);
-  return normalizeRemote(realpathOrSelf(path.isAbsolute(expanded) ? expanded : path.resolve(root, expanded)));
+  const resolved = realpathOrSelf(path.isAbsolute(expanded) ? expanded : path.resolve(root, expanded));
+  return `local:${resolved}`;
 }
 
-function listRemotes(root) {
+function listRemoteUrls(root) {
   let raw;
   try {
     raw = git(["remote", "-v"], root);
   } catch {
     return [];
   }
-  const out = new Set();
-  for (const line of raw.split("\n")) {
-    const url = line.split(/\s+/)[1];
-    const norm = remoteIdentity(url, root);
-    if (norm) out.add(norm);
-  }
-  return [...out];
+  return raw
+    .split("\n")
+    .map((line) => line.split(/\s+/)[1])
+    .filter(Boolean);
+}
+
+function listRemotes(root) {
+  return [...new Set(listRemoteUrls(root).map(normalizeRemote).filter(Boolean))];
+}
+
+function listCloneRemotes(root) {
+  return [...new Set(listRemoteUrls(root).map((remote) => cloneRemoteIdentity(remote, root)).filter(Boolean))];
 }
 
 function expandUserPath(p) {
@@ -134,7 +141,7 @@ export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [],
       return;
     }
     if (known.has(real) || !isGitCheckout(real)) return;
-    const theirs = listRemotes(real);
+    const theirs = listCloneRemotes(real);
     if (!remotesOverlap(remotes, theirs)) return;
     for (const wt of listWorktrees(real)) {
       if (known.has(wt)) continue;
@@ -174,12 +181,12 @@ export function listSiblingCloneWorktrees({ remotes, worktrees, cloneRoots = [],
 /**
  * Fill `repo.siblingWorktrees` from local clones that share this repo's remotes.
  *
- * @param {{ root: string, remotes: string[], worktrees: string[], siblingWorktrees?: string[] }} repo
+ * @param {{ root: string, cloneRemotes: string[], worktrees: string[], siblingWorktrees?: string[] }} repo
  * @param {string[]} [cloneRoots]
  */
 export function attachSiblingClones(repo, cloneRoots = []) {
   repo.siblingWorktrees = listSiblingCloneWorktrees({
-    remotes: repo.remotes,
+    remotes: repo.cloneRemotes,
     worktrees: repo.worktrees,
     cloneRoots,
     repoRoot: repo.root,
@@ -234,6 +241,7 @@ export function resolveRepo(cwd = process.cwd()) {
     name: path.basename(realRoot),
     worktrees: listWorktrees(root),
     remotes: listRemotes(root),
+    cloneRemotes: listCloneRemotes(root),
     siblingWorktrees: [],
   };
 }

--- a/src/tui/render.js
+++ b/src/tui/render.js
@@ -48,7 +48,12 @@ export const STAGE_LABELS = {
 };
 const STAGE_LABEL_WIDTH = Math.max(...Object.values(STAGE_LABELS).map((label) => label.length)) + 1;
 
-const TIER_LABELS = { 1: "ran in this repo", 2: "git remote match", 3: "path match (best-effort)" };
+const TIER_LABELS = {
+  1: "ran in this repo",
+  1.5: "sibling clone",
+  2: "git remote match",
+  3: "path match (best-effort)",
+};
 
 // eslint-disable-next-line no-control-regex -- matching ANSI SGR escapes is the point
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
@@ -150,7 +155,7 @@ function stageElapsed(stage, now) {
 
 function tierLabel(tiers = {}) {
   let best = null;
-  for (const tier of [1, 2, 3]) {
+  for (const tier of [1, 1.5, 2, 3]) {
     if ((tiers[tier] || 0) > (tiers[best] || 0)) best = tier;
   }
   return best ? TIER_LABELS[best] : "";

--- a/test/association.test.js
+++ b/test/association.test.js
@@ -78,8 +78,25 @@ test("a user worktree glob promotes a dead path to tier 3", () => {
   assert.equal(globbed.confidence, "glob");
 });
 
+test("tier 1.5: a live sibling clone is deterministic, not a foreign live path", () => {
+  const { repo } = makeRepo();
+  const sibling = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "demo-sibling-")));
+  repo.siblingWorktrees = [sibling];
+
+  const exact = associate({ cwd: sibling }, repo);
+  assert.equal(exact.tier, 1.5);
+  assert.equal(exact.confidence, "sibling");
+
+  const nested = associate({ cwd: path.join(sibling, "src") }, repo);
+  assert.equal(nested.tier, 1.5);
+
+  const other = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "demo-other-")));
+  assert.equal(associate({ cwd: other }, repo), null);
+});
+
 test("--strict keeps only the deterministic tiers", () => {
   assert.equal(passesStrict({ tier: 1 }, true), true);
+  assert.equal(passesStrict({ tier: 1.5 }, true), true);
   assert.equal(passesStrict({ tier: 2 }, true), true);
   assert.equal(passesStrict({ tier: 3 }, true), false);
   assert.equal(passesStrict({ tier: 3 }, false), true);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -81,6 +81,7 @@ test("invalid config values fail loudly with a usable message", () => {
   assert.throws(() => loadConfig(tempRepo({ memoryFiles: [] })), UserError);
   assert.throws(() => loadConfig(tempRepo({ minGapEvidence: 0 })), UserError);
   assert.throws(() => loadConfig(tempRepo({ discovery: { since: "yesterday" } })), UserError);
+  assert.throws(() => loadConfig(tempRepo({ discovery: { cloneRoots: "home" } })), UserError);
   assert.throws(() => loadConfig(tempRepo("{ not json")), UserError);
   assert.throws(() => loadConfig(tempRepo('"a bare string"')), UserError);
 });

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -136,6 +136,32 @@ test("network remote paths remain case-sensitive", () => {
   assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(foreign)), false);
 });
 
+test("local remotes with spaces retain distinct clone identities", () => {
+  const parent = tempDir("backpass-spaced-remotes-");
+  const firstRemote = path.join(parent, "Project One.git");
+  const secondRemote = path.join(parent, "Project Two.git");
+  git(["init", "--bare", "-q", firstRemote], parent);
+  git(["init", "--bare", "-q", secondRemote], parent);
+
+  const primary = path.join(parent, "primary");
+  const matching = path.join(parent, "matching");
+  const foreign = path.join(parent, "foreign");
+  for (const dir of [primary, matching, foreign]) {
+    fs.mkdirSync(dir);
+    git(["init", "-q", "-b", "main"], dir);
+    git(["config", "user.email", "test@example.com"], dir);
+    git(["config", "user.name", "test"], dir);
+    git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  }
+  git(["remote", "add", "origin", firstRemote], primary);
+  git(["remote", "add", "origin", firstRemote], matching);
+  git(["remote", "add", "origin", secondRemote], foreign);
+
+  const repo = attachSiblingClones(resolveRepo(primary));
+  assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(matching)));
+  assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(foreign)), false);
+});
+
 test("local relative remotes are resolved from each checkout", () => {
   const parent = tempDir("backpass-relative-remotes-");
   const origin = path.join(parent, "origin.git");

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+import { associate } from "../src/discovery/association.js";
 import { attachSiblingClones, ensureLocalExclude, resolveRepo } from "../src/repo.js";
 
 function git(args, cwd) {
@@ -117,6 +118,35 @@ test("local relative remotes are resolved from each checkout", () => {
 
   const repo = attachSiblingClones(resolveRepo(primary), [path.dirname(matching), foreignParent]);
   assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(matching)));
+  assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(foreign)), false);
+
+  const recorded = associate({ cwd: "/vanished/checkout", remotes: ["../origin.git"] }, repo);
+  assert.equal(recorded.tier, 2);
+  assert.equal(recorded.confidence, "remote");
+});
+
+test("distinct local paths remain distinct clone identities", () => {
+  const parent = tempDir("backpass-local-identity-");
+  const remotes = path.join(parent, "remotes");
+  const dottedRemote = path.join(remotes, "project.git");
+  const plainRemote = path.join(remotes, "project");
+  fs.mkdirSync(remotes);
+  git(["init", "--bare", "-q", dottedRemote], parent);
+  git(["init", "--bare", "-q", plainRemote], parent);
+
+  const primary = path.join(parent, "primary");
+  const foreign = path.join(parent, "foreign");
+  for (const dir of [primary, foreign]) {
+    fs.mkdirSync(dir);
+    git(["init", "-q", "-b", "main"], dir);
+    git(["config", "user.email", "test@example.com"], dir);
+    git(["config", "user.name", "test"], dir);
+    git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  }
+  git(["remote", "add", "origin", dottedRemote], primary);
+  git(["remote", "add", "origin", plainRemote], foreign);
+
+  const repo = attachSiblingClones(resolveRepo(primary));
   assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(foreign)), false);
 });
 

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -101,7 +101,8 @@ test("scheme-default ports share a sibling clone identity", () => {
   const primary = path.join(parent, "primary");
   const secureSibling = path.join(parent, "secure-sibling");
   const plainSibling = path.join(parent, "plain-sibling");
-  for (const dir of [primary, secureSibling, plainSibling]) {
+  const gitSibling = path.join(parent, "git-sibling");
+  for (const dir of [primary, secureSibling, plainSibling, gitSibling]) {
     fs.mkdirSync(dir);
     git(["init", "-q", "-b", "main"], dir);
     git(["config", "user.email", "test@example.com"], dir);
@@ -110,12 +111,15 @@ test("scheme-default ports share a sibling clone identity", () => {
   }
   git(["remote", "add", "secure", "https://example.com/acme/secure.git"], primary);
   git(["remote", "add", "plain", "http://example.com/acme/plain.git"], primary);
+  git(["remote", "add", "git", "git://example.com/acme/git.git"], primary);
   git(["remote", "add", "origin", "https://example.com:443/acme/secure.git"], secureSibling);
   git(["remote", "add", "origin", "http://example.com:80/acme/plain.git"], plainSibling);
+  git(["remote", "add", "origin", "git://example.com:9418/acme/git.git"], gitSibling);
 
   const repo = attachSiblingClones(resolveRepo(primary));
   assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(secureSibling)));
   assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(plainSibling)));
+  assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(gitSibling)));
 });
 
 test("network remote paths remain case-sensitive", () => {

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -95,6 +95,49 @@ test("sibling clones that share a remote are listed; a different remote is not",
   assert.equal(repo.worktrees.includes(siblingReal), false);
 });
 
+test("local relative remotes are resolved from each checkout", () => {
+  const parent = tempDir("backpass-relative-remotes-");
+  const origin = path.join(parent, "origin.git");
+  git(["init", "--bare", "-q", origin], parent);
+
+  const primary = path.join(parent, "primary");
+  const matching = path.join(parent, "nested", "matching");
+  const foreignParent = path.join(parent, "foreign");
+  const foreign = path.join(foreignParent, "checkout");
+  for (const dir of [primary, matching, foreign]) {
+    fs.mkdirSync(dir, { recursive: true });
+    git(["init", "-q", "-b", "main"], dir);
+    git(["config", "user.email", "test@example.com"], dir);
+    git(["config", "user.name", "test"], dir);
+    git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  }
+  git(["remote", "add", "origin", "../origin.git"], primary);
+  git(["remote", "add", "origin", "../../origin.git"], matching);
+  git(["remote", "add", "origin", "../origin.git"], foreign);
+
+  const repo = attachSiblingClones(resolveRepo(primary), [path.dirname(matching), foreignParent]);
+  assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(matching)));
+  assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(foreign)), false);
+});
+
+test("relative clone roots are resolved from the repository root", () => {
+  const parent = tempDir("backpass-relative-root-");
+  const primary = path.join(parent, "primary");
+  const sibling = path.join(parent, "catalog", "sibling");
+  const remote = "https://github.com/acme/demo.git";
+  for (const dir of [primary, sibling]) {
+    fs.mkdirSync(dir, { recursive: true });
+    git(["init", "-q", "-b", "main"], dir);
+    git(["config", "user.email", "test@example.com"], dir);
+    git(["config", "user.name", "test"], dir);
+    git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+    git(["remote", "add", "origin", remote], dir);
+  }
+
+  const repo = attachSiblingClones(resolveRepo(primary), ["../catalog"]);
+  assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(sibling)));
+});
+
 test("a non-git directory is skipped gracefully, without creating anything", () => {
   const dir = tempDir("backpass-nongit-");
 

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -86,7 +86,7 @@ test("sibling clones that share a remote are listed; a different remote is not",
     git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
   }
   git(["remote", "add", "origin", remote], primary);
-  git(["remote", "add", "origin", "git@github.com:acme/demo.git"], sibling);
+  git(["remote", "add", "origin", "ssh://git@github.com:22/acme/demo.git"], sibling);
   git(["remote", "add", "origin", "https://github.com/acme/other.git"], other);
 
   const repo = attachSiblingClones(resolveRepo(primary));
@@ -94,6 +94,28 @@ test("sibling clones that share a remote are listed; a different remote is not",
   assert.ok(repo.siblingWorktrees.includes(siblingReal));
   assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(other)), false);
   assert.equal(repo.worktrees.includes(siblingReal), false);
+});
+
+test("scheme-default ports share a sibling clone identity", () => {
+  const parent = tempDir("backpass-default-ports-");
+  const primary = path.join(parent, "primary");
+  const secureSibling = path.join(parent, "secure-sibling");
+  const plainSibling = path.join(parent, "plain-sibling");
+  for (const dir of [primary, secureSibling, plainSibling]) {
+    fs.mkdirSync(dir);
+    git(["init", "-q", "-b", "main"], dir);
+    git(["config", "user.email", "test@example.com"], dir);
+    git(["config", "user.name", "test"], dir);
+    git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  }
+  git(["remote", "add", "secure", "https://example.com/acme/secure.git"], primary);
+  git(["remote", "add", "plain", "http://example.com/acme/plain.git"], primary);
+  git(["remote", "add", "origin", "https://example.com:443/acme/secure.git"], secureSibling);
+  git(["remote", "add", "origin", "http://example.com:80/acme/plain.git"], plainSibling);
+
+  const repo = attachSiblingClones(resolveRepo(primary));
+  assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(secureSibling)));
+  assert.ok(repo.siblingWorktrees.includes(fs.realpathSync(plainSibling)));
 });
 
 test("network remote paths remain case-sensitive", () => {

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-import { ensureLocalExclude } from "../src/repo.js";
+import { attachSiblingClones, ensureLocalExclude, resolveRepo } from "../src/repo.js";
 
 function git(args, cwd) {
   execFileSync("git", args, { cwd, stdio: "ignore" });
@@ -69,6 +69,30 @@ test("resolves the exclude path via `git rev-parse --git-path info/exclude` in a
   const commonExclude = path.join(dir, ".git", "info", "exclude");
   assert.equal(result.path, fs.realpathSync(commonExclude));
   assert.match(fs.readFileSync(commonExclude, "utf8"), /^\.backpass\/$/m);
+});
+
+test("sibling clones that share a remote are listed; a different remote is not", () => {
+  const parent = tempDir("backpass-sib-repo-");
+  const remote = "https://github.com/acme/demo.git";
+  const primary = path.join(parent, "primary");
+  const sibling = path.join(parent, "sibling");
+  const other = path.join(parent, "other");
+  for (const dir of [primary, sibling, other]) {
+    fs.mkdirSync(dir, { recursive: true });
+    git(["init", "-q", "-b", "main"], dir);
+    git(["config", "user.email", "test@example.com"], dir);
+    git(["config", "user.name", "test"], dir);
+    git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  }
+  git(["remote", "add", "origin", remote], primary);
+  git(["remote", "add", "origin", remote], sibling);
+  git(["remote", "add", "origin", "https://github.com/acme/other.git"], other);
+
+  const repo = attachSiblingClones(resolveRepo(primary));
+  const siblingReal = fs.realpathSync(sibling);
+  assert.ok(repo.siblingWorktrees.includes(siblingReal));
+  assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(other)), false);
+  assert.equal(repo.worktrees.includes(siblingReal), false);
 });
 
 test("a non-git directory is skipped gracefully, without creating anything", () => {

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -86,7 +86,7 @@ test("sibling clones that share a remote are listed; a different remote is not",
     git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
   }
   git(["remote", "add", "origin", remote], primary);
-  git(["remote", "add", "origin", remote], sibling);
+  git(["remote", "add", "origin", "git@github.com:acme/demo.git"], sibling);
   git(["remote", "add", "origin", "https://github.com/acme/other.git"], other);
 
   const repo = attachSiblingClones(resolveRepo(primary));
@@ -94,6 +94,24 @@ test("sibling clones that share a remote are listed; a different remote is not",
   assert.ok(repo.siblingWorktrees.includes(siblingReal));
   assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(other)), false);
   assert.equal(repo.worktrees.includes(siblingReal), false);
+});
+
+test("network remote paths remain case-sensitive", () => {
+  const parent = tempDir("backpass-network-case-");
+  const primary = path.join(parent, "primary");
+  const foreign = path.join(parent, "foreign");
+  for (const dir of [primary, foreign]) {
+    fs.mkdirSync(dir);
+    git(["init", "-q", "-b", "main"], dir);
+    git(["config", "user.email", "test@example.com"], dir);
+    git(["config", "user.name", "test"], dir);
+    git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  }
+  git(["remote", "add", "origin", "https://example.com/Team/Repo.git"], primary);
+  git(["remote", "add", "origin", "https://example.com/team/repo.git"], foreign);
+
+  const repo = attachSiblingClones(resolveRepo(primary));
+  assert.equal(repo.siblingWorktrees.includes(fs.realpathSync(foreign)), false);
 });
 
 test("local relative remotes are resolved from each checkout", () => {

--- a/test/sibling-clone-discovery.test.js
+++ b/test/sibling-clone-discovery.test.js
@@ -5,8 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-import { discoverTranscripts } from "../src/discovery/index.js";
-import { attachSiblingClones, resolveRepo } from "../src/repo.js";
+import { discoverForRun } from "../src/commands/scan.js";
+import { resolveRepo } from "../src/repo.js";
 import { loadConfig } from "../src/config.js";
 
 /**
@@ -69,8 +69,9 @@ function discoverFrom(repoRoot, { homeDir, cloneRoots = [], strict = false }) {
   process.env.HOME = homeDir;
   try {
     const repo = resolveRepo(repoRoot);
-    attachSiblingClones(repo, cloneRoots);
-    return discoverTranscripts({ repo, config: configFor(repoRoot), strict });
+    const config = configFor(repoRoot);
+    config.discovery.cloneRoots = cloneRoots;
+    return discoverForRun({ repo, config, strict, limit: null });
   } finally {
     process.env.HOME = prevHome;
   }

--- a/test/sibling-clone-discovery.test.js
+++ b/test/sibling-clone-discovery.test.js
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { discoverTranscripts } from "../src/discovery/index.js";
+import { attachSiblingClones, resolveRepo } from "../src/repo.js";
+import { loadConfig } from "../src/config.js";
+
+/**
+ * A Claude session whose cwd is a sibling clone sharing origin used to vanish:
+ * Claude records no remote, and `git worktree list` cannot see another clone.
+ * These tests drive real discovery (enumerate → classify → associate).
+ */
+
+function git(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+}
+
+function initClone(dir, remote) {
+  fs.mkdirSync(dir, { recursive: true });
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  if (remote) git(["remote", "add", "origin", remote], dir);
+  return fs.realpathSync(dir);
+}
+
+function writeClaudeSession(homeDir, cwd, id, text) {
+  const projectDir = path.join(homeDir, ".claude", "projects", cwd.replace(/[/.]/g, "-"));
+  fs.mkdirSync(projectDir, { recursive: true });
+  const file = path.join(projectDir, `${id}.jsonl`);
+  fs.writeFileSync(
+    file,
+    [
+      JSON.stringify({ type: "mode", mode: "normal", sessionId: id }),
+      JSON.stringify({
+        parentUuid: null,
+        isSidechain: false,
+        type: "user",
+        message: { role: "user", content: text },
+        uuid: "u1",
+        timestamp: "2026-08-20T10:00:00.000Z",
+        cwd,
+        gitBranch: "main",
+        sessionId: id,
+      }),
+    ].join("\n") + "\n",
+  );
+  return file;
+}
+
+function configFor(repoRoot) {
+  const config = loadConfig(repoRoot, { discovery: { harnesses: ["claude"], since: "all" } });
+  const cache = { version: 1, entries: {} };
+  config.state = { readScanCache: () => cache, writeScanCache: () => {} };
+  return config;
+}
+
+/**
+ * @param {string} repoRoot
+ * @param {{ homeDir: string, cloneRoots?: string[], strict?: boolean }} opts
+ */
+function discoverFrom(repoRoot, { homeDir, cloneRoots = [], strict = false }) {
+  const prevHome = process.env.HOME;
+  process.env.HOME = homeDir;
+  try {
+    const repo = resolveRepo(repoRoot);
+    attachSiblingClones(repo, cloneRoots);
+    return discoverTranscripts({ repo, config: configFor(repoRoot), strict });
+  } finally {
+    process.env.HOME = prevHome;
+  }
+}
+
+function userEntries(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((name) => name !== ".git")
+    .sort();
+}
+
+test("discovery attaches a Claude session whose cwd is a sibling clone sharing the remote", async () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-sib-"));
+  const remote = "https://github.com/acme/sshhhip.git";
+  const primary = initClone(path.join(parent, "sshhhip-firstmate"), remote);
+  const sibling = initClone(path.join(parent, "sshhhip"), remote);
+  const other = initClone(path.join(parent, "unrelated"), "https://github.com/acme/other.git");
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-sib-home-"));
+
+  writeClaudeSession(homeDir, sibling, "sibling-session", "Ship the SSHHIP parser.");
+  writeClaudeSession(homeDir, other, "foreign-session", "Work on a different repo.");
+
+  const beforeSibling = userEntries(sibling);
+  const marker = path.join(sibling, "KEEP.txt");
+  fs.writeFileSync(marker, "untouched\n");
+  const statusBefore = git(["status", "--porcelain"], sibling);
+
+  const { transcripts } = await discoverFrom(primary, { homeDir });
+
+  assert.deepEqual(
+    transcripts.map((t) => t.nativeId).sort(),
+    ["sibling-session"],
+    "the sibling clone session is in the corpus; the foreign clone is not",
+  );
+  assert.equal(transcripts[0].association.tier, 1.5);
+  assert.equal(transcripts[0].association.confidence, "sibling");
+  assert.equal(transcripts[0].cwd, sibling);
+
+  const strict = await discoverFrom(primary, { homeDir, strict: true });
+  assert.equal(strict.transcripts.length, 1);
+  assert.equal(strict.transcripts[0].association.tier, 1.5);
+
+  assert.deepEqual(userEntries(sibling).sort(), [...beforeSibling, "KEEP.txt"].sort());
+  assert.equal(fs.readFileSync(marker, "utf8"), "untouched\n");
+  assert.equal(fs.existsSync(path.join(sibling, ".backpass")), false);
+  assert.equal(git(["status", "--porcelain"], sibling), statusBefore);
+});
+
+test("a nested extra cloneRoot attaches a clone that is not a directory sibling", async () => {
+  const primaryParent = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-pri-"));
+  const extraParent = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-extra-"));
+  const remote = "https://github.com/acme/sshhhip.git";
+  const primary = initClone(path.join(primaryParent, "checkout"), remote);
+  const nested = initClone(path.join(extraParent, "lab", "sshhhip"), remote);
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-extra-home-"));
+
+  writeClaudeSession(homeDir, nested, "nested-session", "History lives in the lab clone.");
+
+  const without = await discoverFrom(primary, { homeDir });
+  assert.equal(without.transcripts.length, 0, "a non-sibling clone is not found by default");
+
+  const withRoot = await discoverFrom(primary, { homeDir, cloneRoots: [path.join(extraParent, "lab")] });
+  assert.equal(withRoot.transcripts.length, 1);
+  assert.equal(withRoot.transcripts[0].nativeId, "nested-session");
+  assert.equal(withRoot.transcripts[0].association.tier, 1.5);
+});
+
+test("a worktree of the sibling clone is attached, not only the clone root", async () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-wt-"));
+  const remote = "https://github.com/acme/sshhhip.git";
+  const primary = initClone(path.join(parent, "primary"), remote);
+  const sibling = initClone(path.join(parent, "sibling"), remote);
+  const worktree = path.join(parent, "sibling-wt");
+  git(["worktree", "add", "-q", worktree, "-b", "wt-branch"], sibling);
+  const wtReal = fs.realpathSync(worktree);
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-wt-home-"));
+
+  writeClaudeSession(homeDir, wtReal, "wt-session", "Session ran in the sibling worktree.");
+
+  const { transcripts } = await discoverFrom(primary, { homeDir });
+  assert.equal(transcripts.length, 1);
+  assert.equal(transcripts[0].nativeId, "wt-session");
+  assert.equal(transcripts[0].association.tier, 1.5);
+  assert.match(transcripts[0].association.reason, /sibling clone/);
+});


### PR DESCRIPTION
## Intent

Let backpass find agent history that lives in a SIBLING clone. Today SSHHIP's entire interactive Claude history was invisible because it lives in a sibling clone's worktrees and Claude transcripts carry no git remote, so clone-scoped discovery never found it. Fix (a "tier 1.5" association): backpass already reads the repo's remotes for tier 2 - enumerate LOCAL clones/worktrees that share those remotes (and/or accept configured extra roots) so sessions in a sibling clone attach to the corpus. Keep it safe and read-only over those roots. Cover behaviorally through the real discovery path: a session in a sibling clone sharing the remote is discovered and attached.

## What Changed

- Discover local sibling clones and worktrees sharing a fetch or push remote, including clones under configured `discovery.cloneRoots`.
- Associate sessions from those paths as deterministic tier 1.5 matches retained by `--strict`, with updated CLI, TUI, documentation, and end-to-end discovery coverage.

## Risk Assessment

✅ Low: The change is well-bounded, preserves read-only discovery, behaviorally covers sibling clones and worktrees, and no material source-verifiable defects remain.

## Testing

Focused tests and an isolated end-to-end CLI scan confirmed that strict discovery attaches Claude history from a sibling clone sharing an equivalent SSH/HTTPS remote, excludes an unrelated clone, and leaves the sibling checkout unchanged; the worktree remained clean.

<details>
<summary>Evidence: End-to-end sibling-clone CLI scan and read-only verification</summary>

Source: [End-to-end sibling-clone CLI scan and read-only verification](https://github.com/kunchenguid/backpass/blob/46bfa35f024d18ba9c85d98639c2f8eefbbdcf55/.no-mistakes/evidence/fm/backpass-sibling-clone-discovery-r1/sibling-clone-cli-scan.txt)

```text
$ HOME=<isolated> node bin/backpass.js scan --harness claude --since all --strict
primary · 1 worktree(s) · since all

HARNESS  SCANNED  MATCHED  SELF  CACHED  NOTE
claude   2        1        0     0

1 transcript(s) associated with this repo · tier1 0 (exact) · tier1.5 1 (sibling clone) · tier2 0 (remote) · tier3 0 (best-effort)

HARNESS  SESSION       WHEN   SIZE  TIER  HOW
claude   sibling-hist  today  0KB   t1.5  cwd is sibling clone /private/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/backpass-cli-e2e.TfSQfU/sibling

Sibling clone status unchanged: yes
Sibling marker unchanged: yes
Sibling .backpass created: no
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"664d0cca6628b49c6823651b0717e5544c3872c2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (5) ✅</summary>

- ⚠️ `src/repo.js:118` - Sibling matching compares normalized remote strings without resolving relative local remote paths against each checkout. Two unrelated clones in different roots with `../origin.git` will falsely overlap, while differently spelled relative paths to the same repository will not overlap. Resolve local-path remotes relative to each checkout before normalization at the shared `listRemotes` boundary.
- ⚠️ `src/repo.js:134` - Relative `discovery.cloneRoots` entries are resolved against the invocation cwd, so the same repository config discovers different clones when backpass runs from the repo root versus a nested directory. Resolve configured relative roots against `repo.root` so discovery is stable across supported invocation locations.

🔧 Fix: Resolve sibling paths relative to each checkout
3 issues (2 warnings, 1 info) still open:

- ⚠️ `src/repo.js:84` - Resolving repository-local relative remotes to absolute paths changes `repo.remotes`, while tier-2 association still applies only `normalizeRemote` to transcript-recorded URLs. A Codex or Grok session recording `../origin.git` now produces `../origin`, which cannot match the repository&#39;s absolute identity, so deterministic association is lost. Preserve a comparable raw identity or normalize both sides with appropriate checkout context.
- ⚠️ `src/repo.js:71` - Canonical local filesystem paths are passed through URL normalization, which lowercases them and strips `.git`. On a case-sensitive filesystem, distinct remotes such as `/tmp/Origin.git` and `/tmp/origin.git`, or existing `/tmp/project.git` and `/tmp/project`, therefore overlap and can attach another repository&#39;s transcripts as tier 1.5. Treat canonical local paths as opaque filesystem identities rather than URL-normalizing them.
- ℹ️ `src/cli.js:90` - CLI help still says `--strict` keeps only tiers 1 and 2, although the changed logic also keeps tier 1.5. Update the help text to describe all deterministic tiers accurately.

🔧 Fix: Separate local clone and transcript remote identities
2 warnings still open:

- ⚠️ `src/repo.js:67` - Sibling clone identity still passes network remotes through `normalizeRemote`, which lowercases the entire URL. On a server with case-sensitive repository paths, `https://example.com/Team/Repo.git` and `https://example.com/team/repo.git` can identify different repositories but overlap here, causing unrelated sessions to attach as deterministic tier 1.5. Normalize the host while preserving path case at the clone-identity boundary.
- ⚠️ `src/cli.js:236` - Sibling enumeration runs before every command, including `status`, `init`, `apply`, and `propose`, even though those commands do not collect transcripts. Each invocation scans configured roots and starts git processes for candidate checkouts, creating avoidable latency that can be substantial for large clone roots. Attach sibling clones at the shared `discoverForRun` boundary instead.

🔧 Fix: Scope sibling scans and preserve remote path case
1 warning still open:

- ⚠️ `src/repo.js:62` - Equivalent SSH remotes do not overlap when one uses an explicit default port. For example, `ssh://git@example.com:22/acme/repo.git` becomes `remote:example.com:22/acme/repo`, while `git@example.com:acme/repo.git` becomes `remote:example.com/acme/repo`; the sibling session remains undiscovered. Remove scheme-default ports when constructing clone remote identities.

🔧 Fix: Normalize scheme-default remote ports
1 warning still open:

- ⚠️ `src/repo.js:110` - `git remote -v` URLs are truncated at the first whitespace. Distinct valid local remotes such as `/srv/remotes/Project One.git` and `/srv/remotes/Project Two.git` both become `/srv/remotes/Project`, causing unrelated clones and their transcripts to attach as deterministic tier 1.5. Read complete URLs via Git&#39;s structured per-remote commands or otherwise preserve the full URL.

🔧 Fix: Preserve complete structured remote URLs
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/sibling-clone-discovery.test.js test/repo.test.js test/association.test.js test/config.test.js`
- <code>Created isolated primary, sibling, and unrelated clones, then ran `HOME=&lt;isolated&gt; NO_COLOR=1 node bin/backpass.js scan --harness claude --since all --strict` from the primary clone</code>
- <code>Compared sibling clone Git status, marker contents, and `.backpass` absence before and after CLI discovery</code>
- <code>`git status --short` to confirm testing left the worktree clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
