### PR TITLE
fix: decide gap cluster domains after grouping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,9 +206,9 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   `totals.orchestrationGapSightings` and travel into clustering as votes. Cluster
   domain is decided after grouping (`src/fold.js`): withhold a cluster from a
   proposal only when a majority of its sightings vote orchestration (ties stay
-  project). Mixed clusters always appear in the evidence report (`N sightings, M
-  orchestration`) so one inconsistent classifier call cannot drop a real
-  recurrence below `minGapEvidence`. There is deliberately no orchestrator-memory
+  project). Mixed clusters always appear in the evidence report with both sighting counts,
+  so one inconsistent classifier call cannot drop a real recurrence below
+  `minGapEvidence`. There is deliberately no orchestrator-memory
   write path. When this repository IS that orchestrating tool, those mistakes are
   `project` (`src/prompts/analysis.md`).
   A gap may also carry `coveredBySkill`: the analysis (shown every skill's name and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,10 +203,14 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   degrades to lexical identity with a warning, never an abort. Gaps also carry `domain`;
   `orchestration` sightings (mistakes caused by the external harness or tooling that
   orchestrated the task, not by this repo) are counted in
-  `totals.orchestrationGapSightings` and excluded from clustering, so they can
-  never reach a proposal - there is deliberately no orchestrator-memory write path.
-  When this repository IS that orchestrating tool, those mistakes are `project`
-  (`src/prompts/analysis.md`).
+  `totals.orchestrationGapSightings` and travel into clustering as votes. Cluster
+  domain is decided after grouping (`src/fold.js`): withhold a cluster from a
+  proposal only when a majority of its sightings vote orchestration (ties stay
+  project). Mixed clusters always appear in the evidence report (`N sightings, M
+  orchestration`) so one inconsistent classifier call cannot drop a real
+  recurrence below `minGapEvidence`. There is deliberately no orchestrator-memory
+  write path. When this repository IS that orchestrating tool, those mistakes are
+  `project` (`src/prompts/analysis.md`).
   A gap may also carry `coveredBySkill`: the analysis (shown every skill's name and
   trigger line) judged an existing skill's content to cover the mistake - a failed
   trigger. The fold counts those citations per skill onto the cluster

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,9 +206,9 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   `totals.orchestrationGapSightings` and travel into clustering as votes. Cluster
   domain is decided after grouping (`src/fold.js`): withhold a cluster from a
   proposal only when a majority of its sightings vote orchestration (ties stay
-  project). Mixed clusters always appear in the evidence report with both sighting counts,
-  so one inconsistent classifier call cannot drop a real recurrence below
-  `minGapEvidence`. There is deliberately no orchestrator-memory
+  project). Mixed clusters always appear in the evidence report with total and
+  orchestration sighting counts, so one inconsistent classifier call cannot drop a real
+  recurrence below `minGapEvidence`. There is deliberately no orchestrator-memory
   write path. When this repository IS that orchestrating tool, those mistakes are
   `project` (`src/prompts/analysis.md`).
   A gap may also carry `coveredBySkill`: the analysis (shown every skill's name and

--- a/README.md
+++ b/README.md
@@ -228,9 +228,10 @@ run's parallel fan-out corroborate. A failed consolidation call degrades the run
 lexical identity and says so; it never aborts. All sightings cluster before their domain
 is decided. Each sighting votes `project` or `orchestration`; only a majority-orchestration
 cluster is excluded from synthesis, while a tie stays eligible. Mixed clusters are always
-reported with their orchestration count. Every majority-excluded cluster, including a
-pure-orchestration cluster, remains clearly labeled as a report-only diagnostic rather
-than becoming an instruction in the project's memory file.
+reported with their orchestration count, even below the evidence floor. A corroborated
+majority-excluded cluster, including a pure-orchestration cluster, remains clearly labeled
+as a report-only diagnostic rather than becoming an instruction in the project's memory
+file; an uncorroborated pure-orchestration singleton stays hidden.
 
 Only evidence judged against the _current_ memory-surface hash, stamped with one of the two
 interaction categories, and belonging to this run's selected sample is folded into a

--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ run's parallel fan-out corroborate. A failed consolidation call degrades the run
 lexical identity and says so; it never aborts. All sightings cluster before their domain
 is decided. Each sighting votes `project` or `orchestration`; only a majority-orchestration
 cluster is excluded from synthesis, while a tie stays eligible. Mixed clusters are always
-reported with their orchestration count, and those excluded by the majority vote remain
-clearly labeled as report-only diagnostics rather than becoming instructions in the
-project's memory file.
+reported with their orchestration count. Every majority-excluded cluster, including a
+pure-orchestration cluster, remains clearly labeled as a report-only diagnostic rather
+than becoming an instruction in the project's memory file.
 
 Only evidence judged against the _current_ memory-surface hash, stamped with one of the two
 interaction categories, and belonging to this run's selected sample is folded into a

--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ units that substantially overlap a project skill. An overlap with a skill descri
 always-loaded tokens and points the shrink at the memory-file copy; an overlap with a
 triggered skill body is placement evidence only, since the memory copy may be the only
 always-loaded coverage. Neither kind is deleted automatically. Duplicate gaps across
-sessions are clustered, and clusters seen in fewer than `minGapEvidence` sessions (default 2) are dropped. One bad session never rewrites the weights.
+sessions are clustered, and only clusters seen in at least `minGapEvidence` sessions
+(default 2) are eligible for synthesis. Mixed-domain clusters below that floor remain
+visible as report-only diagnostics. One bad session never rewrites the weights.
 
 Whether two sightings are one gap is a judgment call, not a word-overlap score - models
 paraphrase, and a paraphrase that fails a lexical match would hide real recurrence.
@@ -223,9 +225,11 @@ it sees a gap already on the books, and, when at least two open entries exist, o
 consolidation call sees the full open gap set and merges entries that describe the same
 mistake. That second judgment is what lets two sightings of a brand-new gap in the same
 run's parallel fan-out corroborate. A failed consolidation call degrades the run to
-lexical identity and says so; it never aborts. Orchestration-domain gaps are counted and
-reported but never cluster: a mistake caused not by this repository but by the external
-agent harness or tooling that orchestrated a session does not become an instruction in the
+lexical identity and says so; it never aborts. All sightings cluster before their domain
+is decided. Each sighting votes `project` or `orchestration`; only a majority-orchestration
+cluster is excluded from synthesis, while a tie stays eligible. Mixed clusters are always
+reported with their orchestration count, and those excluded by the majority vote remain
+clearly labeled as report-only diagnostics rather than becoming instructions in the
 project's memory file.
 
 Only evidence judged against the _current_ memory-surface hash, stamped with one of the two

--- a/README.md
+++ b/README.md
@@ -372,9 +372,8 @@ changed since the proposal measured it, exactly as it refuses a drifted memory f
 `backpass apply` is the only command that writes. It serves a review surface through
 [`lavish-axi`](https://github.com/kunchenguid/lavish-axi): one card per edit with the diff,
 the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT. A compact
-gap funnel shows how accumulated sightings narrowed through domain filtering, clustering,
-and the corroboration floor to the gaps eligible for a proposal; older proposals without
-recorded funnel counts omit it.
+gap funnel summarizes recorded gap evidence and proposal eligibility; older proposals
+without recorded funnel counts omit it.
 
 The surface is a static template shipped in the package - the CLI injects one JSON payload,
 so it is instant, deterministic, and identical every run. Nothing there is model-generated.

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -107,7 +107,8 @@ export async function bootstrapRun(ctx, deps = {}) {
   config.state.writeSummary(folded);
   emitProgress("fold:done", {
     instructions: folded.instructions.length,
-    clustersFound: folded.totals.gapClusters + folded.totals.droppedGapSingletons,
+    clustersFound:
+      folded.totals.gapClusters + (folded.totals.reportOnlyGapClusters || 0) + folded.totals.droppedGapSingletons,
     clustersKept: folded.totals.gapClusters,
     minGapEvidence: config.minGapEvidence,
     ms: 0,

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -104,7 +104,8 @@ export async function runProposal(ctx, precomputed = null) {
   config.state.writeSummary(summary);
   emitProgress("fold:done", {
     instructions: summary.instructions.length,
-    clustersFound: summary.totals.gapClusters + summary.totals.droppedGapSingletons,
+    clustersFound:
+      summary.totals.gapClusters + (summary.totals.reportOnlyGapClusters || 0) + summary.totals.droppedGapSingletons,
     clustersKept: summary.totals.gapClusters,
     minGapEvidence: config.minGapEvidence,
     ms: Date.now() - foldStarted,

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -115,9 +115,15 @@ export async function cmdStatus(ctx) {
     `  evidence        ${counts.ok || 0} ok · ${counts.skipped || 0} skipped · ${color.red(String(counts.failed || 0))} failed`,
   );
   if (summary) {
+    const eligibleClusters = summary.totals.gapClusters;
+    const reportOnlyClusters = summary.totals.reportOnlyGapClusters || 0;
+    const totalClusters = eligibleClusters + reportOnlyClusters;
+    const clusterSplit = reportOnlyClusters
+      ? ` (${eligibleClusters} synthesis eligible · ${reportOnlyClusters} report only)`
+      : "";
     out(
       `  gradients       ${summary.analyzedSessions} session(s) · ${summary.totals.positive}+ ` +
-        `${summary.totals.negative}- · ${summary.totals.gapClusters} gap cluster(s)`,
+        `${summary.totals.negative}- · ${totalClusters} gap cluster(s)${clusterSplit}`,
     );
   }
   out(`  rejections      ${Object.keys(rejections.entries).length} remembered`);

--- a/src/fold.js
+++ b/src/fold.js
@@ -174,8 +174,8 @@ export function foldEvidence(
   const gaps = proposalClusters
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
-  const excludedMixedGaps = decided
-    .filter((cluster) => cluster.majorityOrchestration && cluster.mixed && cluster.sessions >= minGapEvidence)
+  const reportOnlyGaps = decided
+    .filter((cluster) => cluster.mixed && (cluster.majorityOrchestration || cluster.sessions < minGapEvidence))
     .sort((a, b) => b.sessions - a.sessions);
 
   const droppedGapSingletons = proposalClusters.length - gaps.length;
@@ -201,7 +201,8 @@ export function foldEvidence(
     instructions: instructionRows,
     gaps,
     crossSurfaceDuplicates: duplicates,
-    excludedMixedGaps,
+    reportOnlyGaps,
+    gapEligibilityEnforced: true,
   };
 }
 
@@ -299,6 +300,14 @@ function failedTriggerOf(items, minGapEvidence) {
 
 /** Compact rendering of the folded evidence for the synthesis prompt. */
 export function renderEvidenceForPrompt(summary) {
+  return renderEvidence(summary);
+}
+
+export function renderEvidenceReport(summary) {
+  return renderEvidence(summary);
+}
+
+function renderEvidence(summary) {
   const lines = [];
 
   const mix = summary.analyzedByInteraction;
@@ -352,7 +361,7 @@ export function renderEvidenceForPrompt(summary) {
   }
 
   lines.push("");
-  lines.push("### Gap clusters (mistakes no current instruction covers)");
+  lines.push("### Synthesis-eligible gap clusters (mistakes no current instruction covers)");
   if (summary.totals.orchestrationGapSightings) {
     lines.push(
       `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) counted as domain ` +
@@ -360,12 +369,9 @@ export function renderEvidenceForPrompt(summary) {
         `as their own instruction`,
     );
   }
-  for (const gap of summary.excludedMixedGaps || []) {
-    lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
-  }
   if (!summary.gaps.length) {
     lines.push(
-      summary.excludedMixedGaps?.length
+      summary.reportOnlyGaps?.length
         ? "- no gap cluster is eligible for a repository proposal"
         : "- none above the evidence threshold",
     );
@@ -381,6 +387,14 @@ export function renderEvidenceForPrompt(summary) {
     }
     for (const quote of gap.quotes.slice(0, 3)) {
       lines.push(`    "${oneLine(quote.text)}" (${quote.source})`);
+    }
+  }
+
+  if (summary.reportOnlyGaps?.length) {
+    lines.push("");
+    lines.push("### Report-only mixed gap clusters (mechanically ineligible for synthesis)");
+    for (const gap of summary.reportOnlyGaps) {
+      lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     }
   }
 

--- a/src/fold.js
+++ b/src/fold.js
@@ -175,12 +175,14 @@ export function foldEvidence(
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
   const reportOnlyGaps = decided
-    .filter((cluster) => cluster.majorityOrchestration || (cluster.mixed && cluster.sessions < minGapEvidence))
+    .filter((cluster) =>
+      cluster.mixed
+        ? cluster.majorityOrchestration || cluster.sessions < minGapEvidence
+        : cluster.majorityOrchestration && cluster.sessions >= minGapEvidence,
+    )
     .sort((a, b) => b.sessions - a.sessions);
 
-  const droppedGapSingletons = proposalClusters.filter(
-    (cluster) => cluster.sessions < minGapEvidence && !cluster.mixed,
-  ).length;
+  const droppedGapSingletons = decided.filter((cluster) => cluster.sessions < minGapEvidence && !cluster.mixed).length;
 
   return {
     version: 1,

--- a/src/fold.js
+++ b/src/fold.js
@@ -306,14 +306,15 @@ function failedTriggerOf(items, minGapEvidence) {
 
 /** Compact rendering of the folded evidence for the synthesis prompt. */
 export function renderEvidenceForPrompt(summary) {
-  return renderEvidence(summary);
+  return renderEvidence(summary, { includeReportOnly: false });
 }
 
+/** Full evidence report, including diagnostics that must never reach synthesis. */
 export function renderEvidenceReport(summary) {
-  return renderEvidence(summary);
+  return renderEvidence(summary, { includeReportOnly: true });
 }
 
-function renderEvidence(summary) {
+function renderEvidence(summary, { includeReportOnly }) {
   const lines = [];
 
   const mix = summary.analyzedByInteraction;
@@ -399,10 +400,9 @@ function renderEvidence(summary) {
     }
   }
 
-  if (summary.reportOnlyGaps?.length) {
+  if (includeReportOnly && summary.reportOnlyGaps?.length) {
     lines.push("");
     lines.push("### REPORT ONLY - not synthesis-eligible evidence");
-    lines.push("Do not create or justify proposals from these diagnostic clusters.");
     for (const gap of summary.reportOnlyGaps) {
       lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     }

--- a/src/fold.js
+++ b/src/fold.js
@@ -178,7 +178,9 @@ export function foldEvidence(
     .filter((cluster) => cluster.mixed && (cluster.majorityOrchestration || cluster.sessions < minGapEvidence))
     .sort((a, b) => b.sessions - a.sessions);
 
-  const droppedGapSingletons = proposalClusters.length - gaps.length;
+  const droppedGapSingletons = proposalClusters.filter(
+    (cluster) => cluster.sessions < minGapEvidence && !cluster.mixed,
+  ).length;
 
   return {
     version: 1,

--- a/src/fold.js
+++ b/src/fold.js
@@ -193,6 +193,7 @@ export function foldEvidence(
       // per-sighting votes; cluster domain is decided after grouping.
       gapSightings: allObservations.length,
       gapClusters: gaps.length,
+      reportOnlyGapClusters: reportOnlyGaps.length,
       droppedGapSingletons,
       orchestrationGapSightings,
       usedRawTranscript: usedRawCount,
@@ -313,9 +314,12 @@ function renderEvidence(summary) {
   const mix = summary.analyzedByInteraction;
   const mixBit = mix ? ` (interactive ${mix[INTERACTIVE] || 0} · non-interactive ${mix[NON_INTERACTIVE] || 0})` : "";
   lines.push(`Sessions analyzed: ${summary.analyzedSessions}${mixBit}`);
+  const reportOnlyGapClusters = summary.totals.reportOnlyGapClusters || 0;
+  const totalGapClusters = summary.totals.gapClusters + reportOnlyGapClusters;
   lines.push(
     `Totals: ${summary.totals.positive} positive, ${summary.totals.negative} negative, ` +
-      `${summary.totals.gapClusters} gap clusters (${summary.totals.droppedGapSingletons} singletons dropped below threshold)`,
+      `${totalGapClusters} gap clusters (${summary.totals.gapClusters} synthesis eligible, ` +
+      `${reportOnlyGapClusters} report only, ${summary.totals.droppedGapSingletons} singletons dropped below threshold)`,
   );
   lines.push("");
   lines.push("### Per-instruction evidence");

--- a/src/fold.js
+++ b/src/fold.js
@@ -21,11 +21,13 @@ import { crossSurfaceDuplicates } from "./overlap.js";
  *     ledger); the clustering here stays deterministic. Per-sighting `domain` votes
  *     travel with the cluster; the fold decides the cluster domain after grouping
  *     (majority orchestration is excluded from proposals; mixed clusters stay visible).
- *  3. Gap clusters below `minGapEvidence` are dropped. Batch size > 1: one bad session
- *     never rewrites the weights. Sessions are counted across runs, not per run: when the
- *     caller passes `gapObservations` (the pruned gap ledger, `src/gap-ledger.js`) the
- *     clusters are built from those instead of this run's records, so a gap seen once now
- *     and once on a later run graduates. Without a ledger the records alone are used.
+ *  3. Gap clusters below `minGapEvidence` are ineligible for synthesis. Mixed-domain
+ *     clusters remain visible as report-only diagnostics; other under-floor clusters are
+ *     dropped. Batch size > 1 means one bad session never rewrites the weights. Sessions
+ *     are counted across runs, not per run: when the caller passes `gapObservations` (the
+ *     pruned gap ledger, `src/gap-ledger.js`) the clusters are built from those instead of
+ *     this run's records, so a gap seen once now and once on a later run graduates. Without
+ *     a ledger the records alone are used.
  *  4. Memory-file units whose text substantially overlaps a skill description or body are
  *     flagged (`crossSurfaceDuplicates` in `src/overlap.js`). Description overlap exposes
  *     duplicated always-loaded tokens; body overlap is placement evidence because skill

--- a/src/fold.js
+++ b/src/fold.js
@@ -175,7 +175,7 @@ export function foldEvidence(
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
   const reportOnlyGaps = decided
-    .filter((cluster) => cluster.mixed && (cluster.majorityOrchestration || cluster.sessions < minGapEvidence))
+    .filter((cluster) => cluster.majorityOrchestration || (cluster.mixed && cluster.sessions < minGapEvidence))
     .sort((a, b) => b.sessions - a.sessions);
 
   const droppedGapSingletons = proposalClusters.filter(
@@ -410,7 +410,7 @@ function renderEvidence(summary) {
 function gapSessionLabel(gap) {
   const orch = gap.orchestrationSightings || 0;
   if (!orch) return `sessions=${gap.sessions}`;
-  const extra = gap.majorityOrchestration ? "; majority vote excluded" : "";
+  const extra = gap.majorityOrchestration ? "; domain excluded by majority vote" : "";
   return `sessions=${gap.sessions} (${gap.sessions} sightings, ${orch} orchestration${extra})`;
 }
 

--- a/src/fold.js
+++ b/src/fold.js
@@ -18,8 +18,9 @@ import { crossSurfaceDuplicates } from "./overlap.js";
  *  2. Near-duplicate gaps from different sessions are clustered, so "three sessions
  *     re-derived the db schema" arrives as one item with three quotes. Judged identity
  *     happens upstream (analysis citations and the consolidation pass reshape the
- *     ledger); the clustering here stays deterministic. Orchestration-domain sightings
- *     are excluded before clustering and surfaced only as a count.
+ *     ledger); the clustering here stays deterministic. Per-sighting `domain` votes
+ *     travel with the cluster; the fold decides the cluster domain after grouping
+ *     (majority orchestration is excluded from proposals; mixed clusters stay visible).
  *  3. Gap clusters below `minGapEvidence` are dropped. Batch size > 1: one bad session
  *     never rewrites the weights. Sessions are counted across runs, not per run: when the
  *     caller passes `gapObservations` (the pruned gap ledger, `src/gap-ledger.js`) the
@@ -108,14 +109,15 @@ export function foldEvidence(
     }
   }
 
-  // Orchestration-domain sightings are mistakes caused not by this repository but by the
-  // external agent harness or tooling that orchestrated the session; they are counted for
-  // legibility but never cluster, so they can never corroborate into a project proposal.
+  // Orchestration-domain votes are mistakes caused not by this repository but by the
+  // external agent harness or tooling that orchestrated the session. They still cluster
+  // with project sightings of the same gap; a cluster is withheld from proposals only
+  // when a majority of its sightings vote orchestration. Mixed clusters stay visible
+  // so one inconsistent classifier call cannot drop a real recurrence below the floor.
   const allObservations = gapObservations ?? recordObservations;
-  const projectObservations = allObservations.filter((obs) => obs?.domain !== "orchestration");
-  const orchestrationGapSightings = allObservations.length - projectObservations.length;
+  const orchestrationGapSightings = allObservations.filter((obs) => obs?.domain === "orchestration").length;
 
-  const gapClusters = clusterGapObservations(projectObservations);
+  const gapClusters = clusterGapObservations(allObservations);
 
   // Instructions that exist in the file but drew no evidence at all are the strongest
   // removal / extraction candidates, so they must appear in the summary too.
@@ -154,18 +156,29 @@ export function foldEvidence(
     })
     .sort((a, b) => b.negative - a.negative || b.sessions - a.sessions || a.instruction.localeCompare(b.instruction));
 
-  const gaps = gapClusters
-    .map((cluster) => ({
+  const decided = gapClusters.map((cluster) => {
+    const vote = clusterDomainVote(cluster.items);
+    return {
       proposedInstruction: cluster.proposedInstruction,
       sessions: cluster.sessions.size,
       recurrenceRisk: highestRisk(cluster.items),
       quotes: cluster.items.slice(0, 6).map((i) => ({ text: i.quote, effect: i.mistake, source: i.source })),
+      orchestrationSightings: vote.orchestrationSightings,
+      mixed: vote.mixed,
+      majorityOrchestration: vote.majorityOrchestration,
       ...failedTriggerOf(cluster.items, minGapEvidence),
-    }))
+    };
+  });
+
+  const proposalClusters = decided.filter((cluster) => !cluster.majorityOrchestration);
+  const gaps = proposalClusters
     .filter((cluster) => cluster.sessions >= minGapEvidence)
     .sort((a, b) => b.sessions - a.sessions);
+  const excludedMixedGaps = decided
+    .filter((cluster) => cluster.majorityOrchestration && cluster.mixed && cluster.sessions >= minGapEvidence)
+    .sort((a, b) => b.sessions - a.sessions);
 
-  const droppedGapSingletons = gapClusters.length - gaps.length;
+  const droppedGapSingletons = proposalClusters.length - gaps.length;
 
   return {
     version: 1,
@@ -176,8 +189,8 @@ export function foldEvidence(
       positive: positiveCount,
       negative: negativeCount,
       // The gap funnel's top: every sighting this fold clustered over (the pruned ledger
-      // when one is passed, this run's records otherwise). Orchestration sightings are the
-      // slice excluded before clustering; project-domain is the difference.
+      // when one is passed, this run's records otherwise). Orchestration sightings are
+      // per-sighting votes; cluster domain is decided after grouping.
       gapSightings: allObservations.length,
       gapClusters: gaps.length,
       droppedGapSingletons,
@@ -188,6 +201,7 @@ export function foldEvidence(
     instructions: instructionRows,
     gaps,
     crossSurfaceDuplicates: duplicates,
+    excludedMixedGaps,
   };
 }
 
@@ -208,12 +222,17 @@ export function clusterGapObservations(observations) {
       recurrenceRisk: obs.recurrenceRisk,
       source: obs.source,
       sessionId: obs.sessionId,
+      domain: observationDomain(obs),
       coveredBySkills: new Set(obs.coveredBySkill ? [obs.coveredBySkill] : []),
     };
     if (cluster) {
       const sessionItem = cluster.items.find((candidate) => candidate.sessionId === obs.sessionId);
       if (sessionItem) {
         if (obs.coveredBySkill) sessionItem.coveredBySkills.add(obs.coveredBySkill);
+        // One session, one vote: a project classification from the same session
+        // keeps the cluster eligible rather than letting a later orchestration
+        // label silently win.
+        if (observationDomain(obs) !== "orchestration") sessionItem.domain = "project";
       } else {
         cluster.items.push(item);
       }
@@ -231,6 +250,24 @@ export function clusterGapObservations(observations) {
     }
   }
   return clusters;
+}
+
+function observationDomain(obs) {
+  return obs?.domain === "orchestration" ? "orchestration" : "project";
+}
+
+/**
+ * Cluster domain is a majority of per-sighting votes, not a pre-filter. Ties (including
+ * 1 of 2) stay project so one inconsistent analysis call cannot kill a real recurrence.
+ */
+function clusterDomainVote(items) {
+  const orchestrationSightings = items.filter((item) => item.domain === "orchestration").length;
+  const sightings = items.length;
+  return {
+    orchestrationSightings,
+    mixed: orchestrationSightings > 0 && orchestrationSightings < sightings,
+    majorityOrchestration: sightings > 0 && orchestrationSightings * 2 > sightings,
+  };
 }
 
 function highestRisk(items) {
@@ -318,15 +355,19 @@ export function renderEvidenceForPrompt(summary) {
   lines.push("### Gap clusters (mistakes no current instruction covers)");
   if (summary.totals.orchestrationGapSightings) {
     lines.push(
-      `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) caused by the ` +
-        `orchestrating harness or tooling were excluded; they never enter this repository's memory file`,
+      `- ${summary.totals.orchestrationGapSightings} orchestration-domain sighting(s) counted as domain ` +
+        `votes (clusters excluded only on a majority vote); they never enter this repository's memory file ` +
+        `as their own instruction`,
     );
+  }
+  for (const gap of summary.excludedMixedGaps || []) {
+    lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
   }
   if (!summary.gaps.length) {
     lines.push("- none above the evidence threshold");
   }
   for (const gap of summary.gaps) {
-    lines.push(`- sessions=${gap.sessions} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
+    lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     if (gap.failedTriggerSkill) {
       lines.push(
         `    FAILED TRIGGER: the existing skill "${gap.failedTriggerSkill}" already covers this ` +
@@ -340,6 +381,13 @@ export function renderEvidenceForPrompt(summary) {
   }
 
   return lines.join("\n");
+}
+
+function gapSessionLabel(gap) {
+  const orch = gap.orchestrationSightings || 0;
+  if (!orch) return `sessions=${gap.sessions}`;
+  const extra = gap.majorityOrchestration ? "; majority vote excluded" : "";
+  return `sessions=${gap.sessions} (${gap.sessions} sightings, ${orch} orchestration${extra})`;
 }
 
 function oneLine(text, max = 240) {

--- a/src/fold.js
+++ b/src/fold.js
@@ -364,7 +364,11 @@ export function renderEvidenceForPrompt(summary) {
     lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
   }
   if (!summary.gaps.length) {
-    lines.push("- none above the evidence threshold");
+    lines.push(
+      summary.excludedMixedGaps?.length
+        ? "- no gap cluster is eligible for a repository proposal"
+        : "- none above the evidence threshold",
+    );
   }
   for (const gap of summary.gaps) {
     lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);

--- a/src/fold.js
+++ b/src/fold.js
@@ -205,7 +205,6 @@ export function foldEvidence(
     gaps,
     crossSurfaceDuplicates: duplicates,
     reportOnlyGaps,
-    gapEligibilityEnforced: true,
   };
 }
 
@@ -398,7 +397,8 @@ function renderEvidence(summary) {
 
   if (summary.reportOnlyGaps?.length) {
     lines.push("");
-    lines.push("### Report-only mixed gap clusters (mechanically ineligible for synthesis)");
+    lines.push("### REPORT ONLY - not synthesis-eligible evidence");
+    lines.push("Do not create or justify proposals from these diagnostic clusters.");
     for (const gap of summary.reportOnlyGaps) {
       lines.push(`- ${gapSessionLabel(gap)} risk=${gap.recurrenceRisk} :: ${gap.proposedInstruction}`);
     }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -309,6 +309,7 @@ export function mergeGapEntries(ledger, groups) {
           const earlier =
             Date.parse(obs.firstObservedAt || obs.observedAt) < Date.parse(prior.firstObservedAt || prior.observedAt);
           if (earlier) prior.firstObservedAt = obs.firstObservedAt || obs.observedAt;
+          if (prior.domain === "orchestration" && obs.domain !== "orchestration") prior.domain = "project";
           if (!prior.coveredBySkill && obs.coveredBySkill) prior.coveredBySkill = obs.coveredBySkill;
         }
       }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -30,9 +30,10 @@ import { sha256 } from "./state.js";
  *  - Every observation carries the `domain` the analysis judged: `orchestration` when the
  *    mistake was not caused by this repository but by an external agent harness or tooling
  *    that orchestrated the task, `project` for every other mistake.
- *    Orchestration sightings are recorded for legibility but never counted toward
- *    corroboration and never surface in a proposal; a missing domain counts as project,
- *    so evidence from before the field existed keeps its old behavior.
+ *    Each observation stores that vote. The fold clusters first and decides domain
+ *    afterward (majority orchestration withholds a cluster from proposals; a mixed
+ *    cluster stays visible). A missing domain counts as project, so evidence from
+ *    before the field existed keeps its old behavior.
  *  - Sessions are keyed by canonical transcript identity (with the legacy id as a fallback),
  *    so re-analyzing or re-sampling the same source session overwrites its observation and
  *    never adds a count. Persisted observations only contribute when that identity belongs

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -132,17 +132,6 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-function reportOnlyEvidence(edit, summary) {
-  if (summary?.gapEligibilityEnforced !== true) return null;
-  for (const gap of summary.reportOnlyGaps || []) {
-    const cited = edit.evidence.find((evidence) =>
-      (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
-    );
-    if (cited) return gap;
-  }
-  return null;
-}
-
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
 function unrecoveredRemovedLines(hunk, lineCounts) {
   const missing = [];
@@ -513,13 +502,6 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    const excludedGap = reportOnlyEvidence(edit, summary);
-    if (excludedGap) {
-      violations.push(
-        `edit ${edit.id} ("${edit.title}") cites the report-only gap "${excludedGap.proposedInstruction}"`,
-      );
-      continue;
-    }
     if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,6 +1,6 @@
 import { renderHunkLines } from "./diff.js";
 import { mixFromCounts } from "./interaction.js";
-import { memoryTextHash, similarity } from "./memory.js";
+import { memoryTextHash, parseMemoryUnits, similarity } from "./memory.js";
 import { GAP_SIMILARITY_THRESHOLD } from "./gap-ledger.js";
 import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
@@ -133,33 +133,49 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-function insertedCandidates(hunks) {
-  const lines = hunks
-    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text.trim()))
-    .filter(Boolean);
-  return [...lines, lines.join("\n")].filter(Boolean);
+function changedUnits(hunk, type) {
+  const text = (hunk.lines || [])
+    .filter((line) => line.type === type)
+    .map((line) => line.text)
+    .join("\n");
+  return parseMemoryUnits(text).map((unit) => unit.text);
 }
 
-function matchesInsertedGap(hunks, gap) {
-  return insertedCandidates(hunks).some(
-    (inserted) => similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD,
-  );
-}
-
-function reportOnlyGapForInsertion(hunks, summary) {
-  if (summary?.gapEligibilityEnforced !== true) return null;
-  return (summary.reportOnlyGaps || []).find((gap) => matchesInsertedGap(hunks, gap));
-}
-
-function eligibleGapForAddition(edit, hunks, summary) {
-  if (summary?.gapEligibilityEnforced !== true) return true;
+function eligibleGapForUnit(edit, unit, summary) {
   return (summary.gaps || []).find(
     (gap) =>
-      matchesInsertedGap(hunks, gap) &&
+      similarity(unit, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
       edit.evidence.some((evidence) =>
         (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
       ),
   );
+}
+
+function unsupportedNetNewUnit(edit, hunks, summary) {
+  if (summary?.gapEligibilityEnforced !== true) return null;
+  for (const hunk of hunks) {
+    const removed = changedUnits(hunk, "del");
+    const inserted = changedUnits(hunk, "ins");
+    if (inserted.length <= removed.length) continue;
+    const unmatchedRemoved = [...removed];
+    for (const unit of inserted) {
+      let bestIndex = -1;
+      let bestScore = 0;
+      for (let index = 0; index < unmatchedRemoved.length; index += 1) {
+        const score = similarity(unit, unmatchedRemoved[index]);
+        if (score > bestScore) {
+          bestIndex = index;
+          bestScore = score;
+        }
+      }
+      if (bestScore >= GAP_SIMILARITY_THRESHOLD) {
+        unmatchedRemoved.splice(bestIndex, 1);
+      } else if (!eligibleGapForUnit(edit, unit, summary)) {
+        return unit;
+      }
+    }
+  }
+  return null;
 }
 
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
@@ -532,10 +548,10 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    const reportOnlyGap = preservesAlwaysLoaded(edit.kind) ? null : reportOnlyGapForInsertion(hunks, summary);
-    if (reportOnlyGap) {
+    const unsupportedAddition = preservesAlwaysLoaded(edit.kind) ? null : unsupportedNetNewUnit(edit, hunks, summary);
+    if (unsupportedAddition) {
       violations.push(
-        `edit ${edit.id} ("${edit.title}") inserts the report-only gap "${reportOnlyGap.proposedInstruction}"`,
+        `edit ${edit.id} ("${edit.title}") adds "${unsupportedAddition.slice(0, 120)}", which does not match any synthesis-eligible gap and its evidence`,
       );
       continue;
     }
@@ -543,12 +559,6 @@ export function buildProposal(rawResult, context) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
-      );
-      continue;
-    }
-    if (edit.kind !== "extract" && onlyAdds && !eligibleGapForAddition(edit, hunks, summary)) {
-      violations.push(
-        `edit ${edit.id} ("${edit.title}") adds a new instruction that does not match any synthesis-eligible gap and its evidence`,
       );
       continue;
     }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -133,14 +133,29 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
+function insertedCandidates(hunks) {
+  const lines = hunks
+    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text.trim()))
+    .filter(Boolean);
+  return [...lines, lines.join("\n")].filter(Boolean);
+}
+
+function matchesInsertedGap(hunks, gap) {
+  return insertedCandidates(hunks).some(
+    (inserted) => similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD,
+  );
+}
+
+function reportOnlyGapForInsertion(hunks, summary) {
+  if (summary?.gapEligibilityEnforced !== true) return null;
+  return (summary.reportOnlyGaps || []).find((gap) => matchesInsertedGap(hunks, gap));
+}
+
 function eligibleGapForAddition(edit, hunks, summary) {
   if (summary?.gapEligibilityEnforced !== true) return true;
-  const inserted = hunks
-    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text))
-    .join("\n");
   return (summary.gaps || []).find(
     (gap) =>
-      similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
+      matchesInsertedGap(hunks, gap) &&
       edit.evidence.some((evidence) =>
         (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
       ),
@@ -517,6 +532,13 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
+    const reportOnlyGap = preservesAlwaysLoaded(edit.kind) ? null : reportOnlyGapForInsertion(hunks, summary);
+    if (reportOnlyGap) {
+      violations.push(
+        `edit ${edit.id} ("${edit.title}") inserts the report-only gap "${reportOnlyGap.proposedInstruction}"`,
+      );
+      continue;
+    }
     if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -707,10 +707,10 @@ export function buildProposal(rawResult, context) {
       positive: summary?.totals?.positive ?? 0,
       negative: summary?.totals?.negative ?? 0,
       gapClusters: summary?.totals?.gapClusters ?? 0,
-      // The gap funnel, for the apply surface: sightings -> project-domain (sightings
-      // minus orchestration) -> distinct gaps (clusters + dropped) -> eligible
-      // (clusters). `null`, never 0, when the summary predates a count - the surface
-      // hides what was not recorded rather than showing an invented zero.
+      // Gap counts retained for the apply surface: all sightings, orchestration-domain
+      // votes, synthesis-eligible clusters, and clusters dropped below the evidence floor.
+      // `null`, never 0, when the summary predates a count - the surface hides what was
+      // not recorded rather than showing an invented zero.
       gapSightings: summary?.totals?.gapSightings ?? null,
       orchestrationGapSightings: summary?.totals?.orchestrationGapSightings ?? null,
       droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -707,12 +707,13 @@ export function buildProposal(rawResult, context) {
       positive: summary?.totals?.positive ?? 0,
       negative: summary?.totals?.negative ?? 0,
       gapClusters: summary?.totals?.gapClusters ?? 0,
-      // Gap counts retained for the apply surface: all sightings, orchestration-domain
-      // votes, synthesis-eligible clusters, and clusters dropped below the evidence floor.
+      // Gap counts retained for the apply surface: all sightings, synthesis-eligible
+      // clusters, report-only clusters, and clusters dropped below the evidence floor.
       // `null`, never 0, when the summary predates a count - the surface hides what was
       // not recorded rather than showing an invented zero.
       gapSightings: summary?.totals?.gapSightings ?? null,
       orchestrationGapSightings: summary?.totals?.orchestrationGapSightings ?? null,
+      reportOnlyGapClusters: summary?.totals?.reportOnlyGapClusters ?? null,
       droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,
       skillExtractions: accepted.reduce((n, e) => {
         if (e.kind !== "extract") return n;

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,7 +1,6 @@
 import { renderHunkLines } from "./diff.js";
 import { mixFromCounts } from "./interaction.js";
-import { memoryTextHash, parseMemoryUnits, similarity } from "./memory.js";
-import { GAP_SIMILARITY_THRESHOLD } from "./gap-ledger.js";
+import { memoryTextHash } from "./memory.js";
 import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
@@ -133,47 +132,13 @@ function countSources(evidence) {
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
 }
 
-function changedUnits(hunk, type) {
-  const text = (hunk.lines || [])
-    .filter((line) => line.type === type)
-    .map((line) => line.text)
-    .join("\n");
-  return parseMemoryUnits(text).map((unit) => unit.text);
-}
-
-function eligibleGapForUnit(edit, unit, summary) {
-  return (summary.gaps || []).find(
-    (gap) =>
-      similarity(unit, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
-      edit.evidence.some((evidence) =>
-        (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
-      ),
-  );
-}
-
-function unsupportedNetNewUnit(edit, hunks, summary) {
+function reportOnlyEvidence(edit, summary) {
   if (summary?.gapEligibilityEnforced !== true) return null;
-  for (const hunk of hunks) {
-    const removed = changedUnits(hunk, "del");
-    const inserted = changedUnits(hunk, "ins");
-    if (inserted.length <= removed.length) continue;
-    const unmatchedRemoved = [...removed];
-    for (const unit of inserted) {
-      let bestIndex = -1;
-      let bestScore = 0;
-      for (let index = 0; index < unmatchedRemoved.length; index += 1) {
-        const score = similarity(unit, unmatchedRemoved[index]);
-        if (score > bestScore) {
-          bestIndex = index;
-          bestScore = score;
-        }
-      }
-      if (bestScore >= GAP_SIMILARITY_THRESHOLD) {
-        unmatchedRemoved.splice(bestIndex, 1);
-      } else if (!eligibleGapForUnit(edit, unit, summary)) {
-        return unit;
-      }
-    }
+  for (const gap of summary.reportOnlyGaps || []) {
+    const cited = edit.evidence.find((evidence) =>
+      (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
+    );
+    if (cited) return gap;
   }
   return null;
 }
@@ -548,10 +513,10 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    const unsupportedAddition = preservesAlwaysLoaded(edit.kind) ? null : unsupportedNetNewUnit(edit, hunks, summary);
-    if (unsupportedAddition) {
+    const excludedGap = reportOnlyEvidence(edit, summary);
+    if (excludedGap) {
       violations.push(
-        `edit ${edit.id} ("${edit.title}") adds "${unsupportedAddition.slice(0, 120)}", which does not match any synthesis-eligible gap and its evidence`,
+        `edit ${edit.id} ("${edit.title}") cites the report-only gap "${excludedGap.proposedInstruction}"`,
       );
       continue;
     }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,6 +1,7 @@
 import { renderHunkLines } from "./diff.js";
 import { mixFromCounts } from "./interaction.js";
-import { memoryTextHash } from "./memory.js";
+import { memoryTextHash, similarity } from "./memory.js";
+import { GAP_SIMILARITY_THRESHOLD } from "./gap-ledger.js";
 import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
@@ -130,6 +131,20 @@ function normalizeEvidence(evidence) {
 function countSources(evidence) {
   if (!Array.isArray(evidence)) return 0;
   return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
+}
+
+function eligibleGapForAddition(edit, hunks, summary) {
+  if (summary?.gapEligibilityEnforced !== true) return true;
+  const inserted = hunks
+    .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "ins").map((line) => line.text))
+    .join("\n");
+  return (summary.gaps || []).find(
+    (gap) =>
+      similarity(inserted, gap.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD &&
+      edit.evidence.some((evidence) =>
+        (gap.quotes || []).some((quote) => evidence.text === quote.text && evidence.source === quote.source),
+      ),
+  );
 }
 
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
@@ -506,6 +521,12 @@ export function buildProposal(rawResult, context) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
+      );
+      continue;
+    }
+    if (edit.kind !== "extract" && onlyAdds && !eligibleGapForAddition(edit, hunks, summary)) {
+      violations.push(
+        `edit ${edit.id} ("${edit.title}") adds a new instruction that does not match any synthesis-eligible gap and its evidence`,
       );
       continue;
     }

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -823,27 +823,26 @@
 
         // ---- run context: one frame, the gap funnel beside the run stats ----
         // A single bordered band. The left pane tells the gap story as proportional
-        // bars - sightings recorded by analysis -> project-domain (orchestration
-        // excluded) -> distinct gaps after clustering -> eligible to propose - with
-        // each drop-off explained in plain words. The right pane holds the run facts
-        // (edits, evidence, skills) as stat cells; a separate stat row would duplicate
-        // the funnel's last stage. Every count is recorded by the fold (`totals` in
+        // bars - sightings recorded by analysis -> distinct gaps after clustering ->
+        // eligible to propose - with each drop-off explained in plain words. Domain is
+        // voted after clustering, so orchestration sightings are not subtracted before
+        // the distinct-gap stage. The right pane holds the run facts (edits, evidence,
+        // skills) as stat cells. Every count is recorded by the fold (`totals` in
         // evidence-summary.json); a proposal saved before the counts existed falls
         // back to the classic stat row rather than showing zeros nobody measured.
         function funnelCounts() {
           if (typeof (P.stats || {}).gapSightings !== "number") return null;
           var eligible = P.stats.gapClusters || 0;
           var dropped = P.stats.droppedGapSingletons || 0;
-          var orch = P.stats.orchestrationGapSightings || 0;
-          var project = Math.max(0, P.stats.gapSightings - orch);
+          var reportOnly = P.stats.reportOnlyGapClusters || 0;
+          var distinct = eligible + reportOnly + dropped;
           return {
             floor: Number((P.config || {}).minGapEvidence) || 2,
             sighted: P.stats.gapSightings,
-            orch: orch,
-            project: project,
-            distinct: eligible + dropped,
-            merged: Math.max(0, project - (eligible + dropped)),
+            distinct: distinct,
+            merged: Math.max(0, P.stats.gapSightings - distinct),
             dropped: dropped,
+            reportOnly: reportOnly,
             eligible: eligible,
           };
         }
@@ -872,12 +871,6 @@
           funnelBar(bars, funnel.sighted, "sightings", funnel.sighted);
           funnelDrop(
             bars,
-            funnel.orch,
-            "orchestration: mistakes in how the task was run, not in this project - excluded from proposals by design",
-          );
-          funnelBar(bars, funnel.project, "project-domain", funnel.sighted);
-          funnelDrop(
-            bars,
             funnel.merged,
             "merged: repeat sightings of a gap already counted - they corroborate it rather than add a new one",
           );
@@ -888,6 +881,11 @@
             "below the corroboration floor: seen in fewer than " +
               funnel.floor +
               " sessions so far - more transcripts can corroborate them",
+          );
+          funnelDrop(
+            bars,
+            funnel.reportOnly,
+            "report only: mixed clusters below the floor or clusters excluded by a majority orchestration vote",
           );
           funnelBar(bars, funnel.eligible, "eligible to propose", funnel.sighted, true);
 
@@ -921,15 +919,12 @@
               funnel.floor +
               "-session corroboration floor - more transcripts may corroborate " +
               (funnel.dropped === 1 ? "it." : "them.");
-          } else if (!funnel.eligible && funnel.orch >= funnel.sighted) {
+          } else if (!funnel.eligible && funnel.reportOnly) {
             funnelNote =
-              "All " +
-              funnel.sighted +
-              " sighting" +
-              (funnel.sighted === 1 ? " was" : "s were") +
-              " orchestration-domain (caused by the orchestrating harness, not this repository) and " +
-              (funnel.sighted === 1 ? "is" : "are") +
-              " excluded by design.";
+              funnel.reportOnly +
+              " distinct gap cluster" +
+              (funnel.reportOnly === 1 ? " is" : "s are") +
+              " report only and excluded from proposals.";
           }
           if (funnelNote && !funnel.sighted) {
             var noteEl = document.getElementById("funnel-note");

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -47,7 +47,7 @@ const discoverNone = async () => ({ transcripts: [], perHarness: {} });
 const discoverTwo = async () => ({ transcripts: [transcript("s1"), transcript("s2")], perHarness: { claude: {} } });
 
 /** Stands in for the tier-1 model: every session reports the same gap against the starter. */
-function writeFakeEvidence({ transcripts, memoryFile, config, memoryHash }, domainAt = () => undefined) {
+function writeFakeEvidence({ transcripts, memoryFile, config, memoryHash }, domainAt = (_index) => undefined) {
   for (const [index, t] of transcripts.entries()) {
     config.state.writeEvidence(t.id, {
       status: "ok",

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -13,6 +13,8 @@ import { loadConfig } from "../src/config.js";
 import { UserError, setLoggerSink } from "../src/logger.js";
 import { isPointerTo, memorySetHash, memoryTextHash, parseMemoryUnits } from "../src/memory.js";
 import { State } from "../src/state.js";
+import { clearProgressSink, setProgressSink } from "../src/progress.js";
+import { ProposalViolation } from "../src/proposal.js";
 
 const CLI = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../bin/backpass");
 
@@ -45,8 +47,8 @@ const discoverNone = async () => ({ transcripts: [], perHarness: {} });
 const discoverTwo = async () => ({ transcripts: [transcript("s1"), transcript("s2")], perHarness: { claude: {} } });
 
 /** Stands in for the tier-1 model: every session reports the same gap against the starter. */
-function fakeAnalyze({ transcripts, memoryFile, config, memoryHash }) {
-  for (const t of transcripts) {
+function writeFakeEvidence({ transcripts, memoryFile, config, memoryHash }, domainAt = () => undefined) {
+  for (const [index, t] of transcripts.entries()) {
     config.state.writeEvidence(t.id, {
       status: "ok",
       transcript: {
@@ -66,11 +68,20 @@ function fakeAnalyze({ transcripts, memoryFile, config, memoryHash }) {
           proposedInstruction: "Run migrations only against a scratch database.",
           recurrenceRisk: "high",
           quote: "applied the migration to prod-db",
+          ...(domainAt(index) ? { domain: domainAt(index) } : {}),
         },
       ],
     });
   }
   return { total: transcripts.length, analyzed: transcripts.length, cached: 0, skipped: 0, failed: 0, usage: [] };
+}
+
+function fakeAnalyze(args) {
+  return writeFakeEvidence(args);
+}
+
+function fakeAnalyzeMixed(args) {
+  return writeFakeEvidence(args, (index) => (index === 1 ? "orchestration" : "project"));
 }
 
 /**
@@ -239,6 +250,28 @@ test("bootstrap analyzes and folds only the balanced capped sample", async () =>
   assert.deepEqual(captured.folded, captured.analyzed);
   assert.equal(captured.analyzed.filter((item) => item.interaction === "interactive").length, 2);
   assert.equal(captured.analyzed.filter((item) => item.interaction === "non-interactive").length, 98);
+});
+
+test("bootstrap progress counts a report-only mixed cluster once", async () => {
+  const repo = makeRepo();
+  const ctx = makeCtx(repo, { minGapEvidence: 3 });
+  const events = [];
+  setProgressSink((event, data) => events.push({ event, data }));
+  try {
+    await bootstrapRun(ctx, {
+      discover: discoverTwo,
+      analyze: fakeAnalyzeMixed,
+      synthesize: async () => {
+        throw new ProposalViolation("stop after fold", []);
+      },
+    });
+  } finally {
+    clearProgressSink();
+  }
+
+  const folded = events.find((entry) => entry.event === "fold:done");
+  assert.equal(folded.data.clustersFound, 1);
+  assert.equal(folded.data.clustersKept, 0);
 });
 
 test("with transcripts: analysis gaps become the first evidence-backed instruction", async () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { parseMemoryUnits } from "../src/memory.js";
 
 function record(id, overrides = {}) {
@@ -182,12 +182,40 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
     0,
     "a majority orchestration vote still withholds the cluster from a proposal",
   );
-  assert.equal(majorityOrch.excludedMixedGaps.length, 1);
-  assert.equal(majorityOrch.excludedMixedGaps[0].sessions, 3);
-  const renderedMajority = renderEvidenceForPrompt(majorityOrch);
+  assert.equal(majorityOrch.reportOnlyGaps.length, 1);
+  assert.equal(majorityOrch.reportOnlyGaps[0].sessions, 3);
+  const renderedMajority = renderEvidenceReport(majorityOrch);
   assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
+  assert.match(renderEvidenceForPrompt(majorityOrch), /Report-only mixed gap clusters/);
+});
+
+test("a below-threshold mixed cluster remains visible only in the report", () => {
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q1", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            quote: "q2",
+            recurrenceRisk: "high",
+            domain: "orchestration",
+          },
+        ],
+      }),
+    ],
+    { minGapEvidence: 3 },
+  );
+
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
+  assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -190,7 +190,7 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
-  assert.match(renderEvidenceForPrompt(majorityOrch), /Report-only mixed gap clusters/);
+  assert.match(renderEvidenceForPrompt(majorityOrch), /REPORT ONLY - not synthesis-eligible evidence/);
 });
 
 test("a below-threshold mixed cluster remains visible only in the report", () => {
@@ -219,7 +219,7 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
-  assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
+  assert.match(renderEvidenceForPrompt(summary), /REPORT ONLY - not synthesis-eligible evidence/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -187,7 +187,7 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   assert.equal(majorityOrch.totals.reportOnlyGapClusters, 1);
   const renderedMajority = renderEvidenceReport(majorityOrch);
   assert.match(renderedMajority, /1 gap clusters \(0 synthesis eligible, 1 report only/);
-  assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
+  assert.match(renderedMajority, /3 sightings, 2 orchestration; domain excluded by majority vote/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
   assert.match(renderEvidenceForPrompt(majorityOrch), /REPORT ONLY - not synthesis-eligible evidence/);

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -217,6 +217,7 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.gaps.length, 0);
   assert.equal(summary.reportOnlyGaps.length, 1);
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
+  assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
   assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
 });

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -184,7 +184,10 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   );
   assert.equal(majorityOrch.excludedMixedGaps.length, 1);
   assert.equal(majorityOrch.excludedMixedGaps[0].sessions, 3);
-  assert.match(renderEvidenceForPrompt(majorityOrch), /3 sightings, 2 orchestration; majority vote excluded/);
+  const renderedMajority = renderEvidenceForPrompt(majorityOrch);
+  assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
+  assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
+  assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -130,7 +130,11 @@ test("the fold records the sightings it clustered over - the gap funnel's top", 
   assert.equal(fromLedger.totals.gapSightings, 4);
   assert.equal(fromLedger.totals.orchestrationGapSightings, 1);
   assert.equal(fromLedger.totals.gapClusters, 1, "two sessions corroborate the lockfile gap");
-  assert.equal(fromLedger.totals.droppedGapSingletons, 1, "the schema gap stays below the floor");
+  assert.equal(
+    fromLedger.totals.droppedGapSingletons,
+    2,
+    "the schema and pure-orchestration gaps stay below the floor",
+  );
 });
 
 test("a two-sighting cluster with one orchestration vote survives instead of dropping below the floor", () => {
@@ -220,6 +224,31 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
   assert.match(renderEvidenceForPrompt(summary), /REPORT ONLY - not synthesis-eligible evidence/);
+});
+
+test("a pure orchestration singleton stays hidden below the evidence floor", () => {
+  const phrasing = "Stop after the report on scout tasks.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            quote: "q1",
+            recurrenceRisk: "low",
+            domain: "orchestration",
+          },
+        ],
+      }),
+    ],
+    { minGapEvidence: 2 },
+  );
+
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.reportOnlyGaps.length, 0);
+  assert.equal(summary.totals.reportOnlyGapClusters, 0);
+  assert.equal(summary.totals.droppedGapSingletons, 1);
+  assert.doesNotMatch(renderEvidenceForPrompt(summary), /Stop after the report/);
 });
 
 test("the same gap repeated inside one session does not clear the threshold", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -133,6 +133,60 @@ test("the fold records the sightings it clustered over - the gap funnel's top", 
   assert.equal(fromLedger.totals.droppedGapSingletons, 1, "the schema gap stays below the floor");
 });
 
+test("a two-sighting cluster with one orchestration vote survives instead of dropping below the floor", () => {
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        gaps: [{ proposedInstruction: phrasing, quote: "rewrote the tunnel", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            quote: "rewrote the tunnel again",
+            recurrenceRisk: "high",
+            domain: "orchestration",
+          },
+        ],
+      }),
+    ],
+    { minGapEvidence: 2 },
+  );
+
+  assert.equal(summary.gaps.length, 1, "one inconsistent orchestration vote cannot kill a two-session recurrence");
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(summary.gaps[0].orchestrationSightings, 1);
+  assert.equal(summary.gaps[0].mixed, true);
+  assert.equal(summary.gaps[0].majorityOrchestration, false);
+  assert.equal(summary.totals.orchestrationGapSightings, 1);
+  assert.equal(summary.totals.droppedGapSingletons, 0);
+  assert.match(renderEvidenceForPrompt(summary), /2 sightings, 1 orchestration/);
+
+  const majorityOrch = foldEvidence(
+    [
+      record("s1", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q1", recurrenceRisk: "low", domain: "orchestration" }],
+      }),
+      record("s2", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "low", domain: "orchestration" }],
+      }),
+      record("s3", {
+        gaps: [{ proposedInstruction: phrasing, quote: "q3", recurrenceRisk: "low" }],
+      }),
+    ],
+    { minGapEvidence: 2 },
+  );
+  assert.equal(
+    majorityOrch.gaps.length,
+    0,
+    "a majority orchestration vote still withholds the cluster from a proposal",
+  );
+  assert.equal(majorityOrch.excludedMixedGaps.length, 1);
+  assert.equal(majorityOrch.excludedMixedGaps[0].sessions, 3);
+  assert.match(renderEvidenceForPrompt(majorityOrch), /3 sightings, 2 orchestration; majority vote excluded/);
+});
+
 test("the same gap repeated inside one session does not clear the threshold", () => {
   const summary = foldEvidence(
     [

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -194,7 +194,7 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   assert.match(renderedMajority, /3 sightings, 2 orchestration; domain excluded by majority vote/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
-  assert.match(renderEvidenceForPrompt(majorityOrch), /REPORT ONLY - not synthesis-eligible evidence/);
+  assert.doesNotMatch(renderEvidenceForPrompt(majorityOrch), /Read docs\/sshhip\.md|REPORT ONLY/);
 });
 
 test("a below-threshold mixed cluster remains visible only in the report", () => {
@@ -223,7 +223,8 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.droppedGapSingletons, 0);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
-  assert.match(renderEvidenceForPrompt(summary), /REPORT ONLY - not synthesis-eligible evidence/);
+  assert.match(renderEvidenceReport(summary), /Read docs\/sshhip\.md/);
+  assert.doesNotMatch(renderEvidenceForPrompt(summary), /Read docs\/sshhip\.md|REPORT ONLY/);
 });
 
 test("a pure orchestration singleton stays hidden below the evidence floor", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -184,7 +184,9 @@ test("a two-sighting cluster with one orchestration vote survives instead of dro
   );
   assert.equal(majorityOrch.reportOnlyGaps.length, 1);
   assert.equal(majorityOrch.reportOnlyGaps[0].sessions, 3);
+  assert.equal(majorityOrch.totals.reportOnlyGapClusters, 1);
   const renderedMajority = renderEvidenceReport(majorityOrch);
+  assert.match(renderedMajority, /1 gap clusters \(0 synthesis eligible, 1 report only/);
   assert.match(renderedMajority, /3 sightings, 2 orchestration; majority vote excluded/);
   assert.match(renderedMajority, /no gap cluster is eligible for a repository proposal/);
   assert.doesNotMatch(renderedMajority, /none above the evidence threshold/);
@@ -214,6 +216,7 @@ test("a below-threshold mixed cluster remains visible only in the report", () =>
 
   assert.equal(summary.gaps.length, 0);
   assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.match(renderEvidenceReport(summary), /2 sightings, 1 orchestration/);
   assert.match(renderEvidenceForPrompt(summary), /Report-only mixed gap clusters/);
 });

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -18,9 +18,9 @@ import { renderEvidenceForPrompt } from "../src/fold.js";
  * the analysis prompt actually handed to the model states the causal test for
  * `orchestration` (the mistake was caused by the harness around the session, not by this
  * repository - except when this repository IS that tool, in which case those mistakes
- * are `project`), and the mechanics behind it are unchanged - orchestration sightings are
- * recorded and counted but never corroborate, while a gap with no domain at all is still
- * treated as `project`.
+ * are `project`), and the mechanics behind it: orchestration sightings are recorded as
+ * votes and a cluster is withheld from a proposal only on a majority vote, while a gap
+ * with no domain at all is still treated as `project`.
  */
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -225,7 +225,9 @@ test("an orchestration gap is counted but never corroborates, while a gap with n
   );
 
   const rendered = renderEvidenceForPrompt(summary);
-  assert.ok(!rendered.includes(ORCHESTRATION_GAP), "the orchestration gap never reaches the synthesis prompt");
+  const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
+  assert.ok(!eligibleEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap is not synthesis-eligible");
+  assert.ok(reportOnlyEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap remains visible as report-only");
   assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/, "the run stays legible about what it cut");
 
   const ledger = state.readGapLedger();

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -9,7 +9,7 @@ import { spawnSync } from "node:child_process";
 import { State } from "../src/state.js";
 import { resolveMemoryFiles } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
-import { renderEvidenceForPrompt } from "../src/fold.js";
+import { renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 
 /**
  * A gap's `domain` decides whether it can ever become an instruction, so this drives the
@@ -224,11 +224,11 @@ test("an orchestration gap is counted but never corroborates, while a gap with n
     "only the domain-less gap - counted as project - can reach a proposal",
   );
 
-  const rendered = renderEvidenceForPrompt(summary);
-  const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
-  assert.ok(!eligibleEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap is not synthesis-eligible");
-  assert.ok(reportOnlyEvidence.includes(ORCHESTRATION_GAP), "the orchestration gap remains visible as report-only");
-  assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/, "the run stays legible about what it cut");
+  const prompt = renderEvidenceForPrompt(summary);
+  assert.ok(!prompt.includes(ORCHESTRATION_GAP), "the orchestration gap never reaches synthesis");
+  const report = renderEvidenceReport(summary);
+  assert.ok(report.includes(ORCHESTRATION_GAP), "the orchestration gap remains visible as report-only");
+  assert.match(report, /2 orchestration-domain sighting\(s\).*excluded/, "the run stays legible about what it cut");
 
   const ledger = state.readGapLedger();
   const domains = Object.values(ledger.entries).map((entry) => Object.values(entry.sessions)[0].domain);

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -311,6 +311,30 @@ test("mergeGapEntries unions sessions without double-counting and keeps the shor
   assert.deepEqual(Object.keys(entries[0].sessions).sort(), ["s1", "s2", "shared"], "a session never counts twice");
 });
 
+test("mergeGapEntries reconciles conflicting domain votes without target-order bias", () => {
+  const orchestrationId = "a".repeat(16);
+  const projectId = "b".repeat(16);
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const ledger = ledgerWith(
+    { id: orchestrationId, text: `${phrasing} Carefully.`, sessions: ["orch-only", "shared"] },
+    { id: projectId, text: phrasing, sessions: ["project-only", "shared"] },
+  );
+  ledger.entries[orchestrationId].sessions["orch-only"].domain = "orchestration";
+  ledger.entries[orchestrationId].sessions.shared.domain = "orchestration";
+  ledger.entries[projectId].sessions["project-only"].domain = "project";
+  ledger.entries[projectId].sessions.shared.domain = "project";
+
+  mergeGapEntries(ledger, [[orchestrationId, projectId]]);
+  const summary = foldEvidence([], {
+    gapObservations: ledgerGapObservations(ledger, MEMORY_PATH),
+    minGapEvidence: 2,
+  });
+
+  assert.equal(summary.gaps.length, 1, "the chosen merge target cannot turn a conflicting vote into orchestration");
+  assert.equal(summary.gaps[0].sessions, 3);
+  assert.equal(summary.gaps[0].orchestrationSightings, 1);
+});
+
 test("mergeGapEntries preserves absorbed citations for duplicate sessions", () => {
   const targetId = "a".repeat(16);
   const absorbedId = "b".repeat(16);

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -7,7 +7,7 @@ import path from "node:path";
 import { State } from "../src/state.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
-import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import {
   gapEntryId,
   ledgerGapObservations,
@@ -255,10 +255,12 @@ test("orchestration-domain gaps are counted but never cluster into a proposal", 
   assert.equal(summary.reportOnlyGaps.length, 1);
   assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.orchestrationGapSightings, 2, "but the run stays legible about what it excluded");
-  const rendered = renderEvidenceForPrompt(summary);
-  assert.match(rendered, /1 gap clusters \(0 synthesis eligible, 1 report only/);
-  assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/);
-  assert.match(rendered, /2 sightings, 2 orchestration; domain excluded by majority vote/);
+  const prompt = renderEvidenceForPrompt(summary);
+  assert.doesNotMatch(prompt, /Stop after the report on scout tasks/);
+  const report = renderEvidenceReport(summary);
+  assert.match(report, /1 gap clusters \(0 synthesis eligible, 1 report only/);
+  assert.match(report, /2 orchestration-domain sighting\(s\).*excluded/);
+  assert.match(report, /2 sightings, 2 orchestration; domain excluded by majority vote/);
 
   // The same shape in the project domain clusters as usual - the exclusion is the
   // domain, not the text.

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -252,8 +252,13 @@ test("orchestration-domain gaps are counted but never cluster into a proposal", 
   const summary = await run(h, [record("claude-s1", [orchestration]), record("codex-s2", [orchestration])]);
 
   assert.equal(summary.gaps.length, 0, "two sessions corroborate it, and it still never becomes a proposal");
+  assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.equal(summary.totals.reportOnlyGapClusters, 1);
   assert.equal(summary.totals.orchestrationGapSightings, 2, "but the run stays legible about what it excluded");
-  assert.match(renderEvidenceForPrompt(summary), /2 orchestration-domain sighting\(s\).*excluded/);
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.match(rendered, /1 gap clusters \(0 synthesis eligible, 1 report only/);
+  assert.match(rendered, /2 orchestration-domain sighting\(s\).*excluded/);
+  assert.match(rendered, /2 sightings, 2 orchestration; domain excluded by majority vote/);
 
   // The same shape in the project domain clusters as usual - the exclusion is the
   // domain, not the text.

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -263,6 +263,20 @@ test("orchestration-domain gaps are counted but never cluster into a proposal", 
   assert.equal(clustered.gaps.length, 1);
 });
 
+test("a mixed two-sighting cluster with one orchestration vote still graduates", async () => {
+  const h = harness();
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const summary = await run(h, [
+    record("claude-s1", [{ proposedInstruction: phrasing, domain: "project" }]),
+    record("codex-s2", [{ proposedInstruction: phrasing, domain: "orchestration" }]),
+  ]);
+
+  assert.equal(summary.gaps.length, 1, "the cluster is not silently dropped below the two-session floor");
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(summary.gaps[0].orchestrationSightings, 1);
+  assert.match(renderEvidenceForPrompt(summary), /2 sightings, 1 orchestration/);
+});
+
 // ---------- consolidation-pass merges (the mechanical half) ----------
 
 function ledgerWith(...entries) {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -13,7 +13,7 @@ import {
   SHRINK_EDIT_TOKENS,
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
-import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
@@ -270,27 +270,13 @@ test("folded domain votes separate synthesis evidence from report-only diagnosti
     folded(["orchestration", "orchestration", "project"], 2),
     folded(["project", "orchestration"], 3),
   ]) {
-    const rendered = renderEvidenceForPrompt(summary);
-    const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
-    assert.doesNotMatch(eligibleEvidence, /Read docs\/sshhip\.md|quote [123]/);
-    assert.match(reportOnlyEvidence, /not synthesis-eligible evidence/);
-    assert.match(reportOnlyEvidence, /Do not create or justify proposals/);
-    assert.match(reportOnlyEvidence, /Read docs\/sshhip\.md/);
-    assert.doesNotMatch(reportOnlyEvidence, /quote [123]/);
+    const prompt = renderEvidenceForPrompt(summary);
+    assert.doesNotMatch(prompt, /Read docs\/sshhip\.md|quote [123]|REPORT ONLY/);
+    const report = renderEvidenceReport(summary);
+    assert.match(report, /REPORT ONLY - not synthesis-eligible evidence/);
+    assert.match(report, /Read docs\/sshhip\.md/);
+    assert.doesNotMatch(report, /quote [123]/);
   }
-
-  const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
-  const reportOnlyQuote = reportOnly.reportOnlyGaps[0].quotes[0];
-  const reportOnlyEvidence = [{ polarity: "negative", text: reportOnlyQuote.text, source: reportOnlyQuote.source }];
-  const unrelated = gate({
-    edit: memoryEdit((text) => text.replace("- Prefer small commits.", "- Prefer focused commits.")),
-    annotation: {
-      edits: [claim(["H1"], { kind: "rewrite", evidence: reportOnlyEvidence, transcripts: 3 })],
-    },
-    context: { summary: reportOnly },
-  });
-  assert.equal(unrelated.violations.length, 0);
-  assert.equal(unrelated.proposal.edits.length, 1);
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {
@@ -376,6 +362,7 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
           negative: 7,
           gapSightings: 9,
           gapClusters: 0,
+          reportOnlyGapClusters: 2,
           droppedGapSingletons: 3,
           orchestrationGapSightings: 6,
         },
@@ -388,6 +375,7 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   });
   assert.equal(funneled.proposal.stats.gapSightings, 9);
   assert.equal(funneled.proposal.stats.orchestrationGapSightings, 6);
+  assert.equal(funneled.proposal.stats.reportOnlyGapClusters, 2);
   assert.equal(funneled.proposal.stats.droppedGapSingletons, 3);
   assert.equal(funneled.proposal.stats.gapClusters, 0);
 
@@ -395,6 +383,7 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   const legacy = gate({ edit, annotation });
   assert.equal(legacy.proposal.stats.gapSightings, null);
   assert.equal(legacy.proposal.stats.orchestrationGapSightings, null);
+  assert.equal(legacy.proposal.stats.reportOnlyGapClusters, null);
   assert.equal(legacy.proposal.stats.droppedGapSingletons, null);
 });
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -13,6 +13,7 @@ import {
   SHRINK_EDIT_TOKENS,
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
+import { foldEvidence } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
@@ -212,6 +213,68 @@ test("an edit spanning several single-newline list items lands: find is measured
 });
 
 // ---------- evidence gates ----------
+
+test("folded domain votes mechanically control new-instruction eligibility", () => {
+  const phrasing = "Read docs/sshhip.md before changing the tunnel.";
+  const folded = (domains, minGapEvidence) =>
+    foldEvidence(
+      domains.map((domain, index) => ({
+        status: "ok",
+        transcript: {
+          id: `s${index + 1}`,
+          harness: "claude",
+          startedAt: Date.parse("2026-08-01T00:00:00Z"),
+        },
+        positive: [],
+        negative: [],
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            mistake: `mistake ${index + 1}`,
+            quote: `quote ${index + 1}`,
+            recurrenceRisk: "high",
+            domain,
+          },
+        ],
+      })),
+      { minGapEvidence },
+    );
+  const propose = (summary, minGapEvidence) => {
+    const displayed = summary.gaps[0] || summary.reportOnlyGaps[0];
+    const evidence = displayed.quotes.slice(0, 1).map((quote) => ({
+      polarity: "negative",
+      text: quote.text,
+      source: quote.source,
+    }));
+    return gate({
+      edit: memoryEdit((text) => `${text}- ${phrasing}\n`),
+      annotation: {
+        edits: [
+          claim(["H1"], {
+            kind: "add",
+            evidence,
+            transcripts: Math.max(displayed.sessions, minGapEvidence),
+          }),
+        ],
+      },
+      config: config({ minGapEvidence }),
+      context: { summary },
+    });
+  };
+
+  const eligible = propose(folded(["project", "orchestration"], 2), 2);
+  assert.equal(eligible.violations.length, 0);
+  assert.equal(eligible.proposal.edits.length, 1);
+
+  for (const [summary, minGapEvidence] of [
+    [folded(["orchestration", "orchestration", "project"], 2), 2],
+    [folded(["project", "orchestration"], 3), 3],
+  ]) {
+    const excluded = propose(summary, minGapEvidence);
+    assert.equal(excluded.proposal.edits.length, 0);
+    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+  }
+});
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {
   const lines = Array.from({ length: 6 }, (_, i) => `- Rule number ${i}.`);

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -13,7 +13,7 @@ import {
   SHRINK_EDIT_TOKENS,
   SHRINK_MAX_EDITS,
 } from "../src/proposal.js";
-import { foldEvidence } from "../src/fold.js";
+import { foldEvidence, renderEvidenceForPrompt } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
@@ -214,7 +214,7 @@ test("an edit spanning several single-newline list items lands: find is measured
 
 // ---------- evidence gates ----------
 
-test("folded domain votes mechanically control new-instruction eligibility", () => {
+test("folded domain votes separate synthesis evidence from report-only diagnostics", () => {
   const phrasing = "Read docs/sshhip.md before changing the tunnel.";
   const folded = (domains, minGapEvidence) =>
     foldEvidence(
@@ -266,37 +266,26 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   assert.equal(eligible.violations.length, 0);
   assert.equal(eligible.proposal.edits.length, 1);
 
-  for (const [summary, minGapEvidence] of [
-    [folded(["orchestration", "orchestration", "project"], 2), 2],
-    [folded(["project", "orchestration"], 3), 3],
+  for (const summary of [
+    folded(["orchestration", "orchestration", "project"], 2),
+    folded(["project", "orchestration"], 3),
   ]) {
-    const excluded = propose(summary, minGapEvidence);
-    assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /cites the report-only gap/.test(violation)));
+    const rendered = renderEvidenceForPrompt(summary);
+    const [eligibleEvidence, reportOnlyEvidence] = rendered.split("### REPORT ONLY");
+    assert.doesNotMatch(eligibleEvidence, /Read docs\/sshhip\.md|quote [123]/);
+    assert.match(reportOnlyEvidence, /not synthesis-eligible evidence/);
+    assert.match(reportOnlyEvidence, /Do not create or justify proposals/);
+    assert.match(reportOnlyEvidence, /Read docs\/sshhip\.md/);
+    assert.doesNotMatch(reportOnlyEvidence, /quote [123]/);
   }
 
   const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
   const reportOnlyQuote = reportOnly.reportOnlyGaps[0].quotes[0];
   const reportOnlyEvidence = [{ polarity: "negative", text: reportOnlyQuote.text, source: reportOnlyQuote.source }];
-  const rewritten = gate({
-    edit: memoryEdit((text) =>
-      text.replace(
-        "- Prefer small commits.\n- Use Node 18 via nvm before running any script.",
-        "- Prefer focused commits.\n- Consult the SSHHIP guide prior to tunnel edits.",
-      ),
-    ),
+  const unrelated = gate({
+    edit: memoryEdit((text) => text.replace("- Prefer small commits.", "- Prefer focused commits.")),
     annotation: {
       edits: [claim(["H1"], { kind: "rewrite", evidence: reportOnlyEvidence, transcripts: 3 })],
-    },
-    context: { summary: reportOnly },
-  });
-  assert.equal(rewritten.proposal.edits.length, 0);
-  assert.ok(rewritten.violations.some((violation) => /cites the report-only gap/.test(violation)));
-
-  const unrelated = gate({
-    edit: memoryEdit((text) => `${text}- Preserve build logs for failed releases.\n`),
-    annotation: {
-      edits: [claim(["H1"], { kind: "add", transcripts: 3 })],
     },
     context: { summary: reportOnly },
   });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -272,8 +272,19 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   ]) {
     const excluded = propose(summary, minGapEvidence);
     assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+    assert.ok(excluded.violations.some((violation) => /report-only gap/.test(violation)));
   }
+
+  const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
+  const rewritten = gate({
+    edit: memoryEdit((text) => text.replace("- Prefer small commits.", `- Prefer focused commits.\n- ${phrasing}`)),
+    annotation: {
+      edits: [claim(["H1"], { kind: "rewrite", transcripts: 3 })],
+    },
+    context: { summary: reportOnly },
+  });
+  assert.equal(rewritten.proposal.edits.length, 0);
+  assert.ok(rewritten.violations.some((violation) => /inserts the report-only gap/.test(violation)));
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -272,19 +272,24 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   ]) {
     const excluded = propose(summary, minGapEvidence);
     assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /report-only gap/.test(violation)));
+    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
   }
 
   const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
   const rewritten = gate({
-    edit: memoryEdit((text) => text.replace("- Prefer small commits.", `- Prefer focused commits.\n- ${phrasing}`)),
+    edit: memoryEdit((text) =>
+      text.replace(
+        "- Prefer small commits.",
+        "- Prefer focused commits.\n- Consult the SSHHIP guide prior to tunnel edits.",
+      ),
+    ),
     annotation: {
       edits: [claim(["H1"], { kind: "rewrite", transcripts: 3 })],
     },
     context: { summary: reportOnly },
   });
   assert.equal(rewritten.proposal.edits.length, 0);
-  assert.ok(rewritten.violations.some((violation) => /inserts the report-only gap/.test(violation)));
+  assert.ok(rewritten.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -272,24 +272,36 @@ test("folded domain votes mechanically control new-instruction eligibility", () 
   ]) {
     const excluded = propose(summary, minGapEvidence);
     assert.equal(excluded.proposal.edits.length, 0);
-    assert.ok(excluded.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+    assert.ok(excluded.violations.some((violation) => /cites the report-only gap/.test(violation)));
   }
 
   const reportOnly = folded(["orchestration", "orchestration", "project"], 2);
+  const reportOnlyQuote = reportOnly.reportOnlyGaps[0].quotes[0];
+  const reportOnlyEvidence = [{ polarity: "negative", text: reportOnlyQuote.text, source: reportOnlyQuote.source }];
   const rewritten = gate({
     edit: memoryEdit((text) =>
       text.replace(
-        "- Prefer small commits.",
+        "- Prefer small commits.\n- Use Node 18 via nvm before running any script.",
         "- Prefer focused commits.\n- Consult the SSHHIP guide prior to tunnel edits.",
       ),
     ),
     annotation: {
-      edits: [claim(["H1"], { kind: "rewrite", transcripts: 3 })],
+      edits: [claim(["H1"], { kind: "rewrite", evidence: reportOnlyEvidence, transcripts: 3 })],
     },
     context: { summary: reportOnly },
   });
   assert.equal(rewritten.proposal.edits.length, 0);
-  assert.ok(rewritten.violations.some((violation) => /does not match any synthesis-eligible gap/.test(violation)));
+  assert.ok(rewritten.violations.some((violation) => /cites the report-only gap/.test(violation)));
+
+  const unrelated = gate({
+    edit: memoryEdit((text) => `${text}- Preserve build logs for failed releases.\n`),
+    annotation: {
+      edits: [claim(["H1"], { kind: "add", transcripts: 3 })],
+    },
+    context: { summary: reportOnly },
+  });
+  assert.equal(unrelated.violations.length, 0);
+  assert.equal(unrelated.proposal.edits.length, 1);
 });
 
 test("the per-run edit cap is enforced - it is the learning rate", () => {

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -34,6 +34,23 @@ async function captureStatus(repo, json) {
   return lines;
 }
 
+test("status counts synthesis-eligible and report-only gap clusters", async () => {
+  const repo = makeRepo({ "AGENTS.md": MEMORY });
+  const state = new State(repo.root).ensure();
+  state.writeSummary({
+    analyzedSessions: 4,
+    totals: {
+      positive: 2,
+      negative: 1,
+      gapClusters: 1,
+      reportOnlyGapClusters: 2,
+    },
+  });
+
+  const text = (await captureStatus(repo, false)).join("\n");
+  assert.match(text, /3 gap cluster\(s\) \(1 synthesis eligible · 2 report only\)/);
+});
+
 test("status reports one always-loaded budget over memory and skill descriptions", async () => {
   const repo = makeRepo({
     "AGENTS.md": MEMORY,


### PR DESCRIPTION
## Intent

REBASE/CONFLICT RECOVERY (not a re-implementation): the cluster domain-voting improvement (backpass #5) is COMPLETE and was green on PR #86 (branch fm/backpass-cluster-domain-vote-r1, head b4872829250c14dfa8d78fcf24eb4c557df5d417), but a sibling backpass PR (#85, corpus classification) landed first, so #86 now has merge conflicts with main and cannot merge.

Reconcile and re-land that work; do NOT redesign or re-implement the feature. The existing #86 work is authoritative. This branch (fm/backpass-cluster-vote-rebase-recovery-r1) was created from that head and rebased onto current origin/main. Resolve conflicts by PRESERVING BOTH SIDES: keep #86's domain-voting / report-only-accounting / status-counting changes AND every change already on main from #85 and other landed backpass PRs. Do NOT drop, revert, or overwrite either side's logic. Conflicts were expected where both touched src/fold.js, src/gap-ledger.js, src/proposal.js, src/commands/propose.js, and tests; merge the intents, do not pick one.

This is purely a rebase + conflict reconciliation + re-validation of already-completed, already-reviewed work. After resolving, the test suite must stay green, the rebased branch must be pushed, and no-mistakes must go GREEN on the new head so it can land under the project's yolo-on posture.

## What Changed

- Cluster all gap sightings before applying per-session project or orchestration domain votes, with ties remaining synthesis eligible and majority-orchestration clusters excluded.
- Keep mixed and corroborated excluded clusters visible as report-only evidence while preventing them from reaching synthesis.
- Update status, progress counts, proposal statistics, and the apply funnel to distinguish synthesis-eligible, report-only, and below-threshold clusters.

## Risk Assessment

✅ Low: The target is based on current main, preserves the authoritative feature source, and introduces no substantiated correctness or intent-conformance issues.

## Testing

Inspected the rebased change, ran targeted fold, ledger, CLI, proposal, bootstrap, and status tests, then manually verified domain voting through generated report and synthesis outputs and the rendered apply UI. Tied mixed-domain clusters remained synthesis eligible, majority-orchestration clusters were report only, below-floor singletons stayed hidden, and the worktree remained clean.

- Evidence: [Rendered apply UI showing post-clustering gap funnel and report-only count](https://github.com/kunchenguid/backpass/blob/5a0d8c0ad1b1af8dd231c5854af67c411efc1839/.no-mistakes/evidence/fm/backpass-cluster-vote-rebase-recovery-r1/apply-domain-vote.png)

<details>
<summary>Evidence: Reviewer-openable rendered apply surface</summary>

Source: [Reviewer-openable rendered apply surface](https://github.com/kunchenguid/backpass/blob/5a0d8c0ad1b1af8dd231c5854af67c411efc1839/.no-mistakes/evidence/fm/backpass-cluster-vote-rebase-recovery-r1/apply-domain-vote.html)

```text
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>backpass apply</title>
    <style>
      :root {
        --bg: #0b0e14;
        --panel: #10141d;
        --panel-2: #0e1219;
        --line: #1c2431;
        --line-soft: #161d28;
        --text: #d9dfea;
        --dim: #8a93a5;
        --faint: #5a6375;
        --accent: #4fe3c1;
        --accent-dim: rgba(79, 227, 193, 0.12);
        --reject: #ff5d73;
        --reject-dim: rgba(255, 93, 115, 0.1);
        --defer: #ffc857;
        --defer-dim: rgba(255, 200, 87, 0.1);
        --blue: #6ea8ff;
        --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
      }
      * {
        box-sizing: border-box;
      }
      html {
        background: var(--bg);
      }
      body {
        margin: 0;
        background: var(--bg);
        color: var(--text);
        font-family: var(--sans);
        font-size: 15px;
        line-height: 1.55;
        -webkit-font-smoothing: antialiased;
        background-image:
          linear-gradient(rgba(110, 168, 255, 0.025) 1px, transparent 1px),
          linear-gradient(90deg, rgba(110, 168, 255, 0.025) 1px, transparent 1px);
        background-size: 48px 48px;
      }
      .wrap {
        max-width: 1080px;
        margin: 0 auto;
        padding: 48px 28px 140px;
      }
      .microlabel {
        font-family: var(--mono);
        font-size: 10.5px;
        letter-spacing: 0.14em;
        text-transform: uppercase;
        color: var(--faint);
      }
      .num {
        font-variant-numeric: tabular-nums;
      }

      /* ---------- header ---------- */
      .brand {
        display: flex;
        align-items: baseline;
        gap: 14px;
        margin-bottom: 6px;
        flex-wrap: wrap;
      }
      .brand h1 {
        font-family: var(--mono);
        font-weight: 500;
        font-size: 22px;
        margin: 0;
        letter-spacing: 0.01em;
      }
      .brand h1 .cmd {
        color: var(--accent);
      }
      .brand .ver {
        font-family: var(--mono);
        font-size: 11.5px;
        color: var(--faint);
      }
      .runline {
        font-family: var(--mono);
        font-size: 12px;
        color: var(--dim);
        margin-bottom: 34px;
        word-break: break-word;
      }
      .runline b {
        color: var(--text);
        font-weight: 500;
      }

      .statrow {
        display: grid;
        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
        gap: 1px;
        background: var(--line);
        border: 1px solid var(--line);
        margin-bottom: 36px;
      }
      .stat {
        background: var(--panel);
        padding: 14px 16px;
        min-width: 0;
      }
      .stat .v {
        font-family: var(--mono);
        font-size: 21px;
        font-weight: 500;
        color: var(--text);
      }
      .stat .v em {
        font-style: normal;
        color: var(--accent);
      }
      .stat .k {
        font-family: var(--mono);
        font-size: 10.5px;
        letter-spacing: 0.12em;
        text-transform: uppercase;
        color: var(--faint);
        margin-top: 3px;
      }

      /* ---------- gap funnel ---------- */
      /* The template's own display rules (.statrow's grid) would beat the UA
         stylesheet's [hidden]; this keeps the hidden attribute authoritative. */
      [hidden] {
        display: none !important;
      }
      .run-context {
        border: 1px solid var(--line);
        background: var(--line);
        display: grid;
        grid-template-columns: minmax(0, 3fr) minmax(280px, 2fr);
        gap: 1px;
        margin-bottom: 36px;
      }
      .ctx-funnel {
        background: var(--panel);
        padding: 13px 18px 14px;
        min-width: 0;
      }
      .ctx-stats {
        display: grid;
        grid-template-columns: 1fr 1fr;
        grid-auto-rows: 1fr;
        gap: 1px;
        min-width: 0;
      }
      .funnel-head {
        display: flex;
        justify-content: space-between;
        align-items: baseline;
        flex-wrap: wrap;
        gap: 8px;
        margin-bottom: 10px;
      }
      .funnel-head .t {
        font-size: 13px;
        color: var(--dim);
      }
      .funnel-head .facts {
        font-family: var(--mono);
        font-size: 11px;
        color: var(--faint);
      }
      .funnel-head .facts b {
        color: var(--text);
        font-weight: 500;
      }
      .frow {
        display: flex;
        align-items: center;
        gap: 12px;
        margin: 4px 0;
      }
      .frow .fl {
        width: 148px;
        flex: none;
        font-family: var(--mono);
        font-size: 10px;
        letter-spacing: 0.11em;
        text-transform: uppercase;
        color: var(--faint);
        white-space: nowrap;
        overflow: hidden;
        text-overflow: ellipsis;
      }
      .frow .fb {
        flex: 1;
        min-width: 0;
        display: flex;
        align-items: center;
        height: 16px;
        background: var(--panel-2);
        border: 1px solid var(--line-soft);
      }
      .frow .fb i {
        display: block;
        height: 100%;
        background: rgba(110, 168, 255, 0.38);
        border-right: 1px solid rgba(110, 168, 255, 0.75);
      }
      .frow.lit .fb i {
        background: rgba(79, 227, 193, 0.4);
        border-right-color: var(--accent);
      }
      .frow.zero .fb i {
        border-right: none;
      }
      .frow .fv {
        flex: none;
        width: 34px;
        font-family: var(--mono);
        font-size: 12.5px;
        color: var(--text);
      }
      .frow.zero .fv {
        color: var(--faint);
      }
      .frow.lit .fv {
        color: var(--accent);
      }
      .fdrop {
        margin: 1px 0 6px 160px;
        font-size: 12px;
        color: var(--dim);
      }
      .fdrop b {
        font-family: var(--mono);
        font-weight: 500;
        color: var(--faint);
      }
      .funnel-note {
        margin-top: 10px;
        padding-top: 9px;
        border-top: 1px dashed var(--line-soft);
        font-size: 12.5px;
        color: var(--dim);
      }

      /* ---------- budget gauge ---------- */
      .gauge-block {
        border: 1px solid var(--line);
        background: var(--panel);
        padding: 18px 20px 20px;
        margin-bottom: 44px;
      }
      .gauge-head {
        display: flex;
        justify-content: space-between;
        align-items: baseline;
        flex-wrap: wrap;
        gap: 8px;
        margin-bottom: 12px;
      }
      .gauge-head .t {
        font-size: 13px;
        color: var(--dim);
      }
      .gauge-head .readout {
        font-family: var(--mono);
        font-size: 12.5px;
        color: var(--dim);
      }
      .gauge-head .readout b {
        color: var(--accent);
        font-weight: 500;
      }
      .gauge-head .readout b.over {
        color: var(--reject);
      }
      .gauge {
        position: relative;
        height: 8px;
        background: var(--panel-2);
        border: 1px solid var(--line-soft);
      }
      .gauge .fill-now {
        position: absolute;
        inset: 0 auto 0 0;
        background: linear-gradient(90deg, rgba(110, 168, 255, 0.35), rgba(110, 168, 255, 0.6));
      }
      .gauge .fill-after {
        position: absolute;
        inset: 0 auto 0 0;
        background: linear-gradient(90deg, rgba(79, 227, 193, 0.5), var(--accent));
        transition: width 0.35s ease;
      }
      .gauge .fill-after.over {
        background: linear-gradient(90deg, rgba(255, 93, 115, 0.5), var(--reject));
      }
      .gauge .cap {
        position: absolute;
        top: -5px;
        bottom: -5px;
        left: 100%;
        width: 2px;
        background: var(--reject);
        opacity: 0.8;
      }
      .gauge-legend {
        display: flex;
        gap: 22px;
        margin-top: 10px;
        font-family: var(--mono);
        font-size: 11px;
        color: var(--faint);
        flex-wrap: wrap;
      }
      .gauge-legend i {
        display: inline-block;
   

... [24443 bytes truncated] ...

div", "diff");
          diffLines(edit).forEach(function (line) {
            diff.appendChild(el("span", line.type, line.text));
          });
          body.appendChild(diff);

          if ((edit.evidence || []).length) {
            var det = el("details", "evidence");
            var counts = { positive: 0, negative: 0 };
            edit.evidence.forEach(function (q) {
              counts[q.polarity === "positive" ? "positive" : "negative"] += 1;
            });
            det.appendChild(
              el(
                "summary",
                null,
                "evidence · " +
                  (edit.transcripts || 0) +
                  " transcripts (" +
                  counts.negative +
                  "-, " +
                  counts.positive +
                  "+)",
              ),
            );
            edit.evidence.forEach(function (q) {
              var quote = el(
                "div",
                "quote " + (q.polarity === "positive" ? "positive" : "negative"),
                "“" + q.text + "”",
              );
              quote.appendChild(el("span", "src", q.source));
              det.appendChild(quote);
            });
            body.appendChild(det);
          }

          var decide = el("div", "decide");
          ["accept", "reject"].forEach(function (choice) {
            var btn = el("button", choice === "accept" ? "on-accept" : "", choice.toUpperCase());
            btn.type = "button";
            btn.addEventListener("click", function () {
              decisions[edit.id] = choice === "accept" ? "accepted" : "rejected";
              card.setAttribute("data-state", decisions[edit.id]);
              Array.prototype.forEach.call(decide.children, function (b) {
                b.className = "";
              });
              btn.className = "on-" + choice;
              recompute();
            });
            decide.appendChild(btn);
          });
          body.appendChild(decide);
          card.appendChild(body);
          host.appendChild(card);
        });

        function nonEmpty(line) {
          return line.length > 0;
        }

        function editFiles(edit) {
          if (!Array.isArray(edit.hunks)) return edit.file ? [edit.file] : [];
          var files = edit.hunks.reduce(function (files, hunk) {
            var file = hunk.file || edit.file;
            if (file && files.indexOf(file) === -1) files.push(file);
            return files;
          }, []);
          return files.length ? files : edit.file ? [edit.file] : [];
        }

        // The skills one extract creates. A proposal saved before an extract could carry
        // several (merged removals) has a single `skill`; both shapes read the same way.
        function editSkills(edit) {
          if (Array.isArray(edit.skills)) {
            return edit.skills.filter(function (skill) {
              return skill;
            });
          }
          return edit.skill ? [edit.skill] : [];
        }

        // Measured edits carry display lines per hunk (ctx/del/ins); a legacy
        // find/replace edit is shown as removed then added lines.
        function diffLines(edit) {
          if (Array.isArray(edit.hunks)) {
            var out = [];
            edit.hunks.forEach(function (hunk, i) {
              if (i > 0) out.push({ type: "gap", text: "\u2026" });
              out.push({ type: "file", text: "--- " + (hunk.file || edit.file) + " ---" });
              (hunk.lines || []).forEach(function (line) {
                out.push(line);
              });
            });
            return out;
          }
          return (edit.find || "")
            .split("\n")
            .filter(nonEmpty)
            .map(function (text) {
              return { type: "del", text: text };
            })
            .concat(
              (edit.replace || "")
                .split("\n")
                .filter(nonEmpty)
                .map(function (text) {
                  return { type: "ins", text: text };
                }),
            );
        }

        // ---- notes ----
        if ((P.notes || []).length) {
          document.getElementById("notes").hidden = false;
          var list = document.getElementById("noteslist");
          P.notes.forEach(function (n) {
            list.appendChild(el("li", null, n));
          });
        }

        // ---- live tally + projection ----
        function recompute() {
          var accepted = 0,
            rejected = 0,
            tok = budget.current,
            descriptionTok = budget.descriptionTokens || 0;
          edits.forEach(function (e) {
            if (decisions[e.id] === "accepted") {
              accepted += 1;
              // The always-loaded projection: memory-file deltas plus each edit's
              // measured description-line delta (a tuned skill trigger, or the
              // description a created skill adds). Skill bodies never move this bar.
              if (e.targetsMemoryFile) tok += e.deltaTokens || 0;
              tok += e.descriptionDelta || 0;
              descriptionTok += e.descriptionDelta || 0;
            } else if (decisions[e.id] === "rejected") {
              rejected += 1;
            }
          });
          var over = tok > budget.capTokens;

          document.getElementById("gauge-title").textContent =
            "Always-loaded budget · " + (P.memoryFile.path || "") + (descriptionTok > 0 ? " + skill descriptions" : "");
          document.getElementById("n-accept").textContent = accepted;
          document.getElementById("n-reject").textContent = rejected;

          var readout = document.getElementById("gauge-readout");
          readout.textContent = "";
          readout.appendChild(document.createTextNode("now " + fmt(budget.current) + " tok -> if accepted "));
          // In shrink mode the file started over budget: progress is the goal, not arrival.
          readout.appendChild(
            el("b", (budget.mode === "shrink" ? tok >= budget.current : over) ? "over" : null, fmt(tok) + " tok"),
          );
          readout.appendChild(
            document.createTextNode(
              " / " +
                fmt(budget.capTokens) +
                " cap" +
                (budget.mode === "shrink"
                  ? " · shrink plan: " + fmt(Math.max(0, tok - budget.capTokens)) + " tok still over"
                  : ""),
            ),
          );

          var after = document.getElementById("gauge-after");
          after.style.width = pct(tok, budget.capTokens) + "%";
          after.className = "fill-after" + (over ? " over" : "");

          var proj = document.getElementById("projline");
          proj.textContent = "";
          proj.appendChild(document.createTextNode("projected: "));
          proj.appendChild(el("b", over ? "over" : null, fmt(tok)));
          proj.appendChild(document.createTextNode(" / " + fmt(budget.capTokens) + " tok"));

          var btn = document.getElementById("btn-apply");
          btn.textContent =
            accepted > 0 ? "APPLY " + accepted + " EDIT" + (accepted === 1 ? "" : "S") + " ->" : "NOTHING TO APPLY";
          btn.disabled = accepted === 0 && rejected === 0;
        }

        // ---- the single structured decision vector back to the CLI ----
        document.getElementById("btn-apply").addEventListener("click", function () {
          var vector = edits
            .map(function (e) {
              return e.id + "=" + decisions[e.id];
            })
            .join(" ");
          var message = "BACKPASS_DECISIONS " + vector;
          if (window.lavish && typeof window.lavish.queuePrompt === "function") {
            window.lavish.queuePrompt(message, {
              tag: "choice",
              text: vector,
              data: { question: "backpass-apply-decisions", decisions: decisions },
              queueKey: "backpass-apply-decisions",
            });
            this.textContent = "QUEUED - SEND FROM THE PANEL";
          } else {
            this.textContent = "QUEUED (offline preview)";
          }
          this.disabled = true;
        });

        recompute();
      })();
    </script>
  </body>
</html>
```
</details>
<details>
<summary>Evidence: Domain-vote evidence report, synthesis input, and observable checks</summary>

Source: [Domain-vote evidence report, synthesis input, and observable checks](https://github.com/kunchenguid/backpass/blob/5a0d8c0ad1b1af8dd231c5854af67c411efc1839/.no-mistakes/evidence/fm/backpass-cluster-vote-rebase-recovery-r1/domain-vote-evidence.txt)

```text
=== USER-FACING EVIDENCE REPORT ===
Sessions analyzed: 6 (interactive 6 · non-interactive 0)
Totals: 0 positive, 0 negative, 2 gap clusters (1 synthesis eligible, 1 report only, 1 singletons dropped below threshold)

\### Per-instruction evidence
A negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.

\### Synthesis-eligible gap clusters (mistakes no current instruction covers)
- 4 orchestration-domain sighting(s) counted as domain votes (clusters excluded only on a majority vote); they never enter this repository's memory file as their own instruction
- sessions=2 (2 sightings, 1 orchestration) risk=high :: Read docs/ship.md before changing the tunnel.
    "quote from tie-project" (pi · project · 2026-01-01)
    "quote from tie-orchestration" (pi · orchestr · 2026-01-01)

\### REPORT ONLY - not synthesis-eligible evidence
- sessions=3 (3 sightings, 2 orchestration; domain excluded by majority vote) risk=high :: Stop after the report on scout tasks.

=== SYNTHESIS INPUT ===
Sessions analyzed: 6 (interactive 6 · non-interactive 0)
Totals: 0 positive, 0 negative, 2 gap clusters (1 synthesis eligible, 1 report only, 1 singletons dropped below threshold)

\### Per-instruction evidence
A negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.

\### Synthesis-eligible gap clusters (mistakes no current instruction covers)
- 4 orchestration-domain sighting(s) counted as domain votes (clusters excluded only on a majority vote); they never enter this repository's memory file as their own instruction
- sessions=2 (2 sightings, 1 orchestration) risk=high :: Read docs/ship.md before changing the tunnel.
    "quote from tie-project" (pi · project · 2026-01-01)
    "quote from tie-orchestration" (pi · orchestr · 2026-01-01)

=== OBSERVABLE CHECKS ===
{
  "synthesisEligible": [
    "Read docs/ship.md before changing the tunnel."
  ],
  "reportOnly": [
    "Stop after the report on scout tasks."
  ],
  "droppedBelowFloor": 1,
  "majorityClusterAbsentFromSynthesis": true,
  "pureOrchestrationSingletonAbsentFromReport": true
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ef4e28cbe93562d32784680f9a292eabe373f20a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat f887a320aeb5764e928b6f2fceb1f85142424eb7..HEAD` and targeted diff inspection</code>
- `node --test test/fold.test.js test/gap-ledger.test.js test/gap-domain-cli.test.js test/proposal.test.js test/bootstrap.test.js test/status.test.js`
- <code>Generated domain-vote report and synthesis output using `foldEvidence`, `renderEvidenceReport`, and `renderEvidenceForPrompt`</code>
- `Rendered the real apply template with representative cluster counts, opened it in Chrome at 1440x1100, and captured a screenshot`
- <code>`git status --short` after cleanup</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
