### PR TITLE
fix(skills): parse YAML block-scalar descriptions correctly

### DIFF
--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -99,6 +99,8 @@ signal.
    an existing skill when that file is the right home, instead of creating a new one.
 9. Change only `./{{MEMORY_PATH}}` and files under `./{{SKILLS_DIR}}/`. Never delete a
    file. Do not create notes, scripts, or scratch files.
+10. Do not assert or dramatize an agent's motives or intent beyond what the evidence
+    supports.
 
 ## Where an instruction belongs
 

--- a/src/skills.js
+++ b/src/skills.js
@@ -111,7 +111,7 @@ export function skillDescriptionTokens(skills) {
   return (skills || []).reduce((sum, s) => sum + (s.descriptionTokens ?? estimateTokens(s.description || "")), 0);
 }
 
-/** Minimal YAML frontmatter reader: only `key: value` and folded multi-line values. */
+/** Minimal YAML frontmatter reader for plain values and `>` / `|` multi-line values. */
 export function parseFrontmatter(text) {
   const match = /^---\n([\s\S]*?)\n---/.exec(text);
   if (!match) return {};

--- a/src/skills.js
+++ b/src/skills.js
@@ -117,27 +117,62 @@ export function parseFrontmatter(text) {
   if (!match) return {};
   const result = {};
   let currentKey = null;
-  let blockStyle = null; // "fold" (>) | "literal" (|) | null for plain scalars
-  let blockIndent = null;
+  let block = null;
+
+  const finishBlock = () => {
+    if (!block) return;
+    const lines = block.lines;
+    let value;
+    if (block.style === "|") {
+      value = lines.length ? `${lines.join("\n")}\n` : "";
+    } else {
+      value = foldBlockLines(lines);
+    }
+    if (block.chomp === "-") value = value.replace(/\n+$/, "");
+    if (block.chomp === "") value = value.replace(/\n*$/, lines.some(Boolean) ? "\n" : "");
+    result[block.key] = value;
+    block = null;
+  };
+
   for (const line of match[1].split("\n")) {
     const kv = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
     if (kv) {
+      finishBlock();
       currentKey = kv[1];
       const rawValue = kv[2].trim();
-      const blockIndicator = /^([>|])[+-]?$/.exec(rawValue);
-      blockStyle = blockIndicator ? (blockIndicator[1] === "|" ? "literal" : "fold") : null;
-      blockIndent = null;
-      result[currentKey] = blockIndicator ? "" : rawValue.replace(/^["']|["']$/g, "");
-    } else if (currentKey && blockStyle && /^\s+\S/.test(line)) {
-      if (blockIndent === null) blockIndent = /^\s+/.exec(line)[0].length;
-      const content = line.slice(blockIndent);
-      const separator = blockStyle === "literal" ? "\n" : " ";
-      result[currentKey] = result[currentKey] ? `${result[currentKey]}${separator}${content}` : content;
-    } else if (currentKey && !blockStyle && /^\s+\S/.test(line)) {
+      const blockIndicator = /^([>|])([+-]?)$/.exec(rawValue);
+      if (blockIndicator) {
+        result[currentKey] = "";
+        block = { key: currentKey, style: blockIndicator[1], chomp: blockIndicator[2], indent: null, lines: [] };
+      } else {
+        result[currentKey] = rawValue.replace(/^["']|["']$/g, "");
+      }
+    } else if (block && /^\s*$/.test(line)) {
+      block.lines.push("");
+    } else if (block && /^\s+\S/.test(line)) {
+      if (block.indent === null) block.indent = /^\s+/.exec(line)[0].length;
+      block.lines.push(line.slice(block.indent));
+    } else if (currentKey && !block && /^\s+\S/.test(line)) {
       result[currentKey] = `${result[currentKey]} ${line.trim()}`.trim();
     }
   }
+  finishBlock();
   return result;
+}
+
+function foldBlockLines(lines) {
+  let value = "";
+  let previousContent = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i] === "") continue;
+    if (previousContent < 0) value += "\n".repeat(i);
+    else value += i === previousContent + 1 ? " " : "\n".repeat(i - previousContent - 1);
+    value += lines[i];
+    previousContent = i;
+  }
+  if (previousContent >= 0) value += "\n".repeat(lines.length - previousContent);
+  else value = "\n".repeat(lines.length);
+  return value;
 }
 
 export function renderSkillIndex(skills) {

--- a/src/skills.js
+++ b/src/skills.js
@@ -117,12 +117,23 @@ export function parseFrontmatter(text) {
   if (!match) return {};
   const result = {};
   let currentKey = null;
+  let blockStyle = null; // "fold" (>) | "literal" (|) | null for plain scalars
+  let blockIndent = null;
   for (const line of match[1].split("\n")) {
     const kv = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
     if (kv) {
       currentKey = kv[1];
-      result[currentKey] = kv[2].trim().replace(/^["']|["']$/g, "");
-    } else if (currentKey && /^\s+\S/.test(line)) {
+      const rawValue = kv[2].trim();
+      const blockIndicator = /^([>|])[+-]?$/.exec(rawValue);
+      blockStyle = blockIndicator ? (blockIndicator[1] === "|" ? "literal" : "fold") : null;
+      blockIndent = null;
+      result[currentKey] = blockIndicator ? "" : rawValue.replace(/^["']|["']$/g, "");
+    } else if (currentKey && blockStyle && /^\s+\S/.test(line)) {
+      if (blockIndent === null) blockIndent = /^\s+/.exec(line)[0].length;
+      const content = line.slice(blockIndent);
+      const separator = blockStyle === "literal" ? "\n" : " ";
+      result[currentKey] = result[currentKey] ? `${result[currentKey]}${separator}${content}` : content;
+    } else if (currentKey && !blockStyle && /^\s+\S/.test(line)) {
       result[currentKey] = `${result[currentKey]} ${line.trim()}`.trim();
     }
   }

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -72,12 +72,12 @@ test("parseFrontmatter folds a >- block-scalar description without leaking the i
 
 test("parseFrontmatter handles > and | block-scalar indicators with all chomping suffixes", () => {
   const cases = [
-    { indicator: ">", expected: "Enter away-mode when idle." },
-    { indicator: ">-", expected: "Enter away-mode when idle." },
-    { indicator: ">+", expected: "Enter away-mode when idle." },
-    { indicator: "|", expected: "Enter away-mode\nwhen idle." },
-    { indicator: "|-", expected: "Enter away-mode\nwhen idle." },
-    { indicator: "|+", expected: "Enter away-mode\nwhen idle." },
+    { indicator: ">", expected: "Enter away-mode when idle.\nResume when the user returns.\n" },
+    { indicator: ">-", expected: "Enter away-mode when idle.\nResume when the user returns." },
+    { indicator: ">+", expected: "Enter away-mode when idle.\nResume when the user returns.\n\n\n" },
+    { indicator: "|", expected: "Enter away-mode\nwhen idle.\n\nResume when the user returns.\n" },
+    { indicator: "|-", expected: "Enter away-mode\nwhen idle.\n\nResume when the user returns." },
+    { indicator: "|+", expected: "Enter away-mode\nwhen idle.\n\nResume when the user returns.\n\n\n" },
   ];
   for (const { indicator, expected } of cases) {
     const text = [
@@ -86,6 +86,10 @@ test("parseFrontmatter handles > and | block-scalar indicators with all chomping
       `description: ${indicator}`,
       "  Enter away-mode",
       "  when idle.",
+      "",
+      "  Resume when the user returns.",
+      "",
+      "",
       "---",
       "# Away mode",
       "",

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -50,6 +50,52 @@ test("generated SKILL.md frontmatter marks the skill non-invocable and internal"
   assert.ok(text.endsWith("2. Sign the tarball.\n"));
 });
 
+test("parseFrontmatter folds a >- block-scalar description without leaking the indicator", () => {
+  const text = [
+    "---",
+    "name: away-mode",
+    "description: >-",
+    "  Enter away-mode when the user asks to step away from the",
+    "  keyboard for an extended period.",
+    "---",
+    "# Away mode",
+    "",
+  ].join("\n");
+  const frontmatter = parseFrontmatter(text);
+  assert.equal(
+    frontmatter.description,
+    "Enter away-mode when the user asks to step away from the keyboard for an extended period.",
+  );
+  assert.ok(!/^[>|]/.test(frontmatter.description));
+  assert.ok(!frontmatter.description.includes(">-"));
+});
+
+test("parseFrontmatter handles > and | block-scalar indicators with all chomping suffixes", () => {
+  const cases = [
+    { indicator: ">", expected: "Enter away-mode when idle." },
+    { indicator: ">-", expected: "Enter away-mode when idle." },
+    { indicator: ">+", expected: "Enter away-mode when idle." },
+    { indicator: "|", expected: "Enter away-mode\nwhen idle." },
+    { indicator: "|-", expected: "Enter away-mode\nwhen idle." },
+    { indicator: "|+", expected: "Enter away-mode\nwhen idle." },
+  ];
+  for (const { indicator, expected } of cases) {
+    const text = [
+      "---",
+      "name: away-mode",
+      `description: ${indicator}`,
+      "  Enter away-mode",
+      "  when idle.",
+      "---",
+      "# Away mode",
+      "",
+    ].join("\n");
+    const frontmatter = parseFrontmatter(text);
+    assert.equal(frontmatter.description, expected, `indicator ${indicator}`);
+    assert.ok(!/^[>|]/.test(frontmatter.description), `indicator ${indicator} leaked marker`);
+  }
+});
+
 test("writeSkill lands in .agents/skills and links .claude/skills to it", () => {
   const root = tmpRepo();
   const result = writeSkill(root, SKILL);

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -240,6 +240,10 @@ test("synthesis edits the staging copy natively; measured hunks anchor to the ra
   assert.match(editPrompt, /^<!-- backpass:self-session -->/);
   assert.ok(editPrompt.includes(`The repository itself is at \`${repo.root}\``));
   assert.ok(editPrompt.includes("[AG-001] ("), "the index stays as the lookup table");
+  assert.ok(
+    editPrompt.includes("Do not assert or dramatize an agent's motives or intent beyond what the evidence"),
+    "synthesis prompt guards against unsupported motive claims",
+  );
   const annotatePrompt = fs.readFileSync(
     path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-1.md"),
     "utf8",


### PR DESCRIPTION
## Intent

Fix parseFrontmatter to correctly handle YAML block-scalar indicators (>, >-, >+, |, |-, |+) on a frontmatter value: the parsed value must be the actual folded (spaces-joined) or literal (newline-preserved) text with the indicator and chomping marker removed, not leaked into the value (observed as '>- ' prepended to skill description text, e.g. firstmate skill description fields, polluting every synthesis/analysis prompt). Reproduce first with a failing test on a real skill-description-shaped folded-scalar fixture asserting the parsed value has no leading >/|/- marker and reads as the intended text, covering both > and | variants and all chomping suffixes, then fix. Do not over-reach into a full YAML library; handle the block-scalar indicators cleanly within the existing minimal parser. Additionally, add ONE short, plainly-worded sentence to the synthesis/proposal prompt instructing the model not to assert or dramatize motives/intent it cannot support from the evidence; keep it to a single sentence and do not restructure the prompt. Verify the no-motive sentence through the real prompt-construction/rendering path (not a raw source grep of a string constant). No other parser or prompt behavior should change; all existing tests must still pass.

## What Changed

- Parse folded and literal skill-description scalars with all YAML chomping suffixes without leaking indicator markers.
- Instruct synthesis to avoid unsupported claims about agent motives or intent, with coverage through the rendered prompt path.

## Risk Assessment

🚨 High: The parser silently returns incorrect text for reachable block-scalar inputs and contradicts an explicit required acceptance criterion, so it should not merge without resolution or explicit approval.

## Testing

Inspected the targeted diff, ran the focused parser and real synthesis-path tests, and captured an end-to-end skill-index and rendered-prompt artifact confirming block markers do not leak and the no-motive instruction reaches the generated prompt; all checks passed and the worktree remained unchanged.

<details>
<summary>Evidence: End-to-end frontmatter parsing and rendered synthesis prompt</summary>

Source: [End-to-end frontmatter parsing and rendered synthesis prompt](https://github.com/kunchenguid/backpass/blob/0ca15046cede16b0c9b1652c14c6a00a1129a6c9/.no-mistakes/evidence/fm/backpass-frontmatter-polish-r1/frontmatter-prompt-e2e.txt)

```text
Analysis prompt skill index (loaded from real SKILL.md files):
- fold-clip (.agents/skills/fold-clip/SKILL.md) :: Use this skill for firstmate release operations.
- fold-keep (.agents/skills/fold-keep/SKILL.md) :: Use this skill for firstmate release operations.
- fold-strip (.agents/skills/fold-strip/SKILL.md) :: Use this skill for firstmate release operations.
- literal-clip (.agents/skills/literal-clip/SKILL.md) :: Use this skill for firstmate
release operations.
- literal-keep (.agents/skills/literal-keep/SKILL.md) :: Use this skill for firstmate
release operations.
- literal-strip (.agents/skills/literal-strip/SKILL.md) :: Use this skill for firstmate
release operations.

Marker leak check: PASS - no block indicators leaked

Rendered synthesis prompt policy:
10. Do not assert or dramatize an agent's motives or intent beyond what the evidence supports.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2be5ae80b9f47472ab6a2691c68bde52059af479","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/skills.js:127` - The required &#34;actual folded ... or literal ... text&#34; is not produced for block scalars with blank lines or chomping suffixes. The regex recognizes `+`/`-` but discards which suffix was present, while line 131 skips blank content lines. For example, a `|+` description containing two paragraphs and trailing blank lines silently loses the paragraph blank line and all trailing newlines; `|`, `|-`, and `|+` therefore produce the same value. The new expectations at test/skills.test.js:75-80 codify this incorrect result. Preserve block blank lines, fold or retain them according to style, and apply strip/clip/keep chomping at parseFrontmatter before returning.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/skills.test.js`
- `node --test --test-name-pattern='synthesis edits the staging copy natively' test/synthesize.test.js`
- <code>Manual end-to-end Node check using `loadSkills`, `renderSkillIndexForAnalysis`, and `renderPrompt` across `&gt;`, `&gt;-`, `&gt;+`, `|`, `|-`, and `|+` skill descriptions</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
