### PR TITLE
fix: resolve ambiguous model ids by provider auth type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,8 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   acpx (sessions succeed while logged out), so every real call runs under
   `AgentResolver.withFallthrough`, which demotes a candidate on a classifiable failure
   (`classifyAcpxFailure`). Effortful calls go through `sessionPrompt` so the overlay in
-  `src/harness-invoke.js` can apply. Verdicts cache in `.backpass/agent-probe-cache.json`.
+  `src/harness-invoke.js` can apply. Verdicts cache in `.backpass/agent-probe-cache.json`;
+  Pi and OpenCode entries carry `providerAuthState`, so credential changes invalidate them.
   A probe miss retries once with backoff (`probeAndRecord` in `src/agents.js`); a timeout,
   a bare `exit N`, or an empty advertised-model list is never written as a negative cache
   hit, so a busy harness cannot poison the next run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,16 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   A probe miss retries once with backoff (`probeAndRecord` in `src/agents.js`); a timeout,
   a bare `exit N`, or an empty advertised-model list is never written as a negative cache
   hit, so a busy harness cannot poison the next run.
+- **An ambiguous advertised model is ranked by auth class, never guessed.** Pi (and any
+  harness that lists `provider/id`) can advertise the same bare ladder id under a
+  subscription provider and an API-key provider - classic case: `openai-codex/gpt-5.6-luna`
+  vs `openai/gpt-5.6-luna` when `OPENAI_API_KEY` is set. `resolveModelId` prefers the
+  subscription-backed prefix using `src/provider-auth.js` (Pi provider definitions plus
+  `auth.json` `type`; OpenCode's own auth file, where `openai` is ChatGPT OAuth). Prefix
+  semantics are harness-specific. An unrankable collision is a loud `model-unavailable`
+  that names the ids and tells the user to pass a provider-qualified id - never a silent
+  pick, and never "model not advertised" with the ids hidden. The probe trail prints a
+  winning tie-break.
 - **The Lavish apply surface is chatty and its output is YAML-quoted.** `lavish-axi poll`
   can return feedback that is not a decision vector (a comment, a queued layout report) any
   number of times before the real one; `pollDecisions` in `src/apply/lavish.js` announces

--- a/README.md
+++ b/README.md
@@ -485,10 +485,11 @@ wins:
 Each candidate is checked with a ~1.5s zero-token acpx probe (claude via `claude auth status`,
 because its adapter accepts sessions while logged out). A potentially transient busy-harness
 miss retries once and is not cached; durable verdicts are cached in
-`.backpass/agent-probe-cache.json` for 12h (30min for negatives) and re-probed with `--force`.
-The probe is a filter, not a promise: if the chosen harness answers `AUTH_REQUIRED` or rejects
-the model mid-run, backpass falls through to the next candidate and says so. When a whole
-ladder is exhausted the error lists every candidate with what to run to fix it.
+`.backpass/agent-probe-cache.json` for 12h (30min for negatives). Pi and OpenCode entries
+are re-probed when their credential or auth-file state changes; `--force` re-probes every
+entry. The probe is a filter, not a promise: if the chosen harness answers `AUTH_REQUIRED`
+or rejects the model mid-run, backpass falls through to the next candidate and says so.
+When a whole ladder is exhausted the error lists every candidate with what to run to fix it.
 
 Bare model ids are resolved against what each adapter advertises (`openai-codex/gpt-5.6-luna`
 on pi, `openai/gpt-5.6-luna` on opencode, `gpt-5.6-luna` on codex), so nothing is hardcoded
@@ -498,8 +499,10 @@ harness's provider definitions and auth file (see `src/provider-auth.js`). An un
 collision is refused with the colliding ids named; it is never an arbitrary pick. Ladders
 are ordinary config - reorder or shorten them under `"ladders"`.
 
-Pinning an agent skips its ladder entirely. If that harness fails, backpass reports an
-actionable error and keeps the pin rather than falling through or printing a raw stack:
+Pinning an agent skips its candidate ladder. A bare pinned model id is still resolved
+against that harness's advertised models, including the same collision handling above.
+If the pinned harness cannot resolve or serve it, backpass reports an actionable error and
+keeps the pin rather than falling through or printing a raw stack:
 
 ```sh
 backpass \

--- a/README.md
+++ b/README.md
@@ -492,7 +492,11 @@ ladder is exhausted the error lists every candidate with what to run to fix it.
 
 Bare model ids are resolved against what each adapter advertises (`openai-codex/gpt-5.6-luna`
 on pi, `openai/gpt-5.6-luna` on opencode, `gpt-5.6-luna` on codex), so nothing is hardcoded
-per harness. Ladders are ordinary config - reorder or shorten them under `"ladders"`.
+per harness. When the same bare id is advertised under more than one provider, backpass
+ranks by auth class - a subscription/OAuth provider over an API-key provider - from that
+harness's provider definitions and auth file (see `src/provider-auth.js`). An unrankable
+collision is refused with the colliding ids named; it is never an arbitrary pick. Ladders
+are ordinary config - reorder or shorten them under `"ladders"`.
 
 Pinning an agent skips its ladder entirely. If that harness fails, backpass reports an
 actionable error and keeps the pin rather than falling through or printing a raw stack:

--- a/src/agents.js
+++ b/src/agents.js
@@ -44,6 +44,7 @@ const PROBE_RETRY_BACKOFF_MS = 1_000;
 
 /** Adapters whose model list is open-ended: any id is forwarded, none can be verified. */
 const TRUSTING_MODEL_AGENTS = new Set(["claude"]);
+const PROVIDER_AUTH_SENSITIVE_AGENTS = new Set(["pi", "opencode"]);
 
 export const VERDICT_LABELS = {
   ok: "ok",
@@ -324,7 +325,8 @@ export class AgentResolver {
   async probeAndRecord(candidate, key) {
     const cache = await this.loadCache();
     const cached = cache.entries[key];
-    if (!this.bypassCache && isProbeEntryFresh(cached, { now: this.now() })) {
+    const providerAuthSensitive = PROVIDER_AUTH_SENSITIVE_AGENTS.has(candidate.agent);
+    if (!this.bypassCache && !providerAuthSensitive && isProbeEntryFresh(cached, { now: this.now() })) {
       this.memo.set(key, { ...cached, cached: true });
       return this.memo.get(key);
     }
@@ -384,7 +386,19 @@ export class AgentResolver {
 
     const pinned = this.pinned(role);
     if (pinned) {
-      this.picks[role] = { ...pinned, effort: resolvedEffort(role, pinned.agent, this.config) };
+      let model = pinned.model;
+      if (model && !model.includes("/") && !TRUSTING_MODEL_AGENTS.has(pinned.agent)) {
+        let entry;
+        try {
+          entry = await this.verdictFor({ agent: pinned.agent, model });
+        } catch (err) {
+          if (err instanceof AcpxError) throw new UserError(err.message, "install acpx (npm i -g acpx) and retry");
+          throw err;
+        }
+        if (entry.verdict !== "ok") throw pinnedResolutionError(role, pinned, entry);
+        model = entry.resolvedModel || model;
+      }
+      this.picks[role] = { ...pinned, model, effort: resolvedEffort(role, pinned.agent, this.config) };
       return this.picks[role];
     }
 
@@ -487,6 +501,15 @@ function describeTrail(trail) {
   const losers = trail.filter((t) => t.verdict !== "ok");
   if (!losers.length) return "first candidate in the ladder";
   return `after skipping ${losers.map((t) => `${t.agent}/${t.model} (${VERDICT_LABELS[t.verdict] || t.verdict})`).join(", ")}`;
+}
+
+function pinnedResolutionError(role, pick, entry) {
+  const label = VERDICT_LABELS[entry.verdict] || entry.verdict;
+  const detail = entry.detail ? ` (${entry.detail})` : "";
+  const hint = entry.detail?.includes("provider-qualified")
+    ? `pass a provider-qualified id with --${role}-model`
+    : `pin a different model or harness with --${role}-model <id> or --${role}-agent <agent>`;
+  return new UserError(`pinned ${role} agent ${pick.agent} (${pick.model}) ${label}${detail}`, hint);
 }
 
 function pinnedFailureError(role, pick, verdict, err) {

--- a/src/agents.js
+++ b/src/agents.js
@@ -1,12 +1,7 @@
 import { UserError, color, info, warn } from "./logger.js";
 import { DEFAULT_EFFORT, LEGACY_DEFAULT_AGENTS } from "./config.js";
 import { AcpxError, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
-import {
-  ambiguousModelDetail,
-  providerAuthState,
-  rankCollidingIds,
-  readProviderAuthTypes,
-} from "./provider-auth.js";
+import { ambiguousModelDetail, providerAuthState, rankCollidingIds, readProviderAuthTypes } from "./provider-auth.js";
 import { runCapture } from "./subprocess.js";
 
 /**
@@ -32,7 +27,8 @@ import { runCapture } from "./subprocess.js";
  * on a large profile, so `opencode models` answers first and the ACP probe is capped.
  *
  * Verdicts are cached in `.backpass/agent-probe-cache.json` (12h for ok, 30min for
- * negatives, invalidated on an acpx version change) and memoized for the run.
+ * negatives) and memoized for the run. An acpx version change invalidates every entry;
+ * Pi and OpenCode entries are also keyed to credential environment and auth-file state.
  *
  * A busy harness (another backpass run, a wedged ACP session) looks like a probe
  * timeout, a bare `exit 1`, or an empty advertised-model list. Those retry once with
@@ -229,8 +225,9 @@ export async function probeCandidate(candidate, options = {}) {
 }
 
 /**
- * A cache entry is fresh when it is within its TTL and was recorded against the same
- * acpx version. Negatives expire fast: "I just logged in" is the common repair.
+ * A cache entry is fresh when it is within its TTL. The caller separately checks the
+ * acpx version and, where provider resolution depends on it, auth state. Negatives expire
+ * fast: "I just logged in" is the common repair.
  */
 export function isProbeEntryFresh(entry, { now = Date.now() } = {}) {
   if (!entry || !entry.checkedAt) return false;
@@ -469,9 +466,7 @@ export class AgentResolver {
     const key = candidateKey({ agent: pick.agent, model: pick.ladderModel });
     if (this.memo.get(key)?.verdict === "ok") {
       // First worker to see the failure records it; the rest just re-resolve.
-      const authState = PROVIDER_AUTH_SENSITIVE_AGENTS.has(pick.agent)
-        ? this.providerAuthState(pick.agent)
-        : null;
+      const authState = PROVIDER_AUTH_SENSITIVE_AGENTS.has(pick.agent) ? this.providerAuthState(pick.agent) : null;
       const entry = {
         verdict,
         detail,

--- a/src/agents.js
+++ b/src/agents.js
@@ -1,7 +1,12 @@
 import { UserError, color, info, warn } from "./logger.js";
 import { DEFAULT_EFFORT, LEGACY_DEFAULT_AGENTS } from "./config.js";
 import { AcpxError, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
-import { ambiguousModelDetail, rankCollidingIds, readProviderAuthTypes } from "./provider-auth.js";
+import {
+  ambiguousModelDetail,
+  providerAuthState,
+  rankCollidingIds,
+  readProviderAuthTypes,
+} from "./provider-auth.js";
 import { runCapture } from "./subprocess.js";
 
 /**
@@ -277,7 +282,8 @@ export class AgentResolver {
    * @param {object} config
    * @param {{ state?: { readProbeCache: Function, writeProbeCache: Function }, cwd?: string,
    *   bypassCache?: boolean, probeCandidate?: Function, acpxVersion?: Function, now?: () => number,
-   *   sleep?: (ms: number) => Promise<void>, probeRetryBackoffMs?: number }} [deps]
+   *   providerAuthState?: typeof providerAuthState, sleep?: (ms: number) => Promise<void>,
+   *   probeRetryBackoffMs?: number }} [deps]
    */
   constructor(config, deps = {}) {
     this.config = config;
@@ -286,6 +292,7 @@ export class AgentResolver {
     this.bypassCache = Boolean(deps.bypassCache);
     this.probeCandidate = deps.probeCandidate || probeCandidate;
     this.acpxVersion = deps.acpxVersion || acpxVersion;
+    this.providerAuthState = deps.providerAuthState || providerAuthState;
     this.now = deps.now || (() => Date.now());
     this.sleep = deps.sleep || defaultSleep;
     this.probeRetryBackoffMs = deps.probeRetryBackoffMs ?? PROBE_RETRY_BACKOFF_MS;
@@ -325,8 +332,11 @@ export class AgentResolver {
   async probeAndRecord(candidate, key) {
     const cache = await this.loadCache();
     const cached = cache.entries[key];
-    const providerAuthSensitive = PROVIDER_AUTH_SENSITIVE_AGENTS.has(candidate.agent);
-    if (!this.bypassCache && !providerAuthSensitive && isProbeEntryFresh(cached, { now: this.now() })) {
+    const authState = PROVIDER_AUTH_SENSITIVE_AGENTS.has(candidate.agent)
+      ? this.providerAuthState(candidate.agent)
+      : null;
+    const authStateMatches = authState === null || cached?.authState === authState;
+    if (!this.bypassCache && authStateMatches && isProbeEntryFresh(cached, { now: this.now() })) {
       this.memo.set(key, { ...cached, cached: true });
       return this.memo.get(key);
     }
@@ -349,6 +359,7 @@ export class AgentResolver {
       detail: result.detail || "",
       resolvedModel: result.resolvedModel || null,
       checkedAt: new Date(this.now()).toISOString(),
+      ...(authState === null ? {} : { authState }),
       ...(result.tieBreak ? { tieBreak: result.tieBreak } : {}),
     };
     this.memo.set(key, entry);

--- a/src/agents.js
+++ b/src/agents.js
@@ -469,7 +469,16 @@ export class AgentResolver {
     const key = candidateKey({ agent: pick.agent, model: pick.ladderModel });
     if (this.memo.get(key)?.verdict === "ok") {
       // First worker to see the failure records it; the rest just re-resolve.
-      const entry = { verdict, detail, resolvedModel: null, checkedAt: new Date(this.now()).toISOString() };
+      const authState = PROVIDER_AUTH_SENSITIVE_AGENTS.has(pick.agent)
+        ? this.providerAuthState(pick.agent)
+        : null;
+      const entry = {
+        verdict,
+        detail,
+        resolvedModel: null,
+        checkedAt: new Date(this.now()).toISOString(),
+        ...(authState === null ? {} : { authState }),
+      };
       this.memo.set(key, entry);
       const cache = await this.loadCache();
       cache.entries[key] = entry;

--- a/src/agents.js
+++ b/src/agents.js
@@ -127,9 +127,10 @@ function firstLine(text) {
 }
 
 /**
- * Match a bare model id against what an adapter advertises (design section 4.1):
- * exact, then a unique last-`/`-segment match (`openai-codex/x`, `xai/x`), then a
- * unique `x[...]` variant. Segment *equality* is deliberate: `gpt-5.6-luna-fast`
+ * Match a model id against what an adapter advertises (design section 4.1): exact,
+ * then a unique match after the provider prefix (`openai-codex/x`,
+ * `openrouter/vendor/x`), then a unique `x[...]` variant. Equality is deliberate:
+ * `gpt-5.6-luna-fast`
  * must not satisfy `gpt-5.6-luna`. More than one survivor is ranked by auth class
  * (subscription over API key) when `providerAuthTypes` can decide; otherwise it is
  * a loud non-match that names the ids - never an arbitrary pick.
@@ -142,10 +143,14 @@ function firstLine(text) {
  */
 export function resolveModelId(bareId, advertised, options = {}) {
   if (advertised.includes(bareId)) return { id: bareId };
-  const bySegment = advertised.filter((id) => id.split("/").at(-1) === bareId);
+  const modelName = (id) => {
+    const slash = id.indexOf("/");
+    return slash === -1 ? id : id.slice(slash + 1);
+  };
+  const bySegment = advertised.filter((id) => modelName(id) === bareId);
   if (bySegment.length === 1) return { id: bySegment[0] };
   if (bySegment.length > 1) return rankCollidingIds(bySegment, options.providerAuthTypes);
-  const byVariant = advertised.filter((id) => id.startsWith(`${bareId}[`));
+  const byVariant = advertised.filter((id) => modelName(id).startsWith(`${bareId}[`));
   if (byVariant.length === 1) return { id: byVariant[0] };
   if (byVariant.length > 1) return rankCollidingIds(byVariant, options.providerAuthTypes);
   return { id: null };

--- a/src/agents.js
+++ b/src/agents.js
@@ -1,6 +1,7 @@
 import { UserError, color, info, warn } from "./logger.js";
 import { DEFAULT_EFFORT, LEGACY_DEFAULT_AGENTS } from "./config.js";
 import { AcpxError, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
+import { ambiguousModelDetail, rankCollidingIds, readProviderAuthTypes } from "./provider-auth.js";
 import { runCapture } from "./subprocess.js";
 
 /**
@@ -12,6 +13,12 @@ import { runCapture } from "./subprocess.js";
  * zero-token probe per candidate. The probe is a *filter*, not a guarantee: the first
  * real call is the decider, and a classifiable failure there (AUTH_REQUIRED, model
  * rejected, adapter missing) demotes the candidate and falls through to the next one.
+ *
+ * Bare ladder ids are matched against the advertised list (`resolveModelId`). A unique
+ * `provider/id` wins; a collision is ranked by auth class (subscription over API key)
+ * from `src/provider-auth.js`. An unrankable collision is a loud non-match that names
+ * the ids - never an arbitrary pick, and never silent fallthrough disguised as
+ * "model not advertised".
  *
  * All model invocation still goes through `src/acpx.js`. The one documented exception
  * is `NATIVE_PROBES` below: the claude adapter creates sessions happily while logged
@@ -86,7 +93,7 @@ const NATIVE_PROBES = {
     }
     return null;
   },
-  async opencode({ model }, capture) {
+  async opencode({ model }, capture, options = {}) {
     const result = await capture("opencode", ["models"], { timeoutMs: NATIVE_TIMEOUT_MS });
     if (result.spawnError?.code === "ENOENT") {
       return { verdict: "unreachable", detail: "opencode CLI not found on PATH" };
@@ -100,12 +107,12 @@ const NATIVE_PROBES = {
     if (!advertised.length) {
       return { verdict: "model-unavailable", detail: "`opencode models` advertised no models" };
     }
-    const resolved = resolveModelId(model, advertised);
+    const resolved = resolveAdvertisedModel(model, advertised, "opencode", options);
     if (!resolved.id) {
       return {
         verdict: "model-unavailable",
         detail: resolved.ambiguous
-          ? `ambiguous in \`opencode models\`: ${resolved.ambiguous.join(", ")}`
+          ? ambiguousModelDetail(resolved.ambiguous, { source: "`opencode models`" })
           : "absent from `opencode models` (provider not logged in?)",
       };
     }
@@ -121,19 +128,31 @@ function firstLine(text) {
  * Match a bare model id against what an adapter advertises (design section 4.1):
  * exact, then a unique last-`/`-segment match (`openai-codex/x`, `xai/x`), then a
  * unique `x[...]` variant. Segment *equality* is deliberate: `gpt-5.6-luna-fast`
- * must not satisfy `gpt-5.6-luna`. More than one survivor is a non-match, reported.
+ * must not satisfy `gpt-5.6-luna`. More than one survivor is ranked by auth class
+ * (subscription over API key) when `providerAuthTypes` can decide; otherwise it is
+ * a loud non-match that names the ids - never an arbitrary pick.
  *
- * @returns {{ id: string | null, ambiguous?: string[] }}
+ * @param {string} bareId
+ * @param {string[]} advertised
+ * @param {{ providerAuthTypes?: Record<string, "subscription" | "api_key"> }} [options]
+ * @returns {{ id: string | null, ambiguous?: string[],
+ *   tieBreak?: { preferred: string, over: string[] } }}
  */
-export function resolveModelId(bareId, advertised) {
+export function resolveModelId(bareId, advertised, options = {}) {
   if (advertised.includes(bareId)) return { id: bareId };
   const bySegment = advertised.filter((id) => id.split("/").at(-1) === bareId);
   if (bySegment.length === 1) return { id: bySegment[0] };
-  if (bySegment.length > 1) return { id: null, ambiguous: bySegment };
+  if (bySegment.length > 1) return rankCollidingIds(bySegment, options.providerAuthTypes);
   const byVariant = advertised.filter((id) => id.startsWith(`${bareId}[`));
   if (byVariant.length === 1) return { id: byVariant[0] };
-  if (byVariant.length > 1) return { id: null, ambiguous: byVariant };
+  if (byVariant.length > 1) return rankCollidingIds(byVariant, options.providerAuthTypes);
   return { id: null };
+}
+
+function resolveAdvertisedModel(bareId, advertised, agent, options = {}) {
+  const types =
+    options.providerAuthTypes ?? (options.readProviderAuthTypes || readProviderAuthTypes)(agent, { advertised });
+  return resolveModelId(bareId, advertised, { providerAuthTypes: types });
 }
 
 /** Flatten a ladder model-outer / harness-inner into `{ model, agent }` candidates. */
@@ -153,15 +172,18 @@ export function candidateKey({ agent, model }) {
  * @param {{ cwd?: string, sessionName?: string,
  *   probeSession?: (args: { agent: string, sessionName: string, cwd?: string, timeoutMs?: number }) =>
  *     Promise<{ verdict: string, detail: string, availableModels?: string[], transient?: boolean }>,
- *   runCapture?: typeof runCapture }} [options]
- * @returns {Promise<{ verdict: string, detail: string, resolvedModel: string | null, transient?: boolean }>}
+ *   runCapture?: typeof runCapture,
+ *   providerAuthTypes?: Record<string, "subscription" | "api_key">,
+ *   readProviderAuthTypes?: typeof readProviderAuthTypes }} [options]
+ * @returns {Promise<{ verdict: string, detail: string, resolvedModel: string | null,
+ *   transient?: boolean, tieBreak?: { preferred: string, over: string[] } }>}
  */
 export async function probeCandidate(candidate, options = {}) {
   const { cwd, sessionName, probeSession: probe = probeSession, runCapture: capture = runCapture } = options;
   const { agent, model } = candidate;
   const native = NATIVE_PROBES[agent];
   if (native) {
-    const early = await native(candidate, capture);
+    const early = await native(candidate, capture, options);
     if (early) return { resolvedModel: null, ...early };
   }
 
@@ -183,16 +205,21 @@ export async function probeCandidate(candidate, options = {}) {
   if (TRUSTING_MODEL_AGENTS.has(agent)) {
     return { verdict: "ok", detail: "model accepted on faith; the first real call verifies it", resolvedModel: model };
   }
-  const resolved = resolveModelId(model, result.availableModels || []);
+  const advertised = result.availableModels || [];
+  const resolved = resolveAdvertisedModel(model, advertised, agent, options);
   if (!resolved.id) {
     const detail = resolved.ambiguous
-      ? `ambiguous among advertised ids: ${resolved.ambiguous.join(", ")}`
-      : result.availableModels?.length
-        ? `not among ${result.availableModels.length} advertised model(s)`
+      ? ambiguousModelDetail(resolved.ambiguous)
+      : advertised.length
+        ? `not among ${advertised.length} advertised model(s)`
         : "adapter advertised no models";
     return { verdict: "model-unavailable", detail, resolvedModel: null };
   }
-  return { verdict: "ok", detail: "", resolvedModel: resolved.id };
+  const tieBreak = resolved.tieBreak;
+  const detail = tieBreak
+    ? `preferred subscription provider ${tieBreak.preferred} over ${tieBreak.over.join(", ")}`
+    : "";
+  return { verdict: "ok", detail, resolvedModel: resolved.id, ...(tieBreak ? { tieBreak } : {}) };
 }
 
 /**
@@ -320,6 +347,7 @@ export class AgentResolver {
       detail: result.detail || "",
       resolvedModel: result.resolvedModel || null,
       checkedAt: new Date(this.now()).toISOString(),
+      ...(result.tieBreak ? { tieBreak: result.tieBreak } : {}),
     };
     this.memo.set(key, entry);
     if (isTransientProbeResult(entry)) {
@@ -389,10 +417,20 @@ export class AgentResolver {
 
   announce(role, pick, trail) {
     const losers = trail.filter((t) => t.verdict !== "ok");
-    const cached = trail.at(-1)?.cached ? color.dim(" (cached)") : "";
+    const winner = trail.at(-1);
+    const cached = winner?.cached ? color.dim(" (cached)") : "";
     info(`${color.cyan("·")} ${role}: ${pick.agent} (${pick.model}) effort=${pick.effort || "unset"}${cached}`);
+    if (winner?.tieBreak) {
+      info(
+        color.dim(
+          `    preferred subscription provider ${winner.tieBreak.preferred} over ${winner.tieBreak.over.join(", ")}`,
+        ),
+      );
+    }
     for (const t of losers) {
-      info(color.dim(`    skipped ${t.agent}/${t.model}: ${VERDICT_LABELS[t.verdict] || t.verdict}`));
+      const label = VERDICT_LABELS[t.verdict] || t.verdict;
+      const extra = t.detail && /ambiguous/i.test(t.detail) ? ` (${t.detail})` : "";
+      info(color.dim(`    skipped ${t.agent}/${t.model}: ${label}${extra}`));
     }
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -17,8 +17,11 @@ export const OPT_IN_HARNESSES = ["cursor-ide"];
  * flattened model-outer / harness-inner, and the first candidate that is installed,
  * authenticated, and serves the model wins. Model ids are the bare ids the vendors use;
  * per-harness spellings (`openai-codex/...`, `openai/...`, `xai/...`) are resolved at
- * probe time against what the adapter advertises - never hard-coded. Ladders live in
- * config so a user can reorder or shorten them in `.backpassrc.json` without a release.
+ * probe time against what the adapter advertises - never hard-coded. A collision of the
+ * same bare id under two providers is ranked by auth class (subscription over API key;
+ * see `src/provider-auth.js`); an unrankable collision is refused, not guessed. Ladders
+ * live in config so a user can reorder or shorten them in `.backpassrc.json` without a
+ * release.
  */
 export const DEFAULT_LADDERS = {
   analysis: [

--- a/src/provider-auth.js
+++ b/src/provider-auth.js
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -117,6 +118,36 @@ export function opencodeAuthFilePath({ env = process.env, homedir = os.homedir()
   const xdg = env.XDG_DATA_HOME;
   const base = typeof xdg === "string" && xdg.trim() ? xdg.trim() : path.join(homedir, ".local", "share");
   return path.join(base, "opencode", "auth.json");
+}
+
+export function providerAuthState(agent, options = {}) {
+  const { env = process.env, homedir = os.homedir() } = options;
+  const file =
+    options.authFile === undefined
+      ? agent === "pi"
+        ? piAuthFilePath({ env, homedir })
+        : agent === "opencode"
+          ? opencodeAuthFilePath({ env, homedir })
+          : null
+      : options.authFile;
+  const hash = crypto.createHash("sha256");
+  hash.update(`${agent}\0${file || ""}\0`);
+  if (file) {
+    try {
+      hash.update(fs.readFileSync(file));
+    } catch {
+      hash.update("missing");
+    }
+  }
+  const credentialEnv = Object.entries(env)
+    .filter(
+      ([name, value]) =>
+        typeof value === "string" &&
+        /(?:^|_)(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET_ACCESS_KEY)$/.test(name),
+    )
+    .sort(([left], [right]) => left.localeCompare(right));
+  for (const [name, value] of credentialEnv) hash.update(`\0${name}\0${value}`);
+  return hash.digest("hex");
 }
 
 /**

--- a/src/provider-auth.js
+++ b/src/provider-auth.js
@@ -49,8 +49,8 @@ import path from "node:path";
 /**
  * Pi built-in provider auth modes from Pi's own provider definitions
  * (`docs/providers.md`). Dual-auth providers (`xai`, `anthropic`, `openrouter`,
- * `radius`) are omitted so a live `auth.json` `type` decides; advertised-but-unstored
- * providers infer `api_key` (env-var keys never appear in the file).
+ * `radius`) are omitted so a live `auth.json` `type` decides. Without that signal,
+ * their auth class remains unknown.
  *
  * This is a mode table, not a winner list: ranking is always subscription over
  * API key, never a named-provider preference order.
@@ -102,7 +102,7 @@ function readJsonObject(file) {
     const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
   } catch {
-    // Missing, unreadable, or invalid: degrade to definitions / inference.
+    // Missing, unreadable, or invalid: degrade to provider definitions.
   }
   return null;
 }
@@ -128,7 +128,7 @@ export function opencodeAuthFilePath({ env = process.env, homedir = os.homedir()
  * @returns {Record<string, AuthClass>}
  */
 export function readProviderAuthTypes(agent, options = {}) {
-  const { advertised = [], env = process.env, homedir = os.homedir() } = options;
+  const { env = process.env, homedir = os.homedir() } = options;
   /** @type {Record<string, AuthClass>} */
   const types = {};
   if (agent === "pi") Object.assign(types, PI_PROVIDER_AUTH_MODE);
@@ -146,15 +146,6 @@ export function readProviderAuthTypes(agent, options = {}) {
     if (parsed) Object.assign(types, parseAuthFileTypes(parsed));
   }
 
-  // Pi and OpenCode only advertise a provider when some credential resolved, and
-  // env-var API keys never appear in the auth file. Remaining advertised prefixes
-  // therefore infer as api_key. OAuth-only prefixes are already classified above.
-  if (agent === "pi" || agent === "opencode") {
-    for (const id of advertised) {
-      const provider = providerOf(id);
-      if (provider && !types[provider]) types[provider] = "api_key";
-    }
-  }
   return types;
 }
 

--- a/src/provider-auth.js
+++ b/src/provider-auth.js
@@ -61,10 +61,10 @@ export const PI_PROVIDER_AUTH_MODE = {
   openai: "api_key",
 };
 
-/** Last `/`-segment's provider prefix; empty when the id is bare. */
+/** Provider prefix before the first `/`; empty when the id is bare. */
 export function providerOf(advertisedId) {
   const text = String(advertisedId);
-  const slash = text.lastIndexOf("/");
+  const slash = text.indexOf("/");
   return slash === -1 ? "" : text.slice(0, slash);
 }
 

--- a/src/provider-auth.js
+++ b/src/provider-auth.js
@@ -142,8 +142,7 @@ export function providerAuthState(agent, options = {}) {
   const credentialEnv = Object.entries(env)
     .filter(
       ([name, value]) =>
-        typeof value === "string" &&
-        /(?:^|_)(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET_ACCESS_KEY)$/.test(name),
+        typeof value === "string" && /(?:^|_)(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET_ACCESS_KEY)$/.test(name),
     )
     .sort(([left], [right]) => left.localeCompare(right));
   for (const [name, value] of credentialEnv) hash.update(`\0${name}\0${value}`);

--- a/src/provider-auth.js
+++ b/src/provider-auth.js
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Auth-class signals for advertised-model tie-breaks (`resolveModelId` in `src/agents.js`).
+ *
+ * The ACP/status surface backpass consumes is a flat list of `provider/id` (or bare)
+ * strings with no auth type. When a bare ladder id matches more than one advertised id,
+ * rank by auth class - subscription over API key - using the best signal that harness
+ * exposes. Provider-definition modes (path a) and the harness auth file's `type` (path
+ * c2) are the Pi model; other harnesses reuse the same ranker with their own signals.
+ *
+ * Per-harness investigation (2026-08-30, backpass v0.1.15; advertised lists from acpx
+ * status / native CLIs; auth *types* only, never secret values):
+ *
+ *   pi        `provider/id`. Duplicate bare ids: yes - `openai` vs `openai-codex` for
+ *             seven gpt-5.x ids when `OPENAI_API_KEY` is set (reproduced with a dummy
+ *             key). Dual-auth providers exist (`xai`, `anthropic`, `openrouter`,
+ *             `radius`) but share one advertised id. Auth type is not on the ACP list;
+ *             Pi's provider definitions plus `~/.pi/agent/auth.json` `type` (honours
+ *             `PI_CODING_AGENT_DIR`). Env-var keys never appear in that file.
+ *   opencode  `provider/id`. No duplicate bare ids observed (`openai` is ChatGPT OAuth
+ *             here; a dummy `OPENAI_API_KEY` did not add a second provider). Dual-auth
+ *             across providers is possible. Auth type in
+ *             `~/.local/share/opencode/auth.json` `type` (honours `XDG_DATA_HOME`).
+ *             Prefix semantics differ from Pi: OpenCode files ChatGPT OAuth under
+ *             `openai`, so a global prefix preference list would mis-rank.
+ *   codex     Bare ids, no slash, no collision. Dual login exists (`auth_mode: chatgpt`
+ *             vs `codex login --with-api-key`) but is one model namespace - Codex
+ *             picks the credential, it does not advertise two prefixed ids. Auth type
+ *             is in `~/.codex/auth.json` `auth_mode` and is not an id-ranking signal.
+ *   claude    Aliases (`default`, `sonnet`, `opus[1m]`, ...). `TRUSTING_MODEL_AGENTS`
+ *             skips resolve. Dual auth (`claude.ai` vs API key) is on `claude auth
+ *             status` (`authMethod` / `subscriptionType`), not used for id ranking.
+ *   grok      Bare ids (`grok-4.6`, `grok-4.5`), no collision. grok.com OIDC vs API
+ *             key is one namespace. No prefix to rank.
+ *   cursor    Parameterized bare ids (`gpt-5.6-luna[context=...]`), no prefixes, no
+ *             collision. Dual auth (`login` vs `--api-key`) is process-level. Not on
+ *             the default ladder; a custom ladder uses the same resolver.
+ *   hermes    Discovery only; not an acpx model-resolution backend.
+ *
+ * Harnesses with no auth-class signal (codex/claude/grok/cursor, and custom-ladder
+ * acpx agents) keep unique matches unchanged and refuse unrankable collisions loudly.
+ */
+
+/** @typedef {"subscription" | "api_key"} AuthClass */
+
+/**
+ * Pi built-in provider auth modes from Pi's own provider definitions
+ * (`docs/providers.md`). Dual-auth providers (`xai`, `anthropic`, `openrouter`,
+ * `radius`) are omitted so a live `auth.json` `type` decides; advertised-but-unstored
+ * providers infer `api_key` (env-var keys never appear in the file).
+ *
+ * This is a mode table, not a winner list: ranking is always subscription over
+ * API key, never a named-provider preference order.
+ */
+export const PI_PROVIDER_AUTH_MODE = {
+  "openai-codex": "subscription",
+  "github-copilot": "subscription",
+  openai: "api_key",
+};
+
+/** Last `/`-segment's provider prefix; empty when the id is bare. */
+export function providerOf(advertisedId) {
+  const text = String(advertisedId);
+  const slash = text.lastIndexOf("/");
+  return slash === -1 ? "" : text.slice(0, slash);
+}
+
+/**
+ * Map a harness credential `type` onto the two ranking classes.
+ * @param {unknown} type
+ * @returns {AuthClass | null}
+ */
+export function credentialTypeToAuthClass(type) {
+  if (type === "oauth" || type === "oidc" || type === "chatgpt") return "subscription";
+  if (type === "api_key" || type === "api") return "api_key";
+  return null;
+}
+
+/**
+ * Pull `{ provider: authClass }` out of a harness auth.json object. Values that are
+ * not objects, or whose `type` is unknown, are skipped - never guessed from key names.
+ * @param {unknown} value
+ * @returns {Record<string, AuthClass>}
+ */
+export function parseAuthFileTypes(value) {
+  /** @type {Record<string, AuthClass>} */
+  const types = {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) return types;
+  for (const [provider, rec] of Object.entries(value)) {
+    if (!rec || typeof rec !== "object" || Array.isArray(rec)) continue;
+    const mapped = credentialTypeToAuthClass(/** @type {{ type?: unknown }} */ (rec).type);
+    if (mapped) types[provider] = mapped;
+  }
+  return types;
+}
+
+function readJsonObject(file) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+  } catch {
+    // Missing, unreadable, or invalid: degrade to definitions / inference.
+  }
+  return null;
+}
+
+export function piAuthFilePath({ env = process.env, homedir = os.homedir() } = {}) {
+  const override = env.PI_CODING_AGENT_DIR;
+  if (typeof override === "string" && override.trim()) return path.join(override.trim(), "auth.json");
+  return path.join(homedir, ".pi", "agent", "auth.json");
+}
+
+export function opencodeAuthFilePath({ env = process.env, homedir = os.homedir() } = {}) {
+  const xdg = env.XDG_DATA_HOME;
+  const base = typeof xdg === "string" && xdg.trim() ? xdg.trim() : path.join(homedir, ".local", "share");
+  return path.join(base, "opencode", "auth.json");
+}
+
+/**
+ * Auth-class map for one harness. File reads are fail-soft and never log contents.
+ *
+ * @param {string} agent
+ * @param {{ advertised?: string[], env?: NodeJS.ProcessEnv, homedir?: string,
+ *   authFile?: string | null }} [options]
+ * @returns {Record<string, AuthClass>}
+ */
+export function readProviderAuthTypes(agent, options = {}) {
+  const { advertised = [], env = process.env, homedir = os.homedir() } = options;
+  /** @type {Record<string, AuthClass>} */
+  const types = {};
+  if (agent === "pi") Object.assign(types, PI_PROVIDER_AUTH_MODE);
+
+  const file =
+    options.authFile === undefined
+      ? agent === "pi"
+        ? piAuthFilePath({ env, homedir })
+        : agent === "opencode"
+          ? opencodeAuthFilePath({ env, homedir })
+          : null
+      : options.authFile;
+  if (file && (agent === "pi" || agent === "opencode")) {
+    const parsed = readJsonObject(file);
+    if (parsed) Object.assign(types, parseAuthFileTypes(parsed));
+  }
+
+  // Pi and OpenCode only advertise a provider when some credential resolved, and
+  // env-var API keys never appear in the auth file. Remaining advertised prefixes
+  // therefore infer as api_key. OAuth-only prefixes are already classified above.
+  if (agent === "pi" || agent === "opencode") {
+    for (const id of advertised) {
+      const provider = providerOf(id);
+      if (provider && !types[provider]) types[provider] = "api_key";
+    }
+  }
+  return types;
+}
+
+/**
+ * Rank colliding advertised ids by auth class. Exactly one subscription and the
+ * rest API-key wins; anything else (unknown, two subscriptions, two API keys) refuses.
+ *
+ * @param {string[]} colliding
+ * @param {Record<string, AuthClass> | undefined} providerAuthTypes
+ * @returns {{ id: string, tieBreak: { preferred: string, over: string[] } }
+ *   | { id: null, ambiguous: string[] }}
+ */
+export function rankCollidingIds(colliding, providerAuthTypes) {
+  if (!Array.isArray(colliding) || colliding.length < 2) {
+    return { id: null, ambiguous: colliding || [] };
+  }
+  if (!providerAuthTypes || typeof providerAuthTypes !== "object") {
+    return { id: null, ambiguous: colliding };
+  }
+  const classes = colliding.map((id) => ({
+    id,
+    auth: providerAuthTypes[providerOf(id)] || null,
+  }));
+  if (classes.some((row) => !row.auth)) return { id: null, ambiguous: colliding };
+  const subscription = classes.filter((row) => row.auth === "subscription");
+  const apiKey = classes.filter((row) => row.auth === "api_key");
+  if (subscription.length === 1 && apiKey.length === classes.length - 1) {
+    return {
+      id: subscription[0].id,
+      tieBreak: { preferred: subscription[0].id, over: apiKey.map((row) => row.id) },
+    };
+  }
+  return { id: null, ambiguous: colliding };
+}
+
+/** Probe/ladder copy when a collision cannot be ranked. */
+export function ambiguousModelDetail(ids, { source = "advertised ids" } = {}) {
+  return `ambiguous among ${source}: ${ids.join(", ")} (cannot rank auth types; disambiguate with a provider-qualified id)`;
+}

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -56,6 +56,7 @@ function scriptedProbe(verdicts) {
  * @param {Record<string, any>} verdicts
  * @param {{ config?: any, state?: ReturnType<typeof memoryState>, now?: () => number,
  *   bypassCache?: boolean, acpxVersion?: () => Promise<string | null>,
+ *   providerAuthState?: (agent: string) => string,
  *   sleep?: (ms: number) => Promise<void> }} [options]
  */
 function resolverWith(
@@ -171,9 +172,7 @@ test("the real ladder keeps Pi when its ambiguous model has a subscription winne
           verdict: "ok",
           detail: "",
           availableModels:
-            candidate.agent === "pi"
-              ? ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"]
-              : ["gpt-5.6-luna"],
+            candidate.agent === "pi" ? ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"] : ["gpt-5.6-luna"],
         }),
       });
     },

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -610,7 +610,7 @@ test("probe verdicts are cached with TTLs and invalidated on an acpx version cha
   );
 });
 
