### PR TITLE
fix: decide gap domains after clustering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,9 +200,9 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   `totals.orchestrationGapSightings` and travel into clustering as votes. Cluster
   domain is decided after grouping (`src/fold.js`): withhold a cluster from a
   proposal only when a majority of its sightings vote orchestration (ties stay
-  project). Mixed clusters always appear in the evidence report (`N sightings, M
-  orchestration`) so one inconsistent classifier call cannot drop a real
-  recurrence below `minGapEvidence`. There is deliberately no orchestrator-memory
+  project). Mixed clusters always appear in the evidence report with both sighting counts,
+  so one inconsistent classifier call cannot drop a real recurrence below
+  `minGapEvidence`. There is deliberately no orchestrator-memory
   write path. When this repository IS that orchestrating tool, those mistakes are
   `project` (`src/prompts/analysis.md`).
   A gap may also carry `coveredBySkill`: the analysis (shown every skill's name and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,10 +197,14 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   degrades to lexical identity with a warning, never an abort. Gaps also carry `domain`;
   `orchestration` sightings (mistakes caused by the external harness or tooling that
   orchestrated the task, not by this repo) are counted in
-  `totals.orchestrationGapSightings` and excluded from clustering, so they can
-  never reach a proposal - there is deliberately no orchestrator-memory write path.
-  When this repository IS that orchestrating tool, those mistakes are `project`
-  (`src/prompts/analysis.md`).
+  `totals.orchestrationGapSightings` and travel into clustering as votes. Cluster
+  domain is decided after grouping (`src/fold.js`): withhold a cluster from a
+  proposal only when a majority of its sightings vote orchestration (ties stay
+  project). Mixed clusters always appear in the evidence report (`N sightings, M
+  orchestration`) so one inconsistent classifier call cannot drop a real
+  recurrence below `minGapEvidence`. There is deliberately no orchestrator-memory
+  write path. When this repository IS that orchestrating tool, those mistakes are
+  `project` (`src/prompts/analysis.md`).
   A gap may also carry `coveredBySkill`: the analysis (shown every skill's name and
   trigger line) judged an existing skill's content to cover the mistake - a failed
   trigger. The fold counts those citations per skill onto the cluster

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ that substantially overlap a project skill. An overlap with a skill description 
 always-loaded tokens and points the shrink at the memory-file copy; an overlap with a
 triggered skill body is placement evidence only, since the memory copy may be the only
 always-loaded coverage. Neither kind is deleted automatically. Duplicate gaps across
-sessions are clustered, and clusters seen in fewer than `minGapEvidence` sessions (default 2) are dropped. One bad session never rewrites the weights.
+sessions are clustered, and only clusters seen in at least `minGapEvidence` sessions
+(default 2) are eligible for synthesis. Mixed-domain clusters below that floor remain
+visible as report-only diagnostics. One bad session never rewrites the weights.
 
 Whether two sightings are one gap is a judgment call, not a word-overlap score - models
 paraphrase, and a paraphrase that fails a lexical match would hide real recurrence.
@@ -208,9 +210,11 @@ it sees a gap already on the books, and, when at least two open entries exist, o
 consolidation call sees the full open gap set and merges entries that describe the same
 mistake. That second judgment is what lets two sightings of a brand-new gap in the same
 run's parallel fan-out corroborate. A failed consolidation call degrades the run to
-lexical identity and says so; it never aborts. Orchestration-domain gaps are counted and
-reported but never cluster: a mistake caused not by this repository but by the external
-agent harness or tooling that orchestrated a session does not become an instruction in the
+lexical identity and says so; it never aborts. All sightings cluster before their domain
+is decided. Each sighting votes `project` or `orchestration`; only a majority-orchestration
+cluster is excluded from synthesis, while a tie stays eligible. Mixed clusters are always
+reported with their orchestration count, and those excluded by the majority vote remain
+clearly labeled as report-only diagnostics rather than becoming instructions in the
 project's memory file.
 
 Only evidence judged against the _current_ memory-surface hash is folded into a proposal. A

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ run's parallel fan-out corroborate. A failed consolidation call degrades the run
 lexical identity and says so; it never aborts. All sightings cluster before their domain
 is decided. Each sighting votes `project` or `orchestration`; only a majority-orchestration
 cluster is excluded from synthesis, while a tie stays eligible. Mixed clusters are always
-reported with their orchestration count, and those excluded by the majority vote remain
-clearly labeled as report-only diagnostics rather than becoming instructions in the
-project's memory file.
+reported with their orchestration count. Every majority-excluded cluster, including a
+pure-orchestration cluster, remains clearly labeled as a report-only diagnostic rather
+than becoming an instruction in the project's memory file.
 
 Only evidence judged against the _current_ memory-surface hash is folded into a proposal. A
 transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the

--- a/README.md
+++ b/README.md
@@ -213,9 +213,10 @@ run's parallel fan-out corroborate. A failed consolidation call degrades the run
 lexical identity and says so; it never aborts. All sightings cluster before their domain
 is decided. Each sighting votes `project` or `orchestration`; only a majority-orchestration
 cluster is excluded from synthesis, while a tie stays eligible. Mixed clusters are always
-reported with their orchestration count. Every majority-excluded cluster, including a
-pure-orchestration cluster, remains clearly labeled as a report-only diagnostic rather
-than becoming an instruction in the project's memory file.
+reported with their orchestration count, even below the evidence floor. A corroborated
+majority-excluded cluster, including a pure-orchestration cluster, remains clearly labeled
+as a report-only diagnostic rather than becoming an instruction in the project's memory
+file; an uncorroborated pure-orchestration singleton stays hidden.
 
 Only evidence judged against the _current_ memory-surface hash is folded into a proposal. A
 transcript that fell out of this run's sample - the time window, `maxTranscripts`, or the

--- a/README.md
+++ b/README.md
@@ -356,9 +356,8 @@ changed since the proposal measured it, exactly as it refuses a drifted memory f
 `backpass apply` is the only command that writes. It serves a review surface through
 [`lavish-axi`](https://github.com/kunchenguid/lavish-axi): one card per edit with the diff,
 the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT. A compact
-gap funnel shows how accumulated sightings narrowed through domain filtering, clustering,
-and the corroboration floor to the gaps eligible for a proposal; older proposals without
-recorded funnel counts omit it.
+gap funnel summarizes recorded gap evidence and proposal eligibility; older proposals
+without recorded funnel counts omit it.
 
 The surface is a static template shipped in the package - the CLI injects one JSON payload,
 so it is instant, deterministic, and identical every run. Nothing there is model-generated.

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -106,7 +106,8 @@ export async function bootstrapRun(ctx, deps = {}) {
   config.state.writeSummary(folded);
   emitProgress("fold:done", {
     instructions: folded.instructions.length,
-    clustersFound: folded.totals.gapClusters + folded.totals.droppedGapSingletons,
+    clustersFound:
+      folded.totals.gapClusters + (folded.totals.reportOnlyGapClusters || 0) + folded.totals.droppedGapSingletons,
     clustersKept: folded.totals.gapClusters,
     minGapEvidence: config.minGapEvidence,
     ms: 0,

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -80,7 +80,8 @@ export async function runProposal(ctx, precomputed = null) {
   config.state.writeSummary(summary);
   emitProgress("fold:done", {
     instructions: summary.instructions.length,
-    clustersFound: summary.totals.gapClusters + summary.totals.droppedGapSingletons,
+    clustersFound:
+      summary.totals.gapClusters + (summary.totals.reportOnlyGapClusters || 0) + summary.totals.droppedGapSingletons,
     clustersKept: summary.totals.gapClusters,
     minGapEvidence: config.minGapEvidence,
     ms: Date.now() - foldStarted,

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -115,9 +115,15 @@ export async function cmdStatus(ctx) {
     `  evidence        ${counts.ok || 0} ok · ${counts.skipped || 0} skipped · ${color.red(String(counts.failed || 0))} failed`,
   );
   if (summary) {
+    const eligibleClusters = summary.totals.gapClusters;
+    const reportOnlyClusters = summary.totals.reportOnlyGapClusters || 0;
+    const totalClusters = eligibleClusters + reportOnlyClusters;
+    const clusterSplit = reportOnlyClusters
+      ? ` (${eligibleClusters} synthesis eligible · ${reportOnlyClusters} report only)`
+      : "";
     out(
       `  gradients       ${summary.analyzedSessions} session(s) · ${summary.totals.positive}+ ` +
-        `${summary.totals.negative}- · ${summary.totals.gapClusters} gap cluster(s)`,
+        `${summary.totals.negative}- · ${totalClusters} gap cluster(s)${clusterSplit}`,
     );
   }
   out(`  rejections      ${Object.keys(rejections.entries).length} remembered`);

--- a/src/fold.js
+++ b/src/fold.js
@@ -18,11 +18,13 @@ import { crossSurfaceDuplicates } from "./overlap.js";
  *     ledger); the clustering here stays deterministic. Per-sighting `domain` votes
  *     travel with the cluster; the fold decides the cluster domain after grouping
  *     (majority orchestration is excluded from proposals; mixed clusters stay visible).
- *  3. Gap clusters below `minGapEvidence` are dropped. Batch size > 1: one bad session
- *     never rewrites the weights. Sessions are counted across runs, not per run: when the
- *     caller passes `gapObservations` (the pruned gap ledger, `src/gap-ledger.js`) the
- *     clusters are built from those instead of this run's records, so a gap seen once now
- *     and once on a later run graduates. Without a ledger the records alone are used.
+ *  3. Gap clusters below `minGapEvidence` are ineligible for synthesis. Mixed-domain
+ *     clusters remain visible as report-only diagnostics; other under-floor clusters are
+ *     dropped. Batch size > 1 means one bad session never rewrites the weights. Sessions
+ *     are counted across runs, not per run: when the caller passes `gapObservations` (the
+ *     pruned gap ledger, `src/gap-ledger.js`) the clusters are built from those instead of
+ *     this run's records, so a gap seen once now and once on a later run graduates. Without
+ *     a ledger the records alone are used.
  *  4. Memory-file units whose text substantially overlaps a skill description or body are
  *     flagged (`crossSurfaceDuplicates` in `src/overlap.js`). Description overlap exposes
  *     duplicated always-loaded tokens; body overlap is placement evidence because skill

--- a/src/fold.js
+++ b/src/fold.js
@@ -188,7 +188,6 @@ export function foldEvidence(
     gaps,
     crossSurfaceDuplicates: duplicates,
     reportOnlyGaps,
-    gapEligibilityEnforced: true,
   };
 }
 
@@ -376,7 +375,8 @@ function renderEvidence(summary) {
 
   if (summary.reportOnlyGaps?.length) {
     lines.push("");
-    lines.push("### Report-only mixed gap clusters (mechanically ineligible for synthesis)");
+    lines.push("### REPORT ONLY - not synthesis-eligible evidence");
+    lines.push("Do not create or justify proposals from these diagnostic clusters.");
     for (const gap of summary.reportOnlyGaps) {
       lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     }

--- a/src/fold.js
+++ b/src/fold.js
@@ -15,8 +15,9 @@ import { crossSurfaceDuplicates } from "./overlap.js";
  *  2. Near-duplicate gaps from different sessions are clustered, so "three sessions
  *     re-derived the db schema" arrives as one item with three quotes. Judged identity
  *     happens upstream (analysis citations and the consolidation pass reshape the
- *     ledger); the clustering here stays deterministic. Orchestration-domain sightings
- *     are excluded before clustering and surfaced only as a count.
+ *     ledger); the clustering here stays deterministic. Per-sighting `domain` votes
+ *     travel with the cluster; the fold decides the cluster domain after grouping
+ *     (majority orchestration is excluded from proposals; mixed clusters stay visible).
  *  3. Gap clusters below `minGapEvidence` are dropped. Batch size > 1: one bad session
  *     never rewrites the weights. Sessions are counted across runs, not per run: when the
  *     caller passes `gapObservations` (the pruned gap ledger, `src/gap-ledger.js`) the
@@ -100,14 +101,15 @@ export function foldEvidence(
     }
   }
 
-  // Orchestration-domain sightings are mistakes caused not by this repository but by the
-  // external agent harness or tooling that orchestrated the session; they are counted for
-  // legibility but never cluster, so they can never corroborate into a project proposal.
+  // Orchestration-domain votes are mistakes caused not by this repository but by the
+  // external agent harness or tooling that orchestrated the session. They still cluster
+  // with project sightings of the same gap; a cluster is withheld from proposals only
+  // when a majority of its sightings vote orchestration. Mixed clusters stay visible
+  // so one inconsistent classifier call cannot drop a real recurrence below the floor.
   const allObservations = gapObservations ?? recordObservations;
-  const projectObservations = allObservations.filter((obs) => obs?.domain !== "orchestration");
-  const orchestrationGapSightings = allObservations.length - projectObservations.length;
+  const orchestrationGapSightings = allObservations.filter((obs) => obs?.domain === "orchestration").length;
 
-  const gapClusters = clusterGapObservations(projectObservations);
+  const gapClusters = clusterGapObservations(allObservations);
 
   // Instructions that exist in the file but drew no evidence at all are the strongest
   // removal / extraction candidates, so they must appear in the summary too.
@@ -138,18 +140,29 @@ export function foldEvidence(
     })
     .sort((a, b) => b.negative - a.negative || b.sessions - a.sessions || a.instruction.localeCompare(b.instruction));
 
-  const gaps = gapClusters
-    .map((cluster) => ({
+  const decided = gapClusters.map((cluster) => {
+    const vote = clusterDomainVote(cluster.items);
+    return {
       proposedInstruction: cluster.proposedInstruction,
       sessions: cluster.sessions.size,
       recurrenceRisk: highestRisk(cluster.items),
       quotes: cluster.items.slice(0, 6).map((i) => ({ text: i.quote, effect: i.mistake, source: i.source })),
+      orchestrationSightings: vote.orchestrationSightings,
+      mixed: vote.mixed,
+      majorityOrchestration: vote.majorityOrchestration,
       ...failedTriggerOf(cluster.items, minGapEvidence),
-    }))
+    };
+  });
+
+  const proposalClusters = decided.filter((cluster) => !cluster.majorityOrchestration);
+  const gaps = proposalClusters
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
+  const excludedMixedGaps = decided
+    .filter((cluster) => cluster.majorityOrchestration && cluster.mixed && cluster.sessions >= minGapEvidence)
+    .sort((a, b) => b.sessions - a.sessions);
 
-  const droppedGapSingletons = gapClusters.length - gaps.length;
+  const droppedGapSingletons = proposalClusters.length - gaps.length;
 
   return {
     version: 1,
@@ -159,8 +172,8 @@ export function foldEvidence(
       positive: positiveCount,
       negative: negativeCount,
       // The gap funnel's top: every sighting this fold clustered over (the pruned ledger
-      // when one is passed, this run's records otherwise). Orchestration sightings are the
-      // slice excluded before clustering; project-domain is the difference.
+      // when one is passed, this run's records otherwise). Orchestration sightings are
+      // per-sighting votes; cluster domain is decided after grouping.
       gapSightings: allObservations.length,
       gapClusters: gaps.length,
       droppedGapSingletons,
@@ -171,6 +184,7 @@ export function foldEvidence(
     instructions: instructionRows,
     gaps,
     crossSurfaceDuplicates: duplicates,
+    excludedMixedGaps,
   };
 }
 
@@ -191,12 +205,17 @@ export function clusterGapObservations(observations) {
       recurrenceRisk: obs.recurrenceRisk,
       source: obs.source,
       sessionId: obs.sessionId,
+      domain: observationDomain(obs),
       coveredBySkills: new Set(obs.coveredBySkill ? [obs.coveredBySkill] : []),
     };
     if (cluster) {
       const sessionItem = cluster.items.find((candidate) => candidate.sessionId === obs.sessionId);
       if (sessionItem) {
         if (obs.coveredBySkill) sessionItem.coveredBySkills.add(obs.coveredBySkill);
+        // One session, one vote: a project classification from the same session
+        // keeps the cluster eligible rather than letting a later orchestration
+        // label silently win.
+        if (observationDomain(obs) !== "orchestration") sessionItem.domain = "project";
       } else {
         cluster.items.push(item);
       }
@@ -214,6 +233,24 @@ export function clusterGapObservations(observations) {
     }
   }
   return clusters;
+}
+
+function observationDomain(obs) {
+  return obs?.domain === "orchestration" ? "orchestration" : "project";
+}
+
+/**
+ * Cluster domain is a majority of per-sighting votes, not a pre-filter. Ties (including
+ * 1 of 2) stay project so one inconsistent analysis call cannot kill a real recurrence.
+ */
+function clusterDomainVote(items) {
+  const orchestrationSightings = items.filter((item) => item.domain === "orchestration").length;
+  const sightings = items.length;
+  return {
+    orchestrationSightings,
+    mixed: orchestrationSightings > 0 && orchestrationSightings < sightings,
+    majorityOrchestration: sightings > 0 && orchestrationSightings * 2 > sightings,
+  };
 }
 
 function highestRisk(items) {
@@ -296,15 +333,19 @@ export function renderEvidenceForPrompt(summary) {
   lines.push("### Gap clusters (mistakes no current instruction covers)");
   if (summary.totals.orchestrationGapSightings) {
     lines.push(
-      `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) caused by the ` +
-        `orchestrating harness or tooling were excluded; they never enter this repository's memory file`,
+      `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) counted as domain ` +
+        `votes (clusters excluded only on a majority vote); they never enter this repository's memory file ` +
+        `as their own instruction`,
     );
+  }
+  for (const gap of summary.excludedMixedGaps || []) {
+    lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
   }
   if (!summary.gaps.length) {
     lines.push("- none above the evidence threshold");
   }
   for (const gap of summary.gaps) {
-    lines.push(`- sessions=${gap.sessions} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
+    lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     if (gap.failedTriggerSkill) {
       lines.push(
         `    FAILED TRIGGER: the existing skill "${gap.failedTriggerSkill}" already covers this ` +
@@ -318,6 +359,13 @@ export function renderEvidenceForPrompt(summary) {
   }
 
   return lines.join("\n");
+}
+
+function gapSessionLabel(gap) {
+  const orch = gap.orchestrationSightings || 0;
+  if (!orch) return `sessions=${gap.sessions}`;
+  const extra = gap.majorityOrchestration ? "; majority vote excluded" : "";
+  return `sessions=${gap.sessions} (${gap.sessions} sightings, ${orch} orchestration${extra})`;
 }
 
 function oneLine(text, max = 240) {

--- a/src/fold.js
+++ b/src/fold.js
@@ -176,6 +176,7 @@ export function foldEvidence(
       // per-sighting votes; cluster domain is decided after grouping.
       gapSightings: allObservations.length,
       gapClusters: gaps.length,
+      reportOnlyGapClusters: reportOnlyGaps.length,
       droppedGapSingletons,
       orchestrationGapSightings,
       usedRawTranscript: usedRawCount,
@@ -294,9 +295,12 @@ function renderEvidence(summary) {
   const lines = [];
 
   lines.push(`Sessions analyzed: ${summary.analyzedSessions}`);
+  const reportOnlyGapClusters = summary.totals.reportOnlyGapClusters || 0;
+  const totalGapClusters = summary.totals.gapClusters + reportOnlyGapClusters;
   lines.push(
     `Totals: ${summary.totals.positive} positive, ${summary.totals.negative} negative, ` +
-      `${summary.totals.gapClusters} gap clusters (${summary.totals.droppedGapSingletons} singletons dropped below threshold)`,
+      `${totalGapClusters} gap clusters (${summary.totals.gapClusters} synthesis eligible, ` +
+      `${reportOnlyGapClusters} report only, ${summary.totals.droppedGapSingletons} singletons dropped below threshold)`,
   );
   lines.push("");
   lines.push("### Per-instruction evidence");

--- a/src/fold.js
+++ b/src/fold.js
@@ -342,7 +342,11 @@ export function renderEvidenceForPrompt(summary) {
     lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
   }
   if (!summary.gaps.length) {
-    lines.push("- none above the evidence threshold");
+    lines.push(
+      summary.excludedMixedGaps?.length
+        ? "- no gap cluster is eligible for a repository proposal"
+        : "- none above the evidence threshold",
+    );
   }
   for (const gap of summary.gaps) {
     lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);

--- a/src/fold.js
+++ b/src/fold.js
@@ -289,14 +289,15 @@ function failedTriggerOf(items, minGapEvidence) {
 
 /** Compact rendering of the folded evidence for the synthesis prompt. */
 export function renderEvidenceForPrompt(summary) {
-  return renderEvidence(summary);
+  return renderEvidence(summary, { includeReportOnly: false });
 }
 
+/** Full evidence report, including diagnostics that must never reach synthesis. */
 export function renderEvidenceReport(summary) {
-  return renderEvidence(summary);
+  return renderEvidence(summary, { includeReportOnly: true });
 }
 
-function renderEvidence(summary) {
+function renderEvidence(summary, { includeReportOnly }) {
   const lines = [];
 
   lines.push(`Sessions analyzed: ${summary.analyzedSessions}`);
@@ -377,10 +378,9 @@ function renderEvidence(summary) {
     }
   }
 
-  if (summary.reportOnlyGaps?.length) {
+  if (includeReportOnly && summary.reportOnlyGaps?.length) {
     lines.push("");
     lines.push("### REPORT ONLY - not synthesis-eligible evidence");
-    lines.push("Do not create or justify proposals from these diagnostic clusters.");
     for (const gap of summary.reportOnlyGaps) {
       lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     }

--- a/src/fold.js
+++ b/src/fold.js
@@ -159,7 +159,7 @@ export function foldEvidence(
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
   const reportOnlyGaps = decided
-    .filter((cluster) => cluster.mixed && (cluster.majorityOrchestration || cluster.sessions < minGapEvidence))
+    .filter((cluster) => cluster.majorityOrchestration || (cluster.mixed && cluster.sessions < minGapEvidence))
     .sort((a, b) => b.sessions - a.sessions);
 
   const droppedGapSingletons = proposalClusters.filter(
@@ -388,7 +388,7 @@ function renderEvidence(summary) {
 function gapSessionLabel(gap) {
   const orch = gap.orchestrationSightings || 0;
   if (!orch) return `sessions=${gap.sessions}`;
-  const extra = gap.majorityOrchestration ? "; majority vote excluded" : "";
+  const extra = gap.majorityOrchestration ? "; domain excluded by majority vote" : "";
   return `sessions=${gap.sessions} (${gap.sessions} sightings, ${orch} orchestration${extra})`;
 }
 

--- a/src/fold.js
+++ b/src/fold.js
@@ -159,12 +159,14 @@ export function foldEvidence(
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
   const reportOnlyGaps = decided
-    .filter((cluster) => cluster.majorityOrchestration || (cluster.mixed && cluster.sessions < minGapEvidence))
+    .filter((cluster) =>
+      cluster.mixed
+        ? cluster.majorityOrchestration || cluster.sessions < minGapEvidence
+        : cluster.majorityOrchestration && cluster.sessions >= minGapEvidence,
+    )
     .sort((a, b) => b.sessions - a.sessions);
 
-  const droppedGapSingletons = proposalClusters.filter(
-    (cluster) => cluster.sessions < minGapEvidence && !cluster.mixed,
-  ).length;
+  const droppedGapSingletons = decided.filter((cluster) => cluster.sessions < minGapEvidence && !cluster.mixed).length;
 
   return {
     version: 1,

--- a/src/fold.js
+++ b/src/fold.js
@@ -158,8 +158,8 @@ export function foldEvidence(
   const gaps = proposalClusters
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
-  const excludedMixedGaps = decided
-    .filter((cluster) => cluster.majorityOrchestration && cluster.mixed && cluster.sessions >= minGapEvidence)
+  const reportOnlyGaps = decided
+    .filter((cluster) => cluster.mixed && (cluster.majorityOrchestration || cluster.sessions < minGapEvidence))
     .sort((a, b) => b.sessions - a.sessions);
 
   const droppedGapSingletons = proposalClusters.length - gaps.length;
@@ -184,7 +184,8 @@ export function foldEvidence(
     instructions: instructionRows,
     gaps,
     crossSurfaceDuplicates: duplicates,
-    excludedMixedGaps,
+    reportOnlyGaps,
+    gapEligibilityEnforced: true,
   };
 }
 
@@ -282,6 +283,14 @@ function failedTriggerOf(items, minGapEvidence) {
 
 /** Compact rendering of the folded evidence for the synthesis prompt. */
 export function renderEvidenceForPrompt(summary) {
+  return renderEvidence(summary);
+}
+
+export function renderEvidenceReport(summary) {
+  return renderEvidence(summary);
+}
+
+function renderEvidence(summary) {
   const lines = [];
 
   lines.push(`Sessions analyzed: ${summary.analyzedSessions}`);
@@ -330,7 +339,7 @@ export function renderEvidenceForPrompt(summary) {
   }
 
   lines.push("");
-  lines.push("### Gap clusters (mistakes no current instruction covers)");
+  lines.push("### Synthesis-eligible gap clusters (mistakes no current instruction covers)");
   if (summary.totals.orchestrationGapSightings) {
     lines.push(
       `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) counted as domain ` +
@@ -338,12 +347,9 @@ export function renderEvidenceForPrompt(summary) {
         `as their own instruction`,
     );
   }
-  for (const gap of summary.excludedMixedGaps || []) {
-    lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
-  }
   if (!summary.gaps.length) {
     lines.push(
-      summary.excludedMixedGaps?.length
+      summary.reportOnlyGaps?.length
         ? "- no gap cluster is eligible for a repository proposal"
         : "- none above the evidence threshold",
     );
@@ -359,6 +365,14 @@ export function renderEvidenceForPrompt(summary) {
     }
     for (const quote of gap.quotes.slice(0, 3)) {
       lines.push(`    "${oneLine(quote.text)}" (${quote.source})`);
+    }
+  }
+
+  if (summary.reportOnlyGaps?.length) {
+    lines.push("");
+    lines.push("### Report-only mixed gap clusters (mechanically ineligible for synthesis)");
+    for (const gap of summary.reportOnlyGaps) {
+      lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     }
   }
 

--- a/src/fold.js
+++ b/src/fold.js
@@ -162,7 +162,9 @@ export function foldEvidence(
     .filter((cluster) => cluster.mixed && (cluster.majorityOrchestration || cluster.sessions < minGapEvidence))
     .sort((a, b) => b.sessions - a.sessions);
 
-  const droppedGapSingletons = proposalClusters.length - gaps.length;
+  const droppedGapSingletons = proposalClusters.filter(
+    (cluster) => cluster.sessions < minGapEvidence && !cluster.mixed,
+  ).length;
 
   return {
     version: 1,

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -29,9 +29,10 @@ import { sha256 } from "./state.js";
  *  - Every observation carries the `domain` the analysis judged: `orchestration` when the
  *    mistake was not caused by this repository but by an external agent harness or tooling
  *    that orchestrated the task, `project` for every other mistake.
- *    Orchestration sightings are recorded for legibility but never counted toward
- *    corroboration and never surface in a proposal; a missing domain counts as project,
- *    so evidence from before the field existed keeps its old behavior.
+ *    Each observation stores that vote. The fold clusters first and decides domain
+ *    afterward (majority orchestration withholds a cluster from proposals; a mixed
+ *    cluster stays visible). A missing domain counts as project, so evidence from
+ *    before the field existed keeps its old behavior.
  *  - Sessions are keyed by transcript id (harness + native session id), so re-analyzing
  *    or re-sampling the same session overwrites its observation and never adds a count.
  *  - A gap is a fact about its session: re-analysis that no longer mentions it is model

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -306,6 +306,7 @@ export function mergeGapEntries(ledger, groups) {
           const earlier =
             Date.parse(obs.firstObservedAt || obs.observedAt) < Date.parse(prior.firstObservedAt || prior.observedAt);
           if (earlier) prior.firstObservedAt = obs.firstObservedAt || obs.observedAt;
+          if (prior.domain === "orchestration" && obs.domain !== "orchestration") prior.domain = "project";
           if (!prior.coveredBySkill && obs.coveredBySkill) prior.coveredBySkill = obs.coveredBySkill;
         }
       }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -705,12 +705,13 @@ export function buildProposal(rawResult, context) {
       positive: summary?.totals?.positive ?? 0,
       negative: summary?.totals?.negative ?? 0,
       gapClusters: summary?.totals?.gapClusters ?? 0,
-      // Gap counts retained for the apply surface: all sightings, orchestration-domain
-      // votes, synthesis-eligible clusters, and clusters dropped below the evidence floor.
+      // Gap counts retained for the apply surface: all sightings, synthesis-eligible
+      // clusters, report-only clusters, and clusters dropped below the evidence floor.
       // `null`, never 0, when the summary predates a count - the surface hides what was
       // not recorded rather than showing an invented zero.
       gapSightings: summary?.totals?.gapSightings ?? null,
       orchestrationGapSightings: summary?.totals?.orchestrationGapSightings ?? null,
+      reportOnlyGapClusters: summary?.totals?.reportOnlyGapClusters ?? null,
       droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,
       skillExtractions: accepted.reduce((n, e) => {
         if (e.kind !== "extract") return n;

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -131,17 +131,6 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-function reportOnlyEvidence(edit, summary) {
-  if (summary?.gapEligibilityEnforced !== true) return null;
-  for (const gap of summary.reportOnlyGaps || []) {
-    const cited = edit.evidence.find((evidence) =>
-      (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
-    );
-    if (cited) return gap;
-  }
-  return null;
-}
-
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
 function unrecoveredRemovedLines(hunk, lineCounts) {
   const missing = [];
@@ -512,13 +501,6 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    const excludedGap = reportOnlyEvidence(edit, summary);
-    if (excludedGap) {
-      violations.push(
-        `edit ${edit.id} ("${edit.title}") cites the report-only gap "${excludedGap.proposedInstruction}"`,
-      );
-      continue;
-    }
     if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -705,10 +705,10 @@ export function buildProposal(rawResult, context) {
       positive: summary?.totals?.positive ?? 0,
       negative: summary?.totals?.negative ?? 0,
       gapClusters: summary?.totals?.gapClusters ?? 0,
-      // The gap funnel, for the apply surface: sightings -> project-domain (sightings
-      // minus orchestration) -> distinct gaps (clusters + dropped) -> eligible
-      // (clusters). `null`, never 0, when the summary predates a count - the surface
-      // hides what was not recorded rather than showing an invented zero.
+      // Gap counts retained for the apply surface: all sightings, orchestration-domain
+      // votes, synthesis-eligible clusters, and clusters dropped below the evidence floor.
+      // `null`, never 0, when the summary predates a count - the surface hides what was
+      // not recorded rather than showing an invented zero.
       gapSightings: summary?.totals?.gapSightings ?? null,
       orchestrationGapSightings: summary?.totals?.orchestrationGapSightings ?? null,
       droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,5 +1,6 @@
 import { renderHunkLines } from "./diff.js";
-import { memoryTextHash } from "./memory.js";
+import { memoryTextHash, similarity } from "./memory.js";
+import { GAP_SIMILARITY_THRESHOLD } from "./gap-ledger.js";
 import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
@@ -129,6 +130,20 @@ function normalizeEvidence(evidence) {
 function countSources(evidence) {
   if (!Array.isArray(evidence)) return 0;
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
+}
+
+function eligibleGapForAddition(edit, hunks, summary) {
+  if (summary?.gapEligibilityEnforced !== true) return true;
+  const inserted = hunks
+    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text))
+    .join("\n");
+  return (summary.gaps || []).find(
+    (gap) =>
+      similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
+      edit.evidence.some((evidence) =>
+        (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
+      ),
+  );
 }
 
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
@@ -505,6 +520,12 @@ export function buildProposal(rawResult, context) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
+      );
+      continue;
+    }
+    if (edit.kind !== "extract" && onlyAdds && !eligibleGapForAddition(edit, hunks, summary)) {
+      violations.push(
+        `edit ${edit.id} ("${edit.title}") adds a new instruction that does not match any synthesis-eligible gap and its evidence`,
       );
       continue;
     }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -132,14 +132,29 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
+function insertedCandidates(hunks) {
+  const lines = hunks
+    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text.trim()))
+    .filter(Boolean);
+  return [...lines, lines.join("\n")].filter(Boolean);
+}
+
+function matchesInsertedGap(hunks, gap) {
+  return insertedCandidates(hunks).some(
+    (inserted) => similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD,
+  );
+}
+
+function reportOnlyGapForInsertion(hunks, summary) {
+  if (summary?.gapEligibilityEnforced !== true) return null;
+  return (summary.reportOnlyGaps || []).find((gap) => matchesInsertedGap(hunks, gap));
+}
+
 function eligibleGapForAddition(edit, hunks, summary) {
   if (summary?.gapEligibilityEnforced !== true) return true;
-  const inserted = hunks
-    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text))
-    .join("\n");
   return (summary.gaps || []).find(
     (gap) =>
-      similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
+      matchesInsertedGap(hunks, gap) &&
       edit.evidence.some((evidence) =>
         (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
       ),
@@ -516,6 +531,13 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
+    const reportOnlyGap = preservesAlwaysLoaded(edit.kind) ? null : reportOnlyGapForInsertion(hunks, summary);
+    if (reportOnlyGap) {
+      violations.push(
+        `edit ${edit.id} ("${edit.title}") inserts the report-only gap "${reportOnlyGap.proposedInstruction}"`,
+      );
+      continue;
+    }
     if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,5 +1,5 @@
 import { renderHunkLines } from "./diff.js";
-import { memoryTextHash, similarity } from "./memory.js";
+import { memoryTextHash, parseMemoryUnits, similarity } from "./memory.js";
 import { GAP_SIMILARITY_THRESHOLD } from "./gap-ledger.js";
 import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
@@ -132,33 +132,49 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-function insertedCandidates(hunks) {
-  const lines = hunks
-    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text.trim()))
-    .filter(Boolean);
-  return [...lines, lines.join("\n")].filter(Boolean);
+function changedUnits(hunk, type) {
+  const text = (hunk.lines || [])
+    .filter((line) => line.type === type)
+    .map((line) => line.text)
+    .join("\n");
+  return parseMemoryUnits(text).map((unit) => unit.text);
 }
 
-function matchesInsertedGap(hunks, gap) {
-  return insertedCandidates(hunks).some(
-    (inserted) => similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD,
-  );
-}
-
-function reportOnlyGapForInsertion(hunks, summary) {
-  if (summary?.gapEligibilityEnforced !== true) return null;
-  return (summary.reportOnlyGaps || []).find((gap) => matchesInsertedGap(hunks, gap));
-}
-
-function eligibleGapForAddition(edit, hunks, summary) {
-  if (summary?.gapEligibilityEnforced !== true) return true;
+function eligibleGapForUnit(edit, unit, summary) {
   return (summary.gaps || []).find(
     (gap) =>
-      matchesInsertedGap(hunks, gap) &&
+      similarity(unit, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
       edit.evidence.some((evidence) =>
         (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
       ),
   );
+}
+
+function unsupportedNetNewUnit(edit, hunks, summary) {
+  if (summary?.gapEligibilityEnforced !== true) return null;
+  for (const hunk of hunks) {
+    const removed = changedUnits(hunk, "del");
+    const inserted = changedUnits(hunk, "ins");
+    if (inserted.length <= removed.length) continue;
+    const unmatchedRemoved = [...removed];
+    for (const unit of inserted) {
+      let bestIndex = -1;
+      let bestScore = 0;
+      for (let index = 0; index < unmatchedRemoved.length; index += 1) {
+        const score = similarity(unit, unmatchedRemoved[index]);
+        if (score > bestScore) {
+          bestIndex = index;
+          bestScore = score;
+        }
+      }
+      if (bestScore >= GAP_SIMILARITY_THRESHOLD) {
+        unmatchedRemoved.splice(bestIndex, 1);
+      } else if (!eligibleGapForUnit(edit, unit, summary)) {
+        return unit;
+      }
+    }
+  }
+  return null;
 }
 
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
@@ -531,10 +547,10 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    const reportOnlyGap = preservesAlwaysLoaded(edit.kind) ? null : reportOnlyGapForInsertion(hunks, summary);
-    if (reportOnlyGap) {
+    const unsupportedAddition = preservesAlwaysLoaded(edit.kind) ? null : unsupportedNetNewUnit(edit, hunks, summary);
+    if (unsupportedAddition) {
       violations.push(
-        `edit ${edit.id} ("${edit.title}") inserts the report-only gap "${reportOnlyGap.proposedInstruction}"`,
+        `edit ${edit.id} ("${edit.title}") adds "${unsupportedAddition.slice(0, 120)}", which does not match any synthesis-eligible gap and its evidence`,
       );
       continue;
     }
@@ -542,12 +558,6 @@ export function buildProposal(rawResult, context) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
-      );
-      continue;
-    }
-    if (edit.kind !== "extract" && onlyAdds && !eligibleGapForAddition(edit, hunks, summary)) {
-      violations.push(
-        `edit ${edit.id} ("${edit.title}") adds a new instruction that does not match any synthesis-eligible gap and its evidence`,
       );
       continue;
     }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,6 +1,5 @@
 import { renderHunkLines } from "./diff.js";
-import { memoryTextHash, parseMemoryUnits, similarity } from "./memory.js";
-import { GAP_SIMILARITY_THRESHOLD } from "./gap-ledger.js";
+import { memoryTextHash } from "./memory.js";
 import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
@@ -132,47 +131,13 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-function changedUnits(hunk, type) {
-  const text = (hunk.lines || [])
-    .filter((line) => line.type === type)
-    .map((line) => line.text)
-    .join("\n");
-  return parseMemoryUnits(text).map((unit) => unit.text);
-}
-
-function eligibleGapForUnit(edit, unit, summary) {
-  return (summary.gaps || []).find(
-    (gap) =>
-      similarity(unit, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
-      edit.evidence.some((evidence) =>
-        (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
-      ),
-  );
-}
-
-function unsupportedNetNewUnit(edit, hunks, summary) {
+function reportOnlyEvidence(edit, summary) {
   if (summary?.gapEligibilityEnforced !== true) return null;
-  for (const hunk of hunks) {
-    const removed = changedUnits(hunk, "del");
-    const inserted = changedUnits(hunk, "ins");
-    if (inserted.length <= removed.length) continue;
-    const unmatchedRemoved = [...removed];
-    for (const unit of inserted) {
-      let bestIndex = -1;
-      let bestScore = 0;
-      for (let index = 0; index < unmatchedRemoved.length; index += 1) {
-        const score = similarity(unit, unmatchedRemoved[index]);
-        if (score > bestScore) {
-          bestIndex = index;
-          bestScore = score;
-        }
-      }
-      if (bestScore >= GAP_SIMILARITY_THRESHOLD) {
-        unmatchedRemoved.splice(bestIndex, 1);
-      } else if (!eligibleGapForUnit(edit, unit, summary)) {
-        return unit;
-      }
-    }
+  for (const gap of summary.reportOnlyGaps || []) {
+    const cited = edit.evidence.find((evidence) =>
+      (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
+    );
+    if (cited) return gap;
   }
   return null;
 }
@@ -547,10 +512,10 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    const unsupportedAddition = preservesAlwaysLoaded(edit.kind) ? null : unsupportedNetNewUnit(edit, hunks, summary);
-    if (unsupportedAddition) {
+    const excludedGap = reportOnlyEvidence(edit, summary);
+    if (excludedGap) {
       violations.push(
-        `edit ${edit.id} ("${edit.title}") adds "${unsupportedAddition.slice(0, 120)}", which does not match any synthesis-eligible gap and its evidence`,
+        `edit ${edit.id} ("${edit.title}") cites the report-only gap "${excludedGap.proposedInstruction}"`,
       );
       continue;
     }

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -815,27 +815,26 @@
 
         // ---- run context: one frame, the gap funnel beside the run stats ----
         // A single bordered band. The left pane tells the gap story as proportional
-        // bars - sightings recorded by analysis -> project-domain (orchestration
-        // excluded) -> distinct gaps after clustering -> eligible to propose - with
-        // each drop-off explained in plain words. The right pane holds the run facts
-        // (edits, evidence, skills) as stat cells; a separate stat row would duplicate
-        // the funnel's last stage. Every count is recorded by the fold (`totals` in
+        // bars - sightings recorded by analysis -> distinct gaps after clustering ->
+        // eligible to propose - with each drop-off explained in plain words. Domain is
+        // voted after clustering, so orchestration sightings are not subtracted before
+        // the distinct-gap stage. The right pane holds the run facts (edits, evidence,
+        // skills) as stat cells. Every count is recorded by the fold (`totals` in
         // evidence-summary.json); a proposal saved before the counts existed falls
         // back to the classic stat row rather than showing zeros nobody measured.
         function funnelCounts() {
           if (typeof (P.stats || {}).gapSightings !== "number") return null;
           var eligible = P.stats.gapClusters || 0;
           var dropped = P.stats.droppedGapSingletons || 0;
-          var orch = P.stats.orchestrationGapSightings || 0;
-          var project = Math.max(0, P.stats.gapSightings - orch);
+          var reportOnly = P.stats.reportOnlyGapClusters || 0;
+          var distinct = eligible + reportOnly + dropped;
           return {
             floor: Number((P.config || {}).minGapEvidence) || 2,
             sighted: P.stats.gapSightings,
-            orch: orch,
-            project: project,
-            distinct: eligible + dropped,
-            merged: Math.max(0, project - (eligible + dropped)),
+            distinct: distinct,
+            merged: Math.max(0, P.stats.gapSightings - distinct),
             dropped: dropped,
+            reportOnly: reportOnly,
             eligible: eligible,
           };
         }
@@ -864,12 +863,6 @@
           funnelBar(bars, funnel.sighted, "sightings", funnel.sighted);
           funnelDrop(
             bars,
-            funnel.orch,
-            "orchestration: mistakes in how the task was run, not in this project - excluded from proposals by design",
-          );
-          funnelBar(bars, funnel.project, "project-domain", funnel.sighted);
-          funnelDrop(
-            bars,
             funnel.merged,
             "merged: repeat sightings of a gap already counted - they corroborate it rather than add a new one",
           );
@@ -880,6 +873,11 @@
             "below the corroboration floor: seen in fewer than " +
               funnel.floor +
               " sessions so far - more transcripts can corroborate them",
+          );
+          funnelDrop(
+            bars,
+            funnel.reportOnly,
+            "report only: mixed clusters below the floor or clusters excluded by a majority orchestration vote",
           );
           funnelBar(bars, funnel.eligible, "eligible to propose", funnel.sighted, true);
 
@@ -913,15 +911,12 @@
               funnel.floor +
               "-session corroboration floor - more transcripts may corroborate " +
               (funnel.dropped === 1 ? "it." : "them.");
-          } else if (!funnel.eligible && funnel.orch >= funnel.sighted) {
+          } else if (!funnel.eligible && funnel.reportOnly) {
             funnelNote =
-              "All " +
-              funnel.sighted +
-              " sighting" +
-              (funnel.sighted === 1 ? " was" : "s were") +
-              " orchestration-domain (caused by the orchestrating harness, not this repository) and " +
-              (funnel.sighted === 1 ? "is" : "are") +
-              " excluded by design.";
+              funnel.reportOnly +
+              " distinct gap cluster" +
+              (funnel.reportOnly === 1 ? " is" : "s are") +
+              " report only and excluded from proposals.";
           }
           if (funnelNote && !funnel.sighted) {
             var noteEl = document.getElementById("funnel-note");

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -13,6 +13,8 @@ import { loadConfig } from "../src/config.js";
 import { UserError, setLoggerSink } from "../src/logger.js";
 import { isPointerTo, memorySetHash, memoryTextHash, parseMemoryUnits } from "../src/memory.js";
 import { State } from "../src/state.js";
+import { clearProgressSink, setProgressSink } from "../src/progress.js";
+import { ProposalViolation } from "../src/proposal.js";
 
 const CLI = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../bin/backpass");
 
@@ -36,8 +38,8 @@ const discoverNone = async () => ({ transcripts: [], perHarness: {} });
 const discoverTwo = async () => ({ transcripts: [transcript("s1"), transcript("s2")], perHarness: { claude: {} } });
 
 /** Stands in for the tier-1 model: every session reports the same gap against the starter. */
-function fakeAnalyze({ transcripts, memoryFile, config, memoryHash }) {
-  for (const t of transcripts) {
+function writeFakeEvidence({ transcripts, memoryFile, config, memoryHash }, domainAt = () => undefined) {
+  for (const [index, t] of transcripts.entries()) {
     config.state.writeEvidence(t.id, {
       status: "ok",
       transcript: { id: t.id, harness: t.harness, startedAt: t.startedAt },
@@ -51,11 +53,20 @@ function fakeAnalyze({ transcripts, memoryFile, config, memoryHash }) {
           proposedInstruction: "Run migrations only against a scratch database.",
           recurrenceRisk: "high",
           quote: "applied the migration to prod-db",
+          ...(domainAt(index) ? { domain: domainAt(index) } : {}),
         },
       ],
     });
   }
   return { total: transcripts.length, analyzed: transcripts.length, cached: 0, skipped: 0, failed: 0, usage: [] };
+}
+
+function fakeAnalyze(args) {
+  return writeFakeEvidence(args);
+}
+
+function fakeAnalyzeMixed(args) {
+  return writeFakeEvidence(args, (index) => (index === 1 ? "orchestration" : "project"));
 }
 
 /**
@@ -175,6 +186,28 @@ test("no memory file and no transcripts: seeds AGENTS.md from defaults plus a CL
   const claude = fs.readFileSync(path.join(repo.root, "CLAUDE.md"), "utf8");
   assert.equal(claude, renderPointer("AGENTS.md"));
   assert.equal(isPointerTo(claude, "AGENTS.md"), true);
+});
+
+test("bootstrap progress counts a report-only mixed cluster once", async () => {
+  const repo = makeRepo();
+  const ctx = makeCtx(repo, { minGapEvidence: 3 });
+  const events = [];
+  setProgressSink((event, data) => events.push({ event, data }));
+  try {
+    await bootstrapRun(ctx, {
+      discover: discoverTwo,
+      analyze: fakeAnalyzeMixed,
+      synthesize: async () => {
+        throw new ProposalViolation("stop after fold", []);
+      },
+    });
+  } finally {
+    clearProgressSink();
+  }
+
+  const folded = events.find((entry) => entry.event === "fold:done");
+  assert.equal(folded.data.clustersFound, 1);
+  assert.equal(folded.data.clustersKept, 0);
 });
 
 test("with transcripts: analysis gaps become the first evidence-backed instruction", async () => {

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -38,7 +38,7 @@ const discoverNone = async () => ({ transcripts: [], perHarness: {} });
 const discoverTwo = async () => ({ transcripts: [transcript("s1"), transcript("s2")], perHarness: { claude: {} } });
 
 /** Stands in for the tier-1 model: every session reports the same gap against the starter. */
-function writeFakeEvidence({ transcripts, memoryFile, config, memoryHash }, domainAt = () => undefined) {
+function writeFakeEvidence({ transcripts, memoryFile, config, memoryHash }, domainAt = (_index) => undefined) {
   for (const [index, t] of transcripts.entries()) {
     config.state.writeEvidence(t.id, {
       status: "ok",

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { parseMemoryUnits } from "../src/memory.js";
 
 function record(id, overrides = {}) {
@@ -182,12 +182,40 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
     0,
     "a majority orchestration vote still withholds the cluster from a proposal",
   );
-  assert.equal(majorityOrch.excludedMixedGaps.length, 1);
-  assert.equal(majorityOrch.excludedMixedGaps[0].sessions, 3);
-  const renderedMajority = renderEvidenceForPrompt(majorityOrch);
+  assert.equal(majorityOrch.reportOnlyGaps.length, 1);
+  assert.equal(majorityOrch.reportOnlyGaps[0].sessions, 3);
+  const renderedMajority = renderEvidenceReport(majorityOrch);
   assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
+  assert.match(renderEvidenceForPrompt(majorityOrch), /Report-only mixed gap clusters/);
+});
+
+test("a below-threshold mixed cluster remains visible only in the report", () => {
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q1", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            quote: "q2",
+            recurrenceRisk: "high",
+            domain: "orchestration",
+          },
+        ],
+      }),
+    ],
+    { minGapEvidence: 3 },
+  );
+
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
+  assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -190,7 +190,7 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
-  assert.match(renderEvidenceForPrompt(majorityOrch), /Report-only mixed gap clusters/);
+  assert.match(renderEvidenceForPrompt(majorityOrch), /REPORT ONLY - not synthesis-eligible evidence/);
 });
 
 test("a below-threshold mixed cluster remains visible only in the report", () => {
@@ -219,7 +219,7 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
-  assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
+  assert.match(renderEvidenceForPrompt(summary), /REPORT ONLY - not synthesis-eligible evidence/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -187,7 +187,7 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   assert.equal(majorityOrch.totals.reportOnlyGapClusters, 1);
   const renderedMajority = renderEvidenceReport(majorityOrch);
   assert.match(renderedMajority, /1 gap clusters \(0 synthesis eligible, 1 report only/);
-  assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
+  assert.match(renderedMajority, /3 sightings, 2 orchestration; domain excluded by majority vote/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
   assert.match(renderEvidenceForPrompt(majorityOrch), /REPORT ONLY - not synthesis-eligible evidence/);

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -217,6 +217,7 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.gaps.length, 0);
   assert.equal(summary.reportOnlyGaps.length, 1);
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
+  assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
   assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
 });

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -184,7 +184,10 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   );
   assert.equal(majorityOrch.excludedMixedGaps.length, 1);
   assert.equal(majorityOrch.excludedMixedGaps[0].sessions, 3);
-  assert.match(renderEvidenceForPrompt(majorityOrch), /3 sightings, 2 orchestration; majority vote excluded/);
+  const renderedMajority = renderEvidenceForPrompt(majorityOrch);
+  assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
+  assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
+  assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -130,7 +130,11 @@ test("the fold records the sightings it clustered over - the gap funnel's top", 
   assert.equal(fromLedger.totals.gapSightings, 4);
   assert.equal(fromLedger.totals.orchestrationGapSightings, 1);
   assert.equal(fromLedger.totals.gapClusters, 1, "two sessions corroborate the lockfile gap");
-  assert.equal(fromLedger.totals.droppedGapSingletons, 1, "the schema gap stays below the floor");
+  assert.equal(
+    fromLedger.totals.droppedGapSingletons,
+    2,
+    "the schema and pure-orchestration gaps stay below the floor",
+  );
 });
 
 test("a two-sighting cluster with one orchestration vote survives instead of dropping below the floor", () => {
@@ -220,6 +224,31 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
   assert.match(renderEvidenceForPrompt(summary), /REPORT ONLY - not synthesis-eligible evidence/);
+});
+
+test("a pure orchestration singleton stays hidden below the evidence floor", () => {
+  const phrasing = "Stop after the report on scout tasks.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            quote: "q1",
+            recurrenceRisk: "low",
+            domain: "orchestration",
+          },
+        ],
+      }),
+    ],
+    { minGapEvidence: 2 },
+  );
+
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.reportOnlyGaps.length, 0);
+  assert.equal(summary.totals.reportOnlyGapClusters, 0);
+  assert.equal(summary.totals.droppedGapSingletons, 1);
+  assert.doesNotMatch(renderEvidenceForPrompt(summary), /Stop after the report/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -133,6 +133,60 @@ test("the fold records the sightings it clustered over - the gap funnel's top", 
   assert.equal(fromLedger.totals.droppedGapSingletons, 1, "the schema gap stays below the floor");
 });
 
+test("a two-sighting cluster with one orchestration vote survives instead of dropping below the floor", () => {
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        gaps: [{ proposedInstruction: phrasing, quote: "rewrote the tunnel", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            quote: "rewrote the tunnel again",
+            recurrenceRisk: "high",
+            domain: "orchestration",
+          },
+        ],
+      }),
+    ],
+    { minGapEvidence: 2 },
+  );
+
+  assert.equal(summary.gaps.length, 1, "one inconsistent orchestration vote cannot kill a two-session recurrence");
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(summary.gaps[0].orchestrationSightings, 1);
+  assert.equal(summary.gaps[0].mixed, true);
+  assert.equal(summary.gaps[0].majorityOrchestration, false);
+  assert.equal(summary.totals.orchestrationGapSightings, 1);
+  assert.equal(summary.totals.droppedGapSingletons, 0);
+  assert.match(renderEvidenceForPrompt(summary), /2 sightings, 1 orchestration/);
+
+  const majorityOrch = foldEvidence(
+    [
+      record("s1", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q1", recurrenceRisk: "low", domain: "orchestration" }],
+      }),
+      record("s2", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "low", domain: "orchestration" }],
+      }),
+      record("s3", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q3", recurrenceRisk: "low" }],
+      }),
+    ],
+    { minGapEvidence: 2 },
+  );
+  assert.equal(
+    majorityOrch.gaps.length,
+    0,
+    "a majority orchestration vote still withholds the cluster from a proposal",
+  );
+  assert.equal(majorityOrch.excludedMixedGaps.length, 1);
+  assert.equal(majorityOrch.excludedMixedGaps[0].sessions, 3);
+  assert.match(renderEvidenceForPrompt(majorityOrch), /3 sightings, 2 orchestration; majority vote excluded/);
+});
+
 test("the same gap repeated inside one session does not clear the threshold", () => {
   const summary = foldEvidence(
     [

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -194,7 +194,7 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   assert.match(renderedMajority, /3 sightings, 2 orchestration; domain excluded by majority vote/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
-  assert.match(renderEvidenceForPrompt(majorityOrch), /REPORT ONLY - not synthesis-eligible evidence/);
+  assert.doesNotMatch(renderEvidenceForPrompt(majorityOrch), /Read docs\/sshhip\.md|REPORT ONLY/);
 });
 
 test("a below-threshold mixed cluster remains visible only in the report", () => {
@@ -223,7 +223,8 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
-  assert.match(renderEvidenceForPrompt(summary), /REPORT ONLY - not synthesis-eligible evidence/);
+  assert.match(renderEvidenceReport(summary), /Read docs\/sshhip\.md/);
+  assert.doesNotMatch(renderEvidenceForPrompt(summary), /Read docs\/sshhip\.md|REPORT ONLY/);
 });
 
 test("a pure orchestration singleton stays hidden below the evidence floor", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -184,7 +184,9 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   );
   assert.equal(majorityOrch.reportOnlyGaps.length, 1);
   assert.equal(majorityOrch.reportOnlyGaps[0].sessions, 3);
+  assert.equal(majorityOrch.totals.reportOnlyGapClusters, 1);
   const renderedMajority = renderEvidenceReport(majorityOrch);
+  assert.match(renderedMajority, /1 gap clusters \(0 synthesis eligible, 1 report only/);
   assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
@@ -214,6 +216,7 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
 
   assert.equal(summary.gaps.length, 0);
   assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
   assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
 });

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -18,9 +18,9 @@ import { renderEvidenceForPrompt } from "../src/fold.js";
  * the analysis prompt actually handed to the model states the causal test for
  * `orchestration` (the mistake was caused by the harness around the session, not by this
  * repository - except when this repository IS that tool, in which case those mistakes
- * are `project`), and the mechanics behind it are unchanged - orchestration sightings are
- * recorded and counted but never corroborate, while a gap with no domain at all is still
- * treated as `project`.
+ * are `project`), and the mechanics behind it: orchestration sightings are recorded as
+ * votes and a cluster is withheld from a proposal only on a majority vote, while a gap
+ * with no domain at all is still treated as `project`.
  */
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -219,7 +219,9 @@ test("an orchestration gap is counted but never corroborates, while a gap with n
   );
 
   const rendered = renderEvidenceForPrompt(summary);
-  assert.ok(!rendered.includes(ORCHESTRATION_GAP), "the orchestration gap never reaches the synthesis prompt");
+  const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
+  assert.ok(!eligibleEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap is not synthesis-eligible");
+  assert.ok(reportOnlyEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap remains visible as report-only");
   assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/, "the run stays legible about what it cut");
 
   const ledger = state.readGapLedger();

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -9,7 +9,7 @@ import { spawnSync } from "node:child_process";
 import { State } from "../src/state.js";
 import { resolveMemoryFiles } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
-import { renderEvidenceForPrompt } from "../src/fold.js";
+import { renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 
 /**
  * A gap's `domain` decides whether it can ever become an instruction, so this drives the
@@ -218,11 +218,11 @@ test("an orchestration gap is counted but never corroborates, while a gap with n
     "only the domain-less gap - counted as project - can reach a proposal",
   );
 
-  const rendered = renderEvidenceForPrompt(summary);
-  const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
-  assert.ok(!eligibleEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap is not synthesis-eligible");
-  assert.ok(reportOnlyEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap remains visible as report-only");
-  assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/, "the run stays legible about what it cut");
+  const prompt = renderEvidenceForPrompt(summary);
+  assert.ok(!prompt.includes(ORCHESTRATION_GAP), "the orchestration gap never reaches synthesis");
+  const report = renderEvidenceReport(summary);
+  assert.ok(report.includes(ORCHESTRATION_GAP), "the orchestration gap remains visible as report-only");
+  assert.match(report, /2 orchestration-domain sighting\(s\).*excluded/, "the run stays legible about what it cut");
 
   const ledger = state.readGapLedger();
   const domains = Object.values(ledger.entries).map((entry) => Object.values(entry.sessions)[0].domain);

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -259,6 +259,20 @@ test("orchestration-domain gaps are counted but never cluster into a proposal", 
   assert.equal(clustered.gaps.length, 1);
 });
 
+test("a mixed two-sighting cluster with one orchestration vote still graduates", async () => {
+  const h = harness();
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const summary = await run(h, [
+    record("claude-s1", [{ proposedInstruction: phrasing, domain: "project" }]),
+    record("codex-s2", [{ proposedInstruction: phrasing, domain: "orchestration" }]),
+  ]);
+
+  assert.equal(summary.gaps.length, 1, "the cluster is not silently dropped below the two-session floor");
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(summary.gaps[0].orchestrationSightings, 1);
+  assert.match(renderEvidenceForPrompt(summary), /2 sightings, 1 orchestration/);
+});
+
 // ---------- consolidation-pass merges (the mechanical half) ----------
 
 function ledgerWith(...entries) {

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -307,6 +307,30 @@ test("mergeGapEntries unions sessions without double-counting and keeps the shor
   assert.deepEqual(Object.keys(entries[0].sessions).sort(), ["s1", "s2", "shared"], "a session never counts twice");
 });
 
+test("mergeGapEntries reconciles conflicting domain votes without target-order bias", () => {
+  const orchestrationId = "a".repeat(16);
+  const projectId = "b".repeat(16);
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const ledger = ledgerWith(
+    { id: orchestrationId, text: `${phrasing} Carefully.`, sessions: ["orch-only", "shared"] },
+    { id: projectId, text: phrasing, sessions: ["project-only", "shared"] },
+  );
+  ledger.entries[orchestrationId].sessions["orch-only"].domain = "orchestration";
+  ledger.entries[orchestrationId].sessions.shared.domain = "orchestration";
+  ledger.entries[projectId].sessions["project-only"].domain = "project";
+  ledger.entries[projectId].sessions.shared.domain = "project";
+
+  mergeGapEntries(ledger, [[orchestrationId, projectId]]);
+  const summary = foldEvidence([], {
+    gapObservations: ledgerGapObservations(ledger, MEMORY_PATH),
+    minGapEvidence: 2,
+  });
+
+  assert.equal(summary.gaps.length, 1, "the chosen merge target cannot turn a conflicting vote into orchestration");
+  assert.equal(summary.gaps[0].sessions, 3);
+  assert.equal(summary.gaps[0].orchestrationSightings, 1);
+});
+
 test("mergeGapEntries preserves absorbed citations for duplicate sessions", () => {
   const targetId = "a".repeat(16);
   const absorbedId = "b".repeat(16);

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -248,8 +248,13 @@ test("orchestration-domain gaps are counted but never cluster into a proposal", 
   const summary = await run(h, [record("claude-s1", [orchestration]), record("codex-s2", [orchestration])]);
 
   assert.equal(summary.gaps.length, 0, "two sessions corroborate it, and it still never becomes a proposal");
+  assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.orchestrationGapSightings, 2, "but the run stays legible about what it excluded");
-  assert.match(renderEvidenceForPrompt(summary), /2 orchestration-domain sighting\(s\).*excluded/);
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.match(rendered, /1 gap clusters \(0 synthesis eligible, 1 report only/);
+  assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/);
+  assert.match(rendered, /2 sightings, 2 orchestration; domain excluded by majority vote/);
 
   // The same shape in the project domain clusters as usual - the exclusion is the
   // domain, not the text.

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -7,7 +7,7 @@ import path from "node:path";
 import { State } from "../src/state.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
-import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import {
   gapEntryId,
   ledgerGapObservations,
@@ -251,10 +251,12 @@ test("orchestration-domain gaps are counted but never cluster into a proposal", 
   assert.equal(summary.reportOnlyGaps.length, 1);
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.orchestrationGapSightings, 2, "but the run stays legible about what it excluded");
-  const rendered = renderEvidenceForPrompt(summary);
-  assert.match(rendered, /1 gap clusters \(0 synthesis eligible, 1 report only/);
-  assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/);
-  assert.match(rendered, /2 sightings, 2 orchestration; domain excluded by majority vote/);
+  const prompt = renderEvidenceForPrompt(summary);
+  assert.doesNotMatch(prompt, /Stop after the report on scout tasks/);
+  const report = renderEvidenceReport(summary);
+  assert.match(report, /1 gap clusters \(0 synthesis eligible, 1 report only/);
+  assert.match(report, /2 orchestration-domain sighting\(s\).*excluded/);
+  assert.match(report, /2 sightings, 2 orchestration; domain excluded by majority vote/);
 
   // The same shape in the project domain clusters as usual - the exclusion is the
   // domain, not the text.

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -13,7 +13,7 @@ import {
   SHRINK_EDIT_TOKENS,
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
-import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
@@ -270,27 +270,13 @@ test("folded domain votes separate synthesis evidence from report-only diagnosti
     folded(["orchestration", "orchestration", "project"], 2),
     folded(["project", "orchestration"], 3),
   ]) {
-    const rendered = renderEvidenceForPrompt(summary);
-    const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
-    assert.doesNotMatch(eligibleEvidence, /Read docs\/sshhip\.md|quote [123]/);
-    assert.match(reportOnlyEvidence, /not synthesis-eligible evidence/);
-    assert.match(reportOnlyEvidence, /Do not create or justify proposals/);
-    assert.match(reportOnlyEvidence, /Read docs\/sshhip\.md/);
-    assert.doesNotMatch(reportOnlyEvidence, /quote [123]/);
+    const prompt = renderEvidenceForPrompt(summary);
+    assert.doesNotMatch(prompt, /Read docs\/sshhip\.md|quote [123]|REPORT ONLY/);
+    const report = renderEvidenceReport(summary);
+    assert.match(report, /REPORT ONLY - not synthesis-eligible evidence/);
+    assert.match(report, /Read docs\/sshhip\.md/);
+    assert.doesNotMatch(report, /quote [123]/);
   }
-
-  const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
-  const reportOnlyQuote = reportOnly.reportOnlyGaps[0].quotes[0];
-  const reportOnlyEvidence = [{ polarity: "negative", text: reportOnlyQuote.text, source: reportOnlyQuote.source }];
-  const unrelated = gate({
-    edit: memoryEdit((text) => text.replace("- Prefer small commits.", "- Prefer focused commits.")),
-    annotation: {
-      edits: [claim(["H1"], { kind: "rewrite", evidence: reportOnlyEvidence, transcripts: 3 })],
-    },
-    context: { summary: reportOnly },
-  });
-  assert.equal(unrelated.violations.length, 0);
-  assert.equal(unrelated.proposal.edits.length, 1);
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {
@@ -376,6 +362,7 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
           negative: 7,
           gapSightings: 9,
           gapClusters: 0,
+          reportOnlyGapClusters: 2,
           droppedGapSingletons: 3,
           orchestrationGapSightings: 6,
         },
@@ -388,6 +375,7 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   });
   assert.equal(funneled.proposal.stats.gapSightings, 9);
   assert.equal(funneled.proposal.stats.orchestrationGapSightings, 6);
+  assert.equal(funneled.proposal.stats.reportOnlyGapClusters, 2);
   assert.equal(funneled.proposal.stats.droppedGapSingletons, 3);
   assert.equal(funneled.proposal.stats.gapClusters, 0);
 
@@ -395,6 +383,7 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   const legacy = gate({ edit, annotation });
   assert.equal(legacy.proposal.stats.gapSightings, null);
   assert.equal(legacy.proposal.stats.orchestrationGapSightings, null);
+  assert.equal(legacy.proposal.stats.reportOnlyGapClusters, null);
   assert.equal(legacy.proposal.stats.droppedGapSingletons, null);
 });
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -13,6 +13,7 @@ import {
   SHRINK_EDIT_TOKENS,
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
+import { foldEvidence } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
@@ -212,6 +213,68 @@ test("an edit spanning several single-newline list items lands: find is measured
 });
 
 // ---------- evidence gates ----------
+
+test("folded domain votes mechanically control new-instruction eligibility", () => {
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const folded = (domains, minGapEvidence) =>
+    foldEvidence(
+      domains.map((domain, index) => ({
+        status: "ok",
+        transcript: {
+          id: `s${index + 1}`,
+          harness: "claude",
+          startedAt: Date.parse("2026-08-01T00:00:00Z"),
+        },
+        positive: [],
+        negative: [],
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            mistake: `mistake ${index + 1}`,
+            quote: `quote ${index + 1}`,
+            recurrenceRisk: "high",
+            domain,
+          },
+        ],
+      })),
+      { minGapEvidence },
+    );
+  const propose = (summary, minGapEvidence) => {
+    const displayed = summary.gaps[0] || summary.reportOnlyGaps[0];
+    const evidence = displayed.quotes.slice(0, 1).map((quote) => ({
+      polarity: "negative",
+      text: quote.text,
+      source: quote.source,
+    }));
+    return gate({
+      edit: memoryEdit((text) => `${text}- ${phrasing}\n`),
+      annotation: {
+        edits: [
+          claim(["H1"], {
+            kind: "add",
+            evidence,
+            transcripts: Math.max(displayed.sessions, minGapEvidence),
+          }),
+        ],
+      },
+      config: config({ minGapEvidence }),
+      context: { summary },
+    });
+  };
+
+  const eligible = propose(folded(["project", "orchestration"], 2), 2);
+  assert.equal(eligible.violations.length, 0);
+  assert.equal(eligible.proposal.edits.length, 1);
+
+  for (const [summary, minGapEvidence] of [
+    [folded(["orchestration", "orchestration", "project"], 2), 2],
+    [folded(["project", "orchestration"], 3), 3],
+  ]) {
+    const excluded = propose(summary, minGapEvidence);
+    assert.equal(excluded.proposal.edits.length, 0);
+    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+  }
+});
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {
   const lines = Array.from({ length: 6 }, (_, i) => `- Rule number ${i}.`);

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -13,7 +13,7 @@ import {
   SHRINK_EDIT_TOKENS,
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
-import { foldEvidence } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
@@ -214,7 +214,7 @@ test("an edit spanning several single-newline list items lands: find is measured
 
 // ---------- evidence gates ----------
 
-test("folded domain votes mechanically control new-instruction eligibility", () => {
+test("folded domain votes separate synthesis evidence from report-only diagnostics", () => {
   const phrasing = "Read docs/sshhip.md before changing the tunnel.";
   const folded = (domains, minGapEvidence) =>
     foldEvidence(
@@ -266,37 +266,26 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   assert.equal(eligible.violations.length, 0);
   assert.equal(eligible.proposal.edits.length, 1);
 
-  for (const [summary, minGapEvidence] of [
-    [folded(["orchestration", "orchestration", "project"], 2), 2],
-    [folded(["project", "orchestration"], 3), 3],
+  for (const summary of [
+    folded(["orchestration", "orchestration", "project"], 2),
+    folded(["project", "orchestration"], 3),
   ]) {
-    const excluded = propose(summary, minGapEvidence);
-    assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /cites the report-only gap/.test(violation)));
+    const rendered = renderEvidenceForPrompt(summary);
+    const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
+    assert.doesNotMatch(eligibleEvidence, /Read docs\/sshhip\.md|quote [123]/);
+    assert.match(reportOnlyEvidence, /not synthesis-eligible evidence/);
+    assert.match(reportOnlyEvidence, /Do not create or justify proposals/);
+    assert.match(reportOnlyEvidence, /Read docs\/sshhip\.md/);
+    assert.doesNotMatch(reportOnlyEvidence, /quote [123]/);
   }
 
   const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
   const reportOnlyQuote = reportOnly.reportOnlyGaps[0].quotes[0];
   const reportOnlyEvidence = [{ polarity: "negative", text: reportOnlyQuote.text, source: reportOnlyQuote.source }];
-  const rewritten = gate({
-    edit: memoryEdit((text) =>
-      text.replace(
-        "- Prefer small commits.\n- Use Node 18 via nvm before running any script.",
-        "- Prefer focused commits.\n- Consult the SSHHIP guide prior to tunnel edits.",
-      ),
-    ),
+  const unrelated = gate({
+    edit: memoryEdit((text) => text.replace("- Prefer small commits.", "- Prefer focused commits.")),
     annotation: {
       edits: [claim(["H1"], { kind: "rewrite", evidence: reportOnlyEvidence, transcripts: 3 })],
-    },
-    context: { summary: reportOnly },
-  });
-  assert.equal(rewritten.proposal.edits.length, 0);
-  assert.ok(rewritten.violations.some((violation) => /cites the report-only gap/.test(violation)));
-
-  const unrelated = gate({
-    edit: memoryEdit((text) => `${text}- Preserve build logs for failed releases.\n`),
-    annotation: {
-      edits: [claim(["H1"], { kind: "add", transcripts: 3 })],
     },
     context: { summary: reportOnly },
   });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -272,8 +272,19 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   ]) {
     const excluded = propose(summary, minGapEvidence);
     assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+    assert.ok(excluded.violations.some((violation) => /report-only gap/.test(violation)));
   }
+
+  const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
+  const rewritten = gate({
+    edit: memoryEdit((text) => text.replace("- Prefer small commits.", `- Prefer focused commits.\n- ${phrasing}`)),
+    annotation: {
+      edits: [claim(["H1"], { kind: "rewrite", transcripts: 3 })],
+    },
+    context: { summary: reportOnly },
+  });
+  assert.equal(rewritten.proposal.edits.length, 0);
+  assert.ok(rewritten.violations.some((violation) => /inserts the report-only gap/.test(violation)));
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -272,19 +272,24 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   ]) {
     const excluded = propose(summary, minGapEvidence);
     assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /report-only gap/.test(violation)));
+    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
   }
 
   const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
   const rewritten = gate({
-    edit: memoryEdit((text) => text.replace("- Prefer small commits.", `- Prefer focused commits.\n- ${phrasing}`)),
+    edit: memoryEdit((text) =>
+      text.replace(
+        "- Prefer small commits.",
+        "- Prefer focused commits.\n- Consult the SSHHIP guide prior to tunnel edits.",
+      ),
+    ),
     annotation: {
       edits: [claim(["H1"], { kind: "rewrite", transcripts: 3 })],
     },
     context: { summary: reportOnly },
   });
   assert.equal(rewritten.proposal.edits.length, 0);
-  assert.ok(rewritten.violations.some((violation) => /inserts the report-only gap/.test(violation)));
+  assert.ok(rewritten.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -272,24 +272,36 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   ]) {
     const excluded = propose(summary, minGapEvidence);
     assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+    assert.ok(excluded.violations.some((violation) => /cites the report-only gap/.test(violation)));
   }
 
   const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
+  const reportOnlyQuote = reportOnly.reportOnlyGaps[0].quotes[0];
+  const reportOnlyEvidence = [{ polarity: "negative", text: reportOnlyQuote.text, source: reportOnlyQuote.source }];
   const rewritten = gate({
     edit: memoryEdit((text) =>
       text.replace(
-        "- Prefer small commits.",
+        "- Prefer small commits.\n- Use Node 18 via nvm before running any script.",
         "- Prefer focused commits.\n- Consult the SSHHIP guide prior to tunnel edits.",
       ),
     ),
     annotation: {
-      edits: [claim(["H1"], { kind: "rewrite", transcripts: 3 })],
+      edits: [claim(["H1"], { kind: "rewrite", evidence: reportOnlyEvidence, transcripts: 3 })],
     },
     context: { summary: reportOnly },
   });
   assert.equal(rewritten.proposal.edits.length, 0);
-  assert.ok(rewritten.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+  assert.ok(rewritten.violations.some((violation) => /cites the report-only gap/.test(violation)));
+
+  const unrelated = gate({
+    edit: memoryEdit((text) => `${text}- Preserve build logs for failed releases.\n`),
+    annotation: {
+      edits: [claim(["H1"], { kind: "add", transcripts: 3 })],
+    },
+    context: { summary: reportOnly },
+  });
+  assert.equal(unrelated.violations.length, 0);
+  assert.equal(unrelated.proposal.edits.length, 1);
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -34,6 +34,23 @@ async function captureStatus(repo, json) {
   return lines;
 }
 
+test("status counts synthesis-eligible and report-only gap clusters", async () => {
+  const repo = makeRepo({ "AGENTS.md": MEMORY });
+  const state = new State(repo.root).ensure();
+  state.writeSummary({
+    analyzedSessions: 4,
+    totals: {
+      positive: 2,
+      negative: 1,
+      gapClusters: 1,
+      reportOnlyGapClusters: 2,
+    },
+  });
+
+  const text = (await captureStatus(repo, false)).join("\n");
+  assert.match(text, /3 gap cluster\(s\) \(1 synthesis eligible · 2 report only\)/);
+});
+
 test("status reports one always-loaded budget over memory and skill descriptions", async () => {
   const repo = makeRepo({
     "AGENTS.md": MEMORY,


### PR DESCRIPTION
## Intent

Fix backpass domain voting so an inconsistent single-sighting classification cannot silently kill a real recurring cluster. Per-sighting domain votes were applied BEFORE clustering: two real SSHHIP recurrences each had 2 sightings, one of which a different analysis call classed orchestration, so it was excluded pre-clustering, fell below the floor, and surfaced nowhere - the classifier's inconsistency, not the evidence, decided the outcome. Record per-sighting votes (already stored) but decide domain AFTER clustering: exclude a cluster only when a majority of its sightings are orchestration, and always show mixed clusters in the report ("2 sightings, 1 orchestration") instead of silently dropping below-floor remainders. Optionally let the consolidation call re-judge domain for merged entries. Cover behaviorally: a 2-sighting cluster with one orchestration vote survives and is shown, rather than being dropped. Stay strictly scoped to this domain-voting/clustering change only.

## What Changed

- Cluster all gap sightings before applying per-sighting domain votes, excluding only clusters with an orchestration majority while keeping ties synthesis-eligible.
- Surface mixed and majority-excluded clusters as report-only diagnostics with orchestration counts in evidence reports and status output.
- Add behavioral coverage for domain voting, ledger merges, proposal eligibility, bootstrap accounting, and status reporting.

## Risk Assessment

✅ Low: The change is well-bounded and consistently applies post-clustering domain voting while preserving evidence thresholds and report-only handling.

## Testing

Inspected the targeted diff, exercised the real analyze/fold/proposal/status/bootstrap paths with focused automated tests, and captured the generated synthesis evidence for all domain-voting branches. Tied mixed sightings remained eligible, excluded clusters were report-only, and uncorroborated pure-orchestration sightings stayed hidden.

<details>
<summary>Evidence: Rendered domain-voting synthesis and report-only evidence</summary>

Source: [Rendered domain-voting synthesis and report-only evidence](https://github.com/kunchenguid/backpass/blob/ae4cf9cf02f96f297f93fd910b0345ea336b0433/.no-mistakes/evidence/fm/backpass-cluster-domain-vote-r1/domain-voting-evidence.txt)

```text
===== TIE SURVIVES: 2 sightings, 1 orchestration, floor 2 =====
Sessions analyzed: 2
Totals: 0 positive, 0 negative, 1 gap clusters (1 synthesis eligible, 0 report only, 0 singletons dropped below threshold)

\### Per-instruction evidence
A negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.

\### Synthesis-eligible gap clusters (mistakes no current instruction covers)
- 1 orchestration-domain sighting(s) counted as domain votes (clusters excluded only on a majority vote); they never enter this repository's memory file as their own instruction
- sessions=2 (2 sightings, 1 orchestration) risk=high :: Read docs/sshhip.md before changing the tunnel.
    "missed tunnel process in session-1" (pi · 1 · 2026-08-01)
    "missed tunnel process in session-2" (pi · 2 · 2026-08-01)

===== MIXED BELOW FLOOR: report only, floor 3 =====
Sessions analyzed: 2
Totals: 0 positive, 0 negative, 1 gap clusters (0 synthesis eligible, 1 report only, 0 singletons dropped below threshold)

\### Per-instruction evidence
A negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.

\### Synthesis-eligible gap clusters (mistakes no current instruction covers)
- 1 orchestration-domain sighting(s) counted as domain votes (clusters excluded only on a majority vote); they never enter this repository's memory file as their own instruction
- no gap cluster is eligible for a repository proposal

\### REPORT ONLY - not synthesis-eligible evidence
Do not create or justify proposals from these diagnostic clusters.
- sessions=2 (2 sightings, 1 orchestration) risk=high :: Read docs/sshhip.md before changing the tunnel.

===== MAJORITY ORCHESTRATION: report only, floor 2 =====
Sessions analyzed: 3
Totals: 0 positive, 0 negative, 1 gap clusters (0 synthesis eligible, 1 report only, 0 singletons dropped below threshold)

\### Per-instruction evidence
A negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.

\### Synthesis-eligible gap clusters (mistakes no current instruction covers)
- 2 orchestration-domain sighting(s) counted as domain votes (clusters excluded only on a majority vote); they never enter this repository's memory file as their own instruction
- no gap cluster is eligible for a repository proposal

\### REPORT ONLY - not synthesis-eligible evidence
Do not create or justify proposals from these diagnostic clusters.
- sessions=3 (3 sightings, 2 orchestration; domain excluded by majority vote) risk=high :: Read docs/sshhip.md before changing the tunnel.

===== PURE ORCHESTRATION SINGLETON: hidden below floor 2 =====
Sessions analyzed: 1
Totals: 0 positive, 0 negative, 0 gap clusters (0 synthesis eligible, 0 report only, 1 singletons dropped below threshold)

\### Per-instruction evidence
A negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.

\### Synthesis-eligible gap clusters (mistakes no current instruction covers)
- 1 orchestration-domain sighting(s) counted as domain votes (clusters excluded only on a majority vote); they never enter this repository's memory file as their own instruction
- none above the evidence threshold
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b4872829250c14dfa8d78fcf24eb4c557df5d417","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (10) ✅</summary>

- 🚨 `src/fold.js:232` - The majority vote can still depend on arbitrary consolidation order. `mergeGapEntries` deduplicates a session by retaining the target entry&#39;s domain, while this new in-fold path resolves duplicate-session classifications in favor of project. For two merged two-session entries sharing one inconsistently classified session, choosing the orchestration entry as the tie target yields a 2-to-1 orchestration majority, while reversing group order yields a 1-to-2 project majority. Reconcile conflicting domains at the ledger merge boundary before discarding the duplicate session.
- 🚨 `src/fold.js:309` - A majority-orchestration mixed cluster is removed from `summary.gaps` but its proposed instruction is still supplied to the synthesis agent. The synthesis rules treat any displayed gap with enough sessions as valid evidence, and `buildProposal` has no gate tying an addition to `summary.gaps`, so the agent can still turn this supposedly excluded cluster into a memory instruction. The intent requires majority-orchestration clusters to be excluded while mixed clusters remain reportable; separating diagnostic reporting from synthesis eligibility, or adding a mechanical eligibility gate, needs user authorization because it changes the reporting or proposal contract.
- ⚠️ `src/fold.js:312` - When only an above-threshold majority-orchestration mixed cluster exists, rendering first prints that cluster and then prints `none above the evidence threshold`. The cluster is above the threshold but domain-ineligible. Reword this fallback to say that no cluster is eligible for a proposal.

🔧 Fix: Reconcile merged domain votes and clarify proposal eligibility
2 errors still open:

- 🚨 `src/fold.js:309` - The required majority-orchestration exclusion is not enforced at the proposal boundary. This line places an excluded cluster&#39;s proposed instruction in the synthesis evidence; the synthesis rules accept any displayed gap meeting the session floor, while `buildProposal` only checks the model-reported transcript count and nonempty evidence. A model can therefore add this instruction despite the majority vote. Separating diagnostic reporting from synthesis-eligible evidence, or adding a mechanical eligibility gate, needs user authorization because it changes the reporting/proposal contract.
- 🚨 `src/fold.js:148` - The intent requires that mixed clusters &#34;always show&#34; in the report, but a mixed cluster below `minGapEvidence` is absent from both `gaps` and `excludedMixedGaps`. For example, with `minGapEvidence=3`, two same-gap sessions split project/orchestration produce a mixed cluster that renders only `none above the evidence threshold`, omitting `2 sightings, 1 orchestration`. Supporting report-only mixed clusters without making them synthesis-eligible requires an authorized reporting boundary.

🔧 Fix: Separate report-only gaps from synthesis eligibility
1 error still open:

- 🚨 `src/proposal.js:397` - The eligibility gate only runs when every hunk is insertion-only. A rewrite can replace an existing line and append a majority-orchestration report-only instruction in the same hunk; `onlyAdds` is then false, so the domain gate is skipped and unrelated evidence can let the edit pass. Enforce report-only exclusion for inserted instructions in mixed replacement hunks at `buildProposal`, so a shown-but-excluded cluster can never enter a proposal.

🔧 Fix: Block report-only gaps in mixed rewrites
2 issues (1 error, 1 warning) still open:

- 🚨 `src/proposal.js:116` - The report-only exclusion uses bigram similarity as mechanical identity, but paraphrases routinely fall below this threshold. For example, rewriting a line while adding “Consult the SSHHIP guide prior to tunnel edits” does not match “Read docs/sshhip.md before changing the tunnel”; `reportOnlyGapForInsertion` returns null, and because the hunk is not insertion-only, the eligible-gap gate is skipped. With any nonempty evidence, the excluded instruction can still enter the proposal. Gate every net-new instruction unit in mixed hunks against synthesis-eligible gaps rather than relying on a fuzzy report-only denylist.
- ⚠️ `src/fold.js:165` - A majority-orchestration mixed cluster produces `gapClusters=0` and `droppedGapSingletons=0` even though `reportOnlyGaps` contains the cluster. The rendered report therefore says “0 gap clusters” immediately before displaying one, and progress reports zero clusters found. Track report-only clusters in diagnostic totals while keeping synthesis-eligible counts distinct.

🔧 Fix: Gate net-new units and count report-only clusters
2 issues (1 error, 1 warning) still open:

- 🚨 `src/proposal.js:132` - The generalized gate contradicts the required &#34;strictly scoped to this domain-voting/clustering change only&#34; constraint by rejecting unrelated non-extract additions, including skill-body improvements, unless they match an eligible gap and quote. It also fails its authorized exclusion guarantee whenever inserted unit count is not greater than removed unit count: replacing two rules with one rewrite plus one report-only orchestration instruction skips the gate entirely and passes with any nonempty evidence. This fixer-introduced machinery exceeds the original finding; revert it and implement the minimal proposal-boundary eligibility mechanism needed to prevent excluded clusters from becoming proposals.
- ⚠️ `src/fold.js:152` - A below-threshold mixed cluster is included in both `reportOnlyGaps` and `droppedGapSingletons`. Consequently the report says the visible cluster was dropped, and `clustersFound` in `src/commands/propose.js` counts one physical cluster twice. Exclude report-only clusters from the dropped count.

🔧 Fix: Scope exclusion gate and fix cluster accounting
2 issues (1 error, 1 warning) still open:

- 🚨 `src/proposal.js:386` - The fixer-introduced gate neither guarantees exclusion nor preserves the authorized scope. The synthesis prompt shows a report-only cluster&#39;s instruction but omits its quotes, while this gate rejects only an exact quote/source citation. An agent can add that excluded instruction, cite any other displayed evidence, claim enough transcripts, and pass. Conversely, a legitimate skill rewrite citing the same quote is rejected, contradicting the explicit requirement not to gate unrelated skill improvements. Replace this machinery with the minimal report-versus-synthesis boundary authorized by the user, rather than another citation heuristic.
- ⚠️ `src/commands/bootstrap.js:109` - Bootstrap still computes `clustersFound` without `reportOnlyGapClusters`. A bootstrap run containing a below-threshold mixed cluster therefore persists and synthesizes the visible report-only cluster but reports zero clusters found in progress, unlike the normal proposal path. Include the report-only count here as well.

🔧 Fix: Separate report-only evidence and fix bootstrap counts
1 warning still open:

- ⚠️ `README.md:200` - The README still says orchestration-domain gaps “never cluster,” but `src/fold.js` now clusters all sightings and excludes only clusters with a majority orchestration vote. Update this user-facing explanation to document post-clustering voting, ties remaining eligible, and mixed clusters remaining visible.

🔧 Fix: Document post-clustering domain voting
1 warning still open:

- ⚠️ `src/fold.js:148` - A pure orchestration cluster is excluded from every cluster category. For example, two sessions reporting the same orchestration gap produce one clustered result, but `gaps`, `reportOnlyGaps`, and `droppedGapSingletons` are all empty, so the report and progress output claim zero clusters were found. Classify these separately as domain-excluded clusters so totals remain truthful. Because the clean remedy adds a persisted summary category, it needs user authorization.

🔧 Fix: Account for pure orchestration clusters
2 issues (1 error, 1 warning) still open:

- ⚠️ `src/commands/status.js:101` - `backpass status` still prints only synthesis-eligible `gapClusters`. A summary containing one pure-orchestration report-only cluster therefore says `0 gap cluster(s)`, contradicting the new truthful accounting. Include `reportOnlyGapClusters` with a legacy-safe zero fallback and label the split if needed.
- 🚨 `test/gap-domain-cli.test.js:176` - This assertion requires the pure-orchestration instruction to be absent from `renderEvidenceForPrompt`, but the new behavior deliberately renders it in the REPORT ONLY section. The test will deterministically fail. Update it to assert absence from the synthesis-eligible section and presence in the labeled report-only section.

🔧 Fix: Count report-only clusters in status
1 warning still open:

- ⚠️ `src/fold.js:149` - Every majority-orchestration cluster becomes report-only regardless of `minGapEvidence`. A single orchestration sighting therefore exposes its proposed instruction in the synthesis prompt and is counted as a cluster instead of being dropped, violating the existing invariant that uncorroborated gaps and singletons stay hidden. Require majority-orchestration clusters to clear the evidence floor unless they are mixed, and count under-floor pure clusters as dropped.

🔧 Fix: Keep pure orchestration singletons below threshold
✅ Re-checked - no issues remain.

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check && node --version && pnpm --version`
- `node --test test/fold.test.js test/gap-ledger.test.js test/gap-domain-cli.test.js test/proposal.test.js test/bootstrap.test.js test/status.test.js`
- <code>Generated folded synthesis evidence for tied and majority-orchestration scenarios using the executable `foldEvidence` and `renderEvidenceForPrompt` interfaces.</code>

✅ No issues found.
- `git diff 6cbb5b2c7e1acf56990507d8cd39545683b63046..5b22f69146c64ba4ecf694e3319ae790f0e887af`
- `node --test test/fold.test.js test/gap-ledger.test.js test/gap-domain-cli.test.js test/proposal.test.js test/bootstrap.test.js test/status.test.js`
- <code>Generated the synthesis evidence output for tied, below-threshold mixed, majority-orchestration, and pure-orchestration singleton scenarios using `foldEvidence` and `renderEvidenceForPrompt`.</code>
</details>

<details>
<summary>🔧 **Document** - 1 issue found ✅</summary>

- ⚠️ `templates/apply.html:812` - The apply surface still visualizes the old pre-clustering domain filter, subtracting every orchestration sighting and claiming each was excluded. Correcting it requires a functional funnel redesign or removal of that stage, beyond documentation-only changes.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
