### PR TITLE
fix(subprocess): launch windows npm shims through the command interpreter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,16 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   (`src/prompts.js`) and discovery drops transcripts whose first user message begins with
   it (`src/discovery/self.js`) before sampling. Keep the sentinel on every model-facing
   prompt; the triviality filter is not a substitute.
+- **A Windows shim refusal must be raised by name, before any generic handling.** On
+  Windows every spawn of an npm `.cmd` goes through `windowsShimLaunch` (`src/subprocess.js`),
+  which refuses an argument no quoting can neutralise (`%VAR%`, a double quote, a newline)
+  rather than passing it to cmd.exe. That refusal arrives as a result with `code: null` and
+  `spawnError.code === "ERR_WINDOWS_SHIM_UNSAFE_ARG"`, so any boundary that inspects the
+  result generically first degrades it into "no session support", "exit null" or "failed to
+  open the apply surface" - none of which names the refused value. Two rounds of this change
+  were spent chasing that degradation at two separate boundaries. Today `run` in `src/acpx.js`
+  is the single funnel for every model call and `openApplySurface` in `src/apply/lavish.js`
+  covers apply; a new spawn boundary must raise it the same way.
 - **acpx is alpha.** All model invocation is isolated behind `src/acpx.js` so an upstream
   CLI change has one blast radius. v1 uses plain `exec` and named sessions only; acpx flows
   are deferred until they are stable upstream. The one sanctioned exception is the

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -60,35 +60,33 @@ export class AcpxError extends Error {
 }
 
 /**
+ * Every acpx call goes through here, which is also where a Windows command-shim
+ * refusal (`src/subprocess.js`) is raised. It has to be raised at the funnel rather
+ * than at each caller: a refusal resolves as `{ code: null, spawnError }`, which every
+ * result inspection downstream would read as a generic failure - `openSession` would
+ * call it "no session support" and the per-turn prompt "exit null", neither naming the
+ * argument backpass refused to pass. Widening `classifyAcpxFailure` is wrong for a
+ * related reason: `unreachable` would silently demote the harness and the next
+ * candidate would fail on the very same argument.
+ *
  * @param {string[]} args
  * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv }} [options]
  */
