### PR TITLE
feat: split oversized paragraphs for precise attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   `{ agent, usage|null }` (`usageRecord` in `src/acpx.js`) and `src/commands/usage.js` is
   the one place that prints them - never `n/a`: nothing when no call ran, the harness by
   name when it stayed silent.
-- **Fold and this-run gap-ledger ingest are scoped to the selected, current memory surface.**
+- **Fold and this-run gap-ledger ingest require selected, current evidence.**
   The run hash (`primaryMemoryFile` in `src/commands/analyze.js`) is `memorySurfaceHash`:
   the memory-set hash extended with every skill's description line - a description edit
   invalidates cached evidence, a skill-body edit never does, and a repo without skills
@@ -177,14 +177,14 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   (memory file + description lines; bodies stay free until triggered), so a repo with
   many skills re-tunes `budgetTokens` once - accepted by the captain's explicit decision.
   `foldForRun` (`src/commands/propose.js`) matches evidence to the selected sample by
-  canonical `transcriptIdentity`, then requires the current `memoryPath`, surface hash, and
-  a valid interaction stamp. The same selection bounds this run's gap-ledger observations,
-  so an old record outside the window or cap cannot overwhelm the sampled corpus. Folding
-  does not migrate, rewrite, or delete excluded evidence; ordinary discovery and analysis
-  backfill legacy unstamped records when they are selected. `analyzeTranscripts` separately
-  reports `summary.staleMemoryHash` and names the old/new hash on stderr, so a full
-  reanalysis without `--force` after a memory edit reads as "the file changed," not as a
-  broken cache - the cache-hit path itself (unchanged file, no `--force`) is unaffected.
+  canonical `transcriptIdentity`, then requires the current memory path, surface hash,
+  transcript signature, `ANALYSIS_INDEX_VERSION`, and a valid interaction stamp through
+  `isEvidenceFresh`. The same selection bounds this run's gap-ledger observations, so an
+  old record outside the window or cap cannot overwhelm the sampled corpus. Folding does
+  not migrate, rewrite, or delete excluded evidence; ordinary discovery and analysis
+  backfill legacy records when selected. `analyzeTranscripts` separately reports
+  `summary.staleMemoryHash` and names the old/new hash on stderr, so a full reanalysis
+  without `--force` after a memory edit reads as "the file changed," not as a broken cache.
 - **Cross-surface duplication is report-only.** `crossSurfaceDuplicates` (`src/overlap.js`)
   flags memory-file units whose text substantially overlaps a skill description or body
   (Dice >= 0.6, same bar as gap coverage). Fold stamps it on the instruction row and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,10 +156,11 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   second full file is warned about, never silently ignored or double-written.
 - **Oversized paragraphs split for attribution only.** `parseMemoryUnits` still emits one
   positional `AG-nnn` per paragraph or list item (apply, reanchor, and the removal floor
-  stay line-oriented). A paragraph above `ATTRIBUTION_SPLIT_TOKENS` also gets `AG-nnn.m`
-  sentence parts in the instruction index and fold so evidence cannot smear across a blob;
-  synthesis is told to restructure that paragraph into list items rather than bold-label
-  it. See `src/memory.js` and `renderEvidenceForPrompt` in `src/fold.js`.
+  stay line-oriented). Eligible prose above `ATTRIBUTION_SPLIT_TOKENS` can also get
+  `AG-nnn.m` parts at high-confidence sentence boundaries; ambiguous spans conservatively remain
+  unsplit. The instruction index and fold use those parts so evidence cannot smear across a
+  blob, and synthesis is told to restructure repeated non-compliance into list items rather
+  than bold-label it. See `src/memory.js` and `renderEvidenceForPrompt` in `src/fold.js`.
 - **Never trust model-reported numbers.** Token deltas and budget projections are measured
   in `src/proposal.js` from the actual text; the synthesis model's own figures are ignored.
   Usage accounting comes from acpx's `[acpx] tokens:` stderr line, which acpx prints
@@ -187,9 +188,10 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   without `--force` after a memory edit reads as "the file changed," not as a broken cache.
 - **Cross-surface duplication is report-only.** `crossSurfaceDuplicates` (`src/overlap.js`)
   flags memory-file units whose text substantially overlaps a skill description or body
-  (Dice >= 0.6, same bar as gap coverage). Fold stamps it on the instruction row and
-  `backpass status` lists it. Description overlap duplicates always-loaded tokens and can
-  guide a shrink to drop the memory-file copy. Body overlap is only placement evidence: a
+  (Dice >= 0.6, same bar as gap coverage). Fold renders each overlap once in the evidence,
+  including an oversized parent that has no instruction row, and `backpass status` lists it.
+  Description overlap duplicates always-loaded tokens and can guide a shrink to drop the
+  memory-file copy. Body overlap is only placement evidence: a
   skill body loads on trigger, so its memory copy may be the only always-loaded coverage.
   Nothing is deleted automatically. Relevance still accrues to the memory-file alias until
   that copy is gone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,12 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
 - **Memory resolution is pointer-aware** (`resolveMemoryFiles` in `src/memory.js`): the
   first configured file is canonical, a `@AGENTS.md`-only CLAUDE.md is a pointer, and a
   second full file is warned about, never silently ignored or double-written.
+- **Oversized paragraphs split for attribution only.** `parseMemoryUnits` still emits one
+  positional `AG-nnn` per paragraph or list item (apply, reanchor, and the removal floor
+  stay line-oriented). A paragraph above `ATTRIBUTION_SPLIT_TOKENS` also gets `AG-nnn.m`
+  sentence parts in the instruction index and fold so evidence cannot smear across a blob;
+  synthesis is told to restructure that paragraph into list items rather than bold-label
+  it. See `src/memory.js` and `renderEvidenceForPrompt` in `src/fold.js`.
 - **Never trust model-reported numbers.** Token deltas and budget projections are measured
   in `src/proposal.js` from the actual text; the synthesis model's own figures are ignored.
   Usage accounting comes from acpx's `[acpx] tokens:` stderr line, which acpx prints

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ most important defence against a model confabulating influence. Negative evidenc
 weighted highest, but its class determines what it supports: non-compliance supports
 reinforcement, while only harm supports removal.
 
+To avoid smearing evidence across a large prose blob, backpass splits eligible prose
+paragraphs above 120 tokens at high-confidence sentence boundaries for attribution only.
+Ambiguous boundaries stay unsplit, and the paragraph remains one line-oriented edit unit.
+When its sentence parts
+draw repeated non-compliance, synthesis is steered to restructure the paragraph into list
+items instead of adding a cosmetic label.
+
 Results are cached per transcript, keyed to the transcript's content, the effective
 memory-surface hash, and the analysis-index version. The surface hash covers the memory-file
 set plus every project skill's name and description. Edit a memory file or skill description

--- a/README.md
+++ b/README.md
@@ -191,18 +191,18 @@ most important defence against a model confabulating influence. Negative evidenc
 weighted highest, but its class determines what it supports: non-compliance supports
 reinforcement, while only harm supports removal.
 
-Results are cached per transcript, keyed to both the transcript's content _and_ the effective
-memory-surface hash: the memory-file set plus every project skill's name and description.
-Edit a memory file or skill description and the evidence correctly re-computes; edit only a
-skill body and the cache remains valid because bodies are inspected only for failed-trigger
-confirmation. A repo without skills keeps the prior memory-set hash. A surface edit therefore
-reanalyzes without `--force` - that is not a cache miss, it is the cache doing its job - and
-the run says so on stderr, naming the old and new hash, so a "0 reused" line reads as "the
-surface changed" rather than "reuse is broken." Evidence files that are not refreshed remain
-on disk but are excluded while their hash is stale. Returning to that memory-surface hash
-makes them hash-eligible again, but the selected-sample and interaction-stamp rules below
-still apply; evidence for transcripts included in the new analysis is replaced with fresh
-judgments.
+Results are cached per transcript, keyed to the transcript's content, the effective
+memory-surface hash, and the analysis-index version. The surface hash covers the memory-file
+set plus every project skill's name and description. Edit a memory file or skill description
+and the evidence correctly re-computes; edit only a skill body and the cache remains valid
+because bodies are inspected only for failed-trigger confirmation. A repo without skills
+keeps the prior memory-set hash. A surface edit therefore reanalyzes without `--force` - that
+is not a cache miss, it is the cache doing its job - and the run says so on stderr, naming the
+old and new hash, so a "0 reused" line reads as "the surface changed" rather than "reuse is
+broken." Evidence files that are not refreshed remain on disk but are excluded while their
+full cache key is stale. They become eligible again only when that complete key is current
+and the selected-sample and interaction-stamp rules below apply; evidence for transcripts
+included in the new analysis is replaced with fresh judgments.
 
 ### 4. Aggregate gradients - and one judged consolidation call
 
@@ -233,12 +233,13 @@ majority-excluded cluster, including a pure-orchestration cluster, remains clear
 as a report-only diagnostic rather than becoming an instruction in the project's memory
 file; an uncorroborated pure-orchestration singleton stays hidden.
 
-Only evidence judged against the _current_ memory-surface hash, stamped with one of the two
-interaction categories, and belonging to this run's selected sample is folded into a
-proposal. A transcript that fell outside the time window or `maxTranscripts` cap, disappeared,
-or still has legacy unstamped evidence can leave an evidence file on disk. That file is left
-untouched, but it does not count toward this run's session total or instruction scores, or
-add a gap observation, until ordinary discovery and analysis select and refresh it.
+Only evidence with the current transcript, memory-surface, and analysis-index cache key,
+stamped with one of the two interaction categories, and belonging to this run's selected
+sample is folded into a proposal. A transcript that fell outside the time window or
+`maxTranscripts` cap, disappeared, or still has legacy evidence can leave an evidence file
+on disk. That file is left untouched, but it does not count toward this run's session total
+or instruction scores, or add a gap observation, until ordinary discovery and analysis
+select and refresh it.
 
 Gap sightings persist across runs in `.backpass/gap-ledger.json` by gap and session, but a
 run only counts observations whose sessions belong to its selected sample. This prevents

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -5,7 +5,7 @@ import { execOneShot, extractJson, sessionPrompt, usageRecord } from "./acpx.js"
 import { distill } from "./distill.js";
 import { classifyInteraction } from "./interaction.js";
 import { readTranscript } from "./discovery/index.js";
-import { renderInstructionIndex } from "./memory.js";
+import { instructionUnits, renderInstructionIndex } from "./memory.js";
 import { renderSkillIndexForAnalysis } from "./skills.js";
 import { renderPrompt } from "./prompts.js";
 import { renderOpenGapIndex } from "./gap-ledger.js";
@@ -41,17 +41,20 @@ function noteOnce(note) {
 export const NEGATIVE_CLASSES = ["harm", "non-compliance", "irrelevant"];
 
 /** Evidence items without a verbatim quote are dropped - the rubric's central rule. */
-export function sanitizeEvidence(parsed) {
+export function sanitizeEvidence(parsed, memoryFile = null) {
   const clean = { positive: [], negative: [], gaps: [], usedRawTranscript: Boolean(parsed?.usedRawTranscript) };
   if (!parsed || typeof parsed !== "object") return clean;
 
+  const validInstructions = memoryFile ? new Set(instructionUnits(memoryFile).map((unit) => unit.id)) : null;
   const hasQuote = (item) => typeof item?.quote === "string" && item.quote.trim().length >= 8;
 
   for (const key of ["positive", "negative"]) {
     for (const item of Array.isArray(parsed[key]) ? parsed[key] : []) {
       if (!hasQuote(item) || typeof item.instruction !== "string") continue;
+      const instruction = item.instruction.trim();
+      if (validInstructions && !validInstructions.has(instruction)) continue;
       const entry = {
-        instruction: item.instruction.trim(),
+        instruction,
         moment: String(item.moment ?? "").slice(0, 80),
         effect: String(item.effect ?? "").slice(0, 400),
         quote: item.quote.trim().slice(0, 600),
@@ -191,7 +194,7 @@ async function analyzeOne({
 
   return {
     status: "ok",
-    evidence: sanitizeEvidence(parsed),
+    evidence: sanitizeEvidence(parsed, memoryFile),
     usage: usageRecord(ranWith, result),
     distilled,
   };

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -52,7 +52,7 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], trans
       e.memoryHash === memoryHash &&
       (e.transcript?.interaction === INTERACTIVE || e.transcript?.interaction === NON_INTERACTIVE) &&
       selected.has(transcriptIdentity(e.transcript)) &&
-      (!e.key || isEvidenceFresh(e, e.transcript, memoryHash)),
+      isEvidenceFresh(e, e.transcript, memoryHash),
   );
 
   const ledger = state.readGapLedger();

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -30,7 +30,10 @@ import { transcriptIdentity } from "../transcript.js";
  */
 export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], transcripts = []) {
   const { state, minGapEvidence, gapLedgerMaxAge } = ctx.config;
-  const selected = new Set(transcripts.map((transcript) => transcriptIdentity(transcript)));
+  const selectedByIdentity = new Map(
+    transcripts.map((transcript) => [transcriptIdentity(transcript), transcript]),
+  );
+  const selected = new Set(selectedByIdentity.keys());
   const evidence = state.listEvidence();
   const identitiesByLegacyId = new Map();
   for (const record of evidence) {
@@ -46,14 +49,16 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], trans
       selectedGapSessions.add(transcript.id);
     }
   }
-  const relevant = evidence.filter(
-    (e) =>
+  const relevant = evidence.filter((e) => {
+    const currentTranscript = selectedByIdentity.get(transcriptIdentity(e.transcript));
+    return (
       e.memoryPath === memoryFile.path &&
       e.memoryHash === memoryHash &&
       (e.transcript?.interaction === INTERACTIVE || e.transcript?.interaction === NON_INTERACTIVE) &&
-      selected.has(transcriptIdentity(e.transcript)) &&
-      isEvidenceFresh(e, e.transcript, memoryHash),
-  );
+      currentTranscript &&
+      isEvidenceFresh(e, currentTranscript, memoryHash)
+    );
+  });
 
   const ledger = state.readGapLedger();
   recordGapObservations(ledger, relevant, { skills });

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -11,6 +11,7 @@ import { primaryMemoryFile } from "./analyze.js";
 import { printUsage } from "./usage.js";
 import { discoverForRun } from "./scan.js";
 import { capTranscripts } from "../sample.js";
+import { isEvidenceFresh } from "../state.js";
 import { transcriptIdentity } from "../transcript.js";
 
 /**
@@ -20,13 +21,12 @@ import { transcriptIdentity } from "../transcript.js";
  * the evidence files that fed an expired sighting are still on disk and would re-add it),
  * then cluster from the ledger.
  *
- * Evidence is filtered to the selected transcript identities, `memoryHash`, and a valid
- * interaction category. Reanalysis rewrites a transcript's evidence against a changed
- * memory file or skill description, but records outside this run's window or cap remain
- * on disk. Folding those records would inflate `analyzedSessions` beyond the sampled
- * corpus; folding another surface's record would also score positional instruction aliases
- * against an index it never saw. Legacy records without a valid interaction category stay
- * excluded until ordinary discovery and analysis select and backfill them.
+ * Evidence is filtered to selected transcript identities, the current memory hash and
+ * analysis-index cache key, and a valid interaction category. Reanalysis rewrites a
+ * transcript's evidence when an input changes, but records outside this run's window or
+ * cap remain on disk. Folding those records would inflate `analyzedSessions` beyond the
+ * sampled corpus or score positional instruction aliases against an index they never saw.
+ * Legacy records stay excluded until ordinary discovery and analysis backfill them.
  */
 export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], transcripts = []) {
   const { state, minGapEvidence, gapLedgerMaxAge } = ctx.config;
@@ -51,7 +51,8 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], trans
       e.memoryPath === memoryFile.path &&
       e.memoryHash === memoryHash &&
       (e.transcript?.interaction === INTERACTIVE || e.transcript?.interaction === NON_INTERACTIVE) &&
-      selected.has(transcriptIdentity(e.transcript)),
+      selected.has(transcriptIdentity(e.transcript)) &&
+      (!e.key || isEvidenceFresh(e, e.transcript, memoryHash)),
   );
 
   const ledger = state.readGapLedger();

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -30,9 +30,7 @@ import { transcriptIdentity } from "../transcript.js";
  */
 export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], transcripts = []) {
   const { state, minGapEvidence, gapLedgerMaxAge } = ctx.config;
-  const selectedByIdentity = new Map(
-    transcripts.map((transcript) => [transcriptIdentity(transcript), transcript]),
-  );
+  const selectedByIdentity = new Map(transcripts.map((transcript) => [transcriptIdentity(transcript), transcript]));
   const selected = new Set(selectedByIdentity.keys());
   const evidence = state.listEvidence();
   const identitiesByLegacyId = new Map();

--- a/src/fold.js
+++ b/src/fold.js
@@ -61,6 +61,7 @@ export function foldEvidence(
         sessions: new Set(),
         sessionsByInteraction: { [INTERACTIVE]: new Set(), [NON_INTERACTIVE]: new Set() },
         harmSessions: new Set(),
+        nonComplianceSessions: new Set(),
         quotes: [],
       });
     }