-test("provider-auth-sensitive harnesses re-probe instead of serving stale resolutions", async () => {
+test("provider-auth-sensitive cache entries are reused only while auth state matches", async () => {
   const now = Date.parse("2026-08-22T00:00:00Z");
   const state = memoryState({
     version: 1,
@@ -621,16 +621,24 @@ test("provider-auth-sensitive harnesses re-probe instead of serving stale resolu
         detail: "",
         resolvedModel: "openai/gpt-5.6-luna",
         checkedAt: new Date(now).toISOString(),
+        authState: "auth-a",
       },
     },
   });
-  const { resolver, calls } = resolverWith(
+  const unchanged = resolverWith(
     { "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" } },
-    { state, now: () => now + 60_000 },
+    { state, now: () => now + 60_000, providerAuthState: () => "auth-a" },
   );
-  const pick = await resolver.resolve("analysis");
-  assert.equal(pick.model, "openai-codex/gpt-5.6-luna");
-  assert.deepEqual(calls, ["pi|gpt-5.6-luna"]);
+  assert.equal((await unchanged.resolver.resolve("analysis")).model, "openai/gpt-5.6-luna");
+  assert.deepEqual(unchanged.calls, []);
+
+  const changed = resolverWith(
+    { "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" } },
+    { state, now: () => now + 60_000, providerAuthState: () => "auth-b" },
+  );
+  assert.equal((await changed.resolver.resolve("analysis")).model, "openai-codex/gpt-5.6-luna");
+  assert.deepEqual(changed.calls, ["pi|gpt-5.6-luna"]);
+  assert.equal(state.cache.entries["pi|gpt-5.6-luna"].authState, "auth-b");
 });
 
 test("a transient probe timeout retries once and does not poison the cache", async () => {

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -155,6 +155,36 @@ test("the resolved model id is the adapter's spelling, never the bare id", async
   assert.equal(pick.ladderModel, "gpt-5.6-luna");
 });
 
+test("the real ladder keeps Pi when its ambiguous model has a subscription winner", async () => {
+  const config = loadConfig(tmpRepo());
+  config.ladders.analysis = [{ model: "gpt-5.6-luna", agents: ["pi", "codex"] }];
+  const calls = [];
+  const resolver = new AgentResolver(config, {
+    state: memoryState(),
+    acpxVersion: async () => "0.13.0",
+    probeCandidate: (candidate, options) => {
+      calls.push(candidate.agent);
+      return probeCandidate(candidate, {
+        ...options,
+        providerAuthTypes: { openai: "api_key", "openai-codex": "subscription" },
+        probeSession: async () => ({
+          verdict: "ok",
+          detail: "",
+          availableModels:
+            candidate.agent === "pi"
+              ? ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"]
+              : ["gpt-5.6-luna"],
+        }),
+      });
+    },
+  });
+
+  const pick = await resolver.resolve("analysis");
+  assert.equal(pick.agent, "pi");
+  assert.equal(pick.model, "openai-codex/gpt-5.6-luna");
+  assert.deepEqual(calls, ["pi"]);
+});
+
 test("claude is decided by `claude auth status`, not by the acpx session probe", async () => {
   // The acpx probe for claude always says ok (a logged-out claude still creates a
   // session). Run the real native check against a fake `claude` on PATH and assert
@@ -404,7 +434,36 @@ test("explicit config or CLI flags pin the role and skip the ladder entirely", a
   assert.equal(opencodeSynthesis.effort, "xhigh");
   assert.deepEqual(opencodeCalls, [], "pinned OpenCode skips the ladder");
 
-  assert.deepEqual(calls, [], "nothing was probed");
+  assert.deepEqual(calls, [], "pins without a bare resolvable id are not probed");
+
+  const bareConfig = loadConfig(tmpRepo({ analysis: { agent: "pi", model: "gpt-5.6-luna" } }));
+  const { resolver: bareResolver, calls: bareCalls } = resolverWith(
+    { "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" } },
+    { config: bareConfig },
+  );
+  const barePick = await bareResolver.resolve("analysis");
+  assert.equal(barePick.model, "openai-codex/gpt-5.6-luna");
+  assert.equal(barePick.pinned, true);
+  assert.deepEqual(bareCalls, ["pi|gpt-5.6-luna"]);
+
+  const { resolver: refusedPinned } = resolverWith(
+    {
+      "pi|gpt-5.6-luna": {
+        verdict: "model-unavailable",
+        detail:
+          "ambiguous among advertised ids: openai/gpt-5.6-luna, other/gpt-5.6-luna (disambiguate with a provider-qualified id)",
+      },
+    },
+    { config: bareConfig },
+  );
+  await assert.rejects(
+    () => refusedPinned.resolve("analysis"),
+    (err) =>
+      err instanceof UserError &&
+      /openai\/gpt-5\.6-luna/.test(err.message) &&
+      /other\/gpt-5\.6-luna/.test(err.message) &&
+      /provider-qualified/.test(err.hint),
+  );
 
   // A pinned agent is the user's decision: an auth failure surfaces as a UserError, it does not fall through.
   await assert.rejects(
@@ -492,42 +551,42 @@ test("a missing acpx is reported once, not once per candidate", async () => {
 test("probe verdicts are cached with TTLs and invalidated on an acpx version change", async () => {
   let now = Date.parse("2026-08-22T00:00:00Z");
   const state = memoryState();
+  const config = loadConfig(tmpRepo());
+  config.ladders.analysis = [{ model: "gpt-5.6-luna", agents: ["codex", "grok"] }];
   const verdicts = {
-    "pi|gpt-5.6-luna": "unauthenticated",
-    "opencode|gpt-5.6-luna": { resolvedModel: "openai/gpt-5.6-luna" },
+    "codex|gpt-5.6-luna": "unauthenticated",
+    "grok|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" },
   };
 
-  const first = resolverWith(verdicts, { state, now: () => now });
-  assert.equal((await first.resolver.resolve("analysis")).agent, "opencode");
+  const first = resolverWith(verdicts, { config, state, now: () => now });
+  assert.equal((await first.resolver.resolve("analysis")).agent, "grok");
   assert.equal(first.calls.length, 2);
 
-  // 10 minutes later: both verdicts are fresh, nothing is probed.
   now += 10 * 60 * 1000;
-  const second = resolverWith(verdicts, { state, now: () => now });
-  assert.equal((await second.resolver.resolve("analysis")).agent, "opencode");
+  const second = resolverWith(verdicts, { config, state, now: () => now });
+  assert.equal((await second.resolver.resolve("analysis")).agent, "grok");
   assert.deepEqual(second.calls, []);
 
-  // 45 minutes later: the negative expired (30min) and is re-probed; the ok (12h) is not.
   now += 35 * 60 * 1000;
   const third = resolverWith(
-    { ...verdicts, "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" } },
-    {
-      state,
-      now: () => now,
-    },
+    { ...verdicts, "codex|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" } },
+    { config, state, now: () => now },
   );
-  assert.equal((await third.resolver.resolve("analysis")).agent, "pi", "logging in is picked up within 30min");
-  assert.deepEqual(third.calls, ["pi|gpt-5.6-luna"]);
+  assert.equal((await third.resolver.resolve("analysis")).agent, "codex", "logging in is picked up within 30min");
+  assert.deepEqual(third.calls, ["codex|gpt-5.6-luna"]);
 
-  // --force bypasses the cache.
-  const forced = resolverWith(verdicts, { state, now: () => now, bypassCache: true });
+  const forced = resolverWith(verdicts, { config, state, now: () => now, bypassCache: true });
   await forced.resolver.resolve("analysis");
   assert.ok(forced.calls.length >= 1);
 
-  // A new acpx drops every entry.
-  const upgraded = resolverWith(verdicts, { state, now: () => now, acpxVersion: async () => "0.14.0" });
+  const upgraded = resolverWith(verdicts, {
+    config,
+    state,
+    now: () => now,
+    acpxVersion: async () => "0.14.0",
+  });
   await upgraded.resolver.resolve("analysis");
-  assert.deepEqual(upgraded.calls, ["pi|gpt-5.6-luna", "opencode|gpt-5.6-luna"]);
+  assert.deepEqual(upgraded.calls, ["codex|gpt-5.6-luna", "grok|gpt-5.6-luna"]);
   assert.equal(state.cache.acpxVersion, "0.14.0");
 
   assert.equal(isProbeEntryFresh(null), false);
@@ -549,6 +608,29 @@ test("probe verdicts are cached with TTLs and invalidated on an acpx version cha
     false,
     "a legacy native timeout is never treated as a durable negative",
   );
+});
+
+test("provider-auth-sensitive harnesses re-probe instead of serving stale resolutions", async () => {
+  const now = Date.parse("2026-08-22T00:00:00Z");
+  const state = memoryState({
+    version: 1,
+    acpxVersion: "0.13.0",
+    entries: {
+      "pi|gpt-5.6-luna": {
+        verdict: "ok",
+        detail: "",
+        resolvedModel: "openai/gpt-5.6-luna",
+        checkedAt: new Date(now).toISOString(),
+      },
+    },
+  });
+  const { resolver, calls } = resolverWith(
+    { "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" } },
+    { state, now: () => now + 60_000 },
+  );
+  const pick = await resolver.resolve("analysis");
+  assert.equal(pick.model, "openai-codex/gpt-5.6-luna");
+  assert.deepEqual(calls, ["pi|gpt-5.6-luna"]);
 });
 
 test("a transient probe timeout retries once and does not poison the cache", async () => {

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -751,6 +751,15 @@ test("bare model ids resolve by segment equality, never by prefix", () => {
   const ambiguous = resolveModelId("grok-4.6", ["xai/grok-4.6", "other/grok-4.6"]);
   assert.equal(ambiguous.id, null);
   assert.deepEqual(ambiguous.ambiguous, ["xai/grok-4.6", "other/grok-4.6"]);
+
+  const nested = resolveModelId("vendor/x", ["openrouter/vendor/x", "direct/vendor/x"], {
+    providerAuthTypes: { openrouter: "subscription", direct: "api_key" },
+  });
+  assert.equal(nested.id, "openrouter/vendor/x");
+  assert.deepEqual(nested.tieBreak, {
+    preferred: "openrouter/vendor/x",
+    over: ["direct/vendor/x"],
+  });
 });
 
 test("pi openai vs openai-codex gpt-5.6-luna prefers the subscription provider", () => {

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -11,7 +11,7 @@ import {
 } from "../src/agents.js";
 import { AcpxError, acpxAgentName, classifyAcpxFailure, effortOptionKey, probeSession } from "../src/acpx.js";
 import { DEFAULT_LADDERS, loadConfig } from "../src/config.js";
-import { UserError, setQuiet } from "../src/logger.js";
+import { UserError, setLoggerSink, setQuiet } from "../src/logger.js";
 
 setQuiet(true);
 
@@ -655,6 +655,200 @@ test("bare model ids resolve by segment equality, never by prefix", () => {
   const ambiguous = resolveModelId("grok-4.6", ["xai/grok-4.6", "other/grok-4.6"]);
   assert.equal(ambiguous.id, null);
   assert.deepEqual(ambiguous.ambiguous, ["xai/grok-4.6", "other/grok-4.6"]);
+});
+
+test("pi openai vs openai-codex gpt-5.6-luna prefers the subscription provider", () => {
+  // Regression: with OPENAI_API_KEY set, Pi advertises the same bare id under the
+  // API-key provider and the ChatGPT-subscription provider. Refusing the collision
+  // used to skip pi as "model not advertised" and silently reroute the ladder.
+  const advertised = ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"];
+  const resolved = resolveModelId("gpt-5.6-luna", advertised, {
+    providerAuthTypes: { openai: "api_key", "openai-codex": "subscription" },
+  });
+  assert.equal(resolved.id, "openai-codex/gpt-5.6-luna");
+  if (!("tieBreak" in resolved)) throw new Error("expected a tie-break");
+  assert.deepEqual(resolved.tieBreak, {
+    preferred: "openai-codex/gpt-5.6-luna",
+    over: ["openai/gpt-5.6-luna"],
+  });
+});
+
+test("each advertised-list shape ranks a subscription+API-key pair and refuses the unrankable rest", async () => {
+  /** @type {Array<{
+   *   agent: string,
+   *   bare: string,
+   *   advertised: string[],
+   *   types: Record<string, "subscription" | "api_key">,
+   *   prefer: string,
+   *   unique: string[],
+   *   uniqueId: string,
+   * }>} */
+  const shapes = [
+    {
+      agent: "pi",
+      bare: "gpt-5.6-luna",
+      advertised: ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"],
+      types: { openai: "api_key", "openai-codex": "subscription" },
+      prefer: "openai-codex/gpt-5.6-luna",
+      unique: ["kimi-coding/k3", "openai-codex/gpt-5.6-luna"],
+      uniqueId: "openai-codex/gpt-5.6-luna",
+    },
+    {
+      agent: "opencode",
+      bare: "gpt-5.6-luna",
+      advertised: ["openai/gpt-5.6-luna", "anthropic/gpt-5.6-luna"],
+      types: { openai: "subscription", anthropic: "api_key" },
+      prefer: "openai/gpt-5.6-luna",
+      unique: ["opencode/free", "openai/gpt-5.6-luna", "openai/gpt-5.6-luna-fast"],
+      uniqueId: "openai/gpt-5.6-luna",
+    },
+    {
+      agent: "codex",
+      bare: "gpt-5.6-luna",
+      advertised: ["openai/gpt-5.6-luna", "azure/gpt-5.6-luna"],
+      types: { openai: "subscription", azure: "api_key" },
+      prefer: "openai/gpt-5.6-luna",
+      unique: ["gpt-5.6-luna", "gpt-5.5"],
+      uniqueId: "gpt-5.6-luna",
+    },
+    {
+      agent: "grok",
+      bare: "grok-4.6",
+      advertised: ["xai/grok-4.6", "openrouter/grok-4.6"],
+      types: { xai: "subscription", openrouter: "api_key" },
+      prefer: "xai/grok-4.6",
+      unique: ["grok-4.6", "grok-4.5"],
+      uniqueId: "grok-4.6",
+    },
+    {
+      agent: "cursor",
+      bare: "gpt-5.6-luna",
+      advertised: ["openai/gpt-5.6-luna", "azure/gpt-5.6-luna"],
+      types: { openai: "subscription", azure: "api_key" },
+      prefer: "openai/gpt-5.6-luna",
+      unique: ["gpt-5.6-luna[context=272k,reasoning=medium,fast=false]", "gpt-5.5[fast=false]"],
+      uniqueId: "gpt-5.6-luna[context=272k,reasoning=medium,fast=false]",
+    },
+  ];
+
+  for (const shape of shapes) {
+    const ranked = resolveModelId(shape.bare, shape.advertised, { providerAuthTypes: shape.types });
+    assert.equal(ranked.id, shape.prefer, `${shape.agent} subscription+api_key`);
+    const refused = resolveModelId(shape.bare, shape.advertised, { providerAuthTypes: {} });
+    assert.equal(refused.id, null, `${shape.agent} unrankable`);
+    assert.deepEqual(refused.ambiguous, shape.advertised);
+    assert.equal(resolveModelId(shape.bare, shape.unique).id, shape.uniqueId, `${shape.agent} unique`);
+  }
+
+  const claude = await probeCandidate(
+    { agent: "claude", model: "claude-sonnet-5" },
+    {
+      sessionName: "t",
+      runCapture: async () => ({ code: 0, stdout: '{"loggedIn": true}\n', stderr: "" }),
+      probeSession: async () => ({ verdict: "ok", detail: "", availableModels: ["default", "sonnet"] }),
+    },
+  );
+  assert.equal(claude.resolvedModel, "claude-sonnet-5", "claude still forwards any id");
+
+  const piProbe = await probeCandidate(
+    { agent: "pi", model: "gpt-5.6-luna" },
+    {
+      sessionName: "t",
+      probeSession: async () => ({
+        verdict: "ok",
+        detail: "",
+        availableModels: ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"],
+      }),
+      providerAuthTypes: { openai: "api_key", "openai-codex": "subscription" },
+    },
+  );
+  assert.equal(piProbe.verdict, "ok");
+  assert.equal(piProbe.resolvedModel, "openai-codex/gpt-5.6-luna");
+  assert.match(piProbe.detail, /preferred subscription provider openai-codex\/gpt-5.6-luna over openai\/gpt-5.6-luna/);
+
+  const loud = await probeCandidate(
+    { agent: "pi", model: "gpt-5.6-luna" },
+    {
+      sessionName: "t",
+      probeSession: async () => ({
+        verdict: "ok",
+        detail: "",
+        availableModels: ["openai/gpt-5.6-luna", "other/gpt-5.6-luna"],
+      }),
+      providerAuthTypes: {},
+    },
+  );
+  assert.equal(loud.verdict, "model-unavailable");
+  assert.match(loud.detail, /openai\/gpt-5.6-luna/);
+  assert.match(loud.detail, /other\/gpt-5.6-luna/);
+  assert.match(loud.detail, /provider-qualified/);
+});
+
+test("a winning subscription tie-break is visible on the probe trail", async () => {
+  const lines = [];
+  setQuiet(false);
+  setLoggerSink((line) => lines.push(String(line)));
+  try {
+    const { resolver } = resolverWith({
+      "pi|gpt-5.6-luna": {
+        resolvedModel: "openai-codex/gpt-5.6-luna",
+        tieBreak: { preferred: "openai-codex/gpt-5.6-luna", over: ["openai/gpt-5.6-luna"] },
+      },
+    });
+    await resolver.resolve("analysis");
+    assert.ok(
+      lines.some((line) =>
+        /preferred subscription provider openai-codex\/gpt-5.6-luna over openai\/gpt-5.6-luna/.test(line),
+      ),
+    );
+  } finally {
+    setLoggerSink(null);
+    setQuiet(true);
+  }
+});
+
+test("opencode's native models probe ranks a subscription collision instead of skipping", async () => {
+  const bin = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fake-opencode-"));
+  fs.writeFileSync(
+    path.join(bin, "opencode"),
+    `#!/bin/sh\necho 'openai/gpt-5.6-luna'\necho 'anthropic/gpt-5.6-luna'\n`,
+  );
+  fs.chmodSync(path.join(bin, "opencode"), 0o755);
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${bin}${path.delimiter}${oldPath}`;
+  try {
+    const ok = await probeCandidate(
+      { agent: "opencode", model: "gpt-5.6-luna" },
+      {
+        sessionName: "t",
+        providerAuthTypes: { openai: "subscription", anthropic: "api_key" },
+        probeSession: async () => ({
+          verdict: "ok",
+          detail: "",
+          availableModels: ["openai/gpt-5.6-luna", "anthropic/gpt-5.6-luna"],
+        }),
+      },
+    );
+    assert.equal(ok.verdict, "ok");
+    assert.equal(ok.resolvedModel, "openai/gpt-5.6-luna");
+
+    const refused = await probeCandidate(
+      { agent: "opencode", model: "gpt-5.6-luna" },
+      {
+        sessionName: "t",
+        providerAuthTypes: {},
+        probeSession: async () => {
+          throw new Error("acpx probe must not run when native models are unrankably ambiguous");
+        },
+      },
+    );
+    assert.equal(refused.verdict, "model-unavailable");
+    assert.match(refused.detail, /openai\/gpt-5.6-luna/);
+    assert.match(refused.detail, /anthropic\/gpt-5.6-luna/);
+    assert.match(refused.detail, /provider-qualified/);
+  } finally {
+    process.env.PATH = oldPath;
+  }
 });
 
 test("acpx failure classification and the per-adapter tables", () => {

--- a/test/agents.test.js
+++ b/test/agents.test.js
@@ -340,11 +340,13 @@ test("non-claude candidates resolve the bare id against the advertised list", as
 });
 
 test("AUTH_REQUIRED mid-run falls through to the next candidate", async () => {
-  const { resolver, calls, state } = resolverWith({
+  const authState = () => "auth-a";
+  const verdicts = {
     "pi|gpt-5.6-luna": { resolvedModel: "openai-codex/gpt-5.6-luna" },
     "opencode|gpt-5.6-luna": "model-unavailable",
     "codex|gpt-5.6-luna": { resolvedModel: "gpt-5.6-luna" },
-  });
+  };
+  const { resolver, calls, state } = resolverWith(verdicts, { providerAuthState: authState });
 
   const attempts = [];
   const result = await resolver.withFallthrough("analysis", async (pick) => {
@@ -357,7 +359,12 @@ test("AUTH_REQUIRED mid-run falls through to the next candidate", async () => {
   assert.deepEqual(attempts, ["pi/openai-codex/gpt-5.6-luna", "codex/gpt-5.6-luna"]);
   assert.deepEqual(calls, ["pi|gpt-5.6-luna", "opencode|gpt-5.6-luna", "codex|gpt-5.6-luna"]);
   assert.equal(state.cache.entries["pi|gpt-5.6-luna"].verdict, "unauthenticated", "the failure is remembered");
+  assert.equal(state.cache.entries["pi|gpt-5.6-luna"].authState, "auth-a");
   assert.equal((await resolver.resolve("analysis")).agent, "codex", "later calls in the run stay on the fallback");
+
+  const replay = resolverWith(verdicts, { state, providerAuthState: authState });
+  assert.equal((await replay.resolver.resolve("analysis")).agent, "codex");
+  assert.deepEqual(replay.calls, [], "the demotion remains cached while auth state is unchanged");
 });
 
 test("parallel workers failing on the same candidate fall through once, together", async () => {

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -115,6 +115,12 @@ if (argv.includes("config") && argv.includes("show")) {
   process.exit(0);
 }
 if (argv.includes("set-mode")) process.exit(0);
+if (argv.includes("status")) {
+  process.stdout.write(JSON.stringify({
+    availableModels: ["gpt-5.6-sol", "grok-4.6", "safe-model"],
+  }) + "\\n");
+  process.exit(0);
+}
 const setAt = argv.indexOf("set");
 if (setAt >= 0) {
   const key = argv[setAt + 1];
@@ -895,7 +901,7 @@ test("the Backpass CLI uses verified overlays for every positional harness", () 
     const result = runBackpass(repo, analysisArgs(agent, model));
     assert.equal(result.status, 0, result.stderr);
     const calls = acpxCalls();
-    const created = calls.find((call) => call.argv.includes("new"));
+    const created = calls.find((call) => call.argv.includes("new") && call.argv.includes("--model"));
     assert.equal(created.argv[created.argv.indexOf("--model") + 1], model);
     const effortCalls = setCalls(calls);
     assert.deepEqual(effortCalls.map(setKey), effortKey ? [effortKey] : []);
@@ -912,8 +918,6 @@ test("the Backpass CLI applies Grok model and effort as process arguments", () =
   fs.mkdirSync(spacedTmp);
   const result = runBackpass(repo, analysisArgs("grok", "grok-4.6"), { TMPDIR: spacedTmp });
   assert.equal(result.status, 0, result.stderr);
-  const calls = acpxCalls();
-  assert.ok(calls.every((call) => !call.argv.includes("grok-build")));
   const spawned = jsonl(grokLog);
   assert.deepEqual(spawned[0], ["-m", "grok-4.6", "--reasoning-effort", "high", "agent", "stdio"]);
   assert.equal(settingsBytes().compare(before), 0);
@@ -925,7 +929,7 @@ test("the Backpass CLI preserves safe process fallbacks and rejects unsafe ones"
     resetLogsAndSettings();
     const before = Buffer.from(settingsBytes());
     const repo = makeCliRepo(`${agent}-fallback`);
-    const model = agent === "grok" ? "grok-4.6" : "safe-model";
+    const model = agent === "grok" ? "xai/grok-4.6" : "provider/safe-model";
     const result = runBackpass(repo, analysisArgs(agent, model), { FAKE_SESSIONS_UNSUPPORTED: "1" });
     assert.equal(result.status, 0, result.stderr);
     assert.ok(acpxCalls().some((call) => call.argv.includes("exec")));
@@ -939,7 +943,9 @@ test("the Backpass CLI preserves safe process fallbacks and rejects unsafe ones"
     resetLogsAndSettings();
     const before = Buffer.from(settingsBytes());
     const repo = makeCliRepo(`${agent}-unsafe-fallback`);
-    const result = runBackpass(repo, analysisArgs(agent, "safe-model"), { FAKE_SESSIONS_UNSUPPORTED: "1" });
+    const result = runBackpass(repo, analysisArgs(agent, "provider/safe-model"), {
+      FAKE_SESSIONS_UNSUPPORTED: "1",
+    });
     assert.equal(result.status, 1);
     assert.match(result.stderr, new RegExp(`${agent} cannot apply invocation-scoped effort=high`));
     assert.match(result.stderr, /upgrade acpx or omit the effort override/);

--- a/test/provider-auth.test.js
+++ b/test/provider-auth.test.js
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  PI_PROVIDER_AUTH_MODE,
+  ambiguousModelDetail,
+  credentialTypeToAuthClass,
+  opencodeAuthFilePath,
+  parseAuthFileTypes,
+  piAuthFilePath,
+  providerOf,
+  rankCollidingIds,
+  readProviderAuthTypes,
+} from "../src/provider-auth.js";
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "backpass-provider-auth-"));
+}
+
+test("credential types map onto subscription vs api_key and skip unknowns", () => {
+  assert.equal(credentialTypeToAuthClass("oauth"), "subscription");
+  assert.equal(credentialTypeToAuthClass("oidc"), "subscription");
+  assert.equal(credentialTypeToAuthClass("chatgpt"), "subscription");
+  assert.equal(credentialTypeToAuthClass("api_key"), "api_key");
+  assert.equal(credentialTypeToAuthClass("api"), "api_key");
+  assert.equal(credentialTypeToAuthClass("unknown"), null);
+  assert.equal(credentialTypeToAuthClass(undefined), null);
+});
+
+test("parseAuthFileTypes reads type only and ignores non-objects", () => {
+  assert.deepEqual(
+    parseAuthFileTypes({
+      "openai-codex": { type: "oauth", access: "secret-must-not-be-copied", refresh: "also-secret" },
+      openai: { type: "api_key", key: "sk-secret" },
+      xai: { type: "mystery" },
+      bare: "oauth",
+    }),
+    { "openai-codex": "subscription", openai: "api_key" },
+  );
+  assert.deepEqual(parseAuthFileTypes(null), {});
+  assert.deepEqual(parseAuthFileTypes([]), {});
+});
+
+test("rankCollidingIds prefers the sole subscription provider and refuses the rest", () => {
+  const pair = ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"];
+  const ranked = rankCollidingIds(pair, { openai: "api_key", "openai-codex": "subscription" });
+  assert.equal(ranked.id, "openai-codex/gpt-5.6-luna");
+  if (!("tieBreak" in ranked)) throw new Error("expected a tie-break");
+  assert.deepEqual(ranked.tieBreak, { preferred: "openai-codex/gpt-5.6-luna", over: ["openai/gpt-5.6-luna"] });
+
+  const reversed = rankCollidingIds([...pair].reverse(), { openai: "api_key", "openai-codex": "subscription" });
+  assert.equal(reversed.id, "openai-codex/gpt-5.6-luna");
+
+  const unrankable = rankCollidingIds(pair, {});
+  assert.equal(unrankable.id, null);
+  if (!("ambiguous" in unrankable)) throw new Error("expected an unrankable collision");
+  assert.deepEqual(unrankable.ambiguous, pair);
+
+  const twoSubs = rankCollidingIds(["a/x", "b/x"], { a: "subscription", b: "subscription" });
+  assert.equal(twoSubs.id, null);
+  if (!("ambiguous" in twoSubs)) throw new Error("expected an unrankable collision");
+  assert.deepEqual(twoSubs.ambiguous, ["a/x", "b/x"]);
+
+  const twoKeys = rankCollidingIds(["a/x", "b/x"], { a: "api_key", b: "api_key" });
+  assert.equal(twoKeys.id, null);
+
+  const unknownHalf = rankCollidingIds(["a/x", "b/x"], { a: "subscription" });
+  assert.equal(unknownHalf.id, null);
+});
+
+test("pi auth.json types overlay definitions; missing advertised prefixes infer api_key", () => {
+  const dir = tmpDir();
+  const authFile = path.join(dir, "auth.json");
+  fs.writeFileSync(
+    authFile,
+    JSON.stringify({
+      "openai-codex": { type: "oauth", access: "x" },
+      xai: { type: "oauth", access: "y" },
+    }),
+  );
+  const types = readProviderAuthTypes("pi", {
+    advertised: ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna", "xai/grok-4.6"],
+    authFile,
+    homedir: dir,
+  });
+  assert.equal(types["openai-codex"], "subscription");
+  assert.equal(types.openai, "api_key", "definition plus env-var inference");
+  assert.equal(types.xai, "subscription", "live dual-auth type from auth.json");
+  assert.equal(PI_PROVIDER_AUTH_MODE.openai, "api_key");
+});
+
+test("pi definitions alone rank openai vs openai-codex without an auth file", () => {
+  const types = readProviderAuthTypes("pi", {
+    advertised: ["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"],
+    authFile: path.join(tmpDir(), "missing.json"),
+    homedir: tmpDir(),
+  });
+  assert.equal(types["openai-codex"], "subscription");
+  assert.equal(types.openai, "api_key");
+  const ranked = rankCollidingIds(["openai/gpt-5.6-luna", "openai-codex/gpt-5.6-luna"], types);
+  assert.equal(ranked.id, "openai-codex/gpt-5.6-luna");
+});
+
+test("opencode auth types come from its auth.json, not Pi's openai=api_key definition", () => {
+  const dir = tmpDir();
+  const authFile = path.join(dir, "auth.json");
+  fs.writeFileSync(
+    authFile,
+    JSON.stringify({
+      openai: { type: "oauth", access: "x" },
+      anthropic: { type: "api_key", key: "y" },
+    }),
+  );
+  const types = readProviderAuthTypes("opencode", {
+    advertised: ["openai/gpt-5.6-luna", "anthropic/gpt-5.6-luna"],
+    authFile,
+    homedir: dir,
+  });
+  assert.equal(types.openai, "subscription", "OpenCode files ChatGPT OAuth under openai");
+  assert.equal(types.anthropic, "api_key");
+  const ranked = rankCollidingIds(["openai/gpt-5.6-luna", "anthropic/gpt-5.6-luna"], types);
+  assert.equal(ranked.id, "openai/gpt-5.6-luna");
+});
+
+test("codex, claude, grok, and cursor expose no auth-class map", () => {
+  for (const agent of ["codex", "claude", "grok", "cursor"]) {
+    assert.deepEqual(readProviderAuthTypes(agent, { advertised: ["gpt-5.6-luna", "openai/gpt-5.6-luna"] }), {});
+  }
+});
+
+test("auth file path overrides honour PI_CODING_AGENT_DIR and XDG_DATA_HOME", () => {
+  assert.equal(
+    piAuthFilePath({ env: { PI_CODING_AGENT_DIR: "/tmp/pi-agent" } }),
+    path.join("/tmp/pi-agent", "auth.json"),
+  );
+  assert.equal(
+    piAuthFilePath({ env: {}, homedir: "/home/user" }),
+    path.join("/home/user", ".pi", "agent", "auth.json"),
+  );
+  assert.equal(
+    opencodeAuthFilePath({ env: { XDG_DATA_HOME: "/tmp/xdg" } }),
+    path.join("/tmp/xdg", "opencode", "auth.json"),
+  );
+  assert.equal(
+    opencodeAuthFilePath({ env: {}, homedir: "/home/user" }),
+    path.join("/home/user", ".local", "share", "opencode", "auth.json"),
+  );
+});
+
+test("ambiguousModelDetail names the ids and how to disambiguate", () => {
+  const detail = ambiguousModelDetail(["openai/gpt-5.6-luna", "other/gpt-5.6-luna"]);
+  assert.match(detail, /openai\/gpt-5.6-luna/);
+  assert.match(detail, /other\/gpt-5.6-luna/);
+  assert.match(detail, /provider-qualified/);
+  assert.equal(providerOf("openai-codex/gpt-5.6-luna"), "openai-codex");
+  assert.equal(providerOf("gpt-5.6-luna"), "");
+});

--- a/test/provider-auth.test.js
+++ b/test/provider-auth.test.js
@@ -150,10 +150,7 @@ test("provider auth state changes with credential files and environment keys", (
   fs.writeFileSync(authFile, JSON.stringify({ openai: { type: "api_key", key: "second" } }));
   const changedFile = providerAuthState("pi", { authFile, env: { OPENAI_API_KEY: "env-first" } });
   assert.notEqual(changedFile, first);
-  assert.notEqual(
-    providerAuthState("pi", { authFile, env: { OPENAI_API_KEY: "env-second" } }),
-    changedFile,
-  );
+  assert.notEqual(providerAuthState("pi", { authFile, env: { OPENAI_API_KEY: "env-second" } }), changedFile);
 });
 
 test("codex, claude, grok, and cursor expose no auth-class map", () => {

--- a/test/provider-auth.test.js
+++ b/test/provider-auth.test.js
@@ -11,6 +11,7 @@ import {
   opencodeAuthFilePath,
   parseAuthFileTypes,
   piAuthFilePath,
+  providerAuthState,
   providerOf,
   rankCollidingIds,
   readProviderAuthTypes,
@@ -137,6 +138,22 @@ test("opencode auth types come from its auth.json, not Pi's openai=api_key defin
   assert.equal(types.anthropic, "api_key");
   const ranked = rankCollidingIds(["openai/gpt-5.6-luna", "anthropic/gpt-5.6-luna"], types);
   assert.equal(ranked.id, "openai/gpt-5.6-luna");
+});
+
+test("provider auth state changes with credential files and environment keys", () => {
+  const dir = tmpDir();
+  const authFile = path.join(dir, "auth.json");
+  fs.writeFileSync(authFile, JSON.stringify({ openai: { type: "api_key", key: "first" } }));
+  const first = providerAuthState("pi", { authFile, env: { OPENAI_API_KEY: "env-first" } });
+  assert.equal(first, providerAuthState("pi", { authFile, env: { OPENAI_API_KEY: "env-first" } }));
+
+  fs.writeFileSync(authFile, JSON.stringify({ openai: { type: "api_key", key: "second" } }));
+  const changedFile = providerAuthState("pi", { authFile, env: { OPENAI_API_KEY: "env-first" } });
+  assert.notEqual(changedFile, first);
+  assert.notEqual(
+    providerAuthState("pi", { authFile, env: { OPENAI_API_KEY: "env-second" } }),
+    changedFile,
+  );
 });
 
 test("codex, claude, grok, and cursor expose no auth-class map", () => {

--- a/test/provider-auth.test.js
+++ b/test/provider-auth.test.js
@@ -69,6 +69,12 @@ test("rankCollidingIds prefers the sole subscription provider and refuses the re
 
   const unknownHalf = rankCollidingIds(["a/x", "b/x"], { a: "subscription" });
   assert.equal(unknownHalf.id, null);
+
+  const nested = rankCollidingIds(["openrouter/vendor/x", "direct/vendor/x"], {
+    openrouter: "subscription",
+    direct: "api_key",
+  });
+  assert.equal(nested.id, "openrouter/vendor/x");
 });
 
 test("pi auth.json types overlay definitions while unknown providers stay unknown", () => {
@@ -164,5 +170,6 @@ test("ambiguousModelDetail names the ids and how to disambiguate", () => {
   assert.match(detail, /other\/gpt-5.6-luna/);
   assert.match(detail, /provider-qualified/);
   assert.equal(providerOf("openai-codex/gpt-5.6-luna"), "openai-codex");
+  assert.equal(providerOf("openrouter/vendor/gpt-5.6-luna"), "openrouter");
   assert.equal(providerOf("gpt-5.6-luna"), "");
 });

--- a/test/provider-auth.test.js
+++ b/test/provider-auth.test.js
@@ -71,7 +71,7 @@ test("rankCollidingIds prefers the sole subscription provider and refuses the re
   assert.equal(unknownHalf.id, null);
 });
 
-test("pi auth.json types overlay definitions; missing advertised prefixes infer api_key", () => {
+test("pi auth.json types overlay definitions while unknown providers stay unknown", () => {
   const dir = tmpDir();
   const authFile = path.join(dir, "auth.json");
   fs.writeFileSync(
@@ -87,9 +87,17 @@ test("pi auth.json types overlay definitions; missing advertised prefixes infer 
     homedir: dir,
   });
   assert.equal(types["openai-codex"], "subscription");
-  assert.equal(types.openai, "api_key", "definition plus env-var inference");
+  assert.equal(types.openai, "api_key", "provider definition");
   assert.equal(types.xai, "subscription", "live dual-auth type from auth.json");
   assert.equal(PI_PROVIDER_AUTH_MODE.openai, "api_key");
+
+  const withoutAuth = readProviderAuthTypes("pi", {
+    advertised: ["openai-codex/gpt-5.6-luna", "xai/gpt-5.6-luna"],
+    authFile: path.join(dir, "missing.json"),
+  });
+  assert.equal(withoutAuth["openai-codex"], "subscription");
+  assert.equal(withoutAuth.xai, undefined);
+  assert.equal(rankCollidingIds(["openai-codex/gpt-5.6-luna", "xai/gpt-5.6-luna"], withoutAuth).id, null);
 });
 
 test("pi definitions alone rank openai vs openai-codex without an auth file", () => {


### PR DESCRIPTION
## Intent

Make backpass's model-id resolution robust across every harness/backend it can drive, so an ambiguous bare model id never silently misroutes a run in any user environment. A user having OPENAI_API_KEY set is a normal environment, not a leak to fix; backpass must handle it. This is a shipped product fix for all users, not a one-machine setup fix.

On an ambiguous bare id, favor the subscription-backed provider over a metered API-key provider, deterministically. When a collision cannot be ranked (auth type unknown for that harness, or two same-type providers), refuse loudly and skip-visibly: a clear error naming the ambiguous ids and how to disambiguate with a provider-qualified id - never silently pick, and never the old silent reroute that labeled Pi "model not advertised" and fell through onto another harness. Announce a winning tie-break in the probe/ladder output.

Use one general auth-class ranker, not a hardcoded single-provider preference list. Determine each provider's auth type from the best signal available for that harness (provider definitions and/or the harness auth config; Pi path a/c2 generalized). Prefix semantics are harness-specific: OpenCode files ChatGPT OAuth under openai, Pi's openai is API-key-only. No new runtime dependency and no upstream harness change. Tests must be environment-independent (mock advertised surfaces / auth signals), not live credentials.

Acceptance: behavioral unit tests for each harness shape found in Phase 1; an ambiguous id with a subscription+API-key pair resolves to subscription; an unrankable collision refuses loudly (error names the ids); a non-ambiguous id still resolves unchanged; the pi openai/openai-codex gpt-5.6-luna case specifically resolves to openai-codex. Reproduce the silent-misroute first as a failing test and keep it as the regression. No unrelated resolver/ladder behavior changed. Unrankable collisions skip that harness visibly rather than aborting the whole ladder, so a working later candidate remains usable. No prefer-API-key override knob.

The PR description MUST include the per-harness investigation matrix so coverage is auditable. Enumerated backends (from DEFAULT_LADDERS + acpx + ALL_HARNESSES): pi, opencode, codex, claude, grok, cursor, hermes. For each: whether advertised-model surface can present duplicate/ambiguous bare ids; whether it has dual-auth (subscription/OAuth and API-key for the same model); whether auth TYPE is available at resolve time in the surface backpass consumes, or only elsewhere, or not at all; and how a silent misroute can happen.

Matrix (Phase 1, 2026-08-30, advertised lists from acpx status / native CLIs; auth types only):
- pi: provider/id. Duplicate bare ids YES (seven gpt-5.x ids, openai vs openai-codex, when OPENAI_API_KEY is set; reproduced with a dummy key). Dual-auth providers exist (xai, anthropic, openrouter, radius) but share one advertised id. Auth type NOT on ACP list; Pi provider definitions plus ~/.pi/agent/auth.json type (PI_CODING_AGENT_DIR). Env-var keys never appear in that file. This was the silent-misroute bug.
- opencode: provider/id. No duplicate bare ids observed (openai is ChatGPT OAuth; dummy OPENAI_API_KEY did not add a second provider). Dual-auth across providers possible. Auth type in ~/.local/share/opencode/auth.json type (XDG_DATA_HOME). Same ranker applies.
- codex: bare ids, no slash, no collision. Dual login exists (auth_mode chatgpt vs codex login --with-api-key) but one model namespace. Auth type in ~/.codex/auth.json auth_mode is not an id-ranking signal. Unique match unchanged; unrankable prefixed collision refuses.
- claude: aliases (default, sonnet, opus[1m]). TRUSTING_MODEL_AGENTS skips resolve. Dual auth (claude.ai vs API key) on claude auth status, not used for id ranking. Forwards any id, unchanged.
- grok: bare ids (grok-4.6, grok-4.5), no collision. grok.com OIDC vs API key is one namespace. Unique match unchanged.
- cursor: parameterized bare ids, no prefixes, no collision. Dual auth (login vs --api-key) is process-level. Not on the default ladder; custom ladder uses the same resolver.
- hermes: discovery only; not an acpx model-resolution backend.

## What Changed

- Resolve duplicate bare model ids with a harness-aware auth-class ranker that deterministically prefers subscription/OAuth providers over API-key providers.
- Refuse unrankable collisions with actionable, provider-qualified errors while visibly skipping ladder candidates, announcing successful tie-breaks, resolving pinned bare ids, and invalidating Pi/OpenCode probe caches when auth state changes.
- Add environment-independent regression coverage for resolver behavior, provider auth signals, cache freshness, pinned models, and the Pi `openai`/`openai-codex` collision.

### Per-harness investigation matrix

| Harness | Ambiguous advertised bare ids | Dual auth | Auth type available to resolver | Silent misroute path |
| --- | --- | --- | --- | --- |
| pi | Yes. `provider/id`; seven GPT-5.x ids can appear under both `openai` and `openai-codex`. | Yes; some dual-auth providers share one advertised id. | Not in ACP output; derived from Pi provider definitions and `PI_CODING_AGENT_DIR` `auth.json`. | Previously treated the collision as unavailable and silently fell through to another harness. |
| opencode | None observed, though provider-prefixed collisions are possible. | Yes, across providers. | Read from `XDG_DATA_HOME` `opencode/auth.json`; `openai` OAuth semantics differ from Pi. | A collision could previously be treated as unavailable and fall through; it is now ranked or refused visibly. |
| codex | No. Advertises one bare-id namespace. | Yes, but both modes share that namespace. | `auth_mode` exists elsewhere but is not an id-ranking signal. | No observed collision path; unique matches remain unchanged and hypothetical prefixed collisions are refused. |
| claude | No. Uses aliases and trusts forwarded model ids. | Yes. | Available from native auth status, but not used for id ranking. | Resolution is skipped, so ids continue to be forwarded unchanged. |
| grok | No. Advertises one bare-id namespace. | Yes, within one namespace. | No provider-prefix ranking signal. | No observed collision path; unique matches remain unchanged. |
| cursor | No. Advertises parameterized bare ids without provider prefixes. | Yes, at process level. | No provider-prefix ranking signal. | Not in default ladders; custom ladders use the same resolver and refuse hypothetical unrankable collisions. |
| hermes | Not applicable. | Not applicable. | Not applicable. | Discovery-only harness, not an acpx model-resolution backend. |

## Risk Assessment

✅ Low: The auth-aware cache keying and demotion fix now preserve existing TTL behavior while preventing stale cross-run provider resolution, with no remaining material source issues found.

## Testing

Inspected the resolver changes, ran the focused resolver and auth-state tests, and exercised the user-visible ladder output end-to-end: Pi selected openai-codex for a subscription/API-key collision, while unknown auth types visibly named both ambiguous IDs and fell through to Codex. The worktree remained clean.

<details>
<summary>Evidence: Model resolution and visible fallback CLI transcript</summary>

Source: [Model resolution and visible fallback CLI transcript](https://github.com/kunchenguid/backpass/blob/b35f1e71a1639b5d241c6df85ee52aef18bb3cd7/.no-mistakes/evidence/fm/backpass-resolver-robust-tiebreak-r1/model-resolution-cli-transcript.txt)

```text
SCENARIO 1: Pi collision has a rankable subscription winner
· analysis: pi (openai-codex/gpt-5.6-luna) effort=medium
    preferred subscription provider openai-codex/gpt-5.6-luna over openai/gpt-5.6-luna
RESULT: pi/openai-codex/gpt-5.6-luna

SCENARIO 2: Pi collision has unknown auth types
· analysis: codex (gpt-5.6-luna) effort=medium
    skipped pi/gpt-5.6-luna: model not advertised (ambiguous among advertised ids: openai/gpt-5.6-luna, openai-codex/gpt-5.6-luna (cannot rank auth types; disambiguate with a provider-qualified id))
RESULT: codex/gpt-5.6-luna
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"315da09e8114a2ab4b147f6f75a7caab12714c12","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (4) ✅</summary>

- 🚨 `src/provider-auth.js:155` - The intent requires unknown auth types and same-type collisions to refuse, but every unclassified Pi/OpenCode advertised prefix is guessed to be `api_key`. Concrete path: Pi advertises `openai-codex/x` and OAuth-authenticated `xai/x`, but `auth.json` is unreadable; `openai-codex` is classified subscription while `xai` is guessed API-key, so the resolver silently chooses one of two actual subscription providers. Leave missing auth signals unknown unless a provider definition conclusively establishes the class.
- 🚨 `src/agents.js:327` - A fresh successful cache entry bypasses advertised-model and auth-class resolution for 12 hours. If Pi is first probed with only `openai/gpt-5.6-luna`, then the user enables `openai-codex` within that TTL, subsequent runs reuse the cached API-key model without observing the new collision or announcing the required subscription tie-break. The durable fix needs cache freshness tied to provider/auth state, or provider-sensitive successes must not be reused; changing persistent cache semantics requires authorization.
- 🚨 `src/agents.js:385` - Configured agents return directly from `resolve()` without probing or calling the new ranker. Thus `--analysis-agent pi --analysis-model gpt-5.6-luna` forwards the ambiguous bare id to Pi unchanged, contrary to the requirement that an ambiguous bare id deterministically favor subscription or refuse loudly in every driven harness. The pinned path must resolve the model before invocation while preserving pinned no-fallthrough behavior.
- ⚠️ `test/agents.test.js:660` - The required regression says to reproduce and retain the silent ladder reroute, but this test only calls `resolveModelId` and observes the collision result. It never executes an `AgentResolver` ladder where the old Pi ambiguity skips to a later harness and the fix keeps Pi, so the shipped failure sequence and skip-visible invariant remain untested.

🔧 Fix: Harden provider tie-breaks, cache freshness, and pinned resolution
3 errors still open:

- 🚨 `src/agents.js:143` - This contradicts the required invariant that &#34;an ambiguous bare model id never silently misroutes.&#34; An exact bare entry wins before aliases are collected, so `gpt-x` with advertised `[&#39;gpt-x&#39;, &#39;provider/gpt-x&#39;]` silently selects `gpt-x`. Prefixed variants such as `[&#39;openai/gpt-x[fast=true]&#39;, &#39;azure/gpt-x[fast=false]&#39;]` match neither the segment nor variant checks and fall through without naming the collision. Normalize all advertised aliases for the requested bare id before choosing or ranking.
- 🚨 `src/provider-auth.js:67` - `providerOf` treats everything before the last slash as the provider, but the advertised contract is `provider/id`, and model ids can themselves contain slashes. For `openrouter/vendor/x` with auth types keyed by `openrouter`, this returns `openrouter/vendor`; a subscription/API-key collision that has sufficient auth signals is therefore incorrectly refused as unknown. Extract the provider from before the first slash.
- 🚨 `src/agents.js:328` - The fix-round code bypasses every fresh disk-cache entry for Pi and OpenCode, even when auth state is unchanged. This makes the documented 12-hour success and 30-minute negative cache ineffective for the default leading harnesses and can add repeated 10-20 second probes to ordinary runs, contradicting &#34;No unrelated resolver/ladder behavior changed.&#34; Revert the blanket bypass and use the previously authorized minimal auth-state-scoped cache invalidation instead.

🔧 Fix: Fix provider extraction for nested model identifiers
2 errors still open:

- 🚨 `src/agents.js:143` - This still violates the required invariant that an ambiguous bare model id never silently misroutes. An exact bare entry wins before prefixed aliases are considered, prefixed variants such as `openai/x[fast=true]` are not collected, and nested model ids use only the last slash segment. For example, resolving `vendor/x` against `openrouter/vendor/x` and `direct/vendor/x` returns an ordinary non-match rather than the required named collision. Normalize each advertised id to its provider-less model id, including variants, before deciding uniqueness or ranking.
- 🚨 `src/agents.js:328` - The fix-round code bypasses every fresh disk-cache entry for Pi and OpenCode, even when auth state is unchanged. This disables the documented 12-hour success and 30-minute negative cache for the default leading harnesses and can add repeated 10-20 second probes, contradicting the required `No unrelated resolver/ladder behavior changed`. Revert this fix-round blanket bypass and implement only the authorized minimal cache invalidation keyed to the relevant advertised/auth state.

🔧 Fix: Key probe cache entries to provider auth state
1 warning still open:

- ⚠️ `src/agents.js:338` - The new auth-state equality gate makes Pi/OpenCode demotions written at line 472 unusable across runs because `demote()` omits `authState`. After a probe succeeds but a real call is rejected, the next run sees the fresh negative entry, fails this equality check, and probes the same candidate again instead of honoring the 30-minute negative TTL. This contradicts the required &#34;No unrelated resolver/ladder behavior changed.&#34; Stamp auth-sensitive demotion entries with the current auth state, as `probeAndRecord()` does.

🔧 Fix: Preserve auth state on cached demotions
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 80b683400a107d4e2dee88b5bfcaec410690a391..fcc235569a35896a6de177baf129602594ce0c0f` and targeted source/test diff inspection</code>
- `node --test test/agents.test.js test/provider-auth.test.js`
- `node --test --test-name-pattern='real ladder keeps Pi|provider-auth-sensitive cache entries|AUTH_REQUIRED mid-run|explicit config or CLI flags pin|each advertised-list shape|winning subscription tie-break|opencode.s native models probe' test/agents.test.js`
- `node --test --test-name-pattern='rankCollidingIds|pi auth.json|pi definitions alone|opencode auth types|provider auth state changes' test/provider-auth.test.js`
- <code>Executed `AgentResolver` with mocked advertised model and auth surfaces to capture rankable Pi selection and visible unrankable fallback behavior</code>
- <code>`git status --short` confirmed testing left the worktree clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