-function run(args, options = {}) {
-  return runCapture(ACPX_BIN, args, options);
+async function run(args, options = {}) {
+  const result = await runCapture(ACPX_BIN, args, options);
+  const spawnError = result.spawnError;
+  if (spawnError?.code === "ERR_WINDOWS_SHIM_UNSAFE_ARG") {
+    const value = spawnError.value === undefined ? "" : JSON.stringify(String(spawnError.value));
+    throw new UserError(
+      `backpass refused to pass ${value} to ${ACPX_BIN} through the Windows command interpreter`,
+      spawnError.message,
+    );
+  }
+  return result;
 }
 
 function notFoundError(result) {
   return new AcpxError(`acpx not found on PATH (looked for "${ACPX_BIN}")`, result);
-}
-
-/**
- * A Windows command-shim refusal (`src/subprocess.js`) as its own user-facing error.
- *
- * It must not travel as a generic non-zero exit: `classifyAcpxFailure` cannot see it,
- * so `openSession` would report "no session support" and every later candidate would
- * fail on the very same argument. Widening the classifier is wrong for the same
- * reason - `unreachable` would silently drop the harness instead of naming the value.
- *
- * @returns {UserError | null}
- */
-export function shimRefusalError(result) {
-  const spawnError = result?.spawnError;
-  if (spawnError?.code !== "ERR_WINDOWS_SHIM_UNSAFE_ARG") return null;
-  const value = spawnError.value === undefined ? "" : JSON.stringify(String(spawnError.value));
-  return new UserError(
-    `backpass refused to pass ${value} to ${ACPX_BIN} through the Windows command interpreter`,
-    spawnError.message,
-  );
 }
 
 /**
@@ -257,8 +255,6 @@ export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
 export async function probeSession({ agent, sessionName, cwd = undefined, timeoutMs = 20_000 }) {
   const acpxAgent = acpxAgentName(agent);
   const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs, cwd });
-  const refusal = shimRefusalError(created);
-  if (refusal) throw refusal;
   if (created.spawnError?.code === "ENOENT") throw notFoundError(created);
   if (created.timedOut) {
     return {
@@ -333,8 +329,6 @@ export async function execOneShot({
       );
     }
     const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
-    const refusal = shimRefusalError(result);
-    if (refusal) throw refusal;
     if (result.spawnError && result.spawnError.code === "ENOENT") throw notFoundError(result);
     if (result.timedOut) {
       throw new AcpxError(`acpx ${agent} exec timed out after ${timeoutSeconds}s`, result);
@@ -375,27 +369,24 @@ export async function openSession({ agent, model = null, effort = null, sessionN
   const notes = [...invocation.notes];
   const acpxAgentArgs = invocationAgentArgs(invocation, agent);
   const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
+  /** @type {Awaited<ReturnType<typeof run>>} */
+  let created;
   try {
     await verifyHarnessInvocation(invocation, cwd);
+    created = await run(
+      [
+        ...(invocation.acpxModel ? ["--model", invocation.acpxModel] : []),
+        ...acpxAgentArgs,
+        "sessions",
+        "new",
+        "--name",
+        sessionName,
+      ],
+      runOpts,
+    );
   } catch (err) {
     invocation.dispose();
     throw err;
-  }
-  const created = await run(
-    [
-      ...(invocation.acpxModel ? ["--model", invocation.acpxModel] : []),
-      ...acpxAgentArgs,
-      "sessions",
-      "new",
-      "--name",
-      sessionName,
-    ],
-    runOpts,
-  );
-  const refusal = shimRefusalError(created);
-  if (refusal) {
-    invocation.dispose();
-    throw refusal;
   }
   if (created.spawnError && created.spawnError.code === "ENOENT") {
     invocation.dispose();
@@ -423,13 +414,16 @@ export async function openSession({ agent, model = null, effort = null, sessionN
   const close = async () => {
     if (closed) return;
     closed = true;
-    const result = await run([...acpxAgentArgs, "sessions", "close", sessionName], {
-      timeoutMs: 30_000,
-      cwd,
-      env: invocation.env,
-    });
-    if (result.code !== 0) warn(`could not close acpx session ${sessionName}`);
-    invocation.dispose();
+    try {
+      const result = await run([...acpxAgentArgs, "sessions", "close", sessionName], {
+        timeoutMs: 30_000,
+        cwd,
+        env: invocation.env,
+      });
+      if (result.code !== 0) warn(`could not close acpx session ${sessionName}`);
+    } finally {
+      invocation.dispose();
+    }
   };
 
   try {

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -72,6 +72,26 @@ function notFoundError(result) {
 }
 
 /**
+ * A Windows command-shim refusal (`src/subprocess.js`) as its own user-facing error.
+ *
+ * It must not travel as a generic non-zero exit: `classifyAcpxFailure` cannot see it,
+ * so `openSession` would report "no session support" and every later candidate would
+ * fail on the very same argument. Widening the classifier is wrong for the same
+ * reason - `unreachable` would silently drop the harness instead of naming the value.
+ *
+ * @returns {UserError | null}
+ */
+export function shimRefusalError(result) {
+  const spawnError = result?.spawnError;
+  if (spawnError?.code !== "ERR_WINDOWS_SHIM_UNSAFE_ARG") return null;
+  const value = spawnError.value === undefined ? "" : JSON.stringify(String(spawnError.value));
+  return new UserError(
+    `backpass refused to pass ${value} to ${ACPX_BIN} through the Windows command interpreter`,
+    spawnError.message,
+  );
+}
+
+/**
  * Availability verdicts for a failed acpx call. Only a *classifiable* failure is a
  * reason to drop a candidate and fall through to the next one; anything else (a
  * timeout on a long prompt, garbage output) stays a plain error so a run never
@@ -237,6 +257,8 @@ export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
 export async function probeSession({ agent, sessionName, cwd = undefined, timeoutMs = 20_000 }) {
   const acpxAgent = acpxAgentName(agent);
   const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs, cwd });
+  const refusal = shimRefusalError(created);
+  if (refusal) throw refusal;
   if (created.spawnError?.code === "ENOENT") throw notFoundError(created);
   if (created.timedOut) {
     return {
@@ -311,6 +333,8 @@ export async function execOneShot({
       );
     }
     const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
+    const refusal = shimRefusalError(result);
+    if (refusal) throw refusal;
     if (result.spawnError && result.spawnError.code === "ENOENT") throw notFoundError(result);
     if (result.timedOut) {
       throw new AcpxError(`acpx ${agent} exec timed out after ${timeoutSeconds}s`, result);
@@ -368,6 +392,11 @@ export async function openSession({ agent, model = null, effort = null, sessionN
     ],
     runOpts,
   );
+  const refusal = shimRefusalError(created);
+  if (refusal) {
+    invocation.dispose();
+    throw refusal;
+  }
   if (created.spawnError && created.spawnError.code === "ENOENT") {
     invocation.dispose();
     throw notFoundError(created);

--- a/src/apply/lavish.js
+++ b/src/apply/lavish.js
@@ -98,6 +98,9 @@ export async function openApplySurface(file) {
   // `--reopen` it exits 0 and prints the dead session's URL - which apply would then hand
   // the reviewer as if it were live. On a live or agent-ended session the flag is a no-op.
   const result = await runLavish([file, "--reopen", "--no-open"]);
+  if (result.spawnError && result.spawnError.code === "ERR_WINDOWS_SHIM_UNSAFE_ARG") {
+    throw new UserError(result.spawnError.message);
+  }
   if (result.spawnError && result.spawnError.code === "ENOENT") {
     throw new UserError(
       `${LAVISH_BIN} not found on PATH`,

--- a/src/apply/lavish.js
+++ b/src/apply/lavish.js
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { UserError, color, info, warn } from "../logger.js";
+import { windowsShimLaunch } from "../subprocess.js";
 
 /**
  * The apply surface (captain decision 4).
@@ -45,7 +46,17 @@ export function renderApplySurface(proposal, state, toolVersion) {
 
 function runLavish(args, { inherit = false } = {}) {
   return new Promise((resolve) => {
-    const child = spawn(LAVISH_BIN, args, { stdio: inherit ? "inherit" : ["ignore", "pipe", "pipe"] });
+    // `lavish-axi` is an npm bin, so on Windows it is a `.cmd` shim that CreateProcess
+    // cannot start: same spawn policy as `runCapture` (issue #43).
+    const launch = windowsShimLaunch(LAVISH_BIN, args);
+    if (launch.error) {
+      resolve({ code: null, stdout: "", stderr: launch.error.message, spawnError: launch.error });
+      return;
+    }
+    const child = spawn(launch.file, launch.args, {
+      stdio: inherit ? "inherit" : ["ignore", "pipe", "pipe"],
+      ...(launch.verbatim ? { windowsVerbatimArguments: true } : {}),
+    });
     let stdout = "";
     let stderr = "";
     if (!inherit) {

--- a/src/harness-invoke.js
+++ b/src/harness-invoke.js
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { UserError } from "./logger.js";
+import { resolveOnPath } from "./subprocess.js";
 
 /**
  * Invocation-scoped model and effort overlays (`src/acpx.js` is the caller).
@@ -357,24 +358,5 @@ function cmdQuote(value) {
   return `"${value.replaceAll("%", "%%").replaceAll('"', '""')}"`;
 }
 
-function resolveOnPath(bin) {
-  if (path.isAbsolute(bin) && isExecutable(bin)) return bin;
-  const extensions = process.platform === "win32" ? (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";") : [""];
-  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
-    if (!dir) continue;
-    for (const extension of extensions) {
-      const candidate = path.join(dir, process.platform === "win32" ? `${bin}${extension.toLowerCase()}` : bin);
-      if (isExecutable(candidate)) return candidate;
-    }
-  }
-  return null;
-}
-
-function isExecutable(file) {
-  try {
-    const st = fs.statSync(file);
-    return st.isFile() && (process.platform === "win32" || Boolean(st.mode & 0o111));
-  } catch {
-    return false;
-  }
-}
+// `resolveOnPath` now lives in `src/subprocess.js`: the Windows npm-shim launch needs
+// the same PATHEXT resolution, and one resolver keeps the two in step.

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -3,6 +3,14 @@ import fs from "node:fs";
 import path from "node:path";
 
 /**
+ * A spawn failure. `value` is set only on a Windows shim refusal
+ * (`ERR_WINDOWS_SHIM_UNSAFE_ARG`), and holds the argument that was refused, so the
+ * boundary reporting it can name the value rather than a generic spawn failure.
+ *
+ * @typedef {NodeJS.ErrnoException & { value?: string }} ShimError
+ */
+
+/**
  * Spawn a command, capture both streams, and resolve (never reject) with a
  * uniform result. Shared by the acpx boundary (`src/acpx.js`) and the native
  * harness probes (`src/agents.js`), so every subprocess in backpass is killed the
@@ -13,7 +21,7 @@ import path from "node:path";
  * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv,
  *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv,
  *   spawnFn?: (file: string, args: string[], options: object) => any }} [options]
- * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: NodeJS.ErrnoException }>}
+ * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: ShimError }>}
  */
 export function runCapture(
   bin,
@@ -102,7 +110,7 @@ export function runCapture(
  * genuinely missing binary still surfaces as its own ENOENT rather than as a shim
  * failure.
  *
- * @returns {{ file: string, args: string[], verbatim: boolean, error?: NodeJS.ErrnoException }}
+ * @returns {{ file: string, args: string[], verbatim: boolean, error?: ShimError }}
  */
 export function windowsShimLaunch(bin, args, { platform = process.platform, env = process.env } = {}) {
   const shim = resolveShimPath(bin, { platform, env });
@@ -111,7 +119,7 @@ export function windowsShimLaunch(bin, args, { platform = process.platform, env 
   for (const value of [shim, ...args]) {
     const reason = unsafeShimReason(String(value));
     if (!reason) continue;
-    /** @type {NodeJS.ErrnoException & { value?: string }} */
+    /** @type {ShimError} */
     const error = new Error(
       `cannot safely pass ${JSON.stringify(String(value))} to the Windows command shim for ${bin}: ${reason}`,
     );

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 
 /**
  * Spawn a command, capture both streams, and resolve (never reject) with a
@@ -8,19 +10,36 @@ import { spawn } from "node:child_process";
  *
  * @param {string} bin
  * @param {string[]} args
- * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv }} [options]
+ * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv,
+ *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv,
+ *   spawnFn?: (file: string, args: string[], options: object) => any }} [options]
  * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: NodeJS.ErrnoException }>}
  */
-export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
+export function runCapture(
+  bin,
+  args,
+  { timeoutMs, cwd, input, env, platform = process.platform, lookupEnv = process.env, spawnFn = spawn } = {},
+) {
   return new Promise((resolve) => {
-    const child = spawn(bin, args, {
+    const launch = windowsShimLaunch(bin, args, { platform, env: lookupEnv });
+    if (launch.error) {
+      // Loud and named: an argument cmd.exe would expand must not reach a shim
+      // silently rewritten into several arguments.
+      resolve({ code: null, stdout: "", stderr: launch.error.message, spawnError: launch.error });
+      return;
+    }
+
+    const child = spawnFn(launch.file, launch.args, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: env ? { ...process.env, ...env } : undefined,
+      // The shim launch hands cmd.exe one already-quoted command line; Node must
+      // not re-quote it.
+      ...(launch.verbatim ? { windowsVerbatimArguments: true } : {}),
       // Give a timed command its own POSIX process group. acpx launches adapter
       // wrappers and harnesses below itself, and killing acpx alone leaves those
       // descendants running with our capture pipes open.
-      detached: process.platform !== "win32" && Boolean(timeoutMs),
+      detached: platform !== "win32" && Boolean(timeoutMs),
     });
     let stdout = "";
     let stderr = "";
@@ -30,7 +49,7 @@ export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
     const timer = timeoutMs
       ? setTimeout(() => {
           timedOut = true;
-          if (process.platform === "win32") {
+          if (platform === "win32") {
             killWindowsTree(child.pid);
             return;
           }
@@ -53,7 +72,7 @@ export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
     });
     child.on("close", (code) => {
       if (timer) clearTimeout(timer);
-      if (timedOut && process.platform !== "win32") killPosixGroup(child, "SIGKILL");
+      if (timedOut && platform !== "win32") killPosixGroup(child, "SIGKILL");
       if (escalationTimer) clearTimeout(escalationTimer);
       resolve({ code, stdout, stderr, timedOut });
     });
@@ -61,6 +80,105 @@ export function runCapture(bin, args, { timeoutMs, cwd, input, env } = {}) {
     if (input !== undefined) child.stdin.end(input);
     else child.stdin.end();
   });
+}
+
+/**
+ * Windows npm-shim launch policy (issue #43).
+ *
+ * npm installs a JS CLI on Windows as `<name>.cmd`; there is no `<name>.exe`. A bare
+ * `spawn("acpx")` goes through CreateProcess, which appends only ".exe", so it fails
+ * with ENOENT even though `where acpx` succeeds - which is exactly the misleading
+ * "acpx not found on PATH" the issue reports. Spawning the resolved `.cmd` directly
+ * does not help either: since the CVE-2024-27980 mitigation, Node >= 18.20 refuses a
+ * `.cmd`/`.bat` without a shell and throws a synchronous EINVAL, which would escape
+ * `runCapture`'s promise executor and break its resolve-never-reject contract.
+ *
+ * So a shim has to go through the command interpreter - but NOT through Node's
+ * `shell: true`, which joins argv with bare spaces and quotes nothing, splitting every
+ * `--cwd` / `--file` path that contains a space. We build the command line ourselves
+ * and pass it verbatim.
+ *
+ * Anything that is not a resolvable `.cmd`/`.bat` is left exactly as it was, so a
+ * genuinely missing binary still surfaces as its own ENOENT rather than as a shim
+ * failure.
+ *
+ * @returns {{ file: string, args: string[], verbatim: boolean, error?: NodeJS.ErrnoException }}
+ */
+export function windowsShimLaunch(bin, args, { platform = process.platform, env = process.env } = {}) {
+  const shim = resolveShimPath(bin, { platform, env });
+  if (!shim) return { file: bin, args, verbatim: false };
+
+  const unsafe = [shim, ...args].find((value) => EXPANDABLE_PERCENT.test(String(value)));
+  if (unsafe !== undefined) {
+    /** @type {NodeJS.ErrnoException} */
+    const error = new Error(
+      `cannot safely pass ${JSON.stringify(String(unsafe))} to the Windows command shim for ${bin}: ` +
+        "cmd.exe expands %VAR% even inside quotes, and there is no escape for it on a command line",
+    );
+    error.code = "ERR_WINDOWS_SHIM_UNSAFE_ARG";
+    return { file: bin, args, verbatim: false, error };
+  }
+
+  const line = [shim, ...args].map((value) => quoteShimArg(String(value))).join(" ");
+  return { file: env.ComSpec || "cmd.exe", args: ["/d", "/s", "/c", `"${line}"`], verbatim: true };
+}
+
+/** A `%...%` pair is the only sequence cmd.exe expands that quoting cannot suppress. */
+const EXPANDABLE_PERCENT = /%[^%]*%/;
+
+/**
+ * Quote one argument of a cmd.exe command line.
+ *
+ * Two parsers see this text: cmd.exe first, then the target's own argv parser (an npm
+ * shim forwards `%*` verbatim to `node.exe`). Double quotes satisfy both - they make
+ * cmd treat `& | < > ^ ( ) !` as literal, and they are what MSVCRT's parser expects -
+ * so the value is quoted whenever it holds any character either parser would act on.
+ * Backslashes preceding a quote, and any trailing run of them, are doubled per the
+ * MSVCRT rules, so a path ending in `\` cannot escape the closing quote.
+ *
+ * NOT `cmdQuote` from `harness-invoke.js`: that one doubles `%` for a batch *file*
+ * body, which on a command *line* is not an escape - it arrives literally, turning
+ * `100%done` into `100%%done`.
+ */
+export function quoteShimArg(value) {
+  if (value.length > 0 && !/[\s"&|<>^()!]/.test(value)) return value;
+  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`;
+}
+
+/**
+ * The `.cmd`/`.bat` this name resolves to on Windows, or null when the plain spawn is
+ * already correct (not Windows, a real executable, or a name that resolves to nothing).
+ */
+function resolveShimPath(bin, { platform, env }) {
+  if (platform !== "win32") return null;
+  const resolved = resolveOnPath(bin, { platform, env });
+  return resolved && /\.(?:cmd|bat)$/i.test(resolved) ? resolved : null;
+}
+
+/**
+ * First match for `bin` on PATH, honouring PATHEXT on Windows. Shared with
+ * `src/harness-invoke.js`, which needs the same resolution to build argv wrappers.
+ */
+export function resolveOnPath(bin, { platform = process.platform, env = process.env } = {}) {
+  if (path.isAbsolute(bin) && isExecutable(bin, platform)) return bin;
+  const extensions = platform === "win32" ? (env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";") : [""];
+  for (const dir of (env.PATH || "").split(path.delimiter)) {
+    if (!dir) continue;
+    for (const extension of extensions) {
+      const candidate = path.join(dir, platform === "win32" ? `${bin}${extension.toLowerCase()}` : bin);
+      if (isExecutable(candidate, platform)) return candidate;
+    }
+  }
+  return null;
+}
+
+function isExecutable(file, platform = process.platform) {
+  try {
+    const st = fs.statSync(file);
+    return st.isFile() && (platform === "win32" || Boolean(st.mode & 0o111));
+  } catch {
+    return false;
+  }
 }
 
 function killPosixGroup(child, signal) {

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -23,8 +23,8 @@ export function runCapture(
   return new Promise((resolve) => {
     const launch = windowsShimLaunch(bin, args, { platform, env: lookupEnv });
     if (launch.error) {
-      // Loud and named: an argument cmd.exe would expand must not reach a shim
-      // silently rewritten into several arguments.
+      // Loud and named: an argument no quoting can neutralise must not reach a shim
+      // where cmd.exe would silently rewrite it into several arguments or commands.
       resolve({ code: null, stdout: "", stderr: launch.error.message, spawnError: launch.error });
       return;
     }
@@ -108,14 +108,15 @@ export function windowsShimLaunch(bin, args, { platform = process.platform, env 
   const shim = resolveShimPath(bin, { platform, env });
   if (!shim) return { file: bin, args, verbatim: false };
 
-  const unsafe = [shim, ...args].find((value) => EXPANDABLE_PERCENT.test(String(value)));
-  if (unsafe !== undefined) {
-    /** @type {NodeJS.ErrnoException} */
+  for (const value of [shim, ...args]) {
+    const reason = unsafeShimReason(String(value));
+    if (!reason) continue;
+    /** @type {NodeJS.ErrnoException & { value?: string }} */
     const error = new Error(
-      `cannot safely pass ${JSON.stringify(String(unsafe))} to the Windows command shim for ${bin}: ` +
-        "cmd.exe expands %VAR% even inside quotes, and there is no escape for it on a command line",
+      `cannot safely pass ${JSON.stringify(String(value))} to the Windows command shim for ${bin}: ${reason}`,
     );
     error.code = "ERR_WINDOWS_SHIM_UNSAFE_ARG";
+    error.value = String(value);
     return { file: bin, args, verbatim: false, error };
   }
 
@@ -123,8 +124,29 @@ export function windowsShimLaunch(bin, args, { platform = process.platform, env 
   return { file: env.ComSpec || "cmd.exe", args: ["/d", "/s", "/c", `"${line}"`], verbatim: true };
 }
 
-/** A `%...%` pair is the only sequence cmd.exe expands that quoting cannot suppress. */
-const EXPANDABLE_PERCENT = /%[^%]*%/;
+/**
+ * Why an argument can never be made safe on a cmd.exe command line, or null when
+ * quoting is enough. Every argument backpass passes is a flag, a model id, a session
+ * name or a path, so none of these can occur legitimately and refusing costs nothing.
+ *
+ * `%NAME%` is expanded even inside quotes and has no command-line escape. A double
+ * quote cannot be escaped for both readers at once - cmd.exe counts quotes while the
+ * target's MSVCRT parser reads backslash rules - so either encoding leaves one of them
+ * mis-parsing the rest of the line. A newline ends the command line outright.
+ */
+function unsafeShimReason(value) {
+  if (EXPANDABLE_PERCENT.test(value)) {
+    return "cmd.exe expands %VAR% even inside quotes, and there is no escape for it on a command line";
+  }
+  if (value.includes('"')) {
+    return "cmd.exe counts double quotes while the target's argv parser reads backslash escapes, so no encoding satisfies both";
+  }
+  if (/[\r\n]/.test(value)) return "a carriage return or newline ends the cmd.exe command line and cannot be quoted";
+  return null;
+}
+
+/** A plausible `%VAR%` reference. A bare or doubled `%` is left alone: cmd expands neither. */
+const EXPANDABLE_PERCENT = /%[A-Za-z_]\w*%/;
 
 /**
  * Quote one argument of a cmd.exe command line.
@@ -132,17 +154,18 @@ const EXPANDABLE_PERCENT = /%[^%]*%/;
  * Two parsers see this text: cmd.exe first, then the target's own argv parser (an npm
  * shim forwards `%*` verbatim to `node.exe`). Double quotes satisfy both - they make
  * cmd treat `& | < > ^ ( ) !` as literal, and they are what MSVCRT's parser expects -
- * so the value is quoted whenever it holds any character either parser would act on.
- * Backslashes preceding a quote, and any trailing run of them, are doubled per the
- * MSVCRT rules, so a path ending in `\` cannot escape the closing quote.
+ * so the value is quoted whenever it is empty or holds whitespace or one of those
+ * operators. A trailing run of backslashes is doubled per the MSVCRT rules, so a path
+ * ending in `\` cannot escape the closing quote. An embedded quote never gets here:
+ * `unsafeShimReason` refuses it rather than pick an encoding one parser would misread.
  *
  * NOT `cmdQuote` from `harness-invoke.js`: that one doubles `%` for a batch *file*
  * body, which on a command *line* is not an escape - it arrives literally, turning
  * `100%done` into `100%%done`.
  */
 export function quoteShimArg(value) {
-  if (value.length > 0 && !/[\s"&|<>^()!]/.test(value)) return value;
-  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`;
+  if (value.length > 0 && !/[\s&|<>^()!]/.test(value)) return value;
+  return `"${value.replace(/(\\*)$/, "$1$1")}"`;
 }
 
 /**

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -181,11 +181,16 @@ function resolveShimPath(bin, { platform, env }) {
 /**
  * First match for `bin` on PATH, honouring PATHEXT on Windows. Shared with
  * `src/harness-invoke.js`, which needs the same resolution to build argv wrappers.
+ *
+ * A Windows PATH entry may legally carry surrounding double quotes, and an entry kept
+ * verbatim never stats: the npm shim would go undetected and the plain spawn would fail
+ * with the very ENOENT this module exists to prevent.
  */
 export function resolveOnPath(bin, { platform = process.platform, env = process.env } = {}) {
   if (path.isAbsolute(bin) && isExecutable(bin, platform)) return bin;
   const extensions = platform === "win32" ? (env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";") : [""];
-  for (const dir of (env.PATH || "").split(path.delimiter)) {
+  for (const entry of (env.PATH || "").split(path.delimiter)) {
+    const dir = entry.replace(/^"|"$/g, "");
     if (!dir) continue;
     for (const extension of extensions) {
       const candidate = path.join(dir, platform === "win32" ? `${bin}${extension.toLowerCase()}` : bin);

--- a/test/acpx-shim-refusal.test.js
+++ b/test/acpx-shim-refusal.test.js
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+/**
+ * The Windows npm-shim refusal (issue #43) as the acpx boundary reports it.
+ *
+ * A refused argument resolves as `{ code: null, spawnError }`, which every generic
+ * result inspection in `src/acpx.js` would otherwise read as "no session support" or
+ * "session prompt failed (exit null)" - neither names the argument, and the first sends
+ * `sessionPrompt` into an exec fallback that fails identically. These drive the real
+ * entry points to prove the refusal is raised, not merely constructible.
+ *
+ * `--cwd` is the argument that carries a repo path onto argv (`baseArgs`), which is why
+ * the fixture repo's own directory name holds the `%VAR%` sequence. The refusal fires
+ * before any spawn, so the stand-in interpreter only has to let `sessions new` succeed;
+ * `test/subprocess.test.js` owns the command line itself. Both stand-ins are real files,
+ * so this runs on every platform rather than being skipped where it matters.
+ */
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-acpx-refusal-"));
+const fakeAcpx = path.join(fixtureDir, "acpx.cmd");
+fs.writeFileSync(fakeAcpx, "@echo off\r\nexit /b 0\r\n");
+
+let fakeComSpec;
+if (process.platform === "win32") {
+  fakeComSpec = process.env.ComSpec || "C:\\Windows\\system32\\cmd.exe";
+} else {
+  fakeComSpec = path.join(fixtureDir, "fake-cmd");
+  fs.writeFileSync(fakeComSpec, `#!${process.execPath}\nprocess.exit(0);\n`);
+  fs.chmodSync(fakeComSpec, 0o755);
+}
+
+const promptFile = path.join(fixtureDir, "prompt.md");
+fs.writeFileSync(promptFile, "analyze this\n");
+
+/** A real, existing repo directory whose name cmd.exe would expand. */
+const refusedCwd = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-%BUILD%-"));
+const refusedInMessage = JSON.stringify(refusedCwd);
+
+process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+
+const { AcpxError, execOneShot, openSession } = await import("../src/acpx.js");
+const { UserError } = await import("../src/logger.js");
+
+async function asWindows(fn) {
+  const platform = Object.getOwnPropertyDescriptor(process, "platform");
+  const previousComSpec = process.env.ComSpec;
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  process.env.ComSpec = fakeComSpec;
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", platform);
+    if (previousComSpec === undefined) delete process.env.ComSpec;
+    else process.env.ComSpec = previousComSpec;
+  }
+}
+
+test.after(() => {
+  fs.rmSync(fixtureDir, { recursive: true, force: true });
+  fs.rmSync(refusedCwd, { recursive: true, force: true });
+});
+
+test("a per-turn prompt refusal is named, not reported as a failed session turn", async () => {
+  await asWindows(async () => {
+    // `sessions new` carries no repo path on argv, so the session opens normally and the
+    // refusal lands on the first turn - the dominant path for every analysis call.
+    const session = await openSession({ agent: "codex", sessionName: "backpass-refusal-turn", cwd: refusedCwd });
+    try {
+      await assert.rejects(
+        () => session.prompt({ promptFile, timeoutSeconds: 5 }),
+        (err) => {
+          assert.ok(err instanceof UserError, `expected a UserError, got ${err.name}: ${err.message}`);
+          assert.ok(err.message.includes(refusedInMessage), err.message);
+          assert.ok(!(err instanceof AcpxError));
+          assert.equal(err.unsupported, undefined);
+          assert.doesNotMatch(err.message, /session prompt failed|exit null/);
+          return true;
+        },
+      );
+    } finally {
+      await session.close();
+    }
+  });
+});
+
+test("the exec one-shot fallback names the same refusal", async () => {
+  await asWindows(async () => {
+    await assert.rejects(
+      () => execOneShot({ agent: "codex", promptFile, cwd: refusedCwd, timeoutSeconds: 5 }),
+      (err) => {
+        assert.ok(err instanceof UserError, `expected a UserError, got ${err.name}: ${err.message}`);
+        assert.ok(err.message.includes(refusedInMessage), err.message);
+        assert.equal(err.unsupported, undefined);
+        return true;
+      },
+    );
+  });
+});
+
+test("a session that opens against an acceptable path still works", async () => {
+  await asWindows(async () => {
+    // Guards the fixture itself: the refusals above must come from the argument, not
+    // from a stand-in that can never open a session.
+    const session = await openSession({ agent: "codex", sessionName: "backpass-refusal-ok", cwd: fixtureDir });
+    const result = await session.prompt({ promptFile, timeoutSeconds: 5 });
+    assert.equal(result.text, "");
+    await session.close();
+  });
+});

--- a/test/shim-refusal.test.js
+++ b/test/shim-refusal.test.js
@@ -79,10 +79,9 @@ test("a per-turn prompt refusal is named, not reported as a failed session turn"
       await assert.rejects(
         () => session.prompt({ promptFile, timeoutSeconds: 5 }),
         (err) => {
-          assert.ok(err instanceof UserError, `expected a UserError, got ${err.name}: ${err.message}`);
+          assert.ok(err instanceof UserError, `expected a UserError, got ${String(err)}`);
           assert.ok(err.message.includes(refusedInMessage), err.message);
-          assert.ok(!(err instanceof AcpxError));
-          assert.equal(err.unsupported, undefined);
+          assert.ok(!(err instanceof AcpxError), err.message);
           assert.doesNotMatch(err.message, /session prompt failed|exit null/);
           return true;
         },
@@ -98,9 +97,9 @@ test("the exec one-shot fallback names the same refusal", async () => {
     await assert.rejects(
       () => execOneShot({ agent: "codex", promptFile, cwd: refusedCwd, timeoutSeconds: 5 }),
       (err) => {
-        assert.ok(err instanceof UserError, `expected a UserError, got ${err.name}: ${err.message}`);
+        assert.ok(err instanceof UserError, `expected a UserError, got ${String(err)}`);
         assert.ok(err.message.includes(refusedInMessage), err.message);
-        assert.equal(err.unsupported, undefined);
+        assert.ok(!(err instanceof AcpxError), err.message);
         return true;
       },
     );
@@ -114,7 +113,7 @@ test("the apply surface names the refusal as its headline", async () => {
     await assert.rejects(
       () => openApplySurface(surface),
       (err) => {
-        assert.ok(err instanceof UserError, `expected a UserError, got ${err.name}: ${err.message}`);
+        assert.ok(err instanceof UserError, `expected a UserError, got ${String(err)}`);
         assert.ok(err.message.includes(JSON.stringify(surface)), err.message);
         assert.doesNotMatch(err.message, /failed to open the apply surface|not found on PATH/);
         return true;

--- a/test/shim-refusal.test.js
+++ b/test/shim-refusal.test.js
@@ -5,13 +5,16 @@ import path from "node:path";
 import test from "node:test";
 
 /**
- * The Windows npm-shim refusal (issue #43) as the acpx boundary reports it.
+ * The Windows npm-shim refusal (issue #43) as each boundary that spawns a shim reports
+ * it: acpx for every model call, lavish-axi for `backpass apply`, which is reachable
+ * without any model call at all.
  *
  * A refused argument resolves as `{ code: null, spawnError }`, which every generic
- * result inspection in `src/acpx.js` would otherwise read as "no session support" or
- * "session prompt failed (exit null)" - neither names the argument, and the first sends
- * `sessionPrompt` into an exec fallback that fails identically. These drive the real
- * entry points to prove the refusal is raised, not merely constructible.
+ * result inspection would otherwise read as "no session support", "session prompt failed
+ * (exit null)" or "failed to open the apply surface" - none of which names the argument,
+ * and the first of which sends `sessionPrompt` into an exec fallback that fails
+ * identically. These drive the real entry points to prove the refusal is raised, not
+ * merely constructible.
  *
  * `--cwd` is the argument that carries a repo path onto argv (`baseArgs`), which is why
  * the fixture repo's own directory name holds the `%VAR%` sequence. The refusal fires
@@ -19,9 +22,11 @@ import test from "node:test";
  * `test/subprocess.test.js` owns the command line itself. Both stand-ins are real files,
  * so this runs on every platform rather than being skipped where it matters.
  */
-const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-acpx-refusal-"));
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-shim-refusal-"));
 const fakeAcpx = path.join(fixtureDir, "acpx.cmd");
 fs.writeFileSync(fakeAcpx, "@echo off\r\nexit /b 0\r\n");
+const fakeLavish = path.join(fixtureDir, "lavish-axi.cmd");
+fs.writeFileSync(fakeLavish, "@echo off\r\nexit /b 0\r\n");
 
 let fakeComSpec;
 if (process.platform === "win32") {
@@ -40,8 +45,10 @@ const refusedCwd = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-%BUILD%-"));
 const refusedInMessage = JSON.stringify(refusedCwd);
 
 process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+process.env.BACKPASS_LAVISH_BIN = fakeLavish;
 
 const { AcpxError, execOneShot, openSession } = await import("../src/acpx.js");
+const { openApplySurface } = await import("../src/apply/lavish.js");
 const { UserError } = await import("../src/logger.js");
 
 async function asWindows(fn) {
@@ -94,6 +101,22 @@ test("the exec one-shot fallback names the same refusal", async () => {
         assert.ok(err instanceof UserError, `expected a UserError, got ${err.name}: ${err.message}`);
         assert.ok(err.message.includes(refusedInMessage), err.message);
         assert.equal(err.unsupported, undefined);
+        return true;
+      },
+    );
+  });
+});
+
+test("the apply surface names the refusal as its headline", async () => {
+  await asWindows(async () => {
+    // `backpass apply` needs no model call, so this is the boundary a user hits first.
+    const surface = path.join(refusedCwd, ".backpass", "apply", "apply.html");
+    await assert.rejects(
+      () => openApplySurface(surface),
+      (err) => {
+        assert.ok(err instanceof UserError, `expected a UserError, got ${err.name}: ${err.message}`);
+        assert.ok(err.message.includes(JSON.stringify(surface)), err.message);
+        assert.doesNotMatch(err.message, /failed to open the apply surface|not found on PATH/);
         return true;
       },
     );

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -326,8 +326,8 @@ test("a refusal is not an availability verdict: it must not demote the harness",
       spawnFn: fakeSpawn(calls),
     });
     // Classifying it would silently drop the candidate, and the next harness would
-    // fail on the very same argument. `test/acpx-shim-refusal.test.js` covers how the
-    // acpx boundary does surface it.
+    // fail on the very same argument. `test/shim-refusal.test.js` covers how each spawn
+    // boundary does surface it.
     assert.equal(classifyAcpxFailure(failure), null);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { classifyAcpxFailure, shimRefusalError } from "../src/acpx.js";
+import { classifyAcpxFailure } from "../src/acpx.js";
 import { quoteShimArg, runCapture } from "../src/subprocess.js";
 
 test(
@@ -287,26 +287,19 @@ test("a percent that is not a variable reference still runs", async () => {
   }
 });
 
-test("a shim refusal reaches acpx as its own named error, not as missing session support", async () => {
+test("a refusal is not an availability verdict: it must not demote the harness", async () => {
   const { dir, lookupEnv } = shimFixture();
   const calls = [];
   try {
-    // The failure the acpx boundary actually receives, produced by the real refusal.
     const failure = await runCapture("acpx", ["--cwd", "%USERPROFILE%\\repo"], {
       platform: "win32",
       lookupEnv,
       spawnFn: fakeSpawn(calls),
     });
-    const err = shimRefusalError(failure);
-    assert.equal(err.name, "UserError");
-    assert.ok(err.message.includes("%USERPROFILE%"), err.message);
-    // Not a session-support verdict and not an availability verdict: falling through to
-    // the next harness would fail on the very same argument.
-    assert.equal(err.unsupported, undefined);
+    // Classifying it would silently drop the candidate, and the next harness would
+    // fail on the very same argument. `test/acpx-shim-refusal.test.js` covers how the
+    // acpx boundary does surface it.
     assert.equal(classifyAcpxFailure(failure), null);
-
-    assert.equal(shimRefusalError({ code: 1, stderr: "boom" }), null);
-    assert.equal(shimRefusalError({ code: null, spawnError: Object.assign(new Error("x"), { code: "ENOENT" }) }), null);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { runCapture } from "../src/subprocess.js";
+import { quoteShimArg, runCapture } from "../src/subprocess.js";
 
 test(
   "a timed leader close still kills a descendant that ignores termination",
@@ -127,3 +128,132 @@ setInterval(() => {}, 1000);
     }
   },
 );
+
+/**
+ * Windows npm-shim launch (issue #43).
+ *
+ * These drive the real `runCapture` with an injected platform and spawn, so they run,
+ * and can fail, on every CI platform. A win32-gated test would be skipped exactly
+ * where the regression it guards would land.
+ */
+
+const SPACED_PATH = "C:\\dir with spaces\\repo";
+
+function fakeSpawn(record) {
+  return (file, args, options) => {
+    record.push({ file, args, options });
+    const child = Object.assign(new EventEmitter(), {
+      pid: 4242,
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      stdin: { end() {} },
+    });
+    setImmediate(() => child.emit("close", 0));
+    return child;
+  };
+}
+
+function shimFixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-win-shim-"));
+  fs.writeFileSync(path.join(dir, "acpx.cmd"), "@echo off\r\n");
+  return {
+    dir,
+    lookupEnv: { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD", ComSpec: "C:\\Windows\\system32\\cmd.exe" },
+  };
+}
+
+test("a windows npm .cmd shim is launched through the command interpreter", async () => {
+  const { dir, lookupEnv } = shimFixture();
+  const calls = [];
+  try {
+    await runCapture("acpx", ["--cwd", SPACED_PATH, "--format", "quiet"], {
+      platform: "win32",
+      lookupEnv,
+      spawnFn: fakeSpawn(calls),
+    });
+    assert.equal(calls.length, 1);
+    const [call] = calls;
+    assert.equal(call.file, "C:\\Windows\\system32\\cmd.exe");
+    assert.deepEqual(call.args.slice(0, 3), ["/d", "/s", "/c"]);
+    assert.equal(call.options.windowsVerbatimArguments, true);
+    assert.ok(call.args[3].includes(path.join(dir, "acpx.cmd")), "the resolved shim leads the command line");
+    // The path with spaces must survive as ONE quoted argument. Node's own
+    // `shell: true` joins argv with bare spaces and would split it here.
+    assert.ok(
+      call.args[3].includes(`"${SPACED_PATH}"`),
+      `a path with spaces must stay one quoted argument, got: ${call.args[3]}`,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a binary that is genuinely missing still reaches spawn as itself", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-win-shim-empty-"));
+  const calls = [];
+  try {
+    await runCapture("definitely-not-installed", ["--version"], {
+      platform: "win32",
+      lookupEnv: { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+      spawnFn: fakeSpawn(calls),
+    });
+    // Not rewritten into a cmd.exe call: the caller must still see its own ENOENT,
+    // which `classifyAcpxFailure` maps to `unreachable`.
+    assert.equal(calls[0].file, "definitely-not-installed");
+    assert.deepEqual(calls[0].args, ["--version"]);
+    assert.equal(calls[0].options.windowsVerbatimArguments, undefined);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a real executable and every non-windows platform are left alone", async () => {
+  const { dir, lookupEnv } = shimFixture();
+  fs.writeFileSync(path.join(dir, "acpx.exe"), "");
+  const calls = [];
+  try {
+    await runCapture("acpx", ["--version"], { platform: "win32", lookupEnv, spawnFn: fakeSpawn(calls) });
+    assert.equal(calls[0].file, "acpx", ".exe resolves ahead of .cmd in PATHEXT and needs no shim");
+
+    await runCapture("acpx", ["--version"], { platform: "linux", lookupEnv, spawnFn: fakeSpawn(calls) });
+    assert.equal(calls[1].file, "acpx");
+    assert.equal(calls[1].options.windowsVerbatimArguments, undefined);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("shim arguments are quoted for both cmd.exe and the target's argv parser", () => {
+  // Left bare: nothing either parser acts on.
+  assert.equal(quoteShimArg("--format"), "--format");
+  assert.equal(quoteShimArg("gpt-5.6-luna"), "gpt-5.6-luna");
+  assert.equal(quoteShimArg("100%done"), "100%done");
+  // Quoted: whitespace, or an operator cmd.exe would act on outside quotes.
+  assert.equal(quoteShimArg("with space"), '"with space"');
+  for (const operator of ["a&b", "a|b", "a<b", "a>b", "a^b", "a(b", "a)b", "a!b"]) {
+    assert.equal(quoteShimArg(operator), `"${operator}"`, `${operator} must not reach cmd.exe unquoted`);
+  }
+  // A trailing backslash must not escape the closing quote: MSVCRT doubles the run.
+  assert.equal(quoteShimArg("C:\\dir with spaces\\"), '"C:\\dir with spaces\\\\"');
+  assert.equal(quoteShimArg('has"quote'), '"has\\"quote"');
+  assert.equal(quoteShimArg(""), '""');
+});
+
+test("an argument cmd.exe would expand is refused by name, not passed on", async () => {
+  const { dir, lookupEnv } = shimFixture();
+  const calls = [];
+  try {
+    const result = await runCapture("acpx", ["--cwd", "%USERPROFILE%\\repo"], {
+      platform: "win32",
+      lookupEnv,
+      spawnFn: fakeSpawn(calls),
+    });
+    // Quoting cannot suppress %VAR% on a command line, and expansion would silently
+    // become several arguments. Fail loud and named instead.
+    assert.equal(calls.length, 0);
+    assert.equal(result.spawnError.code, "ERR_WINDOWS_SHIM_UNSAFE_ARG");
+    assert.match(result.stderr, /%VAR%/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { classifyAcpxFailure, shimRefusalError } from "../src/acpx.js";
 import { quoteShimArg, runCapture } from "../src/subprocess.js";
 
 test(
@@ -235,24 +236,77 @@ test("shim arguments are quoted for both cmd.exe and the target's argv parser", 
   }
   // A trailing backslash must not escape the closing quote: MSVCRT doubles the run.
   assert.equal(quoteShimArg("C:\\dir with spaces\\"), '"C:\\dir with spaces\\\\"');
-  assert.equal(quoteShimArg('has"quote'), '"has\\"quote"');
   assert.equal(quoteShimArg(""), '""');
 });
 
-test("an argument cmd.exe would expand is refused by name, not passed on", async () => {
+test("an argument no quoting can neutralise is refused by name, not passed on", async () => {
+  const { dir, lookupEnv } = shimFixture();
+  // Quoting suppresses none of these: cmd.exe expands %VAR% inside quotes, the two
+  // parsers disagree on how a quote is escaped, and a newline ends the command line.
+  // Passing any of them on would silently become several arguments, or commands.
+  const refused = [
+    ["--cwd", "%USERPROFILE%\\repo"],
+    ['a"&whoami&"b'],
+    ["a\nwhoami"],
+    ["a\rwhoami"],
+  ];
+  try {
+    for (const args of refused) {
+      const calls = [];
+      const result = await runCapture("acpx", args, {
+        platform: "win32",
+        lookupEnv,
+        spawnFn: fakeSpawn(calls),
+      });
+      assert.equal(calls.length, 0, `${JSON.stringify(args)} must not reach spawn`);
+      assert.equal(result.spawnError.code, "ERR_WINDOWS_SHIM_UNSAFE_ARG");
+      assert.equal(result.spawnError.value, args[args.length - 1]);
+      assert.ok(result.stderr.includes(JSON.stringify(args[args.length - 1])), result.stderr);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a percent that is not a variable reference still runs", async () => {
   const { dir, lookupEnv } = shimFixture();
   const calls = [];
   try {
-    const result = await runCapture("acpx", ["--cwd", "%USERPROFILE%\\repo"], {
+    // cmd.exe expands neither a lone `%` nor `%%` on a command line, so refusing them
+    // would turn a working Windows run into a hard failure over a legal path.
+    await runCapture("acpx", ["--cwd", "C:\\dev\\50%-off\\repo%%x", "--model", "100%done"], {
       platform: "win32",
       lookupEnv,
       spawnFn: fakeSpawn(calls),
     });
-    // Quoting cannot suppress %VAR% on a command line, and expansion would silently
-    // become several arguments. Fail loud and named instead.
-    assert.equal(calls.length, 0);
-    assert.equal(result.spawnError.code, "ERR_WINDOWS_SHIM_UNSAFE_ARG");
-    assert.match(result.stderr, /%VAR%/);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].args[3].includes("C:\\dev\\50%-off\\repo%%x"), calls[0].args[3]);
+    assert.ok(calls[0].args[3].includes("100%done"), calls[0].args[3]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a shim refusal reaches acpx as its own named error, not as missing session support", async () => {
+  const { dir, lookupEnv } = shimFixture();
+  const calls = [];
+  try {
+    // The failure the acpx boundary actually receives, produced by the real refusal.
+    const failure = await runCapture("acpx", ["--cwd", "%USERPROFILE%\\repo"], {
+      platform: "win32",
+      lookupEnv,
+      spawnFn: fakeSpawn(calls),
+    });
+    const err = shimRefusalError(failure);
+    assert.equal(err.name, "UserError");
+    assert.ok(err.message.includes("%USERPROFILE%"), err.message);
+    // Not a session-support verdict and not an availability verdict: falling through to
+    // the next harness would fail on the very same argument.
+    assert.equal(err.unsupported, undefined);
+    assert.equal(classifyAcpxFailure(failure), null);
+
+    assert.equal(shimRefusalError({ code: 1, stderr: "boom" }), null);
+    assert.equal(shimRefusalError({ code: null, spawnError: Object.assign(new Error("x"), { code: "ENOENT" }) }), null);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -189,6 +189,35 @@ test("a windows npm .cmd shim is launched through the command interpreter", asyn
   }
 });
 
+test("a quoted PATH entry still resolves the shim", async () => {
+  const { dir, lookupEnv } = shimFixture();
+  const other = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-win-shim-other-"));
+  const shim = path.join(dir, "acpx.cmd");
+  // Windows PATH entries may carry surrounding quotes. Kept verbatim, the entry never
+  // stats, the shim goes undetected, and the plain spawn fails with the ENOENT this
+  // whole launch policy exists to prevent. The unquoted arm is the control: a resolver
+  // that stopped resolving anything at all must not read as a pass.
+  const arms = [
+    ["unquoted", [other, dir].join(path.delimiter)],
+    ["quoted", [other, `"${dir}"`].join(path.delimiter)],
+  ];
+  try {
+    for (const [label, PATH] of arms) {
+      const calls = [];
+      await runCapture("acpx", ["--format", "quiet"], {
+        platform: "win32",
+        lookupEnv: { ...lookupEnv, PATH },
+        spawnFn: fakeSpawn(calls),
+      });
+      assert.equal(calls[0].file, lookupEnv.ComSpec, `${label}: must go through the command interpreter`);
+      assert.ok(calls[0].args[3].includes(shim), `${label}: the resolved shim leads the command line`);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(other, { recursive: true, force: true });
+  }
+});
+
 test("a binary that is genuinely missing still reaches spawn as itself", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-win-shim-empty-"));
   const calls = [];

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -273,12 +273,7 @@ test("an argument no quoting can neutralise is refused by name, not passed on", 
   // Quoting suppresses none of these: cmd.exe expands %VAR% inside quotes, the two
   // parsers disagree on how a quote is escaped, and a newline ends the command line.
   // Passing any of them on would silently become several arguments, or commands.
-  const refused = [
-    ["--cwd", "%USERPROFILE%\\repo"],
-    ['a"&whoami&"b'],
-    ["a\nwhoami"],
-    ["a\rwhoami"],
-  ];
+  const refused = [["--cwd", "%USERPROFILE%\\repo"], ['a"&whoami&"b'], ["a\nwhoami"], ["a\rwhoami"]];
   try {
     for (const args of refused) {
       const calls = [];


### PR DESCRIPTION
## What Changed

- `src/subprocess.js` gains `windowsShimLaunch`: on Windows a bin that resolves to a `.cmd`/`.bat` is now spawned through `ComSpec` with a self-built, verbatim command line (`windowsVerbatimArguments`) instead of a bare `spawn`, which CreateProcess could only resolve as `.exe` and reported as a misleading ENOENT. `quoteShimArg` quotes each argument for both cmd.exe and the target's argv parser (doubling trailing backslashes), and `resolveOnPath` moves here from `src/harness-invoke.js` so shim launch and argv wrappers share one PATHEXT resolver.
- An argument no quoting can neutralise (`%VAR%`, a double quote, CR/LF) is refused before the spawn as `{ code: null, spawnError: ERR_WINDOWS_SHIM_UNSAFE_ARG }` carrying the offending value; `run` in `src/acpx.js` (now the single funnel, with `openSession` creation moved inside the try and disposal into a `finally`) and `openApplySurface` in `src/apply/lavish.js` raise it as a `UserError` naming the value, instead of degrading into "no session support" / "exit null" / "failed to open the apply surface". `src/apply/lavish.js` also routes its own `lavish-axi` spawn through the same policy.
- `runCapture` takes injectable `platform`, `lookupEnv`, and `spawnFn` so the Windows path is testable off-Windows; new `test/shim-refusal.test.js` drives the acpx and lavish entry points with a `%VAR%` repo path, and `test/subprocess.test.js` covers command-line construction, quoting, shim resolution, and the refusal reasons. `AGENTS.md` records the refusal contract as a sharp edge.

## Risk Assessment

✅ Low: The change is well-bounded to a single Windows spawn policy behind one shared helper, non-Windows paths early-return unchanged, the refusal is correctly raised at both spawn boundaries without being mistakable for an availability verdict, and the only residual is a narrow delayed-expansion case that needs a non-default registry setting to trigger.

## Testing

Uruchomiłem celowane testy (`test/subprocess.test.js`, `test/shim-refusal.test.js`) — wszystkie przechodzą, dwa pominięcia dotyczą wyłącznie grup procesów POSIX i wykonują się na CI linux/macos. Ponieważ cała zmiana jest windowsowo-specyficzna, a matryca CI to ubuntu+macos, wykonałem na realnym Windows 11 / Node 22.19.0 weryfikację manualną, której CI nigdy nie wykona: produkcyjny runCapture przeciw prawdziwemu shimowi npm `acpx.cmd`, w ramieniu bazowym i docelowym, na 14 kształtach argumentów — przed zmianą 14/14 ENOENT, po zmianie 12 argumentów bajt w bajt i 2 odrzucone po nazwie z podaniem wartości. Na poziomie użytkownika końcowego pokazałem `backpass propose` i `backpass apply` z acpx i lavish-axi zainstalowanymi tak, jak robi to npm (shimy `.cmd`, brak `.exe`): pre-fix oba padają na ENOENT, post-fix propose przechodzi w całości i zapisuje propozycję (exit 0), a apply otwiera powierzchnię recenzji przez shim i odbiera wektor decyzji. Ostatni krok apply — sam zapis — nie kończy się, ale przyczyna leży poza tym diffem: `absentParentDirectories` w `src/apply/writer.js` wpada w nieskończoną pętlę, bo `repo.root` przychodzi z gita z ukośnikami w przód, a cele edycji są sklejane przez `path.join` z backslashami; reprodukuje się identycznie na commicie bazowym. Artefakty (transkrypty CLI, tabela roundtripu, sonda root-cause) leżą w katalogu dowodowym; worktree zostawiam czysty, fikstury tymczasowe usunięte.

<details>
<summary>Evidence: Roundtrip argumentów przez prawdziwy cmd.exe: pre-fix 14/14 ENOENT, post-fix 12 bajt w bajt + 2 odrzucone po nazwie</summary>

<code>=== ARM A - base commit 698d57f (pre-fix) ===&#10;windows path with spaces sent [&#34;--cwd&#34;,&#34;C:\\dir with spaces\\repo&#34;]&#10;-&gt; SPAWN ERROR ENOENT spawn acpx ENOENT&#10;&#10;=== ARM B - target commit da8ff31 (post-fix) ===&#10;windows path with spaces sent [&#34;--cwd&#34;,&#34;C:\\dir with spaces\\repo&#34;]&#10;-&gt; OK argv byte-identical [&#34;--cwd&#34;,&#34;C:\\dir with spaces\\repo&#34;]&#10;trailing backslash -&gt; OK argv byte-identical&#10;percent, no closing pair -&gt; OK argv byte-identical [&#34;--name&#34;,&#34;100%done&#34;]&#10;ampersand / pipe / caret / parentheses / redirect / empty string -&gt; OK argv byte-identical&#10;percent VARIABLE reference -&gt; REFUSED BY NAME cannot safely pass &#34;C:\\dev\\%BUILD%\\repo&#34; to the Windows command shim for acpx: cmd.exe expands %VAR% even inside quotes, and there is no escape for it on a command line&#10;embedded double quote -&gt; REFUSED BY NAME cannot safely pass &#34;a\&#34;b&#34; to the Windows command shim for acpx: cmd.exe counts double quotes while the target&#39;s argv parser reads backslash escapes, so no encoding satisfies both&#10;&#10;=== summary ===&#10;pre-fix : 14/14 argument shapes fail with ENOENT (issue #43)&#10;post-fix: 12/14 arrive byte-identical, 2 refused by name</code>

```text
node v22.19.0 on win32 10.0.26200   ComSpec=C:\WINDOWS\system32\cmd.exe
shim: ~\AppData\Local\Temp\issue43-w9qXJz\acpx.cmd  (no acpx.exe exists, exactly as npm installs a JS CLI)

=== ARM A - base commit 698d57f (pre-fix) ===
  plain flag                                   sent ["--format","quiet"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  whitespace                                   sent ["--name","backpass analyze run"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  windows path with spaces                     sent ["--cwd","C:\\dir with spaces\\repo"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  real temp path with spaces                   sent ["--cwd","~\\AppData\\Local\\Temp\\issue43-w9qXJz\\dir with spaces\\repo"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  trailing backslash                           sent ["--cwd","C:\\dir with spaces\\repo\\"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  percent, no closing pair                     sent ["--name","100%done"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  ampersand                                    sent ["--name","a&b"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  pipe                                         sent ["--name","a|b"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  caret                                        sent ["--name","a^b"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  parentheses                                  sent ["--name","a(b)c"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  redirect                                     sent ["--name","a>b<c"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  empty string                                 sent ["--name",""]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  percent VARIABLE reference (must be refused) sent ["--cwd","C:\\dev\\%BUILD%\\repo"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT
  embedded double quote (must be refused)      sent ["--name","a\"b"]
                                               -> SPAWN ERROR ENOENT  spawn acpx ENOENT

=== ARM B - target commit da8ff31 (post-fix) ===
  plain flag                                   sent ["--format","quiet"]
                                               -> OK  argv byte-identical  ["--format","quiet"]
  whitespace                                   sent ["--name","backpass analyze run"]
                                               -> OK  argv byte-identical  ["--name","backpass analyze run"]
  windows path with spaces                     sent ["--cwd","C:\\dir with spaces\\repo"]
                                               -> OK  argv byte-identical  ["--cwd","C:\\dir with spaces\\repo"]
  real temp path with spaces                   sent ["--cwd","~\\AppData\\Local\\Temp\\issue43-w9qXJz\\dir with spaces\\repo"]
                                               -> OK  argv byte-identical  ["--cwd","~\\AppData\\Local\\Temp\\issue43-w9qXJz\\dir with spaces\\repo"]
  trailing backslash                           sent ["--cwd","C:\\dir with spaces\\repo\\"]
                                               -> OK  argv byte-identical  ["--cwd","C:\\dir with spaces\\repo\\"]
  percent, no closing pair                     sent ["--name","100%done"]
                                               -> OK  argv byte-identical  ["--name","100%done"]
  ampersand                                    sent ["--name","a&b"]
                                               -> OK  argv byte-identical  ["--name","a&b"]
  pipe                                         sent ["--name","a|b"]
                                               -> OK  argv byte-identical  ["--name","a|b"]
  caret                                        sent ["--name","a^b"]
                                               -> OK  argv byte-identical  ["--name","a^b"]
  parentheses                                  sent ["--name","a(b)c"]
                                               -> OK  argv byte-identical  ["--name","a(b)c"]
  redirect                                     sent ["--name","a>b<c"]
                                               -> OK  argv byte-identical  ["--name","a>b<c"]
  empty string                                 sent ["--name",""]
                                               -> OK  argv byte-identical  ["--name",""]
  percent VARIABLE reference (must be refused) sent ["--cwd","C:\\dev\\%BUILD%\\repo"]
                                               -> REFUSED BY NAME  cannot safely pass "C:\\dev\\%BUILD%\\repo" to the Windows command shim for acpx: cmd.exe expands %VAR% even inside quotes, and there is no escape for it on a command line
  embedded double quote (must be refused)      sent ["--name","a\"b"]
                                               -> REFUSED BY NAME  cannot safely pass "a\"b" to the Windows command shim for acpx: cmd.exe counts double quotes while the target's argv parser reads backslash escapes, so no encoding satisfies both

=== summary ===
  pre-fix : 14/14 argument shapes fail with ENOENT (issue #43)
  post-fix: 12/14 arrive byte-identical, 2 refused by name
```
</details>
<details>
<summary>Evidence: Transkrypt CLI na Windows: backpass propose / apply z acpx i lavish-axi zainstalowanymi jako shimy .cmd</summary>

<code>npm-style install: ...\acpx.cmd (acpx.exe present? false)&#10;&#10;=== ARM A - base commit 698d57f (pre-fix) === $ backpass propose&#10;· synthesizing with claude (fake-model) effort=high&#10;error cannot verify acpx adapter configuration for claude: spawn acpx ENOENT&#10;--- exit code: 1 | .backpass/proposal.json: NOT WRITTEN&#10;&#10;=== ARM B - target commit da8ff31 (post-fix) === $ backpass propose&#10;proposal · AGENTS.md · 2 edit(s) from 3 session(s) · interactive 3 · non-interactive 0&#10;budget [#...............................] 98 -&gt; 85 / 5,000 tok&#10;e1 EXTRACT extract the release checklist (-13 tok, 3 transcript(s))&#10;e2 EXTRACT extract incident response (-18 tok, 3 transcript(s))&#10;Review and apply with `backpass apply` (nothing has been written).&#10;--- exit code: 0 | .backpass/proposal.json written: 2 edit(s)&#10;&#10;=== ARM C - pre-fix === $ backpass apply --no-open&#10;error lavish-axi not found on PATH&#10;--- exit code: 1 | decision vector consumed? false&#10;&#10;=== ARM D - post-fix === $ backpass apply --no-open&#10;· review surface: http://127.0.0.1:4387/session/51233fdaf6389690&#10;waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)&#10;--- decision vector consumed from the review surface? true&#10;(zapis zatrzymuje sie w absentParentDirectories - blad wczesniej istniejacy, identyczny na 698d57f)</code>

```text
npm-style install: ~\AppData\Local\Temp\issue43-npm-bin-xREbTq\acpx.cmd
  acpx.exe present? false
  `where acpx` equivalent resolves, but CreateProcess only appends .exe

node v22.19.0 on win32 10.0.26200


==============================================================================
=== ARM A - base commit 698d57f (pre-fix)
=== $ backpass propose        (cwd ~\AppData\Local\Temp\issue43-repo-65tPG8)
==============================================================================
· synthesizing with claude (fake-model) effort=high
error cannot verify acpx adapter configuration for claude: spawn acpx ENOENT
  upgrade acpx or omit the model and effort override
--- exit code: 1
--- .backpass/proposal.json: NOT WRITTEN

==============================================================================
=== ARM B - target commit da8ff31 (post-fix), same shim, same repo scenario
=== $ backpass propose        (cwd ~\AppData\Local\Temp\issue43-repo-JQsgbF)
==============================================================================

proposal · issue43-repo-JQsgbF · AGENTS.md · 2 edit(s) from 3 session(s) · interactive 3 · non-interactive 0
  budget [#...............................] 98 -> 85 / 5,000 tok
  evidence: 0 positive · 3 negative · 0 gap clusters

  e1 EXTRACT  extract the release checklist (-13 tok, 3 transcript(s))
  e2 EXTRACT  extract incident response (-18 tok, 3 transcript(s))

  tier-2 tokens: input=1,500 output=50 total=1,550

Review and apply with `backpass apply` (nothing has been written).
· synthesizing with claude (fake-model) effort=high
--- exit code: 0
--- .backpass/proposal.json written: 2 edit(s): extract the release checklist; extract incident response

==============================================================================
=== ARM C - base commit 698d57f (pre-fix): backpass apply
=== $ backpass apply --no-open        (cwd ~\AppData\Local\Temp\issue43-repo-JQsgbF)
==============================================================================
error lavish-axi not found on PATH
  install lavish-axi, or run `backpass apply --no-ui` for the terminal fallback
--- exit code: 1
--- decision vector consumed from the review surface? false

==============================================================================
=== ARM D - target commit da8ff31 (post-fix): backpass apply, both edits accepted
=== $ backpass apply --no-open        (cwd ~\AppData\Local\Temp\issue43-repo-JQsgbF)
==============================================================================
· review surface: http://127.0.0.1:4387/session/51233fdaf6389690
waiting for your decisions in the browser (Ctrl-C to abort; nothing is written until you send)
--- exit code: null (killed after 45s: SIGKILL)
--- decision vector consumed from the review surface? true

=== summary ===
  propose pre-fix : exit 1, dies on spawn acpx ENOENT although acpx.cmd IS on PATH
  propose post-fix: exit 0, the model call goes through the .cmd shim and the proposal is written
  apply   pre-fix : exit 1, dies on lavish-axi not found on PATH
  apply   post-fix: the review surface opens through the .cmd shim and the decision vector is polled back; the write itself then stalls in absentParentDirectories (pre-existing, reproduces identically at 698d57f)
```
</details>
<details>
<summary>Evidence: Root cause zawieszenia backpass apply na Windows (wcześniej istniejący, nie z tego diffu)</summary>

<code>repo.root (from `git rev-parse --show-toplevel`) = &#34;~/issue43-repo&#34;&#10;accepted edit target (path.join) = &#34;~\\issue43-repo\\.agents\\skills\\release-checklist\\SKILL.md&#34;&#10;&#10;src/apply/writer.js absentParentDirectories walks parents until `current === root`:&#10;step 3: &#34;~\\issue43-repo&#34; &lt;- rowna sie root tylko po normalizacji separatorow&#10;step 9: &#34;C:\\&#34;&#10;path.dirname(&#34;C:\\&#34;) === &#34;C:\\&#34; -&gt; the walk never terminates: infinite loop</code>

```text
backpass apply stalls before writing a byte - root cause probe (pre-existing, not this diff)

repo.root (from `git rev-parse --show-toplevel`) = "~/AppData/Local/Temp/issue43-repo-s1qk4p"
accepted edit target (path.join)              = "~\\AppData\\Local\\Temp\\issue43-repo-s1qk4p\\.agents\\skills\\release-checklist\\SKILL.md"

src/apply/writer.js absentParentDirectories walks parents until `current === root`:
  step 0: "~\\AppData\\Local\\Temp\\issue43-repo-s1qk4p\\.agents\\skills\\release-checklist"
  step 1: "~\\AppData\\Local\\Temp\\issue43-repo-s1qk4p\\.agents\\skills"
  step 2: "~\\AppData\\Local\\Temp\\issue43-repo-s1qk4p\\.agents"
  step 3: "~\\AppData\\Local\\Temp\\issue43-repo-s1qk4p"
  step 4: "~\\AppData\\Local\\Temp"
  step 5: "~\\AppData\\Local"
  step 6: "~\\AppData"
  step 7: "~"
  step 8: "C:\\Users"
  step 9: "C:\\"
  ...
  path.dirname("C:\\") === "C:\\" -> the walk never terminates: infinite loop
```
</details>
<details>
<summary>Evidence: Skrypty które wyprodukowały powyższe dowody (importują moduły z worktree, nic w repo nie zapisują)</summary>

```text
# Windows npm-shim launch (issue #43) — evidence

Host: Windows 11 (10.0.26200), Node v22.19.0, `ComSpec=C:\WINDOWS\system32\cmd.exe`.
CI runs ubuntu + macos only, so nothing automated ever executes cmd.exe; these runs close
that gap on real hardware. Base commit `698d57f`, target commit `da8ff31`.

| file | what it shows |
| --- | --- |
| `windows-shim-roundtrip.txt` | 14 argument shapes through the production `runCapture` against a real npm-form `acpx.cmd` (forwards `%*` to node.exe). Pre-fix: 14/14 ENOENT. Post-fix: 12 arrive byte-identical, 2 refused by name. |
| `windows-cli-transcript.txt` | `backpass propose` and `backpass apply` as a user runs them, with acpx and lavish-axi installed as `.cmd` shims on PATH and no `.exe`. Pre-fix both die on ENOENT; post-fix propose completes and writes the proposal, apply opens the review surface and polls the decision vector back. |
| `apply-hang-root-cause.txt` | Why arm D of the transcript stops before writing: a pre-existing infinite loop in `absentParentDirectories` (`src/apply/writer.js`). Reproduces identically at the base commit; unrelated to this diff. |

Harnesses (`*-harness.mjs`, `probe-*.mjs`) are the scripts that produced the above; they
import the worktree's own modules and write nothing into the repo.
```
</details>
- Outcome: ⚠️ 2 issues (1 warning, 1 info) across 1 run (22m21s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cb193e8b69728351f25648db359ce3d398044871","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/subprocess.js:145` - quoteShimArg escapes an embedded double quote as `\&#34;` (MSVCRT style), but the command line is first parsed by cmd.exe, which does not honour backslash escapes: the `&#34;` closes cmd&#39;s quoted section, so everything after it — including later arguments — is parsed outside quotes. Trace: quoteShimArg(&#39;a&#34;&amp;whoami&amp;&#34;b&#39;) yields `&#34;a\&#34;&amp;whoami&amp;\&#34;b&#34;`; cmd sees quote-open, `a`, literal `\`, quote-close, then `&amp;whoami&amp;` unquoted and executes it as a separate command. The same toggle silently corrupts any later argument even without metacharacters. The fix that satisfies both parsers is doubling (`&#34;&#34;` inside the quoted run), which cmd treats as close+reopen with nothing in between and MSVCRT decodes as a literal quote. Carriage return / newline in an argument is likewise not neutralised by quoting and should be refused like `%`. The existing assertion in test/subprocess.test.js (&#39;has\&#34;quote&#39;) encodes the current behaviour and must move with the fix.
- ⚠️ `src/subprocess.js:28` - The new ERR_WINDOWS_SHIM_UNSAFE_ARG refusal resolves as `{ code: null, spawnError }`, but classifyAcpxFailure (src/acpx.js:86) only special-cases ENOENT and its stderr regex does not match the new message. Concrete path: a repo whose path contains two `%` characters is passed as `--cwd`; openSession (src/acpx.js:375-386) sees code !== 0 and an unclassified failure, so it throws `acpx &lt;agent&gt; has no session support: exit null` with unsupported = true, and sessionPrompt (src/acpx.js:506) then falls back to an exec one-shot that fails again for the same reason. The user is told the harness lacks session support when the real cause is an argument backpass refused to pass. Surface the refusal distinctly at the acpx boundary instead of letting it fall through the session-support branch.
- ℹ️ `src/subprocess.js:127` - EXPANDABLE_PERCENT (/%[^%]*%/) refuses any argument containing two `%` characters anywhere, not only a plausible variable reference: `C:\\dev\\50%-off\\repo`, `a%b%c` with no such variable defined, and even a literal `%%` all trip it, and cmd.exe leaves an undefined `%foo%` literal anyway. On Windows that turns an otherwise working run (the repo path is passed as `--cwd`) into a hard refusal. The loud fail is a deliberate, documented choice; narrowing the predicate to a plausible variable-name shape is a product-behaviour call, so flagging rather than changing it.
- ℹ️ `src/harness-invoke.js:323` - The generated harness wrapper still launches a `.cmd`/`.bat` through Node&#39;s `shell: true`, which is exactly the argv-joining-without-quoting behaviour the new windowsShimLaunch doc rejects: any forwarded argument containing a space is split. Reachable on Windows when CODEX_PATH points at `codex.cmd` (applyCodexWriteAccess, src/harness-invoke.js:216-224) and the acpx codex adapter forwards a path with spaces. This is pre-existing, not introduced here, and the remedy would mean inlining the quoting policy into the standalone wrapper text (the wrapper is a separate process and cannot import subprocess.js) — i.e. it extends the change beyond its stated intent, so it needs authorization rather than a mechanical fix.

🔧 Fix: refuse unquotable shim args and surface refusal at acpx
2 issues (1 warning, 1 info) still open:

- ⚠️ `src/acpx.js:487` - The shim-refusal surfacing was wired into probeSession (260), execOneShot (336) and openSession&#39;s `sessions new` (395), but not into the per-turn `prompt` closure — and that is the only acpx call that actually puts a repo path on argv, so the mislabel the fix round targeted is still reachable on the dominant path. Concrete trace, Windows, repo at `C:\dev\%BUILD%\repo`: probeSession runs `sessions new --name backpass-probe-…` (cwd is a spawn option, not argv) → no refusal, verdict ok. openSession&#39;s create call carries only `--model`/agent args → no refusal, session opens. The first `prompt()` builds `baseArgs({cwd})` → `--cwd C:\dev\%BUILD%\repo` → windowsShimLaunch refuses → `{code:null, stderr:&lt;refusal&gt;, spawnError}` → line 487 throws `AcpxError(&#34;acpx codex session prompt failed (exit null)&#34;)`. classifyAcpxFailure returns null (correct — no demotion), but src/analyze.js:352 fail-softs every non-UserError: it warns `err.message` only and records the transcript as failed, so the user sees N transcripts failing with &#34;exit null&#34; and the named refusal sitting in `err.stderr` is never printed. Remedy is the same three lines already used at the other sites: `const refusal = shimRefusalError(result); if (refusal) throw refusal;` before the timedOut check at 486. The same gap exists at verifyHarnessInvocation (src/acpx.js:200-207), which also passes `--cwd` on argv; there the impact is milder because the UserError already embeds `firstLine(result.stderr)`, so the refused value is at least named.
- ℹ️ `test/subprocess.test.js:300` - The test that claims &#34;a shim refusal reaches acpx as its own named error, not as missing session support&#34; calls `shimRefusalError(failure)` directly. It proves the helper builds a UserError, not that any acpx entry point invokes it — the wiring is the entire content of the finding it was added for. That is exactly why the `prompt` closure gap above passed the suite: nothing exercises probeSession/execOneShot/openSession with a refusing argument. A test that stubs runCapture (or points BACKPASS_ACPX_BIN at a fixture shim with the platform seam) and asserts that `openSession(...).prompt(...)` rejects with a UserError naming the refused value would fail before the fix above and pass after it.

🔧 Fix: raise shim refusal at the acpx run funnel
2 issues (1 warning, 1 info) still open:

- ⚠️ `src/subprocess.js:188` - resolveOnPath splits PATH and joins each entry verbatim, without stripping surrounding double quotes. Windows PATH entries may legally be quoted (e.g. PATH=C:\Windows\system32;&#34;~\AppData\Roaming\npm&#34;), and this repo already compensates for exactly that 40 lines away, inside the generated wrapper: src/harness-invoke.js:312 does entry.replace(/^&#34;|&#34;$/g, &#34;&#34;) before resolving. Concrete failing sequence: acpx.cmd lives in the quoted npm entry -&gt; path.join(&#39;&#34;~\\AppData\\Roaming\\npm&#34;&#39;, &#39;acpx.cmd&#39;) never stats -&gt; resolveOnPath returns null -&gt; resolveShimPath returns null -&gt; runCapture falls back to the plain spawn(&#34;acpx&#34;), whose CreateProcess appends only .exe -&gt; ENOENT -&gt; notFoundError prints &#39;acpx not found on PATH&#39;, which is verbatim the misleading failure issue #43 closes. The fix silently does not apply for that PATH shape. Remedy is the same one-line strip already used in harness-invoke.js, applied to `dir` before path.join.
- ℹ️ `src/apply/lavish.js:107` - The same change wired windowsShimLaunch into runLavish, but the acpx rule the fix round applied (&#39;raise the refusal before any generic handling&#39;) was not extended to the lavish surface. On Windows with a repo at C:\dev\%BUILD%\repo, `backpass apply` (which runs without any model call, so it is reachable independently of analysis) passes &lt;repo&gt;\.backpass\apply\apply.html on argv, windowsShimLaunch refuses, runLavish resolves { code: null, spawnError }, the ENOENT branch at line 101 does not match, and line 107 reports the headline &#39;lavish-axi failed to open the apply surface&#39;. This is cosmetic only: the detail argument is result.stderr, which is the full refusal message naming the refused path, so the user is not left without the cause. pollDecisions (line 145) already names spawnError.message directly. Noting the asymmetry rather than asking for a change.

🔧 Fix: strip quoted PATH entries and name lavish shim refusal
3 infos still open:

- ℹ️ `test/subprocess.test.js:329` - The comment points readers to `test/acpx-shim-refusal.test.js`, but commit 804771a renamed that file to `test/shim-refusal.test.js` (it now also covers the lavish boundary). The referenced path no longer exists, so the pointer to &#34;how the acpx boundary does surface it&#34; dead-ends. Update the name to `test/shim-refusal.test.js`.
- ℹ️ `.github/workflows/ci.yml:24` - Tradeoff note, not a defect. The whole change is Windows-only behavior, and the CI matrix is ubuntu-latest + macos-latest (windows-latest deliberately deferred, line 22-23). The new tests are the right design for that constraint - they drive the real `runCapture`/`openSession`/`openApplySurface` through injected `platform`/`spawnFn`/ComSpec seams, so they run and can fail everywhere - but what they assert is the command line backpass *constructs* (`cmd.exe /d /s /c &#34;&lt;shim&gt; ... &#34;`), never what cmd.exe *does* with it. The `/s` quote-stripping, the `%*` forwarding through the npm shim, and the MSVCRT trailing-backslash rule are correct by reasoning and by matching libuv&#39;s own idiom, but no automated environment executes them. A single manual smoke on a real Windows box (one `backpass scan` from a path containing a space, and one `backpass apply`) would close the last gap; nothing here needs a code change.
- ℹ️ `AGENTS.md:233` - The change creates a contract that now spans three modules and has no entry in the Sharp edges list: on Windows every spawn of an npm `.cmd` goes through `windowsShimLaunch`, and a refused argument arrives as `{ code: null, spawnError.code === &#34;ERR_WINDOWS_SHIM_UNSAFE_ARG&#34; }` that each boundary must raise by name *before* any generic result inspection - otherwise it silently degrades into &#34;no session support&#34; / &#34;exit null&#34; / &#34;failed to open the apply surface&#34;. That exact degradation is what rounds 2 and 3 of this run were spent chasing at two separate boundaries, so a fourth spawn boundary added later would very likely reintroduce it. The remedy is documentation, not code: one Sharp-edges bullet naming `src/subprocess.js` as the launch policy, the error code, and the rule that `src/acpx.js`&#39;s `run` funnel and `src/apply/lavish.js` are the two places that surface it. Flagging rather than writing it, since what goes in AGENTS.md is the author&#39;s call under this repo&#39;s stated bar.

🔧 Fix: document shim refusal contract, fix stale test reference
1 info still open:

- ℹ️ `src/subprocess.js:124` - `quoteShimArg` quotes `!` (line 167) and `unsafeShimReason` does not refuse it, but double quotes do not protect `!` from cmd.exe&#39;s delayed expansion — that phase runs after quote parsing and ignores quotes. `cmd /d /s /c` does not disable it: delayed expansion is off by default but is turned on globally by HKCU/HKLM\Software\Microsoft\Command Processor\DelayedExpansion=1, and the npm shim&#39;s bare `SETLOCAL` inherits that state. Concrete path: a user with that registry value, repo at `C:\dev\build!x!\repo` -&gt; `backpass scan` -&gt; `baseArgs` puts `--cwd C:\dev\build!x!\repo` on argv -&gt; `windowsShimLaunch` finds `acpx.cmd`, sees no unsafe reason, emits `&#34;C:\dev\build!x!\repo&#34;` -&gt; cmd expands the undefined `!x!` to nothing -&gt; acpx receives `C:\dev\build\repo`. backpass reports no error; acpx just analyzes (or fails on) the wrong directory, which is the silent-wrong-value class this module&#39;s own policy comment says must not reach the shim. Remedy is mechanical and matches the existing intent: add `/v:off` ahead of `/c` in the args array at line 124 (`[&#34;/d&#34;, &#34;/s&#34;, &#34;/v:off&#34;, &#34;/c&#34;, ...]`), which overrides the registry for this invocation. Not proposing a widening of `EXPANDABLE_PERCENT` — that would trade this for over-refusal of legal paths the tests deliberately protect.
</details>

<details>
<summary>⚠️ **Test** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `src/apply/writer.js:172` - Poza zakresem tego diffu, ale blokuje ostatni krok demonstracji na Windowsie i dotyczy dokładnie platformy, którą ta gałąź naprawia: `backpass apply` zawiesza się na zawsze, zanim zapisze jakikolwiek bajt. `resolveRepo` zwraca `repo.root` z `git rev-parse --show-toplevel`, czyli na Windowsie z ukośnikami w przód (`~/repo`), podczas gdy cele zaakceptowanych edycji są budowane przez `path.join`, czyli z backslashami. Pętla `for (let current = path.dirname(file); current !== root; current = path.dirname(current))` nigdy nie trafia w warunek stopu, dochodzi do `C:\` i kręci się w miejscu, bo `path.dirname(&#34;C:\\&#34;) === &#34;C:\\&#34;`. Potwierdzone sondą (evidence/apply-hang-root-cause.txt) oraz przez uruchomienie tego samego `applyDecisions` z drzewa commita bazowego 698d57f — zawiesza się identycznie, więc jest to błąd wcześniej istniejący, nie regresja tej zmiany. Do decyzji autora, czy naprawić tutaj (gałąź jest o wsparciu Windows), czy zgłosić osobno.
- ℹ️ `test/proposal.test.js:2039` - `node --test test/proposal.test.js` daje na Windowsie 2 awarie (&#39;apply measures a legacy skill rewrite missing descriptionDelta&#39; oraz &#39;a skill-only shrink reports the remaining always-loaded overage&#39;). Uruchomiłem ten sam plik z drzewa commita bazowego 698d57f — identyczne 70 pass / 2 fail, więc to wcześniej istniejąca luka platformowa (CI to ubuntu+macos), a nie skutek tej zmiany. Odnotowuję wyłącznie informacyjnie, bo gałąź dotyczy wsparcia Windows.
- <code>`node --test test/subprocess.test.js test/shim-refusal.test.js` — 12 pass, 2 skip (oba skipy to testy grup procesów POSIX, wykonywane na CI linux/macos)</code>
- <code>Manualny roundtrip przez prawdziwy cmd.exe: produkcyjny `runCapture(&#34;acpx&#34;, ...)` przeciw realnemu shimowi `acpx.cmd` forwardującemu `%*` do node.exe, 14 kształtów argumentów, ramię bazowe (698d57f) vs docelowe (da8ff31) — `evidence/roundtrip-harness.mjs`</code>
- <code>Manualny transkrypt CLI: `backpass propose --synthesis-agent claude --synthesis-model fake-model` z `acpx.cmd` na PATH (bez `.exe`), ramię pre-fix (drzewo commita 698d57f wyeksportowane przez `git archive`) vs post-fix (worktree) — `evidence/cli-transcript-harness.mjs`</code>
- <code>Manualny transkrypt CLI: `backpass apply --no-open` z `lavish-axi.cmd` na PATH, oba ramiona, z fikstur¹ `test/fixtures/fake-lavish`</code>
- <code>Izolowany `pollDecisions(...)` przez shim `.cmd` — zwraca `{e1: accepted, e2: accepted}` w 499 ms</code>
- <code>`node --test test/proposal.test.js` na worktree i na drzewie commita bazowego — identyczny wynik 70 pass / 2 fail w obu, czyli awarie są wcześniej istniejące i windowsowo-specyficzne</code>
- <code>Sonda root-cause zawieszenia `applyDecisions` — `evidence/probe-apply-writer.mjs` i `evidence/apply-hang-root-cause.txt`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `test/shim-refusal.test.js:82` - `pnpm run typecheck` (tsc --noEmit, checkJs over test/**) fails with 8 errors in the new test/shim-refusal.test.js, which will turn CI red: lines 82, 101, 117 read `err.name` / `err.message` inside the message argument of `assert.ok(err instanceof UserError, ...)`, i.e. before the assertion narrows `err` from `unknown` (TS2339 on &#39;name&#39; and &#39;message&#39;); lines 85 and 103 read `err.unsupported` after narrowing to `UserError`, which does not declare that field (TS2339). I fixed the three source-side counterparts (src/acpx.js:79 and test/subprocess.test.js:292 both read `spawnError.value`) by giving src/subprocess.js a `ShimError` typedef (`NodeJS.ErrnoException &amp; { value?: string }`) and using it in the JSDoc return types of `runCapture` and `windowsShimLaunch`; these 8 remain because the fix has to be made inside a test file and this phase must not change tests. Mechanical remedy, behaviour-preserving: annotate each rejects callback parameter as `(/** @type {any} */ err) =&gt;`, or follow the repo idiom in test/synthesize.test.js:334 (narrow with a bare `assert.ok(err instanceof UserError)` first, then assert on the message) plus one cast for the `err.unsupported` reads. Verified with the locked toolchain (typescript 5.9.3, @types/node 25.9.5); eslint and prettier are clean.

🔧 Fix: narrow error types in shim refusal test asserts
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
