### PR TITLE
fix(acpx): send --agent session prompts through the prompt subcommand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,9 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   CLI change has one blast radius. v1 uses plain `exec` and named sessions only; acpx flows
   are deferred until they are stable upstream. The one sanctioned exception is the
   per-harness native status table in `src/agents.js` (`claude auth status`, `opencode models`).
+  Grok overlays ride acpx `--agent`; that hatch has no `-s` of its own (acpx 0.13.x:
+  `unknown option '-s'`), so `openSession`'s `prompt()` sends the `prompt` subcommand
+  before `-s` when `acpxAgentCommand` is set. Built-in agents keep the implicit form.
 - **Model and effort overrides are invocation-scoped.** Never ACP `set model` / Pi
   `set thought_level` (those rewrite `~/.pi/agent/settings.json`) and never edit-then-restore
   harness defaults. `src/harness-invoke.js` owns the harness overlay mechanisms and

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -471,6 +471,11 @@ export async function openSession({ agent, model = null, effort = null, sessionN
       "--prompt-retries",
       String(promptRetries),
       ...acpxAgentArgs,
+      // `--agent <command>` has no `-s` of its own (acpx 0.13.1/0.13.2: `unknown
+      // option '-s'`, exit 2). `-s`/`--file` live on `prompt`. Built-in agents still
+      // accept the implicit form (`acpx codex -s ... --file ...`); `acpx codex prompt
+      // --help` documents the subcommand too, but changing that path is unnecessary.
+      ...(invocation.acpxAgentCommand ? ["prompt"] : []),
       "-s",
       sessionName,
       "--file",

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -771,6 +771,48 @@ test("a write-access Codex session rejects malformed CODEX_CONFIG before invokin
   assert.deepEqual(acpxCalls(), []);
 });
 
+test("a grok session prompt sends the prompt subcommand before -s", async () => {
+  resetLogsAndSettings();
+  const session = await openSession({
+    agent: "grok",
+    model: "grok-4.6",
+    effort: "high",
+    sessionName: "bp-grok-prompt",
+    cwd: workDir,
+  });
+  await session.prompt({ promptFile, timeoutSeconds: 5 });
+  await session.close();
+
+  const prompted = acpxCalls().find((c) => c.argv.includes("--file") && !c.argv.includes("exec"));
+  assert.ok(prompted, "expected a session prompt invocation");
+  const agentAt = prompted.argv.indexOf("--agent");
+  const promptAt = prompted.argv.indexOf("prompt");
+  const sessionAt = prompted.argv.indexOf("-s");
+  assert.ok(agentAt >= 0, "grok overlays use acpx --agent");
+  assert.ok(promptAt > agentAt, "prompt must follow --agent");
+  assert.equal(prompted.argv[sessionAt + 1], "bp-grok-prompt");
+  assert.ok(promptAt < sessionAt, "acpx --agent rejects -s unless it follows the prompt subcommand");
+});
+
+test("a built-in session prompt keeps the implicit form without a prompt subcommand", async () => {
+  resetLogsAndSettings();
+  const session = await openSession({
+    agent: "codex",
+    model: "gpt-5.6-sol",
+    sessionName: "bp-codex-prompt",
+    cwd: workDir,
+  });
+  await session.prompt({ promptFile, timeoutSeconds: 5 });
+  await session.close();
+
+  const prompted = acpxCalls().find((c) => c.argv.includes("--file") && !c.argv.includes("exec"));
+  assert.ok(prompted, "expected a session prompt invocation");
+  assert.ok(prompted.argv.includes("codex"));
+  assert.ok(!prompted.argv.includes("--agent"));
+  assert.ok(!prompted.argv.includes("prompt"));
+  assert.equal(prompted.argv[prompted.argv.indexOf("-s") + 1], "bp-codex-prompt");
+});
+
 test("a write-access Grok session launches with native file-write permission flags", async () => {
   resetLogsAndSettings();
   const session = await openSession({

--- a/test/harness-invoke.test.js
+++ b/test/harness-invoke.test.js
@@ -200,6 +200,13 @@ if (argv.includes("exec")) {
   process.exit(0);
 }
 if (argv.includes("--file")) {
+  const agentAt = argv.indexOf("--agent");
+  const sessionAt = argv.indexOf("-s");
+  const promptAt = argv.indexOf("prompt");
+  if (agentAt >= 0 && sessionAt >= 0 && (promptAt < 0 || promptAt > sessionAt)) {
+    process.stderr.write("USAGE error: unknown option '-s'\\n");
+    process.exit(2);
+  }
   process.stdout.write('{"edits":[],"notes":[]}\\n');
   process.exit(0);
 }


### PR DESCRIPTION
## Intent

Fix kunchenguid/backpass so a pinned grok synthesis (or analysis) agent works through acpx, and ship it upstream as a PR from the 1955m GitHub account.

backpass propose with synthesis.agent = grok fails every time with `acpx grok session prompt failed (exit 2)`. For grok, src/harness-invoke.js (grokInvocation) always routes through acpx's `--agent <command>` escape hatch (a generated argv wrapper around `grok ... agent stdio`), because synthesis needs write access and/or a model or effort override. In src/acpx.js, openSession()'s prompt() builds `acpx [globals] --agent <cmd> -s <session> --file <prompt>`. acpx 0.13.1 and 0.13.2 both reject that for a raw `--agent` command: `[acpx] error: USAGE error: unknown option '-s'` (exit 2). Built-in agents (`acpx codex -s ... --file ...`) accept it, which is why codex/claude analysis works and grok does not. The working form is the explicit prompt subcommand: `acpx [globals] --agent <cmd> prompt -s <session> --file <prompt>` returns the model's answer (exit 0). Verified with `acpx --cwd <dir> --approve-reads --non-interactive-permissions deny --timeout 120 --format quiet --agent "grok -m grok-4.6 agent stdio" prompt -s <name> --file <file>`. `acpx codex prompt --help` documents `-s, --session <name>` and `-f, --file <path>` as options of `prompt`. `acpx --agent ... sessions new --name <n>` and `acpx --agent ... sessions close <n>` already work (they are subcommands), so only the prompt call is wrong.

Requirements (current accepted form):
1. In src/acpx.js prompt(): emit the prompt subcommand when the invocation uses acpxAgentCommand (the --agent escape hatch). Decide, with evidence from `acpx codex prompt --help` and a live check, whether using prompt unconditionally for built-in agents is also correct; prefer the smallest change that is correct for both, and explain the choice in a short code comment (what and why, no chatter).
2. Check the other -s-before-subcommand calls in openSession() (set-mode, set) for the same escape-hatch problem. grok currently sets neither sessionMode nor setEffortKey, so they may be unreachable for grok today; fix them only if the same bug is reachable, and say so either way in the PR body.
3. Add a regression test in test/harness-invoke.test.js (it already fakes acpx and asserts argv shapes for openSession/sessionPrompt): a grok session prompt must pass prompt before -s; a built-in agent's argv must keep whatever shape is settled on. Keep tests offline and fixture-based.
4. Keep README.md accurate if any user-facing wording about grok/acpx changes. Do not touch CHANGELOG.md or .release-please-manifest.json: CI rejects that.
5. Conventional-commit message, because release-please cuts releases from it, e.g. `fix(acpx): send --agent session prompts through the prompt subcommand`. Mention the exact acpx error and versions in the body.

Do not open the PR manually. The repo gate requires the no-mistakes attestation in the PR body. Submit with git push no-mistakes; the pipeline creates/updates the PR against upstream main.

The code fix is already on branch fm/backpass-grok-acpx. PR https://github.com/kunchenguid/backpass/pull/100 is open against kunchenguid/backpass from fork 1955m/backpass. HEAD is e6a99ae (pipeline follow-up "no-mistakes: apply CI fixes"); the original fix is d560997. Remaining required author action: run a new no-mistakes validation so the pipeline rewrites the PR body with an attestation bound to the resulting HEAD. The current PR body attestation is bound to d560997 while HEAD is e6a99ae; the Require no-mistakes workflow does not re-fire on synchronize. Do not add further code, do not open another PR, do not reply to the maintainer comment. git push no-mistakes reported Everything up-to-date on the unchanged head, so use the documented rerun path rather than inventing a change.

## What Changed

- Emit the explicit `prompt` subcommand before `-s` in `openSession().prompt()` when the invocation uses acpx's `--agent` escape hatch (`acpxAgentCommand`), fixing Grok synthesis/analysis failures where acpx 0.13.1/0.13.2 rejected `unknown option '-s'` (exit 2). Built-in agents keep the implicit `acpx codex -s ... --file ...` form.
- Add offline regression tests that assert Grok argv includes `prompt` before `-s` and built-in codex argv omits the subcommand; the fake acpx shim mirrors the acpx 0.13.x `-s` rejection for `--agent` without `prompt`.
- Document the `--agent` prompt shape in AGENTS.md. The `set-mode` and `set` paths in `openSession()` use the same `-s`-before-subcommand shape but are unchanged: Grok's `grokInvocation` never sets `sessionMode` or `setEffortKey`, so those calls are unreachable for Grok today.

## Risk Assessment

✅ Low: The fix is a single conditional argv insertion gated on the existing `acpxAgentCommand` flag (only set for grok overlays), preserves the working built-in-agent path, and is covered by behavioral regression tests through the public `openSession`/`prompt` API.

## Testing

Ran the new harness-invoke regression tests plus four related grok harness tests (all passed), reproduced the acpx 0.13.2 `unknown option '-s'` failure on the pre-fix argv shape and confirmed the fixed shape passes usage parsing (reaches session lookup), and captured emitted argv showing grok uses `--agent ... prompt -s ...` while codex keeps `codex -s ...` without a prompt subcommand.

<details>
<summary>Evidence: Live acpx 0.13.2 broken vs fixed argv verification</summary>

```text
=== acpx version ===
0.13.2

=== acpx codex prompt --help (excerpt) ===
Usage: acpx codex prompt [options] [prompt...]

Prompt using persistent session

Arguments:
  prompt                Prompt text

Options:
  -s, --session <name>  Use named session instead of cwd default
  --no-wait             Queue prompt and return immediately when another prompt
                        is already running
  -f, --file <path>     Read prompt text from file path (use - for stdin)
  -h, --help            display help for command

=== BROKEN: acpx --agent ... -s (no prompt subcommand) ===
error: unknown option '-s'

Usage: acpx [options] [command] [prompt...]

Headless CLI client for the Agent Client Protocol

Arguments:
  prompt                                  Prompt text

Options:
  -V, --version                           output the version number
  --agent <command>                       Raw ACP agent command (escape hatch)
  --cwd <dir>                             Working directory (default: "/home/ubuntu/work/1955m/.no-mistakes/worktrees/813104c22f3b/01M1HJ66GB9HMEEF9CKTMEN7CH")
  --auth-policy <policy>                  Authentication policy: skip or fail when auth is required
  --approve-all                           Auto-approve all permission requests
  --approve-reads                         Auto-approve read/search requests and prompt for writes
  --deny-all                              Deny all permission requests
  --non-interactive-permissions <policy>  When prompting is unavailable: deny or fail
  --permission-policy <json-or-file>      Permission policy JSON or path (autoApprove, autoDeny, escalate, defaultAction)
  --policy <json-or-file>                 Alias for --permission-policy
  --format <fmt>                          Output format: text, json, quiet
  --suppress-reads                        Suppress raw read-file contents in output
  --model <id>                            Agent model id
  --allowed-tools <list>                  Allowed tool names as a comma-separated list (use "" for no tools)
  --max-turns <count>                     Maximum turns for the session
  --system-prompt <text>                  Replace the agent system prompt (claude-agent-acp via ACP _meta.systemPrompt)
  --append-system-prompt <text>           Append text to the agent system prompt (claude-agent-acp via ACP _meta.systemPrompt.append)
  --prompt-retries <count>                Retry failed prompt turns on transient errors (default: 0)
  --json-strict                           Strict JSON mode: requires --format json and suppresses non-JSON stderr output
  --no-fs                                 Do not advertise ACP filesystem capabilities
  --no-terminal                           Do not advertise ACP terminal capability
  --timeout <seconds>                     Maximum time to wait for agent response
  --ttl <seconds>                         Queue owner idle TTL before shutdown (0 = keep alive forever) (default: 300)
  --mcp-config <path>                     Load MCP servers from a JSON config file instead of project/global mcpServers
  --verbose                               Enable verbose debug logs
  -h, --help                              display help for command

Commands:
  pi [options] [prompt...]                Use pi agent
  openclaw [options] [prompt...]          Use openclaw agent
  codex [options] [prompt...]             Use codex agent
  claude [options] [prompt...]            Use claude agent
  gemini [options] [prompt...]            Use gemini agent
  cursor [options] [prompt...]            Use cursor agent
  copilot [options] [prompt...]           Use copilot agent
  droid [options] [prompt...]             Use droid agent
  fast-agent [options] [prompt...]        Use fast-agent agent
  grok-build [options] [prompt...]        Use grok-build agent
  iflow [options] [prompt...]             Use iflow agent
  kilocode [options] [prompt...]          Use kilocode agent
  kimi [options] [prompt...]              Use kimi agent
  kiro [options] [prompt...]              Use kiro agent
  mux [options] [prompt...]               Use mux agent
  opencode [options] [prompt...]          Use opencode agent
  pool [options] [prompt...]              Use pool agent
  qoder [options] [prompt...]             Use qoder agent
  qwen [options] [prompt...]              Use qwen agent
  trae [options] [prompt...]              Use trae agent
  zeroclaw [options] [prompt...]          Use zeroclaw agent
  prompt [options] [prompt...]            Prompt using codex by default
  exec [options] [prompt...]              One-shot prompt using codex by default
  cancel [options]                        Cancel active prompt for codex by default
  set-mode [options] <mode>               Set session mode for codex by default
  set [options] <key> <value>             Set session config option for codex by default
  status [options]                        Show local status for codex by default
  sessions [options]                      List, ensure, create, or close sessions for this agent
  config                                  Inspect and initialize acpx configuration
  compare [options] <args...>             Run one prompt across multiple agents and summarize the results
  flow                                    Run multi-step ACP workflows from flow files

Examples:
  acpx pi "review recent changes"
  acpx openclaw exec "summarize active session state"
  acpx codex sessions new
  acpx codex "fix the tests"
  acpx codex prompt "fix the tests"
  acpx codex --no-wait "queue follow-up task"
  acpx codex exec "what does this repo do"
  acpx codex cancel
  acpx codex set-mode plan
  acpx codex set model 'gpt-5.2[high]'
  acpx codex -s backend "fix the API"
  acpx codex sessions
  acpx codex sessions new --name backend
  acpx codex sessions ensure --name backend
  acpx codex sessions close backend
  acpx codex status
  acpx config show
  acpx config init
  acpx --ttl 30 codex "investigate flaky tests"
  acpx claude "refactor auth"
  acpx --agent ./my-custom-server "do something"
[acpx] error: USAGE error: unknown option '-s'
exit: 0

=== FIXED: acpx --agent ... prompt -s ===
[acpx] error: NO_SESSION ⚠ No acpx session found (searched up to /tmp/acpx-grok-test-9Qqv). Create one: acpx codex sessions new --name test-session
exit: 0
```
</details>
<details>
<summary>Evidence: Emitted acpx argv for grok vs codex session.prompt()</summary>

```text
{
  "description": "Emitted acpx argv for session.prompt() after openSession()",
  "grok": {
    "argv": [
      "--cwd",
      "/tmp/bp-evidence-cwd-V0f0Pq",
      "--approve-reads",
      "--suppress-reads",
      "--non-interactive-permissions",
      "deny",
      "--timeout",
      "5",
      "--format",
      "quiet",
      "--prompt-retries",
      "1",
      "--agent",
      "<node> <grok-wrapper.cjs>",
      "prompt",
      "-s",
      "bp-grok-prompt",
      "--file",
      "/tmp/bp-evidence-cwd-V0f0Pq/prompt.md"
    ],
    "hasPromptSubcommandBeforeSession": true,
    "usesAgentEscapeHatch": true
  },
  "codex": {
    "argv": [
      "--cwd",
      "/tmp/bp-evidence-cwd-V0f0Pq",
      "--approve-reads",
      "--suppress-reads",
      "--non-interactive-permissions",
      "deny",
      "--timeout",
      "5",
      "--format",
      "quiet",
      "--prompt-retries",
      "1",
      "codex",
      "-s",
      "bp-codex-prompt",
      "--file",
      "/tmp/bp-evidence-cwd-V0f0Pq/prompt.md"
    ],
    "implicitFormWithoutPromptSubcommand": true
  }
}
```
</details>
<details>
<summary>Evidence: Grok prompt regression test output</summary>

```text
✔ a grok session prompt sends the prompt subcommand before -s (262.54097ms)
ℹ tests 1
ℹ suites 0
ℹ pass 1
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 379.267198
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ca560029c313356066f03d6e5a396aa12fdd249c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern="grok session prompt|built-in session prompt" test/harness-invoke.test.js`
- `node --test --test-name-pattern="Grok|grok session|write-access Grok|grok-analysis" test/harness-invoke.test.js`
- <code>Live acpx 0.13.2 check: broken `--agent ... -s` vs fixed `--agent ... prompt -s`</code>
- <code>Executable argv capture via `openSession().prompt()` for grok and codex</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
