### PR TITLE
docs: define user-level backward pass scope

### DIFF
--- a/VISION-ANSWERS.md
+++ b/VISION-ANSWERS.md
@@ -187,6 +187,7 @@ Later ruling: H-13, issue #97 (2026-09-02), supersedes H-8 for an explicit `--sc
 **Author's reasoning.** (verbatim from the 2026-09-02 comment on issue #97)
 
 for open questions -
+
 1. yes amend vision
 2. as proposed
 3. default 1. i don't think we need cross-project evidence as a requirement

--- a/VISION-ANSWERS.md
+++ b/VISION-ANSWERS.md
@@ -6,6 +6,7 @@ Keep this file next to the vision: it is the record of why the vision says what 
 
 Board: `/vision` review, 12 hypotheticals, from-scratch draft r1 (2026-08-23).
 Evidence base: the 20 merged pull requests authored by the repo owner in `kunchenguid/backpass` (#1 through #26), the open issues #23, #24 and #25, community pull request #21, and the module header comments those changes left behind.
+Later ruling: H-13, issue #97 (2026-09-02), supersedes H-8 for an explicit `--scope user` run only.
 
 ## H-1 - Pool the gap ledger across a team
 
@@ -115,7 +116,7 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 
 **Author's reasoning.** for now, my philosophy is that global memory should be handwritten by the user and only contains their preferences. all the learned knowledge is better put into project-level memory
 
-**Folded in as.** The opener now carries the positive half of your reasoning: "a person's own ~/.claude/CLAUDE.md is handwritten preference, and anything learned belongs in project memory instead." The Scope non-goal was tightened to match.
+**Folded in as.** The opener then carried the positive half of your reasoning: "a person's own ~/.claude/CLAUDE.md is handwritten preference, and anything learned belongs in project memory instead." The Scope non-goal was tightened to match. Superseded in part by H-13 (2026-09-02): those two sentences now describe the default project-scoped run; an explicit `--scope user` run is in vision. H-8 itself stays off-mission: a project-scoped run still must not write a user-level file.
 
 ## H-9 - Make --strict the default
 
@@ -172,3 +173,27 @@ Evidence base: the 20 merged pull requests authored by the repo owner in `kunche
 **Author's reasoning.** covering more harnesses is in vision, as long as it doesn't risk existing ones
 
 **Folded in as.** New line with your constraint attached: "More harnesses is always welcome, provided a new one cannot destabilise the ones already working", kept next to the pinned-fixture and fail-soft requirement.
+
+## H-13 - A user-level scope for a user whose weights live at `~/.claude`
+
+**Proposal.** Issue #97 proposes a second run scope, `--scope user`, that trains the user's always-loaded instruction file and user-level skills from every session on the machine. A project-scoped run never writes those files. This is not H-8: H-8 asked a project run to promote a cross-repo gap into `~/.claude/CLAUDE.md`; this asks the user to name the user surface as the target.
+
+**Principle tested.** "It does not train a person's own `~/.claude/CLAUDE.md`." / H-8 off-mission.
+
+**Why it was not obvious.** For: a user who keeps all skills and instructions at user level has no project file for a project run to train, and a user-level skill's description is a trigger condition, not handwritten preference. Against: H-8's reasoning that a global file has no repo to scope evidence to and one wrong instruction pollutes every project at once.
+
+**Verdict.** In vision (explicit `--scope user` only; H-8 remains off-mission for a project-scoped write)
+
+**Author's reasoning.** (verbatim from the 2026-09-02 comment on issue #97)
+
+for open questions -
+1. yes amend vision
+2. as proposed
+3. default 1. i don't think we need cross-project evidence as a requirement
+4. project scoped and user scoped data should be isolated as much as possible
+5. i like the one under ~/.config
+6. follow what project scope does
+7. follow what project scope does
+8. you figure it out. in general we should consider AGENTS.md canonical - many harnesses support that already. CLAUDE.md can contain a pointer to it
+
+**Folded in as.** The opener's "a person's own `~/.claude/CLAUDE.md` is handwritten preference, and anything learned belongs in project memory instead" becomes "By default the project file is the one it trains. A person's user-level surface (`~/.claude/CLAUDE.md`, user-level skills) is a target only when they name it as the scope of a run." The Scope non-goal changes from "It does not train a person's own `~/.claude/CLAUDE.md`" to "It never writes a user-level file from a project-scoped run." Section 8's "and a rule reaches it only with evidence from more than one project" is not folded into `VISION.md`: answer 3 sets `minGapProjects` default 1, so the two-session bar remains the vision requirement and the project-count gate is a configurable setting, not a write-path. Recorded implementation answers for the follow-on cut: canonical user memory file is first-existing with divergence warnings; project-scoped and user-scoped state, evidence, ledgers, rejections, and apply surfaces stay isolated; user-scope state lives under `~/.config/backpass/` (honours `XDG_CONFIG_HOME`); pre-image backups and the extraction target follow what project scope does; treat the user-level `AGENTS.md` the harnesses load as canonical, with `CLAUDE.md` allowed as a pointer. The resist tests are unchanged: nothing here widens what writes without an explicit scope, lowers the two-session bar, or makes anything but per-edit review the default.

--- a/VISION.md
+++ b/VISION.md
@@ -2,7 +2,7 @@
 
 `backpass` exists so that a repository's agent memory file improves from what actually happened in its agent sessions, instead of from whatever a human happened to remember.
 It serves the developer who owns that file, whether it is `AGENTS.md` or the `CLAUDE.md` Claude Code reads in its place, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
-The project file is the one it trains; a person's own `~/.claude/CLAUDE.md` is handwritten preference, and anything learned belongs in project memory instead.
+By default the project file is the one it trains. A person's user-level surface (`~/.claude/CLAUDE.md`, user-level skills) is a target only when they name it as the scope of a run.
 It owns exactly one thing: the backward pass from session transcripts to a proposed change in the memory surface - the memory file and the project's skills.
 
 ## Evidence is the only currency
@@ -75,7 +75,7 @@ A test earns its place by failing when the behavior it names is removed, so a te
 ## Scope
 
 `backpass` is not a code reviewer, not a CI system, not a linter, not a harness, and not a model provider.
-It does not train a person's own `~/.claude/CLAUDE.md`, which is handwritten preference and not a target to write.
+It never writes a user-level file from a project-scoped run.
 It does not rewrite a memory file and will not offer to, because a rewrite cannot be accepted edit by edit and leaves nothing for a rejection to remember.
 Vocabulary is deliberate: the user reads the training loop, while subcommands and internals keep their short names.
 The repo holds itself to its own standard, including excluding its own sessions from the corpus it analyzes.


### PR DESCRIPTION
## Intent

Phase 0 of issue #97 (user-level backward pass): amend VISION.md and record the captain's ruling in VISION-ANSWERS.md. Docs only; no code.

The captain ruled on the section 9 open questions in a 2026-09-02 comment on https://github.com/kunchenguid/backpass/issues/97. Adopt the section 8 VISION.md amendment: the opener becomes "By default the project file is the one it trains. A person's user-level surface (~/.claude/CLAUDE.md, user-level skills) is a target only when they name it as the scope of a run." The Scope non-goal becomes "It never writes a user-level file from a project-scoped run." This supersedes H-8 for an explicit --scope user run only; H-8 stays off-mission for a project-scoped write to a user-level file. Resist tests are unchanged.

Record H-13 in VISION-ANSWERS.md with the captain's eight answers verbatim:
1. yes amend vision
2. as proposed (canonical user memory file = first-existing with divergence warnings)
3. default 1. i don't think we need cross-project evidence as a requirement (minGapProjects defaults to 1; the two-session bar remains the vision requirement; do not fold section 8's "evidence from more than one project" into VISION.md)
4. project scoped and user scoped data should be isolated as much as possible
5. i like the one under ~/.config (user-scope state under ~/.config/backpass/, honour XDG_CONFIG_HOME)
6. follow what project scope does (pre-image backups)
7. follow what project scope does (extraction target)
8. you figure it out. in general we should consider AGENTS.md canonical - many harnesses support that already. CLAUDE.md can contain a pointer to it

Do not implement Phase 1 in this change. README and code stay for the follow-on PR after this lands.

## What Changed

- Amend the vision to allow user-level memory and skills as explicit run targets while keeping project-scoped runs isolated from user-level files.
- Record the captain's H-13 ruling, including scope isolation, state location, evidence threshold, backups, extraction behavior, and canonical memory-file guidance.
- Clarify how H-13 partially supersedes H-8 without changing the existing resist tests.

## Risk Assessment

✅ Low: The change is documentation-only and accurately records the required vision amendment, scope boundary, unchanged resist tests, and all eight captain answers verbatim.

## Testing

Validated the docs-only commit end to end against the live issue #97 captain comment: the required vision amendment, project-scope restriction, H-8 qualification, all eight verbatim answers, default minGapProjects ruling, and unchanged resist tests are present, while the complete diff changes only the two requested vision documents.

<details>
<summary>Evidence: Phase 0 documentation validation with published amendments, H-13 ruling, live captain comment, changed-file scope, and resist-test comparison</summary>

Source: [Phase 0 documentation validation with published amendments, H-13 ruling, live captain comment, changed-file scope, and resist-test comparison](https://github.com/kunchenguid/backpass/blob/5bdcb0c269e8e428120d20d93c658abf8cff9e5f/.no-mistakes/evidence/fm/backpass-user-level-scope-p1-r1/phase0-doc-validation.txt)

```text
Phase 0 documentation validation
Base: b7a604433d3c3bd9a4f3651f25fb9e292b2c4f8f
Target: d642b4b2505805f0b7522d13a39e948f19abdbc2

Complete target change set:
M	VISION-ANSWERS.md
M	VISION.md

Published VISION.md amendment:
3:`backpass` exists so that a repository's agent memory file improves from what actually happened in its agent sessions, instead of from whatever a human happened to remember.
4:It serves the developer who owns that file, whether it is `AGENTS.md` or the `CLAUDE.md` Claude Code reads in its place, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
5:By default the project file is the one it trains. A person's user-level surface (`~/.claude/CLAUDE.md`, user-level skills) is a target only when they name it as the scope of a run.
78:It never writes a user-level file from a project-scoped run.
79:It does not rewrite a memory file and will not offer to, because a rewrite cannot be accepted edit by edit and leaves nothing for a rejection to remember.
80:Vocabulary is deliberate: the user reads the training loop, while subcommands and internals keep their short names.
81:The repo holds itself to its own standard, including excluding its own sessions from the corpus it analyzes.
82:
83:A change aligns when it makes the evidence behind a proposal stronger, cheaper to verify, or harder to fabricate.
84:A change aligns when it lets a person say no faster, or say no once and have it remembered.
85:A change should be resisted when it widens what writes, lowers the two-session bar, or makes anything but per-edit review the default.
86:A change should be resisted when it makes the memory file easier to grow than to shrink.
87:A change should be resisted when it requires `backpass` to hold a key, a server, or a copy of someone else's transcripts.
88:A change should be resisted when it buys coverage with accuracy, or trades a real fix for a quieter degraded path.

Published H-13 ruling and verbatim answer block:
## H-13 - A user-level scope for a user whose weights live at `~/.claude`

**Proposal.** Issue #97 proposes a second run scope, `--scope user`, that trains the user's always-loaded instruction file and user-level skills from every session on the machine. A project-scoped run never writes those files. This is not H-8: H-8 asked a project run to promote a cross-repo gap into `~/.claude/CLAUDE.md`; this asks the user to name the user surface as the target.

**Principle tested.** "It does not train a person's own `~/.claude/CLAUDE.md`." / H-8 off-mission.

**Why it was not obvious.** For: a user who keeps all skills and instructions at user level has no project file for a project run to train, and a user-level skill's description is a trigger condition, not handwritten preference. Against: H-8's reasoning that a global file has no repo to scope evidence to and one wrong instruction pollutes every project at once.

**Verdict.** In vision (explicit `--scope user` only; H-8 remains off-mission for a project-scoped write)

**Author's reasoning.** (verbatim from the 2026-09-02 comment on issue #97)

for open questions -
1. yes amend vision
2. as proposed
3. default 1. i don't think we need cross-project evidence as a requirement
4. project scoped and user scoped data should be isolated as much as possible
5. i like the one under ~/.config
6. follow what project scope does
7. follow what project scope does
8. you figure it out. in general we should consider AGENTS.md canonical - many harnesses support that already. CLAUDE.md can contain a pointer to it

**Folded in as.** The opener's "a person's own `~/.claude/CLAUDE.md` is handwritten preference, and anything learned belongs in project memory instead" becomes "By default the project file is the one it trains. A person's user-level surface (`~/.claude/CLAUDE.md`, user-level skills) is a target only when they name it as the scope of a run." The Scope non-goal changes from "It does not train a person's own `~/.claude/CLAUDE.md`" to "It never writes a user-level file from a project-scoped run." Section 8's "and a rule reaches it only with evidence from more than one project" is not folded into `VISION.md`: answer 3 sets `minGapProjects` default 1, so the two-session bar remains the vision requirement and the project-count gate is a configurable setting, not a write-path. Recorded implementation answers for the follow-on cut: canonical user memory file is first-existing with divergence warnings; project-scoped and user-scoped state, evidence, ledgers, rejections, and apply surfaces stay isolated; user-scope state lives under `~/.config/backpass/` (honours `XDG_CONFIG_HOME`); pre-image backups and the extraction target follow what project scope does; treat the user-level `AGENTS.md` the harnesses load as canonical, with `CLAUDE.md` allowed as a pointer. The resist tests are unchanged: nothing here widens what writes without an explicit scope, lowers the two-session bar, or makes anything but per-edit review the default.

Resist-test tail unchanged from base: YES

Issue #97 captain comment fetched through gh-axi:
comments[1]{author,created,body}:
  kunchenguid,9m ago,"for open questions -\n1. yes amend vision\n2. as proposed\n3. default 1. i don't think we need cross-project evidence as a requirement\n4. project scoped and user scoped data should be isolated as much as possible\n5. i like the one under ~/.config\n6. follow what project scope does\n7. follow what project scope does\n8. you figure it out. in general we should consider AGENTS.md canonical - many harnesses support that already. CLAUDE.md can contain a pointer to it"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2caaf3d3562a8fc28dd8e9e18fb2e053ea530dcb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status --stat b7a604433d3c3bd9a4f3651f25fb9e292b2c4f8f..d642b4b2505805f0b7522d13a39e948f19abdbc2`
- `git diff --unified=80 b7a604433d3c3bd9a4f3651f25fb9e292b2c4f8f..d642b4b2505805f0b7522d13a39e948f19abdbc2 -- VISION.md VISION-ANSWERS.md`
- `npx -y gh-axi issue view 97 --comments --full -R kunchenguid/backpass`
- <code>Compared the published VISION.md resist-test tail between base and target with `cmp`; it is unchanged.</code>
- `Verified the complete target changeset contains only VISION.md and VISION-ANSWERS.md, with no README or code changes.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