@@ -84,6 +85,9 @@ export function foldEvidence(
         // `harmSessions` is what the removal-evidence floor counts. A record from
         // before the class existed carries none and never counts as harm.
         if (polarity === "negative" && item.class === "harm") entry.harmSessions.add(sessionIdentity);
+        if (polarity === "negative" && item.class === "non-compliance") {
+          entry.nonComplianceSessions.add(sessionIdentity);
+        }
         entry.quotes.push({
           polarity,
           text: item.quote,
@@ -130,15 +134,8 @@ export function foldEvidence(
   const duplicates = crossSurfaceDuplicates(memoryFile, skills);
   const overlapById = new Map(duplicates.map((hit) => [hit.instruction, hit]));
 
-  const parentHarmSessions = {};
-  for (const unit of memoryFile?.units || []) {
-    if (!unit.parts?.length) continue;
-    const sessions = new Set(instructions.get(unit.id)?.harmSessions || []);
-    for (const part of unit.parts) {
-      for (const session of instructions.get(part.id)?.harmSessions || []) sessions.add(session);
-    }
-    parentHarmSessions[unit.id] = sessions.size;
-  }
+  const parentHarmSessions = parentSessionCounts(memoryFile, instructions, "harmSessions");
+  const parentNonComplianceSessions = parentSessionCounts(memoryFile, instructions, "nonComplianceSessions");
 
   const instructionRows = [...instructions.values()]
     .map((entry) => {
@@ -164,6 +161,7 @@ export function foldEvidence(
         known: Boolean(unit),
         parentId: unit?.parentId ?? null,
         nonCompliance: entry.quotes.filter((q) => q.polarity === "negative" && q.class === "non-compliance").length,
+        nonComplianceSessions: entry.nonComplianceSessions.size,
         quotes: entry.quotes.slice(0, 6),
         ...(skillOverlap ? { skillOverlap } : {}),
       };
@@ -222,27 +220,39 @@ export function foldEvidence(
     gaps,
     crossSurfaceDuplicates: duplicates,
     reportOnlyGaps,
-    oversized: oversizedRestructureTargets(memoryFile, instructionRows),
+    oversized: oversizedRestructureTargets(memoryFile, parentNonComplianceSessions, minGapEvidence),
   };
+}
+
+function parentSessionCounts(memoryFile, instructions, field) {
+  const counts = {};
+  for (const unit of memoryFile?.units || []) {
+    if (!unit.parts?.length) continue;
+    const sessions = new Set(instructions.get(unit.id)?.[field] || []);
+    for (const part of unit.parts) {
+      for (const session of instructions.get(part.id)?.[field] || []) sessions.add(session);
+    }
+    counts[unit.id] = sessions.size;
+  }
+  return counts;
 }
 
 /**
  * An oversized paragraph whose sentence-parts drew repeated non-compliance. Synthesis
  * should split that blob into list items, not slap a bold label on it.
  */
-function oversizedRestructureTargets(memoryFile, rows) {
+function oversizedRestructureTargets(memoryFile, nonComplianceSessions, minGapEvidence) {
   if (!memoryFile) return [];
-  const byId = new Map(rows.map((row) => [row.instruction, row]));
   const targets = [];
   for (const unit of memoryFile.units) {
     if (!unit.parts?.length) continue;
-    const related = [unit.id, ...unit.parts.map((part) => part.id)].map((id) => byId.get(id)).filter(Boolean);
-    const nonCompliance = related.reduce((n, row) => n + (row.nonCompliance ?? 0), 0);
-    if (nonCompliance < 2) continue;
+    const sessions = nonComplianceSessions[unit.id] || 0;
+    if (sessions < minGapEvidence) continue;
     targets.push({
       id: unit.id,
       tokens: unit.tokens,
       parts: unit.parts.map((part) => part.id),
+      sessions,
     });
   }
   return targets;

--- a/src/fold.js
+++ b/src/fold.js
@@ -416,6 +416,13 @@ function renderEvidence(summary, { includeReportOnly }) {
     }
   }
 
+  const parentHarm = Object.entries(summary.parentHarmSessions || {}).filter(([, sessions]) => sessions > 0);
+  if (parentHarm.length) {
+    lines.push("");
+    lines.push("Parent paragraph removal evidence aggregated across sentence parts:");
+    for (const [id, sessions] of parentHarm) lines.push(`- [${id}] harm-sessions=${sessions}`);
+  }
+
   if (summary.oversized?.length) {
     lines.push("");
     lines.push("### Oversized units that failed to steer");

--- a/src/fold.js
+++ b/src/fold.js
@@ -1,5 +1,5 @@
 import { classifyInteraction, INTERACTIVE, NON_INTERACTIVE } from "./interaction.js";
-import { similarity } from "./memory.js";
+import { findInstructionUnit, instructionUnits, similarity } from "./memory.js";
 import { GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
 import { crossSurfaceDuplicates } from "./overlap.js";
 
@@ -124,7 +124,7 @@ export function foldEvidence(
   // Instructions that exist in the file but drew no evidence at all are the strongest
   // removal / extraction candidates, so they must appear in the summary too.
   if (memoryFile) {
-    for (const unit of memoryFile.units) touch(unit.id);
+    for (const unit of instructionUnits(memoryFile)) touch(unit.id);
   }
 
   const duplicates = crossSurfaceDuplicates(memoryFile, skills);
@@ -132,7 +132,7 @@ export function foldEvidence(
 
   const instructionRows = [...instructions.values()]
     .map((entry) => {
-      const unit = memoryFile?.units.find((u) => u.id === entry.instruction) || null;
+      const unit = findInstructionUnit(memoryFile, entry.instruction);
       const skillOverlap = overlapById.get(entry.instruction);
       return {
         instruction: entry.instruction,
@@ -152,6 +152,8 @@ export function foldEvidence(
         tokens: unit?.tokens ?? null,
         section: unit?.section ?? null,
         known: Boolean(unit),
+        parentId: unit?.parentId ?? null,
+        nonCompliance: entry.quotes.filter((q) => q.polarity === "negative" && q.class === "non-compliance").length,
         quotes: entry.quotes.slice(0, 6),
         ...(skillOverlap ? { skillOverlap } : {}),
       };
@@ -209,7 +211,30 @@ export function foldEvidence(
     gaps,
     crossSurfaceDuplicates: duplicates,
     reportOnlyGaps,
+    oversized: oversizedRestructureTargets(memoryFile, instructionRows),
   };
+}
+
+/**
+ * An oversized paragraph whose sentence-parts drew repeated non-compliance. Synthesis
+ * should split that blob into list items, not slap a bold label on it.
+ */
+function oversizedRestructureTargets(memoryFile, rows) {
+  if (!memoryFile) return [];
+  const byId = new Map(rows.map((row) => [row.instruction, row]));
+  const targets = [];
+  for (const unit of memoryFile.units) {
+    if (!unit.parts?.length) continue;
+    const related = [unit.id, ...unit.parts.map((part) => part.id)].map((id) => byId.get(id)).filter(Boolean);
+    const nonCompliance = related.reduce((n, row) => n + (row.nonCompliance ?? 0), 0);
+    if (nonCompliance < 2) continue;
+    targets.push({
+      id: unit.id,
+      tokens: unit.tokens,
+      parts: unit.parts.map((part) => part.id),
+    });
+  }
+  return targets;
 }
 
 /**
@@ -367,6 +392,22 @@ function renderEvidence(summary, { includeReportOnly }) {
       const cls = quote.polarity === "negative" ? ` [${quote.class ?? "unclassified"}]` : "";
       const effect = quote.effect ? ` :: ${oneLine(quote.effect, 200)}` : "";
       lines.push(`    ${sign}${cls} "${oneLine(quote.text)}"${effect} (${quote.source})`);
+    }
+  }
+
+  if (summary.oversized?.length) {
+    lines.push("");
+    lines.push("### Oversized units that failed to steer");
+    lines.push(
+      "These are one paragraph apiece. Preferred reinforcement is a restructure-in-place: split " +
+        "the paragraph into list items so each claim can be followed. A bold label on the blob is " +
+        "not a strengthen.",
+    );
+    for (const blob of summary.oversized) {
+      lines.push(
+        `- [${blob.id}] is ${blob.tokens} tokens as one paragraph (attribution: ${blob.parts.join(", ")}). ` +
+          `Split it into list items; do not decorate the blob.`,
+      );
     }
   }
 

--- a/src/fold.js
+++ b/src/fold.js
@@ -350,6 +350,23 @@ function failedTriggerOf(items, minGapEvidence) {
     : {};
 }
 
+function renderSkillOverlap(lines, overlap) {
+  const match =
+    `    CROSS-SURFACE: restates skill "${overlap.skill}" ${overlap.surface} ` +
+    `(similarity ${overlap.score.toFixed(2)})`;
+  if (overlap.surface === "description") {
+    lines.push(
+      `${match} - duplicated always-loaded tokens; ` +
+        `drop the memory-file copy, do not treat it as a second instruction`,
+    );
+  } else {
+    lines.push(
+      `${match} - triggered skill-body overlap (report-only); weigh relevance and trigger suitability, ` +
+        `do not infer the memory-file copy should be dropped`,
+    );
+  }
+}
+
 /** Compact rendering of the folded evidence for the synthesis prompt. */
 export function renderEvidenceForPrompt(summary) {
   return renderEvidence(summary, { includeReportOnly: false });
@@ -391,23 +408,7 @@ function renderEvidence(summary, { includeReportOnly }) {
       `- [${row.instruction}] +${row.positive} -${row.negative}${harm} sessions=${row.sessions} relevance=${relevance}${byCategory}${cost}` +
         (row.known ? "" : " (id not found in current file - stale reference)"),
     );
-    if (row.skillOverlap) {
-      const overlap = row.skillOverlap;
-      const match =
-        `    CROSS-SURFACE: restates skill "${overlap.skill}" ${overlap.surface} ` +
-        `(similarity ${overlap.score.toFixed(2)})`;
-      if (overlap.surface === "description") {
-        lines.push(
-          `${match} - duplicated always-loaded tokens; ` +
-            `drop the memory-file copy, do not treat it as a second instruction`,
-        );
-      } else {
-        lines.push(
-          `${match} - triggered skill-body overlap (report-only); weigh relevance and trigger suitability, ` +
-            `do not infer the memory-file copy should be dropped`,
-        );
-      }
-    }
+    if (row.skillOverlap) renderSkillOverlap(lines, row.skillOverlap);
     for (const quote of row.quotes.slice(0, 3)) {
       const sign = quote.polarity === "negative" ? "-" : "+";
       const cls = quote.polarity === "negative" ? ` [${quote.class ?? "unclassified"}]` : "";
@@ -416,11 +417,26 @@ function renderEvidence(summary, { includeReportOnly }) {
     }
   }
 
+  const representedOverlaps = new Set(
+    summary.instructions.filter((row) => row.skillOverlap).map((row) => row.instruction),
+  );
+  const parentOverlaps = (summary.crossSurfaceDuplicates || []).filter(
+    (overlap) => !representedOverlaps.has(overlap.instruction),
+  );
+  if (parentOverlaps.length) {
+    lines.push("");
+    lines.push("Parent paragraph cross-surface overlap:");
+    for (const overlap of parentOverlaps) {
+      lines.push(`- ${overlap.instruction} parent paragraph`);
+      renderSkillOverlap(lines, overlap);
+    }
+  }
+
   const parentHarm = Object.entries(summary.parentHarmSessions || {}).filter(([, sessions]) => sessions > 0);
   if (parentHarm.length) {
     lines.push("");
     lines.push("Parent paragraph removal evidence aggregated across sentence parts:");
-    for (const [id, sessions] of parentHarm) lines.push(`- [${id}] harm-sessions=${sessions}`);
+    for (const [id, sessions] of parentHarm) lines.push(`- ${id} harm-sessions=${sessions}`);
   }
 
   if (summary.oversized?.length) {
@@ -432,8 +448,9 @@ function renderEvidence(summary, { includeReportOnly }) {
         "not a strengthen.",
     );
     for (const blob of summary.oversized) {
+      const parts = blob.parts.map((id) => `[${id}]`).join(", ");
       lines.push(
-        `- [${blob.id}] is ${blob.tokens} tokens as one paragraph (attribution: ${blob.parts.join(", ")}). ` +
+        `- ${blob.id} is ${blob.tokens} tokens as one paragraph (attribution: ${parts}). ` +
           `Split it into list items; do not decorate the blob.`,
       );
     }

--- a/src/fold.js
+++ b/src/fold.js
@@ -130,6 +130,16 @@ export function foldEvidence(
   const duplicates = crossSurfaceDuplicates(memoryFile, skills);
   const overlapById = new Map(duplicates.map((hit) => [hit.instruction, hit]));
 
+  const parentHarmSessions = {};
+  for (const unit of memoryFile?.units || []) {
+    if (!unit.parts?.length) continue;
+    const sessions = new Set(instructions.get(unit.id)?.harmSessions || []);
+    for (const part of unit.parts) {
+      for (const session of instructions.get(part.id)?.harmSessions || []) sessions.add(session);
+    }
+    parentHarmSessions[unit.id] = sessions.size;
+  }
+
   const instructionRows = [...instructions.values()]
     .map((entry) => {
       const unit = findInstructionUnit(memoryFile, entry.instruction);
@@ -208,6 +218,7 @@ export function foldEvidence(
       crossSurfaceDuplicates: duplicates.length,
     },
     instructions: instructionRows,
+    parentHarmSessions,
     gaps,
     crossSurfaceDuplicates: duplicates,
     reportOnlyGaps,

--- a/src/memory.js
+++ b/src/memory.js
@@ -181,7 +181,10 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
     if (terminator === 0 || /\s/u.test(text[terminator - 1])) return null;
     const beforeTerminator = text.slice(sentenceStart, terminator);
     const precedingToken = beforeTerminator.match(/\S+$/u)?.[0] || "";
-    if (/[\\/]/u.test(precedingToken)) return null;
+    if (/[\\/]/u.test(precedingToken)) {
+      const nextTokens = text.slice(next).trimStart().split(/\s+/u).slice(0, 2).join(" ");
+      if (/[\\/]/u.test(nextTokens)) return null;
+    }
     const rawPrefix = beforeTerminator.trim();
     if (/^\d+$/u.test(rawPrefix)) return null;
     const prefix = rawPrefix.replace(/["')\]}*`_~\u2019\u201d]+$/u, "");

--- a/src/memory.js
+++ b/src/memory.js
@@ -199,6 +199,7 @@ export function splitAttributionSentences(text) {
   const sentences = [];
   let start = 0;
   let codeDelimiter = 0;
+  let quotedPathEnd = -1;
   for (let i = 0; i < text.length; i += 1) {
     let backslashes = 0;
     while (text[i - backslashes - 1] === "\\") backslashes += 1;
@@ -214,7 +215,27 @@ export function splitAttributionSentences(text) {
       i += run - 1;
       continue;
     }
-    if (codeDelimiter || ![".", "!", "?"].includes(text[i])) continue;
+    if (codeDelimiter) continue;
+
+    if (i === quotedPathEnd) {
+      quotedPathEnd = -1;
+      continue;
+    }
+    if (quotedPathEnd > i) continue;
+    if (!escaped && ["\"", "'"].includes(text[i])) {
+      let closing = i + 1;
+      while (closing < text.length) {
+        if (text[closing] === text[i] && text[closing - 1] !== "\\") break;
+        closing += 1;
+      }
+      const value = text.slice(i + 1, closing);
+      if (closing < text.length && /^(?:[A-Za-z]:[\\/]|\\\\|\.{0,2}[\\/]|~[\\/])|[\\/]/u.test(value)) {
+        quotedPathEnd = closing;
+        continue;
+      }
+    }
+
+    if (![".", "!", "?"].includes(text[i])) continue;
     const boundary = confidentSentenceBoundary(text, start, i);
     if (!boundary) continue;
     sentences.push(text.slice(start, boundary.end).trim());

--- a/src/memory.js
+++ b/src/memory.js
@@ -159,12 +159,17 @@ function endsWithAbbreviation(text) {
   return /^(?:\p{L}\.)+\p{L}$/u.test(token);
 }
 
-function embeddedReferencePunctuation(text, index) {
+function startsSentence(text, index) {
+  let start = index;
+  while (start < text.length && /["'([{*`_~\u2018\u201c]/u.test(text[start])) start += 1;
+  return start < text.length && /[\p{L}\p{N}$@/\\]/u.test(text[start]);
+}
+
+function isDotPathToken(text, index) {
   let tokenStart = index;
   while (tokenStart > 0 && !/\s/u.test(text[tokenStart - 1])) tokenStart -= 1;
   const token = text.slice(tokenStart, index + 1).replace(/^["'([{*_~]+/u, "");
-  if (["?", "!"].includes(text[index]) && /^[a-z][a-z0-9+.-]*:\/\//iu.test(token)) return true;
-  return text[index] === "." && /^(?:\.{1,2}|.*[\\/]\.{1,2})$/u.test(token);
+  return token === "." || token === "..";
 }
 
 export function splitAttributionSentences(text) {
@@ -188,11 +193,11 @@ export function splitAttributionSentences(text) {
     let end = i + 1;
     while (end < text.length && /["')\]}*_~\u2019\u201d]/u.test(text[end])) end += 1;
     if (end >= text.length || !/\s/u.test(text[end])) continue;
-    if (embeddedReferencePunctuation(text, i)) continue;
-    if (text[i] === "." && endsWithAbbreviation(text.slice(start, i + 1))) continue;
     let next = end;
     while (next < text.length && /\s/u.test(text[next])) next += 1;
-    if (next >= text.length) continue;
+    if (!startsSentence(text, next)) continue;
+    if (text[i] === "." && isDotPathToken(text, i)) continue;
+    if (text[i] === "." && endsWithAbbreviation(text.slice(start, i + 1))) continue;
     sentences.push(text.slice(start, end).trim());
     start = next;
     i = next - 1;

--- a/src/memory.js
+++ b/src/memory.js
@@ -179,13 +179,8 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
   if (text[terminator] === ".") {
     if (terminator === 0 || /\s/u.test(text[terminator - 1])) return null;
     const beforeTerminator = text.slice(sentenceStart, terminator);
-    const pathStarts = [...beforeTerminator.matchAll(/(?:^|\s)(\S*[\\/])/gu)];
-    const pathHasSpaces = pathStarts.some((pathStart) => {
-      const pathTail = beforeTerminator.slice(pathStart.index + pathStart[0].indexOf(pathStart[1]));
-      return /\s/u.test(pathTail);
-    });
-    const nextToken = text.slice(next).match(/^\S+/u)?.[0] || "";
-    if (pathHasSpaces && /[\\/]/u.test(nextToken)) return null;
+    const precedingToken = beforeTerminator.match(/\S+$/u)?.[0] || "";
+    if (/[\\/]/u.test(precedingToken)) return null;
     const rawPrefix = beforeTerminator.trim();
     if (/^\d+$/u.test(rawPrefix)) return null;
     const prefix = rawPrefix.replace(/["')\]}*`_~\u2019\u201d]+$/u, "");

--- a/src/memory.js
+++ b/src/memory.js
@@ -133,11 +133,37 @@ function unitHasFence(text) {
   return text.split("\n").some((line) => FENCE.test(line));
 }
 
+const ABBREVIATIONS = new Set([
+  "approx",
+  "cf",
+  "dept",
+  "dr",
+  "e.g",
+  "etc",
+  "fig",
+  "i.e",
+  "inc",
+  "jr",
+  "misc",
+  "mr",
+  "mrs",
+  "ms",
+  "no",
+  "prof",
+  "sr",
+  "st",
+  "v",
+  "vs",
+]);
+
 function ambiguousPeriodEnding(text) {
   const token = text.match(/([\p{L}.]+)\.$/u)?.[1] || "";
-  if (!token || /^\p{L}$/u.test(token) || /^(?:\p{L}\.)+\p{L}$/u.test(token)) return true;
-  const words = text.match(/[\p{L}\p{N}]+/gu)?.length || 0;
-  return token.replace(/\./g, "").length <= 8 && words <= 3;
+  if (!token) return true;
+  return (
+    ABBREVIATIONS.has(token.toLowerCase()) ||
+    /^\p{L}$/u.test(token) ||
+    /^(?:\p{L}\.)+\p{L}$/u.test(token)
+  );
 }
 
 function startsSentence(text, index) {

--- a/src/memory.js
+++ b/src/memory.js
@@ -12,13 +12,14 @@ import { estimateTokens } from "./tokens.js";
  *   - units come from list items and paragraphs inside those sections
  *   - each unit gets a content hash (survives cosmetic edits elsewhere in the file)
  *     and a readable alias AG-001, AG-002, ... used in prompts and evidence
- *   - a paragraph above ATTRIBUTION_SPLIT_TOKENS is sentence-split into AG-nnn.m parts
- *     for attribution and fold only; the parent alias and line span stay put
+ *   - eligible prose above ATTRIBUTION_SPLIT_TOKENS is conservatively split at
+ *     high-confidence sentence boundaries into AG-nnn.m attribution parts; the parent
+ *     alias and line span stay put
  *
  * Evidence anchors to an addressable instruction id; the hash lets it re-anchor across runs.
  */
 
-/** Paragraphs above this are too coarse to attribute; sentence parts get dotted ids. */
+/** Eligible prose above this is too coarse to attribute and may get dotted sentence-part ids. */
 export const ATTRIBUTION_SPLIT_TOKENS = 120;
 
 const FENCE = /^\s*(```|~~~)/;

--- a/src/memory.js
+++ b/src/memory.js
@@ -181,7 +181,7 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
     const rawPrefix = text.slice(sentenceStart, terminator).trim();
     if (/^\d+$/u.test(rawPrefix)) return null;
     const prefix = rawPrefix.replace(/["')\]}*`_~\u2019\u201d]+$/u, "");
-    const token = prefix.match(/([\p{L}.]+)$/u)?.[1] || "";
+    const token = prefix.match(/([\p{L}\p{N}.]+)$/u)?.[1] || "";
     if (!token) return null;
     if (
       ABBREVIATIONS.has(token.toLowerCase()) ||
@@ -197,7 +197,6 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
 
 export function splitAttributionSentences(text) {
   const sentences = [];
-  const spanStack = [];
   let start = 0;
   let codeDelimiter = 0;
   for (let i = 0; i < text.length; i += 1) {
@@ -215,31 +214,7 @@ export function splitAttributionSentences(text) {
       i += run - 1;
       continue;
     }
-    if (codeDelimiter) continue;
-
-    const bracketClose = { "[": "]", "(": ")", "<": ">" }[text[i]];
-    if (!escaped && bracketClose) {
-      spanStack.push(bracketClose);
-      continue;
-    }
-    if (!escaped && spanStack.at(-1) === text[i]) {
-      spanStack.pop();
-      continue;
-    }
-
-    if (["*", "_", "~"].includes(text[i])) {
-      let run = 1;
-      while (text[i + run] === text[i]) run += 1;
-      const marker = text[i].repeat(run);
-      if (!escaped && (text[i] !== "~" || run >= 2)) {
-        if (spanStack.at(-1) === marker) spanStack.pop();
-        else if (text[i + run] && !/\s/u.test(text[i + run])) spanStack.push(marker);
-      }
-      i += run - 1;
-      continue;
-    }
-
-    if (spanStack.length || ![".", "!", "?"].includes(text[i])) continue;
+    if (codeDelimiter || ![".", "!", "?"].includes(text[i])) continue;
     const boundary = confidentSentenceBoundary(text, start, i);
     if (!boundary) continue;
     sentences.push(text.slice(start, boundary.end).trim());

--- a/src/memory.js
+++ b/src/memory.js
@@ -133,30 +133,11 @@ function unitHasFence(text) {
   return text.split("\n").some((line) => FENCE.test(line));
 }
 
-const ABBREVIATIONS = new Set([
-  "dr",
-  "e.g",
-  "etc",
-  "fig",
-  "i.e",
-  "inc",
-  "jr",
-  "mr",
-  "mrs",
-  "ms",
-  "no",
-  "prof",
-  "sr",
-  "st",
-  "v",
-  "vs",
-]);
-
-function endsWithAbbreviation(text) {
+function ambiguousPeriodEnding(text) {
   const token = text.match(/([\p{L}.]+)\.$/u)?.[1] || "";
-  if (ABBREVIATIONS.has(token.toLowerCase())) return true;
-  if (/^\p{L}$/u.test(token)) return true;
-  return /^(?:\p{L}\.)+\p{L}$/u.test(token);
+  if (!token || /^\p{L}$/u.test(token) || /^(?:\p{L}\.)+\p{L}$/u.test(token)) return true;
+  const words = text.match(/[\p{L}\p{N}]+/gu)?.length || 0;
+  return token.replace(/\./g, "").length <= 8 && words <= 3;
 }
 
 function startsSentence(text, index) {
@@ -197,7 +178,7 @@ export function splitAttributionSentences(text) {
     while (next < text.length && /\s/u.test(text[next])) next += 1;
     if (!startsSentence(text, next)) continue;
     if (text[i] === "." && isDotPathToken(text, i)) continue;
-    if (text[i] === "." && endsWithAbbreviation(text.slice(start, i + 1))) continue;
+    if (text[i] === "." && ambiguousPeriodEnding(text.slice(start, i + 1))) continue;
     sentences.push(text.slice(start, end).trim());
     start = next;
     i = next - 1;

--- a/src/memory.js
+++ b/src/memory.js
@@ -178,7 +178,15 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
 
   if (text[terminator] === ".") {
     if (terminator === 0 || /\s/u.test(text[terminator - 1])) return null;
-    const rawPrefix = text.slice(sentenceStart, terminator).trim();
+    const beforeTerminator = text.slice(sentenceStart, terminator);
+    const pathStarts = [
+      ...beforeTerminator.matchAll(/(?:^|\s)([A-Za-z]:[\\/]|\\\\|(?:\.{0,2}|~)[\\/])/gu),
+    ];
+    const pathStart = pathStarts.at(-1);
+    const pathTail = pathStart ? beforeTerminator.slice(pathStart.index + pathStart[0].indexOf(pathStart[1])) : "";
+    const nextToken = text.slice(next).match(/^\S+/u)?.[0] || "";
+    if (pathTail && /\s/u.test(pathTail) && /[\\/]/u.test(nextToken)) return null;
+    const rawPrefix = beforeTerminator.trim();
     if (/^\d+$/u.test(rawPrefix)) return null;
     const prefix = rawPrefix.replace(/["')\]}*`_~\u2019\u201d]+$/u, "");
     const token = prefix.match(/([\p{L}\p{N}.]+)$/u)?.[1] || "";

--- a/src/memory.js
+++ b/src/memory.js
@@ -13,9 +13,9 @@ import { estimateTokens } from "./tokens.js";
  *   - each unit gets a content hash (survives cosmetic edits elsewhere in the file)
  *     and a readable alias AG-001, AG-002, ... used in prompts and evidence
  *   - a paragraph above ATTRIBUTION_SPLIT_TOKENS is sentence-split into AG-nnn.m parts
- *     for the instruction index and fold only; the parent alias and line span stay put
+ *     for attribution and fold only; the parent alias and line span stay put
  *
- * Evidence anchors to the alias; the hash is what lets us re-anchor across runs.
+ * Evidence anchors to an addressable instruction id; the hash lets it re-anchor across runs.
  */
 
 /** Paragraphs above this are too coarse to attribute; sentence parts get dotted ids. */
@@ -133,25 +133,50 @@ function unitHasFence(text) {
   return text.split("\n").some((line) => FENCE.test(line));
 }
 
-/**
- * Split a paragraph on sentence boundaries. Abbreviations followed by a lowercase
- * word stay together; a capital after `.!?` starts a new sentence.
- */
+const ABBREVIATIONS = new Set([
+  "dr",
+  "e.g",
+  "etc",
+  "fig",
+  "i.e",
+  "inc",
+  "jr",
+  "mr",
+  "mrs",
+  "ms",
+  "no",
+  "prof",
+  "sr",
+  "st",
+  "v",
+  "vs",
+]);
+
+function endsWithAbbreviation(text) {
+  const token = text.match(/([\p{L}.]+)\.$/u)?.[1] || "";
+  if (ABBREVIATIONS.has(token.toLowerCase())) return true;
+  if (/^\p{L}$/u.test(token)) return true;
+  return /^(?:\p{L}\.)+\p{L}$/u.test(token);
+}
+
 export function splitAttributionSentences(text) {
-  const raw = text
-    .split(/(?<=[.!?]["')\]]*)\s+(?=[A-Z([{])/)
-    .map((piece) => piece.trim())
-    .filter(Boolean);
-  if (raw.length < 2) return [];
-  const merged = [];
-  for (const piece of raw) {
-    if (merged.length && estimateTokens(piece) < 8) {
-      merged[merged.length - 1] = `${merged[merged.length - 1]} ${piece}`;
-    } else {
-      merged.push(piece);
-    }
+  const sentences = [];
+  let start = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    if (![".", "!", "?"].includes(text[i])) continue;
+    let end = i + 1;
+    while (end < text.length && /["')\]}*`_~\u2019\u201d]/u.test(text[end])) end += 1;
+    if (end >= text.length || !/\s/u.test(text[end])) continue;
+    if (text[i] === "." && endsWithAbbreviation(text.slice(start, i + 1))) continue;
+    let next = end;
+    while (next < text.length && /\s/u.test(text[next])) next += 1;
+    if (next >= text.length) continue;
+    sentences.push(text.slice(start, end).trim());
+    start = next;
+    i = next - 1;
   }
-  return merged.length >= 2 ? merged : [];
+  sentences.push(text.slice(start).trim());
+  return sentences.length >= 2 ? sentences.filter(Boolean) : [];
 }
 
 function attributionParts(unit) {
@@ -243,7 +268,8 @@ function formatIndexEntry(unit) {
  * Render the instruction index that both prompt tiers see. It is a lookup table keyed
  * by alias, never a stand-in for the file: units are listed with the lines they occupy
  * so the synthesis agent can find them in the raw file it edits. Oversized paragraphs
- * keep their positional AG-nnn id and expose AG-nnn.m sentence parts for attribution.
+ * retain an unbracketed positional AG-nnn alias for line-oriented edits and expose only
+ * their bracketed AG-nnn.m sentence parts as attribution targets.
  */
 export function renderInstructionIndex(file) {
   const blocks = [];
@@ -251,8 +277,9 @@ export function renderInstructionIndex(file) {
     if (unit.parts?.length) {
       const lines = unit.startLine === unit.endLine ? `L${unit.startLine}` : `L${unit.startLine}-${unit.endLine}`;
       blocks.push(
-        `Oversized paragraph [${unit.id}] (${unit.tokens} tok, ${lines})` +
-          `${unit.section ? ` <${unit.section}>` : ""} is one blob; attribution is per sentence ` +
+        `Oversized paragraph ${unit.id} (${unit.tokens} tok, ${lines})` +
+          `${unit.section ? ` <${unit.section}>` : ""} is one blob; ${unit.id} is only its line-oriented alias. ` +
+          `Attribute evidence only to the sentence-part IDs below ` +
           `(${unit.parts.map((part) => part.id).join(", ")}). If these fail to steer, split the ` +
           `paragraph into list items in place - a bold label on the blob is not a strengthen.`,
       );

--- a/src/memory.js
+++ b/src/memory.js
@@ -12,9 +12,14 @@ import { estimateTokens } from "./tokens.js";
  *   - units come from list items and paragraphs inside those sections
  *   - each unit gets a content hash (survives cosmetic edits elsewhere in the file)
  *     and a readable alias AG-001, AG-002, ... used in prompts and evidence
+ *   - a paragraph above ATTRIBUTION_SPLIT_TOKENS is sentence-split into AG-nnn.m parts
+ *     for the instruction index and fold only; the parent alias and line span stay put
  *
  * Evidence anchors to the alias; the hash is what lets us re-anchor across runs.
  */
+
+/** Paragraphs above this are too coarse to attribute; sentence parts get dotted ids. */
+export const ATTRIBUTION_SPLIT_TOKENS = 120;
 
 const FENCE = /^\s*(```|~~~)/;
 
@@ -108,12 +113,78 @@ export function parseMemoryUnits(text) {
   }
   flush(lines.length);
 
-  return units.map((unit, index) => ({
-    id: alias(index),
-    hash: unitHash(unit.text),
-    tokens: estimateTokens(unit.text),
-    ...unit,
+  return units.map((unit, index) => {
+    const base = {
+      id: alias(index),
+      hash: unitHash(unit.text),
+      tokens: estimateTokens(unit.text),
+      ...unit,
+    };
+    const parts = attributionParts(base);
+    return parts ? { ...base, parts } : base;
+  });
+}
+
+function isListItemText(text) {
+  return /^\s*([-*+]|\d+[.)])\s+/m.test(text);
+}
+
+function unitHasFence(text) {
+  return text.split("\n").some((line) => FENCE.test(line));
+}
+
+/**
+ * Split a paragraph on sentence boundaries. Abbreviations followed by a lowercase
+ * word stay together; a capital after `.!?` starts a new sentence.
+ */
+export function splitAttributionSentences(text) {
+  const raw = text
+    .split(/(?<=[.!?]["')\]]*)\s+(?=[A-Z([{])/)
+    .map((piece) => piece.trim())
+    .filter(Boolean);
+  if (raw.length < 2) return [];
+  const merged = [];
+  for (const piece of raw) {
+    if (merged.length && estimateTokens(piece) < 8) {
+      merged[merged.length - 1] = `${merged[merged.length - 1]} ${piece}`;
+    } else {
+      merged.push(piece);
+    }
+  }
+  return merged.length >= 2 ? merged : [];
+}
+
+function attributionParts(unit) {
+  if (unit.tokens <= ATTRIBUTION_SPLIT_TOKENS) return null;
+  if (isListItemText(unit.text) || unitHasFence(unit.text)) return null;
+  const sentences = splitAttributionSentences(unit.text);
+  if (sentences.length < 2) return null;
+  return sentences.map((text, index) => ({
+    id: `${unit.id}.${index + 1}`,
+    hash: unitHash(text),
+    tokens: estimateTokens(text),
+    text,
+    section: unit.section,
+    startLine: unit.startLine,
+    endLine: unit.endLine,
+    parentId: unit.id,
   }));
+}
+
+/** Addressable instructions for analysis, fold, and prompts: sentence parts when present. */
+export function instructionUnits(memoryFile) {
+  return (memoryFile?.units || []).flatMap((unit) => (unit.parts?.length ? unit.parts : [unit]));
+}
+
+/** Resolve an AG-nnn or AG-nnn.m id onto the parent unit or an attribution part. */
+export function findInstructionUnit(memoryFile, id) {
+  if (!memoryFile?.units || !id) return null;
+  for (const unit of memoryFile.units) {
+    if (unit.id === id) return unit;
+    const part = unit.parts?.find((candidate) => candidate.id === id);
+    if (part) return part;
+  }
+  return null;
 }
 
 /**
@@ -163,18 +234,34 @@ export function memorySurfaceHash(setHash, skills) {
   return `sha256:${sha256(`${setHash}|${layer}`).slice(0, 16)}`;
 }
 
+function formatIndexEntry(unit) {
+  const lines = unit.startLine === unit.endLine ? `L${unit.startLine}` : `L${unit.startLine}-${unit.endLine}`;
+  return `[${unit.id}] (${unit.tokens} tok, ${lines})${unit.section ? ` <${unit.section}>` : ""}\n${unit.text}`;
+}
+
 /**
  * Render the instruction index that both prompt tiers see. It is a lookup table keyed
  * by alias, never a stand-in for the file: units are listed with the lines they occupy
- * so the synthesis agent can find them in the raw file it edits.
+ * so the synthesis agent can find them in the raw file it edits. Oversized paragraphs
+ * keep their positional AG-nnn id and expose AG-nnn.m sentence parts for attribution.
  */
 export function renderInstructionIndex(file) {
-  return file.units
-    .map((u) => {
-      const lines = u.startLine === u.endLine ? `L${u.startLine}` : `L${u.startLine}-${u.endLine}`;
-      return `[${u.id}] (${u.tokens} tok, ${lines})${u.section ? ` <${u.section}>` : ""}\n${u.text}`;
-    })
-    .join("\n\n");
+  const blocks = [];
+  for (const unit of file.units) {
+    if (unit.parts?.length) {
+      const lines = unit.startLine === unit.endLine ? `L${unit.startLine}` : `L${unit.startLine}-${unit.endLine}`;
+      blocks.push(
+        `Oversized paragraph [${unit.id}] (${unit.tokens} tok, ${lines})` +
+          `${unit.section ? ` <${unit.section}>` : ""} is one blob; attribution is per sentence ` +
+          `(${unit.parts.map((part) => part.id).join(", ")}). If these fail to steer, split the ` +
+          `paragraph into list items in place - a bold label on the blob is not a strengthen.`,
+      );
+      for (const part of unit.parts) blocks.push(formatIndexEntry(part));
+    } else {
+      blocks.push(formatIndexEntry(unit));
+    }
+  }
+  return blocks.join("\n\n");
 }
 
 export function similarityFeatures(text) {

--- a/src/memory.js
+++ b/src/memory.js
@@ -159,14 +159,32 @@ function endsWithAbbreviation(text) {
   return /^(?:\p{L}\.)+\p{L}$/u.test(token);
 }
 
+function embeddedReferencePunctuation(text, index) {
+  let tokenStart = index;
+  while (tokenStart > 0 && !/\s/u.test(text[tokenStart - 1])) tokenStart -= 1;
+  const token = text.slice(tokenStart, index + 1).replace(/^["'([{*_~]+/u, "");
+  if (["?", "!"].includes(text[index]) && /^[a-z][a-z0-9+.-]*:\/\//iu.test(token)) return true;
+  return text[index] === "." && /^(?:\.{1,2}|.*[\\/]\.{1,2})$/u.test(token);
+}
+
 export function splitAttributionSentences(text) {
   const sentences = [];
   let start = 0;
+  let codeDelimiter = 0;
   for (let i = 0; i < text.length; i += 1) {
-    if (![".", "!", "?"].includes(text[i])) continue;
+    if (text[i] === "`") {
+      let run = 1;
+      while (text[i + run] === "`") run += 1;
+      if (codeDelimiter === 0) codeDelimiter = run;
+      else if (codeDelimiter === run) codeDelimiter = 0;
+      i += run - 1;
+      continue;
+    }
+    if (codeDelimiter || ![".", "!", "?"].includes(text[i])) continue;
     let end = i + 1;
-    while (end < text.length && /["')\]}*`_~\u2019\u201d]/u.test(text[end])) end += 1;
+    while (end < text.length && /["')\]}*_~\u2019\u201d]/u.test(text[end])) end += 1;
     if (end >= text.length || !/\s/u.test(text[end])) continue;
+    if (embeddedReferencePunctuation(text, i)) continue;
     if (text[i] === "." && endsWithAbbreviation(text.slice(start, i + 1))) continue;
     let next = end;
     while (next < text.length && /\s/u.test(text[next])) next += 1;

--- a/src/memory.js
+++ b/src/memory.js
@@ -197,22 +197,49 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
 
 export function splitAttributionSentences(text) {
   const sentences = [];
+  const spanStack = [];
   let start = 0;
   let codeDelimiter = 0;
   for (let i = 0; i < text.length; i += 1) {
+    let backslashes = 0;
+    while (text[i - backslashes - 1] === "\\") backslashes += 1;
+    const escaped = backslashes % 2 === 1;
+
     if (text[i] === "`") {
-      let backslashes = 0;
-      while (text[i - backslashes - 1] === "\\") backslashes += 1;
       let run = 1;
       while (text[i + run] === "`") run += 1;
-      if (backslashes % 2 === 0) {
+      if (!escaped) {
         if (codeDelimiter === 0) codeDelimiter = run;
         else if (codeDelimiter === run) codeDelimiter = 0;
       }
       i += run - 1;
       continue;
     }
-    if (codeDelimiter || ![".", "!", "?"].includes(text[i])) continue;
+    if (codeDelimiter) continue;
+
+    const bracketClose = { "[": "]", "(": ")", "<": ">" }[text[i]];
+    if (!escaped && bracketClose) {
+      spanStack.push(bracketClose);
+      continue;
+    }
+    if (!escaped && spanStack.at(-1) === text[i]) {
+      spanStack.pop();
+      continue;
+    }
+
+    if (["*", "_", "~"].includes(text[i])) {
+      let run = 1;
+      while (text[i + run] === text[i]) run += 1;
+      const marker = text[i].repeat(run);
+      if (!escaped && (text[i] !== "~" || run >= 2)) {
+        if (spanStack.at(-1) === marker) spanStack.pop();
+        else if (text[i + run] && !/\s/u.test(text[i + run])) spanStack.push(marker);
+      }
+      i += run - 1;
+      continue;
+    }
+
+    if (spanStack.length || ![".", "!", "?"].includes(text[i])) continue;
     const boundary = confidentSentenceBoundary(text, start, i);
     if (!boundary) continue;
     sentences.push(text.slice(start, boundary.end).trim());

--- a/src/memory.js
+++ b/src/memory.js
@@ -179,13 +179,13 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
   if (text[terminator] === ".") {
     if (terminator === 0 || /\s/u.test(text[terminator - 1])) return null;
     const beforeTerminator = text.slice(sentenceStart, terminator);
-    const pathStarts = [
-      ...beforeTerminator.matchAll(/(?:^|\s)([A-Za-z]:[\\/]|\\\\|(?:\.{0,2}|~)[\\/])/gu),
-    ];
-    const pathStart = pathStarts.at(-1);
-    const pathTail = pathStart ? beforeTerminator.slice(pathStart.index + pathStart[0].indexOf(pathStart[1])) : "";
+    const pathStarts = [...beforeTerminator.matchAll(/(?:^|\s)(\S*[\\/])/gu)];
+    const pathHasSpaces = pathStarts.some((pathStart) => {
+      const pathTail = beforeTerminator.slice(pathStart.index + pathStart[0].indexOf(pathStart[1]));
+      return /\s/u.test(pathTail);
+    });
     const nextToken = text.slice(next).match(/^\S+/u)?.[0] || "";
-    if (pathTail && /\s/u.test(pathTail) && /[\\/]/u.test(nextToken)) return null;
+    if (pathHasSpaces && /[\\/]/u.test(nextToken)) return null;
     const rawPrefix = beforeTerminator.trim();
     if (/^\d+$/u.test(rawPrefix)) return null;
     const prefix = rawPrefix.replace(/["')\]}*`_~\u2019\u201d]+$/u, "");

--- a/src/memory.js
+++ b/src/memory.js
@@ -173,10 +173,14 @@ export function splitAttributionSentences(text) {
   let codeDelimiter = 0;
   for (let i = 0; i < text.length; i += 1) {
     if (text[i] === "`") {
+      let backslashes = 0;
+      while (text[i - backslashes - 1] === "\\") backslashes += 1;
       let run = 1;
       while (text[i + run] === "`") run += 1;
-      if (codeDelimiter === 0) codeDelimiter = run;
-      else if (codeDelimiter === run) codeDelimiter = 0;
+      if (backslashes % 2 === 0) {
+        if (codeDelimiter === 0) codeDelimiter = run;
+        else if (codeDelimiter === run) codeDelimiter = 0;
+      }
       i += run - 1;
       continue;
     }

--- a/src/memory.js
+++ b/src/memory.js
@@ -135,48 +135,64 @@ function unitHasFence(text) {
 
 const ABBREVIATIONS = new Set([
   "approx",
+  "capt",
   "cf",
+  "cmdr",
+  "col",
   "dept",
   "dr",
   "e.g",
   "etc",
   "fig",
+  "gen",
+  "gov",
   "i.e",
   "inc",
   "jr",
+  "lt",
   "misc",
   "mr",
   "mrs",
   "ms",
   "no",
   "prof",
+  "rep",
+  "rev",
+  "sen",
   "sr",
   "st",
   "v",
   "vs",
 ]);
 
-function ambiguousPeriodEnding(text) {
-  const token = text.match(/([\p{L}.]+)\.$/u)?.[1] || "";
-  if (!token) return true;
-  return (
-    ABBREVIATIONS.has(token.toLowerCase()) ||
-    /^\p{L}$/u.test(token) ||
-    /^(?:\p{L}\.)+\p{L}$/u.test(token)
-  );
-}
+function confidentSentenceBoundary(text, sentenceStart, terminator) {
+  let end = terminator + 1;
+  while (end < text.length && /["')\]}*_~\u2019\u201d]/u.test(text[end])) end += 1;
+  if (end >= text.length || !/\s/u.test(text[end])) return null;
 
-function startsSentence(text, index) {
-  let start = index;
-  while (start < text.length && /["'([{*`_~\u2018\u201c]/u.test(text[start])) start += 1;
-  return start < text.length && /[\p{L}\p{N}$@/\\]/u.test(text[start]);
-}
+  let next = end;
+  while (next < text.length && /\s/u.test(text[next])) next += 1;
+  let visibleNext = next;
+  while (visibleNext < text.length && /["'([{*`_~\u2018\u201c]/u.test(text[visibleNext])) visibleNext += 1;
+  if (visibleNext >= text.length || !/[\p{L}\p{N}$@/\\]/u.test(text[visibleNext])) return null;
 
-function isDotPathToken(text, index) {
-  let tokenStart = index;
-  while (tokenStart > 0 && !/\s/u.test(text[tokenStart - 1])) tokenStart -= 1;
-  const token = text.slice(tokenStart, index + 1).replace(/^["'([{*_~]+/u, "");
-  return token === "." || token === "..";
+  if (text[terminator] === ".") {
+    if (terminator === 0 || /\s/u.test(text[terminator - 1])) return null;
+    const rawPrefix = text.slice(sentenceStart, terminator).trim();
+    if (/^\d+$/u.test(rawPrefix)) return null;
+    const prefix = rawPrefix.replace(/["')\]}*`_~\u2019\u201d]+$/u, "");
+    const token = prefix.match(/([\p{L}.]+)$/u)?.[1] || "";
+    if (!token) return null;
+    if (
+      ABBREVIATIONS.has(token.toLowerCase()) ||
+      /^\p{L}$/u.test(token) ||
+      /^(?:\p{L}\.)+\p{L}$/u.test(token)
+    ) {
+      return null;
+    }
+  }
+
+  return { end, next };
 }
 
 export function splitAttributionSentences(text) {
@@ -197,17 +213,11 @@ export function splitAttributionSentences(text) {
       continue;
     }
     if (codeDelimiter || ![".", "!", "?"].includes(text[i])) continue;
-    let end = i + 1;
-    while (end < text.length && /["')\]}*_~\u2019\u201d]/u.test(text[end])) end += 1;
-    if (end >= text.length || !/\s/u.test(text[end])) continue;
-    let next = end;
-    while (next < text.length && /\s/u.test(text[next])) next += 1;
-    if (!startsSentence(text, next)) continue;
-    if (text[i] === "." && isDotPathToken(text, i)) continue;
-    if (text[i] === "." && ambiguousPeriodEnding(text.slice(start, i + 1))) continue;
-    sentences.push(text.slice(start, end).trim());
-    start = next;
-    i = next - 1;
+    const boundary = confidentSentenceBoundary(text, start, i);
+    if (!boundary) continue;
+    sentences.push(text.slice(start, boundary.end).trim());
+    start = boundary.next;
+    i = boundary.next - 1;
   }
   sentences.push(text.slice(start).trim());
   return sentences.length >= 2 ? sentences.filter(Boolean) : [];

--- a/src/memory.js
+++ b/src/memory.js
@@ -186,11 +186,7 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
     const prefix = rawPrefix.replace(/["')\]}*`_~\u2019\u201d]+$/u, "");
     const token = prefix.match(/([\p{L}\p{N}.]+)$/u)?.[1] || "";
     if (!token) return null;
-    if (
-      ABBREVIATIONS.has(token.toLowerCase()) ||
-      /^\p{L}$/u.test(token) ||
-      /^(?:\p{L}\.)+\p{L}$/u.test(token)
-    ) {
+    if (ABBREVIATIONS.has(token.toLowerCase()) || /^\p{L}$/u.test(token) || /^(?:\p{L}\.)+\p{L}$/u.test(token)) {
       return null;
     }
   }
@@ -225,7 +221,7 @@ export function splitAttributionSentences(text) {
       continue;
     }
     if (quotedPathEnd > i) continue;
-    if (!escaped && ["\"", "'"].includes(text[i])) {
+    if (!escaped && ['"', "'"].includes(text[i])) {
       let closing = i + 1;
       while (closing < text.length) {
         if (text[closing] === text[i] && text[closing - 1] !== "\\") break;

--- a/src/memory.js
+++ b/src/memory.js
@@ -183,7 +183,9 @@ function confidentSentenceBoundary(text, sentenceStart, terminator) {
     const precedingToken = beforeTerminator.match(/\S+$/u)?.[0] || "";
     if (/[\\/]/u.test(precedingToken)) {
       const nextTokens = text.slice(next).trimStart().split(/\s+/u).slice(0, 2).join(" ");
-      if (/[\\/]/u.test(nextTokens)) return null;
+      const finalPathSegment = precedingToken.split(/[\\/]/u).at(-1) || "";
+      const pathEndsWithExtension = /\.[\p{L}\p{N}]+$/u.test(finalPathSegment);
+      if (/[\\/]/u.test(nextTokens) && !pathEndsWithExtension) return null;
     }
     const rawPrefix = beforeTerminator.trim();
     if (/^\d+$/u.test(rawPrefix)) return null;

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -28,9 +28,10 @@ skill bodies are free until triggered.
 Every always-loaded token is paid on every future session, forever, and instruction
 following dilutes as the file grows. The budget is the constraint you optimize under.
 
-The index below is a lookup table, not the file: it names each instruction (`AG-nnn`),
-its always-loaded cost, and the lines it occupies in `./{{MEMORY_PATH}}`. The evidence
-refers to instructions by these ids.
+The index below is a lookup table, not the file: it names each instruction (`AG-nnn`,
+or `AG-nnn.m` attribution parts for an oversized paragraph), its always-loaded cost,
+and the lines it occupies in `./{{MEMORY_PATH}}`. The evidence refers to instructions
+by these ids.
 
 {{INSTRUCTION_INDEX}}
 

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -522,7 +522,9 @@ export function buildProposal(rawResult, context) {
       for (const hunk of hunks) {
         if (!hunk.removed || hunk.added) continue;
         for (const unit of unitsRemovedBy(hunk, memoryFile)) {
-          const harm = rows.get(unit.id)?.harmSessions ?? 0;
+          const directHarm = rows.get(unit.id)?.harmSessions ?? 0;
+          const partHarm = summary?.parentHarmSessions?.[unit.id] ?? 0;
+          const harm = Math.max(directHarm, partHarm);
           if (harm < config.minGapEvidence) unsupported.push({ unit, harm });
         }
       }

--- a/src/state.js
+++ b/src/state.js
@@ -193,22 +193,24 @@ export function sha256(text) {
 }
 
 function migrateEvidenceRecord(record, transcript, identity) {
-  const legacyKey = `${transcript.mtimeMs}:${transcript.bytes}:${record.memoryHash}`;
-  const key = record.key === legacyKey ? evidenceKey(transcript, record.memoryHash) : record.key;
-  if (record.transcript?.identity === identity && record.key === key) return record;
+  if (record.transcript?.identity === identity) return record;
   return {
     ...record,
     transcript: { ...record.transcript, identity },
-    key,
   };
 }
 
+export const ANALYSIS_INDEX_VERSION = 2;
+
 /**
- * Cache key for a transcript's analysis: the transcript's own content signature plus
- * the memory-surface hash it was judged against. Either changing invalidates the evidence.
+ * Cache key for a transcript's analysis: its content signature, the memory-surface hash,
+ * and the analysis index version. Changing any of them invalidates the evidence.
  */
 export function evidenceKey(transcript, memoryHash) {
-  return `${transcriptIdentity(transcript)}:${transcript.mtimeMs}:${transcript.bytes}:${memoryHash}`;
+  return (
+    `${transcriptIdentity(transcript)}:${transcript.mtimeMs}:${transcript.bytes}:${memoryHash}:` +
+    `analysis-index-v${ANALYSIS_INDEX_VERSION}`
+  );
 }
 
 /**

--- a/test/analyze-reuse.test.js
+++ b/test/analyze-reuse.test.js
@@ -157,10 +157,14 @@ test("evidence from the previous analysis index is reanalyzed once without --for
   const first = runAnalyze(dir, home);
   assert.equal(first.status, 0, first.output);
   const evidenceDir = path.join(dir, ".backpass", "evidence");
-  const evidenceFile = path.join(evidenceDir, fs.readdirSync(evidenceDir).find((name) => name.endsWith(".json")));
+  const evidenceFile = path.join(
+    evidenceDir,
+    fs.readdirSync(evidenceDir).find((name) => name.endsWith(".json")),
+  );
   const evidence = JSON.parse(fs.readFileSync(evidenceFile, "utf8"));
   evidence.key =
-    `${evidence.transcript.identity}:${evidence.transcript.mtimeMs}:${evidence.transcript.bytes}:` + evidence.memoryHash;
+    `${evidence.transcript.identity}:${evidence.transcript.mtimeMs}:${evidence.transcript.bytes}:` +
+    evidence.memoryHash;
   fs.writeFileSync(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`);
 
   const upgraded = runAnalyze(dir, home);

--- a/test/analyze-reuse.test.js
+++ b/test/analyze-reuse.test.js
@@ -149,6 +149,29 @@ test("the first analysis performs work, an unchanged second reuses it, and --for
   );
 });
 
+test("evidence from the previous analysis index is reanalyzed once without --force", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-home-"));
+  const dir = initRepo(MEMORY);
+  writeSession(home, "session-a", dir);
+
+  const first = runAnalyze(dir, home);
+  assert.equal(first.status, 0, first.output);
+  const evidenceDir = path.join(dir, ".backpass", "evidence");
+  const evidenceFile = path.join(evidenceDir, fs.readdirSync(evidenceDir).find((name) => name.endsWith(".json")));
+  const evidence = JSON.parse(fs.readFileSync(evidenceFile, "utf8"));
+  evidence.key =
+    `${evidence.transcript.identity}:${evidence.transcript.mtimeMs}:${evidence.transcript.bytes}:` + evidence.memoryHash;
+  fs.writeFileSync(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`);
+
+  const upgraded = runAnalyze(dir, home);
+  assert.equal(upgraded.status, 0, upgraded.output);
+  assert.deepEqual([upgraded.summary.analyzed, upgraded.summary.cached], [1, 0]);
+
+  const reused = runAnalyze(dir, home);
+  assert.equal(reused.status, 0, reused.output);
+  assert.deepEqual([reused.summary.analyzed, reused.summary.cached], [0, 1]);
+});
+
 test("editing AGENTS.md without --force reanalyzes and explains that prior evidence is stale, not missing", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-reuse-home-"));
   const dir = initRepo(MEMORY);

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -12,7 +12,7 @@ import { renderPointer, renderStarterMemory } from "../src/bootstrap.js";
 import { loadConfig } from "../src/config.js";
 import { UserError, setLoggerSink } from "../src/logger.js";
 import { isPointerTo, memorySetHash, memoryTextHash, parseMemoryUnits } from "../src/memory.js";
-import { State } from "../src/state.js";
+import { evidenceKey, State } from "../src/state.js";
 import { clearProgressSink, setProgressSink } from "../src/progress.js";
 import { ProposalViolation } from "../src/proposal.js";
 
@@ -49,16 +49,12 @@ const discoverTwo = async () => ({ transcripts: [transcript("s1"), transcript("s
 /** Stands in for the tier-1 model: every session reports the same gap against the starter. */
 function writeFakeEvidence({ transcripts, memoryFile, config, memoryHash }, domainAt = (_index) => undefined) {
   for (const [index, t] of transcripts.entries()) {
+    const evidenceTranscript = { ...t, interaction: "interactive" };
     config.state.writeEvidence(t.id, {
       status: "ok",
-      transcript: {
-        id: t.id,
-        identity: t.identity,
-        harness: t.harness,
-        startedAt: t.startedAt,
-        interaction: "interactive",
-      },
+      transcript: evidenceTranscript,
       memoryHash,
+      key: evidenceKey(evidenceTranscript, memoryHash),
       memoryPath: memoryFile.path,
       positive: [],
       negative: [],

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -165,6 +165,18 @@ test("paths, URLs, and inline code do not create fragment attribution targets", 
   assert.ok(unit.parts.every((part) => !part.text.startsWith("--watch`")));
 });
 
+test("an escaped literal backtick cannot disable sentence attribution", () => {
+  const blob =
+    "Write \\` for literal output. " +
+    Array.from({ length: 12 }, (_, i) => `Run check ${i + 1} before deployment. Deploy safely afterward.`).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.length > 12);
+  assert.equal(unit.parts[0].text, "Write \\` for literal output.");
+  assert.ok(unit.parts.some((part) => part.text === "Deploy safely afterward."));
+});
+
 test("list items and fenced blocks are not sentence-split even when oversized", () => {
   const blob = oversizedParagraph();
   const listed = parseMemoryUnits(`# T\n\n- ${blob}\n`);

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -204,7 +204,7 @@ test("generic punctuation cannot suppress later clear attribution boundaries", (
 
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
-    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
+    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
   const blob = Array.from({ length: 8 }, () => cycle).join(" ");
   const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
 
@@ -213,6 +213,8 @@ test("paths, URLs, and inline code do not create fragment attribution targets", 
   assert.ok(unit.parts.some((part) => part.text === "Read docs/config.md before editing."));
   assert.ok(unit.parts.some((part) => part.text === 'Read "C:\\Program Files\\Foo. Bar\\config" before editing.'));
   assert.ok(unit.parts.every((part) => part.text !== 'Read "C:\\Program Files\\Foo.'));
+  assert.ok(unit.parts.some((part) => part.text === "Read C:\\Program Files\\Foo. Bar\\config before editing."));
+  assert.ok(unit.parts.every((part) => part.text !== "Read C:\\Program Files\\Foo."));
   assert.ok(unit.parts.some((part) => part.text === "Visit https://example.test/docs/config.md before editing."));
   assert.ok(unit.parts.some((part) => part.text === "Run `node app.js. --watch` afterward."));
   assert.ok(unit.parts.every((part) => !part.text.startsWith("--watch`")));

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -151,6 +151,20 @@ test("oversized Markdown-heavy paragraphs split realistic sentences without spli
   assert.ok(unit.parts.some((part) => part.text.startsWith("Review with Dr. Smith")));
 });
 
+test("paths, URLs, and inline code do not create fragment attribution targets", () => {
+  const cycle =
+    "Read docs/config.md before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.";
+  const blob = Array.from({ length: 8 }, () => cycle).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.length > 8);
+  assert.ok(unit.parts.some((part) => part.text === "Read docs/config.md before editing."));
+  assert.ok(unit.parts.some((part) => part.text === "Visit https://example.test/docs/config.md before editing."));
+  assert.ok(unit.parts.some((part) => part.text === "Run `node app.js. --watch` afterward."));
+  assert.ok(unit.parts.every((part) => !part.text.startsWith("--watch`")));
+});
+
 test("list items and fenced blocks are not sentence-split even when oversized", () => {
   const blob = oversizedParagraph();
   const listed = parseMemoryUnits(`# T\n\n- ${blob}\n`);

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -188,6 +188,18 @@ test("ambiguous abbreviations stay attached while clear sentence boundaries stil
   assert.ok(unit.parts.some((part) => part.text === "A clear requirement governs deployment."));
 });
 
+test("Markdown spans and standalone path tokens stay within attribution parts", () => {
+  const cycle = "Keep **alpha. Beta** together. Deploy safely. Work from . Next verify.";
+  const blob = Array.from({ length: 12 }, () => cycle).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.some((part) => part.text === "Keep **alpha. Beta** together."));
+  assert.ok(unit.parts?.some((part) => part.text === "Deploy safely."));
+  assert.ok(unit.parts?.some((part) => part.text === "Work from . Next verify."));
+  assert.ok(unit.parts?.every((part) => part.text !== "Keep **alpha." && part.text !== "Work from ."));
+});
+
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
     "Read docs/config.md before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.";

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -165,6 +165,19 @@ test("paths, URLs, and inline code do not create fragment attribution targets", 
   assert.ok(unit.parts.every((part) => !part.text.startsWith("--watch`")));
 });
 
+test("URL-ending questions and exclamations remain sentence boundaries", () => {
+  const cycle =
+    "Is it https://example.com/docs? Check the result! Visit https://example.com/search?q=one!two before release. Follow AG-001.2 before editing.";
+  const blob = Array.from({ length: 8 }, () => cycle).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.some((part) => part.text === "Is it https://example.com/docs?"));
+  assert.ok(unit.parts?.some((part) => part.text === "Check the result!"));
+  assert.ok(unit.parts?.some((part) => part.text === "Visit https://example.com/search?q=one!two before release."));
+  assert.ok(unit.parts?.some((part) => part.text === "Follow AG-001.2 before editing."));
+});
+
 test("an escaped literal backtick cannot disable sentence attribution", () => {
   const blob =
     "Write \\` for literal output. " +

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -151,6 +151,21 @@ test("oversized Markdown-heavy paragraphs split realistic sentences without spli
   assert.ok(unit.parts.some((part) => part.text.startsWith("Review with Dr. Smith")));
 });
 
+test("the confidence segmenter handles abbreviations, Markdown endings, and short sentences", () => {
+  const cycle =
+    "Consult Capt. Smith before release. Run **checks**. Deploy safely. Run `pnpm test`. Deploy safely. Run checks. pnpm test verifies them.";
+  const blob = Array.from({ length: 8 }, () => cycle).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.every((part) => part.text !== "Consult Capt."));
+  assert.ok(unit.parts?.some((part) => part.text === "Consult Capt. Smith before release."));
+  assert.ok(unit.parts?.some((part) => part.text === "Run **checks**."));
+  assert.ok(unit.parts?.some((part) => part.text === "Run `pnpm test`."));
+  assert.ok(unit.parts?.some((part) => part.text === "Run checks."));
+  assert.ok(unit.parts?.some((part) => part.text === "pnpm test verifies them."));
+});
+
 test("clear short sentences split regardless of segment length", () => {
   const cycle = "Run checks. pnpm test verifies them.";
   const blob = Array.from({ length: 20 }, () => cycle).join(" ");

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -128,12 +128,27 @@ test("an oversized paragraph keeps its positional alias and exposes sentence par
   assert.ok(units[0].parts.every((p) => blob.includes(p.text)));
 
   const index = renderInstructionIndex({ units });
-  assert.match(index, /Oversized paragraph \[AG-001\]/);
+  assert.match(index, /Oversized paragraph AG-001/);
   assert.match(index, /\[AG-001\.1\]/);
   assert.match(index, /\[AG-001\.2\]/);
   assert.match(index, /split the paragraph into list items/);
   assert.match(index, /bold label on the blob is not a strengthen/);
-  assert.doesNotMatch(index, /^\[AG-001\] \(/m, "the blob itself is not an attribution target");
+  assert.doesNotMatch(index, /\[AG-001\]/, "the blob itself is not an attribution target");
+});
+
+test("oversized Markdown-heavy paragraphs split realistic sentences without splitting abbreviations", () => {
+  const cycle =
+    "Review with Dr. Smith before release. `pnpm test` verifies behavior. deploy now checks lowercase commands. Écrivez les résultats clairement.";
+  const blob = Array.from({ length: 8 }, () => cycle).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.length > 8);
+  assert.ok(unit.parts.some((part) => part.text.startsWith("`pnpm test`")));
+  assert.ok(unit.parts.some((part) => part.text.startsWith("deploy now")));
+  assert.ok(unit.parts.some((part) => part.text.startsWith("Écrivez")));
+  assert.ok(unit.parts.every((part) => part.text !== "Review with Dr."));
+  assert.ok(unit.parts.some((part) => part.text.startsWith("Review with Dr. Smith")));
 });
 
 test("list items and fenced blocks are not sentence-split even when oversized", () => {

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -188,16 +188,18 @@ test("ambiguous abbreviations stay attached while clear sentence boundaries stil
   assert.ok(unit.parts.some((part) => part.text === "A clear requirement governs deployment."));
 });
 
-test("Markdown spans and standalone path tokens stay within attribution parts", () => {
-  const cycle = "Keep **alpha. Beta** together. Deploy safely. Work from . Next verify.";
+test("generic punctuation cannot suppress later clear attribution boundaries", () => {
+  const cycle =
+    "Keep retries < 3. Deploy safely. Verify results. Mark *critical text. Continue safely. Work from . Next verify.";
   const blob = Array.from({ length: 12 }, () => cycle).join(" ");
   const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
 
   assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
-  assert.ok(unit.parts?.some((part) => part.text === "Keep **alpha. Beta** together."));
+  assert.ok(unit.parts?.some((part) => part.text === "Keep retries < 3."));
   assert.ok(unit.parts?.some((part) => part.text === "Deploy safely."));
+  assert.ok(unit.parts?.some((part) => part.text === "Verify results."));
+  assert.ok(unit.parts?.some((part) => part.text === "Continue safely."));
   assert.ok(unit.parts?.some((part) => part.text === "Work from . Next verify."));
-  assert.ok(unit.parts?.every((part) => part.text !== "Keep **alpha." && part.text !== "Work from ."));
 });
 
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -151,6 +151,16 @@ test("oversized Markdown-heavy paragraphs split realistic sentences without spli
   assert.ok(unit.parts.some((part) => part.text.startsWith("Review with Dr. Smith")));
 });
 
+test("clear short sentences split regardless of segment length", () => {
+  const cycle = "Run checks. pnpm test verifies them.";
+  const blob = Array.from({ length: 20 }, () => cycle).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.some((part) => part.text === "Run checks."));
+  assert.ok(unit.parts?.some((part) => part.text === "pnpm test verifies them."));
+});
+
 test("ambiguous abbreviations stay attached while clear sentence boundaries still split", () => {
   const cycle = "See approx. Five checks follow. A clear requirement governs deployment.";
   const blob = Array.from({ length: 12 }, () => cycle).join(" ");

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -2,7 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { budgetBar, budgetGateKind, budgetStatus, estimateTokens, formatTokens } from "../src/tokens.js";
-import { parseMemoryUnits, similarity, reanchor, unitHash } from "../src/memory.js";
+import {
+  ATTRIBUTION_SPLIT_TOKENS,
+  parseMemoryUnits,
+  renderInstructionIndex,
+  similarity,
+  reanchor,
+  unitHash,
+} from "../src/memory.js";
 import { extractionBudgetEffect, parseFrontmatter, renderSkillFile } from "../src/skills.js";
 
 test("token estimation prices UTF-8 bytes, not characters", () => {
@@ -91,6 +98,54 @@ test("a fenced code block stays one unit instead of splitting into lines", () =>
   const units = parseMemoryUnits(text);
   assert.equal(units.length, 1);
   assert.ok(units[0].text.includes("const b = 2;"));
+});
+
+function oversizedParagraph(count = 5) {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      `Sentence ${i + 1} states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.`,
+  ).join(" ");
+}
+
+test("an oversized paragraph keeps its positional alias and exposes sentence parts for attribution", () => {
+  const blob = oversizedParagraph();
+  const units = parseMemoryUnits(`# Memory\n\n${blob}\n\n- Keep the next unit's id stable.\n`);
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.deepEqual(
+    units.map((u) => u.id),
+    ["AG-001", "AG-002"],
+    "later units keep positional aliases; parts are dotted, not extra AG-nnn ids",
+  );
+  assert.equal(units[1].text, "- Keep the next unit's id stable.");
+  assert.ok(units[0].parts?.length >= 2, "the blob splits on sentence boundaries");
+  assert.deepEqual(
+    units[0].parts.map((p) => p.id),
+    units[0].parts.map((_, i) => `AG-001.${i + 1}`),
+  );
+  assert.equal(units[0].parts[0].parentId, "AG-001");
+  assert.ok(units[0].parts.every((p) => p.startLine === units[0].startLine && p.endLine === units[0].endLine));
+  assert.ok(units[0].parts.every((p) => blob.includes(p.text)));
+
+  const index = renderInstructionIndex({ units });
+  assert.match(index, /Oversized paragraph \[AG-001\]/);
+  assert.match(index, /\[AG-001\.1\]/);
+  assert.match(index, /\[AG-001\.2\]/);
+  assert.match(index, /split the paragraph into list items/);
+  assert.match(index, /bold label on the blob is not a strengthen/);
+  assert.doesNotMatch(index, /^\[AG-001\] \(/m, "the blob itself is not an attribution target");
+});
+
+test("list items and fenced blocks are not sentence-split even when oversized", () => {
+  const blob = oversizedParagraph();
+  const listed = parseMemoryUnits(`# T\n\n- ${blob}\n`);
+  assert.equal(listed.length, 1);
+  assert.equal(listed[0].id, "AG-001");
+  assert.equal(listed[0].parts, undefined);
+
+  const fenced = parseMemoryUnits(`# T\n\n\`\`\`\n${blob}\n\`\`\`\n`);
+  assert.equal(fenced.length, 1);
+  assert.equal(fenced[0].parts, undefined);
 });
 
 test("instruction hashes survive cosmetic reformatting but not meaning changes", () => {

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -204,7 +204,7 @@ test("generic punctuation cannot suppress later clear attribution boundaries", (
 
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
-    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
+    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Read docs/Program Files/Foo. Bar/config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
   const blob = Array.from({ length: 8 }, () => cycle).join(" ");
   const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
 
@@ -215,6 +215,8 @@ test("paths, URLs, and inline code do not create fragment attribution targets", 
   assert.ok(unit.parts.every((part) => part.text !== 'Read "C:\\Program Files\\Foo.'));
   assert.ok(unit.parts.some((part) => part.text === "Read C:\\Program Files\\Foo. Bar\\config before editing."));
   assert.ok(unit.parts.every((part) => part.text !== "Read C:\\Program Files\\Foo."));
+  assert.ok(unit.parts.some((part) => part.text === "Read docs/Program Files/Foo. Bar/config before editing."));
+  assert.ok(unit.parts.every((part) => part.text !== "Read docs/Program Files/Foo."));
   assert.ok(unit.parts.some((part) => part.text === "Visit https://example.test/docs/config.md before editing."));
   assert.ok(unit.parts.some((part) => part.text === "Run `node app.js. --watch` afterward."));
   assert.ok(unit.parts.every((part) => !part.text.startsWith("--watch`")));

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -151,6 +151,18 @@ test("oversized Markdown-heavy paragraphs split realistic sentences without spli
   assert.ok(unit.parts.some((part) => part.text.startsWith("Review with Dr. Smith")));
 });
 
+test("ambiguous abbreviations stay attached while clear sentence boundaries still split", () => {
+  const cycle = "See approx. Five checks follow. A clear requirement governs deployment.";
+  const blob = Array.from({ length: 12 }, () => cycle).join(" ");
+  const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
+
+  assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
+  assert.ok(unit.parts?.length > 12);
+  assert.ok(unit.parts.every((part) => part.text !== "See approx."));
+  assert.ok(unit.parts.some((part) => part.text === "See approx. Five checks follow."));
+  assert.ok(unit.parts.some((part) => part.text === "A clear requirement governs deployment."));
+});
+
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
     "Read docs/config.md before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.";

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -204,13 +204,16 @@ test("generic punctuation cannot suppress later clear attribution boundaries", (
 
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
-    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Read docs/Program Files/Foo. Bar/config before editing. Read docs/Foo. Bar Baz/config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
+    'Read docs/config.md before editing. Read docs/config.md. Then verify the result. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Read docs/Program Files/Foo. Bar/config before editing. Read docs/Foo. Bar Baz/config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
   const blob = Array.from({ length: 8 }, () => cycle).join(" ");
   const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
 
   assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
   assert.ok(unit.parts?.length > 8);
   assert.ok(unit.parts.some((part) => part.text === "Read docs/config.md before editing."));
+  assert.ok(unit.parts.some((part) => part.text === "Read docs/config.md."));
+  assert.ok(unit.parts.some((part) => part.text === "Then verify the result."));
+  assert.ok(unit.parts.every((part) => part.text !== "Read docs/config.md. Then verify the result."));
   assert.ok(unit.parts.some((part) => part.text === 'Read "C:\\Program Files\\Foo. Bar\\config" before editing.'));
   assert.ok(unit.parts.every((part) => part.text !== 'Read "C:\\Program Files\\Foo.'));
   assert.ok(unit.parts.some((part) => part.text === "Read C:\\Program Files\\Foo. Bar\\config before editing."));

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -204,13 +204,15 @@ test("generic punctuation cannot suppress later clear attribution boundaries", (
 
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
-    "Read docs/config.md before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.";
+    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
   const blob = Array.from({ length: 8 }, () => cycle).join(" ");
   const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
 
   assert.ok(estimateTokens(blob) > ATTRIBUTION_SPLIT_TOKENS);
   assert.ok(unit.parts?.length > 8);
   assert.ok(unit.parts.some((part) => part.text === "Read docs/config.md before editing."));
+  assert.ok(unit.parts.some((part) => part.text === 'Read "C:\\Program Files\\Foo. Bar\\config" before editing.'));
+  assert.ok(unit.parts.every((part) => part.text !== 'Read "C:\\Program Files\\Foo.'));
   assert.ok(unit.parts.some((part) => part.text === "Visit https://example.test/docs/config.md before editing."));
   assert.ok(unit.parts.some((part) => part.text === "Run `node app.js. --watch` afterward."));
   assert.ok(unit.parts.every((part) => !part.text.startsWith("--watch`")));

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -204,7 +204,7 @@ test("generic punctuation cannot suppress later clear attribution boundaries", (
 
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
-    'Read docs/config.md before editing. Read docs/config.md. Then verify the result. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Read docs/Program Files/Foo. Bar/config before editing. Read docs/Foo. Bar Baz/config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
+    'Read docs/config.md before editing. Read docs/config.md. Then verify the result. Read docs/config.md. src/main.js does the work. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Read docs/Program Files/Foo. Bar/config before editing. Read docs/Foo. Bar Baz/config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
   const blob = Array.from({ length: 8 }, () => cycle).join(" ");
   const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
 
@@ -214,6 +214,8 @@ test("paths, URLs, and inline code do not create fragment attribution targets", 
   assert.ok(unit.parts.some((part) => part.text === "Read docs/config.md."));
   assert.ok(unit.parts.some((part) => part.text === "Then verify the result."));
   assert.ok(unit.parts.every((part) => part.text !== "Read docs/config.md. Then verify the result."));
+  assert.ok(unit.parts.some((part) => part.text === "src/main.js does the work."));
+  assert.ok(unit.parts.every((part) => part.text !== "Read docs/config.md. src/main.js does the work."));
   assert.ok(unit.parts.some((part) => part.text === 'Read "C:\\Program Files\\Foo. Bar\\config" before editing.'));
   assert.ok(unit.parts.every((part) => part.text !== 'Read "C:\\Program Files\\Foo.'));
   assert.ok(unit.parts.some((part) => part.text === "Read C:\\Program Files\\Foo. Bar\\config before editing."));

--- a/test/budget.test.js
+++ b/test/budget.test.js
@@ -204,7 +204,7 @@ test("generic punctuation cannot suppress later clear attribution boundaries", (
 
 test("paths, URLs, and inline code do not create fragment attribution targets", () => {
   const cycle =
-    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Read docs/Program Files/Foo. Bar/config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
+    'Read docs/config.md before editing. Read "C:\\Program Files\\Foo. Bar\\config" before editing. Read C:\\Program Files\\Foo. Bar\\config before editing. Read docs/Program Files/Foo. Bar/config before editing. Read docs/Foo. Bar Baz/config before editing. Visit https://example.test/docs/config.md before editing. Run `node app.js. --watch` afterward.';
   const blob = Array.from({ length: 8 }, () => cycle).join(" ");
   const [unit] = parseMemoryUnits(`# T\n\n${blob}\n`);
 
@@ -217,6 +217,8 @@ test("paths, URLs, and inline code do not create fragment attribution targets", 
   assert.ok(unit.parts.every((part) => part.text !== "Read C:\\Program Files\\Foo."));
   assert.ok(unit.parts.some((part) => part.text === "Read docs/Program Files/Foo. Bar/config before editing."));
   assert.ok(unit.parts.every((part) => part.text !== "Read docs/Program Files/Foo."));
+  assert.ok(unit.parts.some((part) => part.text === "Read docs/Foo. Bar Baz/config before editing."));
+  assert.ok(unit.parts.every((part) => part.text !== "Read docs/Foo."));
   assert.ok(unit.parts.some((part) => part.text === "Visit https://example.test/docs/config.md before editing."));
   assert.ok(unit.parts.some((part) => part.text === "Run `node app.js. --watch` afterward."));
   assert.ok(unit.parts.every((part) => !part.text.startsWith("--watch`")));

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -138,7 +138,8 @@ test("state round-trips through disk and survives a corrupt file", () => {
     key: "11:22:sha256:old",
   });
   const migrated = state.readEvidence({ ...legacy, nativeId: "old" });
-  assert.equal(migrated.key, evidenceKey({ ...legacy, nativeId: "old" }, "sha256:old"));
+  assert.equal(migrated.key, "11:22:sha256:old");
+  assert.equal(migrated.transcript.identity.length, 64);
   assert.equal(fs.existsSync(state.evidencePath(legacy.id)), false);
 
   state.writeEvidence(legacy.id, {
@@ -160,7 +161,7 @@ test("state round-trips through disk and survives a corrupt file", () => {
   assert.deepEqual(state.readScanCache(), { version: 1, entries: {} }, "a corrupt cache resets instead of crashing");
 });
 
-test("an interrupted legacy evidence migration still reuses the cached analysis", () => {
+test("an interrupted legacy evidence migration remains stale under the current analysis index", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-state-migration-"));
   const state = new State(dir).ensure();
   const legacy = { harness: "pi", id: "pi-old", path: "/store/old.jsonl", mtimeMs: 11, bytes: 22 };
@@ -176,8 +177,8 @@ test("an interrupted legacy evidence migration still reuses the cached analysis"
   fs.renameSync(state.evidencePath(legacy.id), state.evidencePath(transcript));
 
   const recovered = state.readEvidence(transcript);
-  assert.equal(isEvidenceFresh(recovered, transcript, memoryHash), true);
-  assert.equal(state.readEvidence(transcript).key, evidenceKey(transcript, memoryHash));
+  assert.equal(isEvidenceFresh(recovered, transcript, memoryHash), false);
+  assert.equal(state.readEvidence(transcript).key, `11:22:${memoryHash}`);
 });
 
 test("transcript ids are turned into safe filenames", () => {

--- a/test/consolidate.test.js
+++ b/test/consolidate.test.js
@@ -34,7 +34,7 @@ const { foldForRun } = await import("../src/commands/propose.js");
 const { gapEntryId } = await import("../src/gap-ledger.js");
 const { parseMemoryUnits } = await import("../src/memory.js");
 const { SELF_SESSION_SENTINEL } = await import("../src/prompts.js");
-const { State } = await import("../src/state.js");
+const { evidenceKey, State } = await import("../src/state.js");
 const { setLoggerSink } = await import("../src/logger.js");
 
 setLoggerSink(() => {});
@@ -48,17 +48,19 @@ const SIGHTING_B = "Require every published attestation to reference the precise
 const UNRELATED = "Never force-push to main.";
 
 function record(id, proposedInstruction) {
+  const transcript = {
+    id,
+    identity: id,
+    harness: "claude",
+    startedAt: Date.parse("2026-08-01T00:00:00Z"),
+    interaction: "interactive",
+  };
   return {
     status: "ok",
-    transcript: {
-      id,
-      identity: id,
-      harness: "claude",
-      startedAt: Date.parse("2026-08-01T00:00:00Z"),
-      interaction: "interactive",
-    },
+    transcript,
     memoryPath: MEMORY_PATH,
     memoryHash: "h1",
+    key: evidenceKey(transcript, "h1"),
     positive: [],
     negative: [],
     gaps: [{ proposedInstruction, mistake: "hit it", quote: `quote from ${id}`, recurrenceRisk: "high" }],

--- a/test/distill.test.js
+++ b/test/distill.test.js
@@ -151,7 +151,10 @@ test("split paragraphs accept only sentence-part attribution targets", () => {
     },
     memoryFile,
   );
-  assert.deepEqual(clean.positive.map((item) => item.instruction), ["AG-001.2"]);
+  assert.deepEqual(
+    clean.positive.map((item) => item.instruction),
+    ["AG-001.2"],
+  );
 });
 
 test("sanitizeEvidence tolerates a malformed model response", () => {

--- a/test/distill.test.js
+++ b/test/distill.test.js
@@ -5,6 +5,7 @@ import { distill, isBoilerplate } from "../src/distill.js";
 import { redact } from "../src/redact.js";
 import { estimateTokens } from "../src/tokens.js";
 import { sanitizeEvidence } from "../src/analyze.js";
+import { parseMemoryUnits } from "../src/memory.js";
 
 const META = {
   id: "claude-abc",
@@ -130,6 +131,27 @@ test("evidence items without a verbatim quote are discarded at parse time", () =
   assert.equal(clean.gaps.length, 1);
   assert.equal(clean.usedRawTranscript, true);
   assert.equal(clean.gaps[0].recurrenceRisk, "high");
+});
+
+test("split paragraphs accept only sentence-part attribution targets", () => {
+  const blob = Array.from(
+    { length: 8 },
+    (_, i) => `Sentence ${i + 1} defines a separate requirement that should receive precise evidence attribution.`,
+  ).join(" ");
+  const memoryFile = { units: parseMemoryUnits(`# T\n\n${blob}\n`) };
+  assert.ok(memoryFile.units[0].parts?.length > 1);
+
+  const clean = sanitizeEvidence(
+    {
+      positive: [
+        { instruction: "AG-001", quote: "followed the entire oversized paragraph" },
+        { instruction: "AG-001.2", quote: "followed the second sentence precisely" },
+        { instruction: "AG-999", quote: "cited an instruction that does not exist" },
+      ],
+    },
+    memoryFile,
+  );
+  assert.deepEqual(clean.positive.map((item) => item.instruction), ["AG-001.2"]);
 });
 
 test("sanitizeEvidence tolerates a malformed model response", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -427,6 +427,30 @@ function oversizedParagraph(count = 5) {
   ).join(" ");
 }
 
+test("sentence-part harm renders the parent paragraph's removal aggregate", () => {
+  const blob = oversizedParagraph();
+  const blobFile = { units: parseMemoryUnits(`# T\n\n${blob}\n`) };
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        negative: [{ instruction: "AG-001.1", quote: "sentence one caused damage", class: "harm" }],
+      }),
+      record("s2", {
+        negative: [{ instruction: "AG-001.2", quote: "sentence two caused damage", class: "harm" }],
+      }),
+    ],
+    { memoryFile: blobFile },
+  );
+
+  assert.equal(summary.instructions.find((row) => row.instruction === "AG-001.1").harmSessions, 1);
+  assert.equal(summary.instructions.find((row) => row.instruction === "AG-001.2").harmSessions, 1);
+  assert.equal(summary.parentHarmSessions["AG-001"], 2);
+  assert.match(
+    renderEvidenceForPrompt(summary),
+    /Parent paragraph removal evidence aggregated across sentence parts:\n- \[AG-001\] harm-sessions=2/,
+  );
+});
+
 test("an oversized high-non-compliance paragraph attributes per sentence and invites a restructure, not a bold label", () => {
   const blob = oversizedParagraph();
   const blobFile = { units: parseMemoryUnits(`# T\n\n${blob}\n\n- Keep this list item whole.\n`) };

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -418,3 +418,63 @@ test("a cluster nobody tied to a skill renders without a failed-trigger line", (
   assert.equal(summary.gaps[0].failedTriggerSkill, undefined);
   assert.ok(!renderEvidenceForPrompt(summary).includes("FAILED TRIGGER"));
 });
+
+function oversizedParagraph(count = 5) {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      `Sentence ${i + 1} states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.`,
+  ).join(" ");
+}
+
+test("an oversized high-non-compliance paragraph attributes per sentence and invites a restructure, not a bold label", () => {
+  const blob = oversizedParagraph();
+  const blobFile = { units: parseMemoryUnits(`# T\n\n${blob}\n\n- Keep this list item whole.\n`) };
+  assert.ok(blobFile.units[0].parts?.length >= 2);
+  assert.equal(blobFile.units[1].id, "AG-002");
+
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        negative: [
+          {
+            instruction: "AG-001.2",
+            quote: "skipped the second sentence of the blob entirely here",
+            effect: "the rest of the paragraph never steered",
+            class: "non-compliance",
+          },
+        ],
+      }),
+      record("s2", {
+        negative: [
+          {
+            instruction: "AG-001.2",
+            quote: "ignored sentence two again on the follow-up session",
+            class: "non-compliance",
+          },
+        ],
+      }),
+    ],
+    { memoryFile: blobFile },
+  );
+
+  const hot = summary.instructions.find((row) => row.instruction === "AG-001.2");
+  const quiet = summary.instructions.find((row) => row.instruction === "AG-001.1");
+  const parent = summary.instructions.find((row) => row.instruction === "AG-001");
+  assert.equal(hot.negative, 2);
+  assert.equal(hot.parentId, "AG-001");
+  assert.equal(hot.nonCompliance, 2);
+  assert.equal(quiet.sessions, 0, "a sibling sentence is not smeared with the hot one's evidence");
+  assert.equal(parent, undefined, "the parent blob is not a dead removal candidate of its own");
+  assert.equal(summary.oversized.length, 1);
+  assert.equal(summary.oversized[0].id, "AG-001");
+  assert.ok(summary.oversized[0].tokens > 120);
+
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.match(rendered, /\[AG-001\.2\] \+0 -2/);
+  assert.match(rendered, /### Oversized units that failed to steer/);
+  assert.match(rendered, /Preferred reinforcement is a restructure-in-place/);
+  assert.match(rendered, /bold label on the blob is not a strengthen/);
+  assert.match(rendered, /\[AG-001\] is \d+ tokens as one paragraph \(attribution: AG-001\.1/);
+  assert.doesNotMatch(rendered, /\[AG-001\] \+0 -0/);
+});

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -447,8 +447,23 @@ test("sentence-part harm renders the parent paragraph's removal aggregate", () =
   assert.equal(summary.parentHarmSessions["AG-001"], 2);
   assert.match(
     renderEvidenceForPrompt(summary),
-    /Parent paragraph removal evidence aggregated across sentence parts:\n- \[AG-001\] harm-sessions=2/,
+    /Parent paragraph removal evidence aggregated across sentence parts:\n- AG-001 harm-sessions=2/,
   );
+});
+
+test("an oversized parent preserves its cross-surface warning without becoming an attribution target", () => {
+  const blob = oversizedParagraph();
+  const blobFile = { units: parseMemoryUnits(`# T\n\n${blob}\n`) };
+  const summary = foldEvidence([], {
+    memoryFile: blobFile,
+    skills: [{ name: "oversized-rules", path: ".agents/skills/oversized-rules/SKILL.md", description: blob, body: "" }],
+  });
+
+  assert.equal(summary.crossSurfaceDuplicates[0].instruction, "AG-001");
+  const rendered = renderEvidenceForPrompt(summary);
+  assert.match(rendered, /Parent paragraph cross-surface overlap:\n- AG-001 parent paragraph/);
+  assert.match(rendered, /CROSS-SURFACE: restates skill "oversized-rules" description/);
+  assert.doesNotMatch(rendered, /\[AG-001\](?!\.)/);
 });
 
 test("an oversized high-non-compliance paragraph attributes per sentence and invites a restructure, not a bold label", () => {
@@ -513,6 +528,7 @@ test("an oversized high-non-compliance paragraph attributes per sentence and inv
   assert.match(rendered, /### Oversized units that failed to steer/);
   assert.match(rendered, /Preferred reinforcement is a restructure-in-place/);
   assert.match(rendered, /bold label on the blob is not a strengthen/);
-  assert.match(rendered, /\[AG-001\] is \d+ tokens as one paragraph \(attribution: AG-001\.1/);
+  assert.match(rendered, /- AG-001 is \d+ tokens as one paragraph \(attribution: \[AG-001\.1\]/);
+  assert.doesNotMatch(rendered, /\[AG-001\](?!\.)/);
   assert.doesNotMatch(rendered, /\[AG-001\] \+0 -0/);
 });

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -433,6 +433,19 @@ test("an oversized high-non-compliance paragraph attributes per sentence and inv
   assert.ok(blobFile.units[0].parts?.length >= 2);
   assert.equal(blobFile.units[1].id, "AG-002");
 
+  const oneSession = foldEvidence(
+    [
+      record("s1", {
+        negative: [
+          { instruction: "AG-001.2", quote: "skipped sentence two", class: "non-compliance" },
+          { instruction: "AG-001.3", quote: "skipped sentence three", class: "non-compliance" },
+        ],
+      }),
+    ],
+    { memoryFile: blobFile, minGapEvidence: 2 },
+  );
+  assert.equal(oneSession.oversized.length, 0, "several misses in one session do not corroborate a rewrite");
+
   const summary = foldEvidence(
     [
       record("s1", {
@@ -468,6 +481,7 @@ test("an oversized high-non-compliance paragraph attributes per sentence and inv
   assert.equal(parent, undefined, "the parent blob is not a dead removal candidate of its own");
   assert.equal(summary.oversized.length, 1);
   assert.equal(summary.oversized[0].id, "AG-001");
+  assert.equal(summary.oversized[0].sessions, 2);
   assert.ok(summary.oversized[0].tokens > 120);
 
   const rendered = renderEvidenceForPrompt(summary);

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { State } from "../src/state.js";
+import { evidenceKey, State } from "../src/state.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { foldForRun } from "../src/commands/propose.js";
 import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
@@ -24,11 +24,13 @@ function memoryFile(text = "# T\n\n- Run pnpm test before pushing.\n- Keep the R
 }
 
 function record(id, gaps, { startedAt = Date.parse("2026-08-01T00:00:00Z"), memoryHash = "h1" } = {}) {
+  const transcript = { id, identity: id, harness: "claude", startedAt, interaction: "interactive" };
   return {
     status: "ok",
-    transcript: { id, identity: id, harness: "claude", startedAt, interaction: "interactive" },
+    transcript,
     memoryPath: MEMORY_PATH,
     memoryHash,
+    key: evidenceKey(transcript, memoryHash),
     positive: [],
     negative: [],
     gaps: gaps.map((gap) => ({
@@ -61,6 +63,17 @@ async function run(h, records, file = memoryFile(), memoryHash = "h1") {
 
 const GAP = "Read docs/db.md before writing queries.";
 const GAP_REPHRASED = "Read docs/db.md before writing any queries";
+
+test("keyless legacy evidence stays out of the fold", async () => {
+  const h = harness();
+  const stale = record("claude-old", [GAP]);
+  delete stale.key;
+  const summary = await run(h, [stale]);
+
+  assert.equal(summary.analyzedSessions, 0);
+  assert.equal(summary.totals.gapSightings, 0);
+  assert.deepEqual(h.state.readGapLedger().entries, {});
+});
 
 test("a gap seen once now and once on a later run accumulates to two sessions and graduates", async () => {
   const h = harness();
@@ -106,6 +119,7 @@ test("a legacy session-id observation migrates without counting the identity as 
 
   const migrated = record("claude-s1", [GAP_REPHRASED]);
   migrated.transcript.identity = "stable-identity-s1";
+  migrated.key = evidenceKey(migrated.transcript, migrated.memoryHash);
   const summary = await run(h, [migrated]);
 
   assert.equal(summary.gaps.length, 0, "one upgraded session must remain a singleton");

--- a/test/helpers/synthesis-cli.js
+++ b/test/helpers/synthesis-cli.js
@@ -5,6 +5,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { memorySetHash, memoryTextHash } from "../../src/memory.js";
+import { evidenceKey } from "../../src/state.js";
 import { transcriptIdentity } from "../../src/transcript.js";
 
 /**
@@ -171,6 +172,7 @@ export function makeCliRepo({ memory, sessions = 3, files = {} }) {
         status: "ok",
         memoryPath: "AGENTS.md",
         memoryHash,
+        key: evidenceKey(transcript, memoryHash),
         transcript,
         positive: [],
         negative: [

--- a/test/interaction.test.js
+++ b/test/interaction.test.js
@@ -480,6 +480,7 @@ test("fold selection distinguishes colliding native IDs by source", async () => 
       transcript,
       memoryHash,
       memoryPath: "AGENTS.md",
+      key: evidenceKey(transcript, memoryHash),
       positive: [],
       negative: [],
       gaps: [],
@@ -543,6 +544,7 @@ test("fold keeps legacy-id gap observations for sessions in the selected sample"
       transcript,
       memoryHash,
       memoryPath: "AGENTS.md",
+      key: evidenceKey(transcript, memoryHash),
       positive: [],
       negative: [],
       gaps: [],
@@ -614,6 +616,7 @@ test("fold bounds evidence and ledger observations to the selected sample", asyn
       transcript,
       memoryHash,
       memoryPath: "AGENTS.md",
+      key: evidenceKey(transcript, memoryHash),
       positive: [],
       negative: [],
       gaps,
@@ -645,6 +648,43 @@ test("fold bounds evidence and ledger observations to the selected sample", asyn
   });
   assert.equal(summary.gaps.length, 0);
   assert.equal(Object.keys(state.readGapLedger().entries).length, 1);
+});
+
+test("fold freshness uses the selected transcript's current content signature", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-mix-current-signature-"));
+  const state = new State(dir).ensure();
+  const memoryHash = "sha256:memory";
+  const memoryFile = { path: "AGENTS.md", text: "", units: [] };
+  const stored = {
+    harness: "claude",
+    id: "claude-session",
+    identity: "claude:session",
+    path: "/sessions/session.jsonl",
+    mtimeMs: 100,
+    bytes: 200,
+    interaction: INTERACTIVE,
+  };
+  state.writeEvidence(stored, {
+    status: "ok",
+    transcript: stored,
+    memoryHash,
+    memoryPath: "AGENTS.md",
+    key: evidenceKey(stored, memoryHash),
+    positive: [{ instruction: "AG-001", quote: "followed the old transcript evidence" }],
+    negative: [],
+    gaps: [],
+  });
+  const current = { ...stored, mtimeMs: 101, bytes: 240 };
+  const summary = await foldForRun(
+    { repo: { root: dir }, config: { state, minGapEvidence: 2, gapLedgerMaxAge: "90d" } },
+    memoryFile,
+    memoryHash,
+    [],
+    [current],
+  );
+
+  assert.equal(summary.analyzedSessions, 0);
+  assert.equal(summary.totals.positive, 0);
 });
 
 test("evidence records carry the category and fold reports relevance per category", async () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -15,7 +15,6 @@ import {
 } from "../src/proposal.js";
 import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
-import { foldEvidence } from "../src/fold.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -15,6 +15,8 @@ import {
 } from "../src/proposal.js";
 import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
+import { foldEvidence } from "../src/fold.js";
+import { parseMemoryUnits } from "../src/memory.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
 import { injectPayload, parseDecisions, renderApplySurface } from "../src/apply/lavish.js";
@@ -1725,6 +1727,42 @@ test("non-compliance never satisfies the removal-evidence floor; harm does", () 
   });
   assert.deepEqual(harmed.violations, []);
   assert.equal(harmed.proposal.edits.length, 1);
+});
+
+test("sentence-level harm clears removal of its oversized parent paragraph", () => {
+  const blob = Array.from(
+    { length: 5 },
+    (_, i) =>
+      `Sentence ${i + 1} states an independent requirement about builds, releases, adapters, and review that an agent must follow.`,
+  ).join(" ");
+  const text = `# T\n\n${blob}\n\n- Keep this instruction.\n`;
+  const evidence = (id, negative) => ({
+    status: "ok",
+    transcript: { id, harness: "claude" },
+    positive: [],
+    negative,
+    gaps: [],
+  });
+  const summary = foldEvidence(
+    [
+      evidence("s1", [
+        { instruction: "AG-001.2", quote: "following sentence two broke the build", class: "harm" },
+        { instruction: "AG-001.3", quote: "sentence three caused the same failure", class: "harm" },
+      ]),
+      evidence("s2", [{ instruction: "AG-001.2", quote: "the rule broke release signing", class: "harm" }]),
+    ],
+    { memoryFile: { units: parseMemoryUnits(text) } },
+  );
+  assert.equal(summary.parentHarmSessions["AG-001"], 2, "the same session is counted once across sentence parts");
+
+  const result = gate({
+    text,
+    edit: memoryEdit((current) => current.replace(`${blob}\n\n`, "")),
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "remove the harmful paragraph" })] },
+    context: { summary },
+  });
+  assert.deepEqual(result.violations, []);
+  assert.equal(result.proposal.edits.length, 1);
 });
 
 test("a removal is measured, not declared: relabeling the edit does not dodge the floor", () => {

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -75,7 +75,8 @@ process.env.BACKPASS_ACPX_BIN = fakeAcpx;
 const { synthesizeProposal, ANNOTATE_TURNS } = await import("../src/synthesize.js");
 const { applyDecisions } = await import("../src/apply/writer.js");
 const { loadConfig } = await import("../src/config.js");
-const { readMemoryFile } = await import("../src/memory.js");
+const { parseMemoryUnits, readMemoryFile } = await import("../src/memory.js");
+const { foldEvidence } = await import("../src/fold.js");
 const { ProposalViolation } = await import("../src/proposal.js");
 const { State } = await import("../src/state.js");
 const { UserError, setLoggerSink } = await import("../src/logger.js");
@@ -139,7 +140,7 @@ function summaryFor(sessions = 3) {
 const pick = { agent: "claude", model: "claude-opus-5", effort: "high", pinned: true };
 const agents = { resolve: async () => pick, withFallthrough: async (_role, fn) => fn(pick) };
 
-function setup(script, { text = AGENTS, overrides = {} } = {}) {
+function setup(script, { text = AGENTS, overrides = {}, summary = summaryFor() } = {}) {
   const repo = makeRepo({ "AGENTS.md": text });
   const config = loadConfig(repo.root, overrides);
   config.state = new State(repo.root).ensure();
@@ -151,8 +152,7 @@ function setup(script, { text = AGENTS, overrides = {} } = {}) {
   process.env.FAKE_ACPX_STATE = path.join(repo.root, "fake-state.json");
   fs.writeFileSync(process.env.FAKE_ACPX_SCRIPT, JSON.stringify(script));
   const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
-  const run = () =>
-    synthesizeProposal({ memoryFile, summary: summaryFor(), config, repo, transcripts: [{ harness: "claude" }] });
+  const run = () => synthesizeProposal({ memoryFile, summary, config, repo, transcripts: [{ harness: "claude" }] });
   const calls = () =>
     fs
       .readFileSync(log, "utf8")
@@ -365,4 +365,108 @@ test("an agent that changes nothing yields an empty proposal, never an invented 
   assert.deepEqual(violations, []);
   assert.equal(proposal.edits.length, 0);
   assert.equal(proposal.budget.delta, 0);
+});
+
+function oversizedParagraph(count = 5) {
+  return Array.from(
+    { length: count },
+    (_, i) =>
+      `Sentence ${i + 1} states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.`,
+  ).join(" ");
+}
+
+test("an oversized non-compliance blob synthesizes as a list-item restructure, not a bold-label strengthen", async () => {
+  const blob = oversizedParagraph();
+  const listed = blob
+    .split(/(?<=\.)\s+(?=[A-Z])/)
+    .map((sentence) => `- ${sentence}`)
+    .join("\n");
+  const text = `# Memory\n\n${blob}\n`;
+  const summary = foldEvidence(
+    [
+      {
+        status: "ok",
+        transcript: { id: "s1", harness: "claude" },
+        positive: [],
+        negative: [
+          {
+            instruction: "AG-001.2",
+            quote: "skipped the second sentence of the blob entirely here",
+            class: "non-compliance",
+          },
+        ],
+        gaps: [],
+      },
+      {
+        status: "ok",
+        transcript: { id: "s2", harness: "claude" },
+        positive: [],
+        negative: [
+          {
+            instruction: "AG-001.2",
+            quote: "ignored sentence two again on the follow-up session",
+            class: "non-compliance",
+          },
+        ],
+        gaps: [],
+      },
+    ],
+    { memoryFile: { path: "AGENTS.md", units: parseMemoryUnits(text) } },
+  );
+
+  const { repo, run } = setup(
+    {
+      edit: { "AGENTS.md": { replace: [[blob, `${listed}\n`]] } },
+      annotations: [
+        {
+          reply: {
+            edits: [
+              {
+                changes: ["H1"],
+                kind: "rewrite",
+                title: "split the blob into list items",
+                evidence: [
+                  {
+                    polarity: "negative",
+                    text: "skipped the second sentence of the blob entirely here",
+                    source: "claude · s1 · turn 4",
+                  },
+                ],
+                transcripts: 2,
+                instructions: ["AG-001.2"],
+              },
+            ],
+            verdicts: [
+              {
+                instruction: "AG-001.2",
+                verdict: "strengthen",
+                positive: 0,
+                negative: 2,
+                note: "restructure into list items",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { text, summary },
+  );
+
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits.length, 1);
+  assert.equal(proposal.edits[0].kind, "rewrite");
+  const hunk = proposal.edits[0].hunks[0];
+  assert.equal(hunk.find.includes(blob), true);
+  assert.match(hunk.replace, /^- Sentence 1 /m);
+  assert.match(hunk.replace, /^- Sentence 2 /m);
+  assert.doesNotMatch(hunk.replace, /\*\*[^*]+\*\*/);
+  assert.equal(hunk.replace.includes(blob), false);
+
+  const editPrompt = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-edit.md"), "utf8");
+  assert.match(editPrompt, /Oversized paragraph \[AG-001\]/);
+  assert.match(editPrompt, /\[AG-001\.2\]/);
+  assert.match(editPrompt, /### Oversized units that failed to steer/);
+  assert.match(editPrompt, /Preferred reinforcement is a restructure-in-place/);
+  assert.match(editPrompt, /bold label on the blob is not a strengthen/);
 });

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -464,7 +464,8 @@ test("an oversized non-compliance blob synthesizes as a list-item restructure, n
   assert.equal(hunk.replace.includes(blob), false);
 
   const editPrompt = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-edit.md"), "utf8");
-  assert.match(editPrompt, /Oversized paragraph \[AG-001\]/);
+  assert.match(editPrompt, /Oversized paragraph AG-001/);
+  assert.doesNotMatch(editPrompt, /Oversized paragraph \[AG-001\]/);
   assert.match(editPrompt, /\[AG-001\.2\]/);
   assert.match(editPrompt, /### Oversized units that failed to steer/);
   assert.match(editPrompt, /Preferred reinforcement is a restructure-in-place/);


### PR DESCRIPTION
## Intent

Let backpass synthesis split oversized units instead of faking a strengthen. Today a large blob unit (e.g. a 1,385-token paragraph) smears all attribution, so synthesis "strengthens" it with a bold label instead of restructuring - cosmetic theater. Combined both approaches: (a) at parse time, sub-split paragraph units above ~N tokens on sentence boundaries for ATTRIBUTION ONLY (ids stay positional aliases so nothing else breaks), and (b) prompt-side, when a unit exceeds N tokens and draws heavy non-compliance, explicitly invite a restructure-in-place edit (split into list items) as the preferred reinforcement. Cover behaviorally: an oversized high-non-compliance unit now yields a real restructure/attribution outcome rather than bold-label theater. Ship a green PR; do not self-merge.

## What Changed

- Split prose units over 120 tokens at confident sentence boundaries into attribution-only IDs while preserving the parent edit unit and ambiguous spans.
- Aggregate sentence-level evidence for parent safety checks and steer synthesis to restructure repeatedly ignored paragraphs into list items instead of adding cosmetic labels.
- Version the analysis index cache and fold only evidence matching the current transcript, memory surface, and index version.

## Risk Assessment

✅ Low: The attribution-only splitting, evidence freshness checks, and synthesis guidance are well-bounded and no new material source risks were found.

## Testing

Targeted parser, fold, proposal, synthesis, cache-freshness, and path-boundary scenarios passed after fixing the duplicate test import. The synthesis harness behaviorally produced a list-item rewrite without bold-label theater, while the evidence artifact shows sentence-level attribution, isolated sibling evidence, and generated restructure guidance.

<details>
<summary>Evidence: Oversized paragraph attribution and generated synthesis guidance</summary>

Source: [Oversized paragraph attribution and generated synthesis guidance](https://github.com/kunchenguid/backpass/blob/8ea5a3161d1f6458fc65b1da3f4a1f249cc08563/.no-mistakes/evidence/fm/backpass-oversized-unit-split-r1/oversized-attribution-and-guidance.json)

```text
{
  "instructionIndex": "Oversized paragraph AG-001 (179 tok, L3) <Memory> is one blob; AG-001 is only its line-oriented alias. Attribute evidence only to the sentence-part IDs below (AG-001.1, AG-001.2, AG-001.3, AG-001.4, AG-001.5). If these fail to steer, split the paragraph into list items in place - a bold label on the blob is not a strengthen.\n\n[AG-001.1] (36 tok, L3) <Memory>\nSentence 1 states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.\n\n[AG-001.2] (36 tok, L3) <Memory>\nSentence 2 states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.\n\n[AG-001.3] (36 tok, L3) <Memory>\nSentence 3 states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.\n\n[AG-001.4] (36 tok, L3) <Memory>\nSentence 4 states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.\n\n[AG-001.5] (36 tok, L3) <Memory>\nSentence 5 states an independent requirement about builds, releases, adapters, and review that an agent must actually follow rather than skip.",
  "hotInstruction": {
    "instruction": "AG-001.2",
    "positive": 0,
    "negative": 2,
    "harmSessions": 0,
    "sessions": 2,
    "relevance": 1,
    "relevanceByInteraction": {
      "interactive": 1,
      "non-interactive": 0
    },
    "tokens": 36,
    "section": "Memory",
    "known": true,
    "parentId": "AG-001",
    "nonCompliance": 2,
    "nonComplianceSessions": 2,
    "quotes": [
      {
        "polarity": "negative",
        "text": "skipped sentence two",
        "class": "non-compliance",
        "source": "claude · s1 · unknown date"
      },
      {
        "polarity": "negative",
        "text": "ignored sentence two again",
        "class": "non-compliance",
        "source": "claude · s2 · unknown date"
      }
    ]
  },
  "quietSibling": {
    "instruction": "AG-001.1",
    "positive": 0,
    "negative": 0,
    "harmSessions": 0,
    "sessions": 0,
    "relevance": 0,
    "relevanceByInteraction": {
      "interactive": 0,
      "non-interactive": 0
    },
    "tokens": 36,
    "section": "Memory",
    "known": true,
    "parentId": "AG-001",
    "nonCompliance": 0,
    "nonComplianceSessions": 0,
    "quotes": []
  },
  "oversizedTarget": {
    "id": "AG-001",
    "tokens": 179,
    "parts": [
      "AG-001.1",
      "AG-001.2",
      "AG-001.3",
      "AG-001.4",
      "AG-001.5"
    ],
    "sessions": 2
  },
  "synthesisEvidence": "Sessions analyzed: 2 (interactive 2 · non-interactive 0)\nTotals: 0 positive, 2 negative, 0 gap clusters (0 synthesis eligible, 0 report only, 0 singletons dropped below threshold)\n\n### Per-instruction evidence\nA negative's class is what it means: `harm` = following the instruction caused damage (evidence against it); `non-compliance` = the agent ignored it (evidence it failed to steer - argues for reinforcement, never deletion); `irrelevant` = no real bearing.\n- [AG-001.2] +0 -2 harm-sessions=0 sessions=2 relevance=100.0% (interactive 100.0% · non-interactive 0.0%) cost=36tok\n    - [non-compliance] \"skipped sentence two\" (claude · s1 · unknown date)\n    - [non-compliance] \"ignored sentence two again\" (claude · s2 · unknown date)\n- [AG-001.1] +0 -0 sessions=0 relevance=0.0% (interactive 0.0% · non-interactive 0.0%) cost=36tok\n- [AG-001.3] +0 -0 sessions=0 relevance=0.0% (interactive 0.0% · non-interactive 0.0%) cost=36tok\n- [AG-001.4] +0 -0 sessions=0 relevance=0.0% (interactive 0.0% · non-interactive 0.0%) cost=36tok\n- [AG-001.5] +0 -0 sessions=0 relevance=0.0% (interactive 0.0% · non-interactive 0.0%) cost=36tok\n\n### Oversized units that failed to steer\nThese are one paragraph apiece. Preferred reinforcement is a restructure-in-place: split the paragraph into list items so each claim can be followed. A bold label on the blob is not a strengthen.\n- AG-001 is 179 tokens as one paragraph (attribution: [AG-001.1], [AG-001.2], [AG-001.3], [AG-001.4], [AG-001.5]). Split it into list items; do not decorate the blob.\n\n### Synthesis-eligible gap clusters (mistakes no current instruction covers)\n- none above the evidence threshold"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"60c0b16c93859391bed94b49ce92135429a84e59","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (19) ✅</summary>

- 🚨 `src/memory.js:248` - The rendered analysis index changes from parent IDs to sentence-part IDs, but existing evidence remains fresh because its cache key only includes transcript metadata and the unchanged memory-surface hash. After upgrading with an unchanged memory file, normal runs reuse AG-nnn evidence and never perform sentence-level attribution, so the durable fix does not take effect without --force. The smallest robust remedy needs an analysis-index/schema version in persisted evidence freshness and fold eligibility, which requires authorization because it changes the durable cache schema.
- 🚨 `src/fold.js:107` - Replacing oversized parent rows with only sentence-part rows disconnects valid harm evidence from the line-oriented removal gate. For example, two sessions can report harm against AG-001.2, but a justified pure deletion of that paragraph is checked in proposal.js against rows.get(&#34;AG-001&#34;) and always sees zero harm sessions. Preserve a distinct-session harm aggregate for the parent at the fold boundary while retaining part-level attribution rows.

🔧 Fix: Preserve parent removal evidence across sentence parts
3 errors still open:

- 🚨 `src/memory.js:248` - The analysis index now uses sentence-part IDs, but evidence freshness remains keyed only to transcript metadata and the unchanged memory-surface hash. After upgrading an unchanged repository, cached AG-nnn evidence is reused indefinitely, so sentence-level attribution never takes effect without --force. A durable remedy needs a versioned analysis-index or evidence-cache contract, which changes persisted freshness semantics and therefore needs authorization.
- 🚨 `src/fold.js:187` - The restructure threshold sums non-compliance items and hardcodes 2 rather than counting distinct sessions against minGapEvidence. One session reporting non-compliance for two parts therefore exposes the restructure target, and a replacement rewrite can pass buildProposal because only pure additions and deletions have corroboration gates. Track distinct non-compliance session identities per parent and compare them with minGapEvidence so one bad session cannot rewrite the weights.
- 🚨 `src/memory.js:142` - The required criterion says oversized paragraph units must be split &#34;on sentence boundaries,&#34; but the new regex only recognizes a next sentence beginning with ASCII uppercase or `([{`. A large paragraph whose sentences begin with Markdown or commands, such as &#34;Run checks. `pnpm test` verifies them. `pnpm lint` verifies style.&#34;, remains one unsplit blob because backticks and lowercase command names never satisfy the lookahead. The sentence-boundary policy must be broadened before the required attribution behavior is reliable.

🔧 Fix: Require corroborated sessions for oversized restructures
3 issues (2 errors, 1 warning) still open:

- 🚨 `src/memory.js:248` - The analysis index now uses sentence-part IDs, but evidence freshness remains keyed only to transcript metadata and the unchanged memory-surface hash. After upgrading an unchanged repository, cached AG-nnn evidence is reused indefinitely, so the required sentence-level attribution never takes effect without --force. A durable remedy needs a versioned analysis-index or evidence-cache contract, which changes persisted freshness semantics and therefore needs authorization.
- 🚨 `src/memory.js:142` - The required behavior says oversized paragraphs must be sub-split &#34;on sentence boundaries,&#34; but this regex only recognizes a following sentence beginning with ASCII uppercase or `([{`. For example, an oversized paragraph containing &#34;Run checks. `pnpm test` verifies them. `pnpm lint` verifies style.&#34; remains unsplit because backticks do not satisfy the lookahead. Broaden the sentence-boundary policy before claiming the required attribution behavior.
- ⚠️ `src/fold.js:298` - The fix correctly aggregates sentence-part harm for the line-oriented proposal gate, but the synthesis prompt still renders only individual part rows. With harm against AG-001.1 in one session and AG-001.2 in another, each visible row says harm-sessions=1 while the hidden parent aggregate is 2, so the model is told the parent cannot clear the two-session removal rule even though buildProposal accepts it. Render the parent aggregate at the fold-to-prompt boundary so synthesis and its gate use the same evidence.

🔧 Fix: Expose parent harm aggregates to synthesis
3 errors still open:

- 🚨 `src/memory.js:248` - The analysis index now uses sentence-part IDs, but evidence freshness remains keyed only to transcript metadata and the unchanged memory-surface hash. After upgrading an unchanged repository, cached AG-nnn evidence is reused indefinitely, so the required sentence-level attribution never takes effect without --force. A durable remedy needs a versioned analysis-index or evidence-cache contract, which changes persisted freshness semantics and requires authorization.
- 🚨 `src/memory.js:142` - The required behavior says oversized paragraphs must be sub-split on sentence boundaries, but this regex misses sentences beginning with Markdown, inline code, lowercase commands, or non-ASCII letters, and can split abbreviations before uppercase words. For example, an oversized paragraph containing repeated &#34;Run checks. `pnpm test` verifies them.&#34; remains unsplit. Broaden or replace the sentence-boundary policy before claiming the required attribution behavior.
- 🚨 `src/memory.js:254` - Fresh analysis can still smear evidence across the whole blob. The analysis prompt says to refer only to IDs in brackets, and this header presents the parent as `[AG-001]`; sanitizeEvidence also accepts that ID. A model response attributing two non-compliance events to AG-001 therefore bypasses sentence-level attribution while still triggering the parent aggregate. The required attribution-only split needs the analysis interface or its validation boundary to make only AG-nnn.m IDs valid attribution targets while retaining the parent alias for line-oriented synthesis and apply behavior.

🔧 Fix: Make sentence attribution durable and exclusive
1 error still open:

- 🚨 `src/commands/propose.js:39` - The new cache-version invalidation is bypassed for legacy evidence with no `key`. A keyless record whose `memoryPath` and `memoryHash` match the current surface is folded without reanalysis, so old parent-level AG-nnn attribution can still influence synthesis after upgrading. Require `isEvidenceFresh(...)` for every folded record; keyless records should remain stale until analysis rewrites them.

🔧 Fix: Reject stale keyless evidence during folding
1 error still open:

- 🚨 `src/memory.js:165` - The required behavior says oversized paragraphs must split &#34;on sentence boundaries,&#34; but this loop treats every `.`, `!`, or `?` followed by whitespace as a boundary. An oversized paragraph containing repeated `Read docs/config.md before editing. Run \`node app.js --watch\` afterward.` is incorrectly split after `docs/config.md` and `app.js`, producing fragment-level attribution without error. Make `splitAttributionSentences` distinguish punctuation inside paths, URLs, and inline code from sentence terminators.

🔧 Fix: Protect references and inline code during sentence splitting
1 error still open:

- 🚨 `src/memory.js:175` - The inline-code scanner treats an escaped Markdown backtick as a code-span opener. For an oversized paragraph beginning `Write \` for literal output. Run checks. Deploy safely.`, `codeDelimiter` never closes, so all sentence terminators are ignored and the paragraph receives no attribution parts. Ignore backtick runs preceded by an odd number of backslashes so literal backticks cannot disable attribution splitting.

🔧 Fix: Ignore escaped backticks during sentence splitting
1 error still open:

- 🚨 `src/memory.js:154` - The required sentence-boundary behavior remains wrong for sentences ending in a URL followed by `?` or `!`. For example, `Is it https://example.com/docs? Check the result.` skips the question mark because the token starts with a URL, merging two sentences into one attribution target without error. The prior fix only required protecting periods inside references, so its added `?`/`!` URL exception exceeds that fix and should be reverted to the minimal period-only/reference handling rather than expanded further.

🔧 Fix: Conservatively detect reference-safe sentence boundaries
1 error still open:

- 🚨 `src/memory.js:136` - The required sentence-boundary split still fails for common abbreviations outside this fixed list. In an oversized paragraph containing repeated `See approx. Five checks follow.`, `endsWithAbbreviation` returns false for `approx.`, so the splitter silently creates a fragment ending at `See approx.`. This contradicts the required attribution-only split on sentence boundaries and the authorized instruction not to keep adding punctuation special cases. Use a conservative, non-enumerative abbreviation boundary or ask the user to approve the unavoidable ambiguity rather than extending this list.

🔧 Fix: Conservatively preserve ambiguous abbreviation boundaries
1 error still open:

- 🚨 `src/memory.js:140` - The required attribution-only sentence splitting still fails the explicitly required pattern `Run checks. `pnpm test` verifies them.`. At `checks.`, `ambiguousPeriodEnding` sees two words and a six-letter token, returns true, and suppresses the clear boundary. Repetition therefore creates parts containing both sentences rather than sentence-level attribution. Revert the latest word-count heuristic and use a minimal conservative abbreviation check that does not classify ordinary short sentences as ambiguous.

🔧 Fix: Split clear short sentences without length heuristics
1 error still open:

- 🚨 `src/memory.js:159` - The required parse-time split &#34;on sentence boundaries for ATTRIBUTION ONLY&#34; is still violated. In an oversized repeated `Run **checks**. Deploy safely.` or `Run `pnpm test`. Deploy safely.`, `ambiguousPeriodEnding` sees no letter immediately before the period and suppresses the clear boundary, so both sentences share one attribution part. Conversely, `Consult Capt. Smith before release.` splits after the unlisted abbreviation `Capt.`, creating a fragment target. Fix the shared boundary classifier so closing Markdown/code delimiters do not hide a terminator and abbreviations are handled conservatively without another finite special-case list.

🔧 Fix: Consolidate confidence-based sentence boundary detection
2 errors still open:

- 🚨 `src/memory.js:215` - The consolidated segmenter only tracks backtick spans. An oversized paragraph containing repeated `Keep **alpha. Beta** together. Deploy safely.` splits inside the emphasis span into malformed attribution parts `Keep **alpha.` and `Beta** together.`. It also treats the path token in `Work from . Next verify.` as a boundary. Track Markdown spans and protected path/reference tokens at this shared boundary before accepting terminators.
- 🚨 `test/synthesize.test.js:467` - This assertion still expects `Oversized paragraph [AG-001]`, but `renderInstructionIndex` now intentionally emits the parent alias without brackets so it cannot be cited as an attribution target. The behavioral test will fail. Update it to expect the unbracketed parent and reject a bracketed parent target.

🔧 Fix: Protect Markdown spans and parent attribution aliases
1 error still open:

- 🚨 `src/memory.js:220` - The required parse-time split on sentence boundaries remains unreachable for common non-Markdown text. The new generic span stack treats any `&lt;`, intraword `_`, or unmatched `*` as a Markdown opener. For example, an oversized paragraph repeating `Keep retries &lt; 3. Deploy safely. Verify results.` pushes `&gt;` at `&lt;` and suppresses every later clear boundary, so no attribution parts are produced. This contradicts the required attribution-only sentence splitting. The prior fix exceeded its Markdown-span requirement by classifying generic punctuation as spans; revert that generic tracking to minimal, standards-aware Markdown constructs rather than extending more special cases.

🔧 Fix: Limit span guards to protected attribution contexts
1 error still open:

- 🚨 `src/memory.js:217` - The required path span guard is absent. In an oversized paragraph containing `Read &#34;C:\Program Files\Foo. Bar\config&#34; before editing. Deploy safely.`, the period after `Foo` is followed by whitespace and `B`, so it is accepted as a sentence boundary and produces malformed attribution parts without error. Guard candidate boundaries inside path tokens in the shared `splitAttributionSentences` helper.

🔧 Fix: Guard spaced paths during sentence attribution
2 errors still open:

- 🚨 `src/proposal.js:396` - A pure deletion of an oversized paragraph passes when two sessions report harm for only one sentence part. `parentHarmSessions` unions harm across parts, and this gate applies that aggregate to the parent without checking the other deleted parts. For example, corroborated harm on AG-001.2 authorizes deleting AG-001.1 through AG-001.5 even if those parts are useful or positive. This restores the attribution smearing the change is intended to prevent. Because the current tests deliberately authorize this behavior, ask the user whether whole-paragraph deletion should require corroboration for every part or instead be refused in favor of a targeted rewrite.
- 🚨 `src/memory.js:232` - The path guard recognizes only quoted paths. An oversized paragraph containing `Read C:\Program Files\Foo. Bar\config before editing. Deploy safely.` accepts the period after `Foo` as a sentence boundary and emits malformed parts ending in `Foo.` and beginning with `Bar\config`. Extend the shared path-span guard to cover recognizable unquoted spaced paths rather than limiting protection to quoted values.

🔧 Fix: Guard unquoted spaced paths during attribution
1 error still open:

- 🚨 `src/memory.js:183` - The path guard only recognizes rooted paths beginning after whitespace. An oversized paragraph containing `Read docs/Program Files/Foo. Bar/config before editing. Deploy safely.` finds no `pathStart`, accepts `Foo.` as a sentence boundary, and emits malformed attribution targets without error. Detect candidate boundaries inside recognizable relative path spans at this shared boundary, not only drive, UNC, or slash-prefixed paths.

🔧 Fix: Guard relative spaced paths during attribution
1 error still open:

- 🚨 `src/memory.js:182` - The latest path guard treats any earlier slash-containing token as a path start. Thus `Choose yes/no carefully. docs/config explains it.` suppresses a clear sentence boundary. It still splits inside a longer spaced path such as `Read docs/Foo. Bar Baz/config before editing.` because the token immediately after `Foo.` has no slash. This violates attribution sentence splitting and the required path span guard. Revert this overbroad heuristic and implement a boundary-local recognizable relative-path span guard rather than extending the global slash pattern again.

🔧 Fix: Use boundary-local path guards for attribution
✅ Re-checked - no issues remain.

- 🚨 `src/commands/propose.js:55` - The freshness check compares each evidence key against its own stored transcript metadata, not the currently discovered transcript. If a transcript&#39;s bytes or mtime change while its canonical identity remains stable, `backpass propose` selects it by identity and folds the old evidence because `isEvidenceFresh(e, e.transcript, ...)` is tautologically current. Map selected identities to the discovered transcripts and pass that current transcript to `isEvidenceFresh` at this shared fold boundary.

🔧 Fix: Validate folded evidence against current transcripts
2 warnings still open:

- ⚠️ `src/fold.js:436` - The instruction index deliberately leaves an oversized parent alias unbracketed so only AG-nnn.m parts are attribution targets, but the synthesis evidence later renders the parent as `[AG-001]`. A synthesis response can therefore cite the parent, and `normalizeEdit` accepts it without validation. Render this line with the parent alias unbracketed while retaining the bracketed part IDs.
- ⚠️ `src/fold.js:143` - `crossSurfaceDuplicates` reports overlaps against parent IDs such as AG-001, but oversized parents no longer have instruction rows. Their rows are AG-001.m, so this lookup misses and the CROSS-SURFACE warning disappears from the synthesis prompt. Preserve each otherwise-unrepresented parent overlap once in the rendered evidence.

🔧 Fix: Preserve parent overlaps without attribution targets
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec node --test test/budget.test.js test/fold.test.js test/synthesize.test.js`
- <code>Executed `backpass propose --synthesis-agent claude --synthesis-model fake-model` through the real CLI with two persisted non-compliance sessions targeting `AG-001.2`, then inspected the generated proposal and harness-visible synthesis prompt.</code>

✅ No issues found.
- <code>`node --test test/fold.test.js test/synthesize.test.js test/proposal.test.js test/analyze-reuse.test.js` (initially exposed the duplicate import)</code>
- `node --test test/budget.test.js test/fold.test.js test/synthesize.test.js test/proposal.test.js`
- `node --test test/interaction.test.js --test-name-pattern='current signature'`
- <code>Manual executable check using `parseMemoryUnits`, `foldEvidence`, `renderInstructionIndex`, and `renderEvidenceForPrompt`, persisted as reviewer evidence</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
