### PR TITLE
feat: add user-level memory scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 ## Sharp edges
 
 - **User-scope runs are a separate triple.** `--scope user` trains the first existing
-  of `~/.agents/AGENTS.md`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` from every session
-  on the machine. State is `~/.config/backpass/user/` (0700, honours `XDG_CONFIG_HOME`),
+  of `~/.agents/AGENTS.md`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` from Claude and
+  Codex sessions across projects. State is `~/.config/backpass/user/` (0700, honours `XDG_CONFIG_HOME`),
   never `<repo>/.backpass/`. Association, filters, and the synthetic homedir repo live
   in `src/scope.js`. `minGapProjects` defaults to 1 (the gate exists; cross-project
   corroboration is not required). A project-scoped run never writes a user-level file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,12 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 
 ## Sharp edges
 
+- **User-scope runs are a separate triple.** `--scope user` trains the first existing
+  of `~/.agents/AGENTS.md`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` from every session
+  on the machine. State is `~/.config/backpass/user/` (0700, honours `XDG_CONFIG_HOME`),
+  never `<repo>/.backpass/`. Association, filters, and the synthetic homedir repo live
+  in `src/scope.js`. `minGapProjects` defaults to 1 (the gate exists; cross-project
+  corroboration is not required). A project-scoped run never writes a user-level file.
 - **Sibling clones are a live-path tier, not a recorded-remote one.** `git worktree
 list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches the
   parent of each worktree (and `discovery.cloneRoots`) for other checkouts that share a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
 
 ## Sharp edges
 
-- **User-scope runs are a separate triple.** `--scope user` trains the first existing
-  of `~/.agents/AGENTS.md`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` from Claude and
-  Codex sessions across projects. State is `~/.config/backpass/user/` (0700, honours `XDG_CONFIG_HOME`),
-  never `<repo>/.backpass/`. Association, filters, and the synthetic homedir repo live
-  in `src/scope.js`. `minGapProjects` defaults to 1 (the gate exists; cross-project
-  corroboration is not required). A project-scoped run never writes a user-level file.
+- **User-scope runs are a separate triple.** See README's User-level memory section
+  for user-facing paths and defaults. Association, filters, and the synthetic homedir
+  repo live in `src/scope.js`; user state never enters `<repo>/.backpass/`.
+  `minGapProjects` defaults to 1 (the gate exists; cross-project corroboration is not
+  required). A project-scoped run never writes a user-level file.
 - **Sibling clones are a live-path tier, not a recorded-remote one.** `git worktree
 list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches the
   parent of each worktree (and `discovery.cloneRoots`) for other checkouts that share a

--- a/README.md
+++ b/README.md
@@ -74,6 +74,39 @@ backpass           # collect samples → calculate loss → aggregate gradients 
 backpass apply     # review each edit, accept or reject, then write
 ```
 
+### User-level memory
+
+A run is one scope. The default is the checkout you are in. `backpass --scope user`
+trains the always-loaded user file and user-level skills from every agent session on
+the machine, and writes only those files. A project-scoped run never writes a
+user-level file.
+
+Canonical user memory is the first of these that exists: `~/.agents/AGENTS.md`,
+then `~/.claude/CLAUDE.md` (a pointer to AGENTS.md is valid), then `~/.codex/AGENTS.md`.
+User-level skill extractions follow the project layout: `.agents/skills`, with a
+warning if `~/.claude/skills` is a real directory rather than the usual symlink.
+
+State lives in `~/.config/backpass/user/` (mode 0700; honours `XDG_CONFIG_HOME`),
+isolated from every project's `.backpass/`. Evidence quotes from every project on
+the machine land in that one directory.
+
+Harness load paths, verified for v1:
+
+- **Claude Code** loads `~/.claude/CLAUDE.md` (`CLAUDE_CONFIG_DIR` relocates the config
+  dir) and inlines `@` imports, including `~/` and absolute paths. A CLAUDE.md that is
+  only `@AGENTS.md` (or `@~/...`) is a valid pointer.
+- **Codex** loads `~/.codex/AGENTS.md` (`CODEX_HOME` relocates Codex home). It follows
+  the AGENTS.md convention; `@` import is not assumed.
+
+A target that is a symlink into a read-only store (dotfiles, nix) is refused with
+`<path> is a symlink to <real>, which is not writable; edit the source that generates it`.
+
+```sh
+backpass init --scope user
+backpass --scope user
+backpass apply --scope user
+```
+
 ## How It Works
 
 ### 1. Collect samples - which sessions belong to this repo
@@ -558,8 +591,9 @@ CLI flags on top:
 
 ### State
 
-Everything mutable lives in `.backpass/`, kept out of git via the repo's local exclude
-(`.git/info/exclude`, written by `backpass init`) rather than the tracked `.gitignore`:
+Project-scoped mutable state lives in `.backpass/`, kept out of git via the repo's local
+exclude (`.git/info/exclude`, written by `backpass init`) rather than the tracked
+`.gitignore`:
 
 ```
 .backpass/
@@ -575,6 +609,9 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   apply/apply.html       the rendered review surface
 ```
 
+User-scope state is the same files under `~/.config/backpass/user/` (0700). It is never
+mixed with a checkout's `.backpass/`.
+
 ## Limitations
 
 - **Causal attribution is genuinely hard.** A model can confabulate influence. The
@@ -584,7 +621,8 @@ Everything mutable lives in `.backpass/`, kept out of git via the repo's local e
   pinned by a golden fixture and fails soft.
 - **Cursor IDE is deferred to v1.1.** Its composer→workspace link is version-dependent;
   `--include-cursor-ide` enables a best-effort pass, but it is not a v1 guarantee.
-- Global memory (`~/.claude/CLAUDE.md`) is treated as context, never an edit target.
+- A project-scoped run never writes a user-level file. User-level edits are
+  `--scope user` only (see [User-level memory](#user-level-memory)).
 - Paths are verified on macOS and Linux.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -81,22 +81,25 @@ trains the always-loaded user file and user-level skills from Claude Code and Co
 sessions across projects, and writes only those files. A project-scoped run never
 writes a user-level file.
 
-Canonical user memory is the first of these that exists: `~/.agents/AGENTS.md`,
-then `~/.claude/CLAUDE.md` (a pointer to AGENTS.md is valid), then `~/.codex/AGENTS.md`.
-User-level skill extractions follow the project layout: `.agents/skills`, with a
-warning if `~/.claude/skills` is a real directory rather than the usual symlink.
+Canonical user memory is the first existing file in this order: `~/.agents/AGENTS.md`,
+`$CLAUDE_CONFIG_DIR/CLAUDE.md` (default `~/.claude/CLAUDE.md`), and
+`$CODEX_HOME/AGENTS.md` (default `~/.codex/AGENTS.md`). User-level skill extractions
+follow the project layout at `~/.agents/skills`, with a warning if Claude's active
+`skills` path is a real directory rather than the usual symlink.
 
-State lives in `~/.config/backpass/user/` (mode 0700; honours `XDG_CONFIG_HOME`),
-isolated from every project's `.backpass/`. User-scope evidence, ledgers, proposals,
-and apply surfaces stay in that one directory.
+State lives in `$XDG_CONFIG_HOME/backpass/user/` (default
+`~/.config/backpass/user/`) with mode 0700, isolated from every project's
+`.backpass/`. User-scope evidence, ledgers, proposals, and apply surfaces stay in
+that one directory.
 
 Harness load paths, verified for v1:
 
-- **Claude Code** loads `~/.claude/CLAUDE.md` (`CLAUDE_CONFIG_DIR` relocates the config
-  dir) and inlines `@` imports, including `~/` and absolute paths. A CLAUDE.md that is
-  only `@AGENTS.md` (or `@~/...`) is a valid pointer.
-- **Codex** loads `~/.codex/AGENTS.md` (`CODEX_HOME` relocates Codex home). It follows
-  the AGENTS.md convention; `@` import is not assumed.
+- **Claude Code** loads `CLAUDE.md` from `CLAUDE_CONFIG_DIR` (default `~/.claude`)
+  and inlines `@` imports, including `~/` and absolute paths. A CLAUDE.md containing
+  only an import that resolves to the canonical user memory is a valid pointer, such
+  as `@~/.agents/AGENTS.md` with the default paths.
+- **Codex** loads `AGENTS.md` from `CODEX_HOME` (default `~/.codex`). It follows the
+  AGENTS.md convention; `@` import is not assumed.
 
 A target that is a symlink into a read-only store (dotfiles, nix) is refused with
 `<path> is a symlink to <real>, which is not writable; edit the source that generates it`.
@@ -590,9 +593,10 @@ CLI flags on top:
 ```
 
 That example is the project scope. User scope ignores `.backpassrc.json` and instead
-layers the `"user"` block in `~/.config/backpass/config.json` over its defaults. Its
-scope-specific settings are `memoryFiles`, `skillsDir`, `skillsDirs`,
-`minGapProjects` (default `1`), and these discovery controls:
+layers the `"user"` block in `$XDG_CONFIG_HOME/backpass/config.json` (default
+`~/.config/backpass/config.json`) over its defaults. The user block can override the
+regular settings; its path and user-only settings include `memoryFiles`, `skillsDir`,
+`skillsDirs`, `minGapProjects` (default `1`), and these discovery controls:
 
 ```json
 {
@@ -608,8 +612,9 @@ scope-specific settings are `memoryFiles`, `skillsDir`, `skillsDirs`,
 ```
 
 `includeProjects` and `excludeProjects` are globs matched against each project key and
-session cwd. `--project <glob>` adds command-line include globs. A non-null
-`maxTranscriptsPerProject` applies a sticky, recency-weighted per-project cap before
+session cwd. Repeated `--project <glob>` flags set the include globs for that
+invocation. A non-null `maxTranscriptsPerProject` applies a sticky,
+recency-weighted per-project cap before
 `maxTranscripts` applies to the whole run.
 
 ### State
@@ -632,8 +637,8 @@ exclude (`.git/info/exclude`, written by `backpass init`) rather than the tracke
   apply/apply.html       the rendered review surface
 ```
 
-User-scope state is the same files under `~/.config/backpass/user/` (0700). It is never
-mixed with a checkout's `.backpass/`.
+For the user-scope state location and isolation contract, see
+[User-level memory](#user-level-memory).
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ backpass apply     # review each edit, accept or reject, then write
 ### User-level memory
 
 A run is one scope. The default is the checkout you are in. `backpass --scope user`
-trains the always-loaded user file and user-level skills from every agent session on
-the machine, and writes only those files. A project-scoped run never writes a
-user-level file.
+trains the always-loaded user file and user-level skills from Claude Code and Codex
+sessions across projects, and writes only those files. A project-scoped run never
+writes a user-level file.
 
 Canonical user memory is the first of these that exists: `~/.agents/AGENTS.md`,
 then `~/.claude/CLAUDE.md` (a pointer to AGENTS.md is valid), then `~/.codex/AGENTS.md`.
@@ -87,8 +87,8 @@ User-level skill extractions follow the project layout: `.agents/skills`, with a
 warning if `~/.claude/skills` is a real directory rather than the usual symlink.
 
 State lives in `~/.config/backpass/user/` (mode 0700; honours `XDG_CONFIG_HOME`),
-isolated from every project's `.backpass/`. Evidence quotes from every project on
-the machine land in that one directory.
+isolated from every project's `.backpass/`. User-scope evidence, ledgers, proposals,
+and apply surfaces stay in that one directory.
 
 Harness load paths, verified for v1:
 
@@ -484,7 +484,7 @@ pointer-aware:
 | `backpass propose` | aggregate gradients + gradient descent: the tier-2 pass from cached evidence             |
 | `backpass apply`   | review and write the accepted edits                                                      |
 | `backpass status`  | cache state, failed transcripts, budget bars, and cross-surface overlaps                 |
-| `backpass init`    | write `.backpassrc.json`, exclude `.backpass/` locally                                   |
+| `backpass init`    | initialize the selected scope's config and state                                         |
 
 Run `backpass --help` for the full flag list.
 
@@ -588,6 +588,29 @@ CLI flags on top:
   "jobs": 4
 }
 ```
+
+That example is the project scope. User scope ignores `.backpassrc.json` and instead
+layers the `"user"` block in `~/.config/backpass/config.json` over its defaults. Its
+scope-specific settings are `memoryFiles`, `skillsDir`, `skillsDirs`,
+`minGapProjects` (default `1`), and these discovery controls:
+
+```json
+{
+  "user": {
+    "discovery": {
+      "harnesses": ["claude", "codex"],
+      "includeProjects": [],
+      "excludeProjects": [],
+      "maxTranscriptsPerProject": null
+    }
+  }
+}
+```
+
+`includeProjects` and `excludeProjects` are globs matched against each project key and
+session cwd. `--project <glob>` adds command-line include globs. A non-null
+`maxTranscriptsPerProject` applies a sticky, recency-weighted per-project cap before
+`maxTranscripts` applies to the whole run.
 
 ### State
 

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -70,11 +70,14 @@ export class AcpxError extends Error {
  * candidate would fail on the very same argument.
  *
  * @param {string[]} args
- * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv }} [options]
+ * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv, readOnlyRoots?: string[] }} [options]
  */
 async function run(args, options = {}) {
   const result = await runCapture(ACPX_BIN, args, options);
   const spawnError = result.spawnError;
+  if (spawnError?.code === "ERR_READ_ONLY_ROOTS_UNAVAILABLE") {
+    throw new UserError(spawnError.message, "run synthesis on macOS or Linux with bubblewrap installed");
+  }
   if (spawnError?.code === "ERR_WINDOWS_SHIM_UNSAFE_ARG") {
     const value = spawnError.value === undefined ? "" : JSON.stringify(String(spawnError.value));
     throw new UserError(
@@ -364,11 +367,19 @@ export async function execOneShot({
  *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
  *   close: () => Promise<void> }>}
  */
-export async function openSession({ agent, model = null, effort = null, sessionName, cwd, writeAccess = false }) {
+export async function openSession({
+  agent,
+  model = null,
+  effort = null,
+  sessionName,
+  cwd,
+  writeAccess = false,
+  readOnlyRoots = [],
+}) {
   const invocation = prepareHarnessInvocation({ agent, model, effort, writeAccess });
   const notes = [...invocation.notes];
   const acpxAgentArgs = invocationAgentArgs(invocation, agent);
-  const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
+  const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env, readOnlyRoots };
   /** @type {Awaited<ReturnType<typeof run>>} */
   let created;
   try {
@@ -419,6 +430,7 @@ export async function openSession({ agent, model = null, effort = null, sessionN
         timeoutMs: 30_000,
         cwd,
         env: invocation.env,
+        readOnlyRoots,
       });
       if (result.code !== 0) warn(`could not close acpx session ${sessionName}`);
     } finally {
@@ -476,7 +488,12 @@ export async function openSession({ agent, model = null, effort = null, sessionN
       "--file",
       promptFile,
     ];
-    const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
+    const result = await run(args, {
+      timeoutMs: (timeoutSeconds + 30) * 1000,
+      cwd,
+      env: invocation.env,
+      readOnlyRoots,
+    });
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
     if (result.code !== 0) throw new AcpxError(`acpx ${agent} session prompt failed (exit ${result.code})`, result);
 

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { UserError, warn } from "./logger.js";
 import { runCapture } from "./subprocess.js";
@@ -367,6 +369,25 @@ export async function execOneShot({
  *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
  *   close: () => Promise<void> }>}
  */
+function harnessWritableRoots(agent) {
+  const home = os.homedir();
+  const roots = [os.tmpdir()];
+  if (agent === "claude") {
+    roots.push(path.join(process.env.CLAUDE_CONFIG_DIR || path.join(home, ".claude"), "projects"));
+  } else if (agent === "codex") {
+    roots.push(path.join(process.env.CODEX_HOME || path.join(home, ".codex"), "sessions"));
+  } else if (agent === "pi") {
+    roots.push(path.join(process.env.PI_CODING_AGENT_DIR || path.join(home, ".pi", "agent"), "sessions"));
+  } else if (agent === "opencode") {
+    roots.push(path.join(process.env.XDG_DATA_HOME || path.join(home, ".local", "share"), "opencode"));
+    roots.push(path.join(process.env.XDG_STATE_HOME || path.join(home, ".local", "state"), "opencode"));
+    roots.push(path.join(process.env.XDG_CACHE_HOME || path.join(home, ".cache"), "opencode"));
+  } else if (agent === "grok") {
+    roots.push(path.join(home, ".grok"));
+  }
+  return roots.filter((root) => fs.existsSync(root));
+}
+
 export async function openSession({
   agent,
   model = null,
@@ -377,9 +398,10 @@ export async function openSession({
   readOnlyRoots = [],
 }) {
   const invocation = prepareHarnessInvocation({ agent, model, effort, writeAccess });
+  const writableRoots = readOnlyRoots.length ? [cwd, ...harnessWritableRoots(agent)] : [];
   const notes = [...invocation.notes];
   const acpxAgentArgs = invocationAgentArgs(invocation, agent);
-  const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env, readOnlyRoots };
+  const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env, readOnlyRoots, writableRoots };
   /** @type {Awaited<ReturnType<typeof run>>} */
   let created;
   try {
@@ -431,6 +453,7 @@ export async function openSession({
         cwd,
         env: invocation.env,
         readOnlyRoots,
+        writableRoots,
       });
       if (result.code !== 0) warn(`could not close acpx session ${sessionName}`);
     } finally {
@@ -493,6 +516,7 @@ export async function openSession({
       cwd,
       env: invocation.env,
       readOnlyRoots,
+      writableRoots,
     });
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
     if (result.code !== 0) throw new AcpxError(`acpx ${agent} session prompt failed (exit ${result.code})`, result);

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -371,7 +371,7 @@ export async function execOneShot({
  */
 function harnessWritableRoots(agent) {
   const home = os.homedir();
-  const roots = [os.tmpdir()];
+  const roots = [];
   if (agent === "claude") {
     roots.push(path.join(process.env.CLAUDE_CONFIG_DIR || path.join(home, ".claude"), "projects"));
   } else if (agent === "codex") {

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -72,7 +72,8 @@ export class AcpxError extends Error {
  * candidate would fail on the very same argument.
  *
  * @param {string[]} args
- * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv, readOnlyRoots?: string[] }} [options]
+ * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv,
+ *   readOnlyRoots?: string[], writableRoots?: string[] }} [options]
  */
 async function run(args, options = {}) {
   const result = await runCapture(ACPX_BIN, args, options);
@@ -363,11 +364,6 @@ export async function execOneShot({
  * Resolves to the handle, or throws an `AcpxError` (`unsupported: true` when the adapter
  * has no session support; `sessionPrompt` only falls back when it can preserve the requested overlays).
  *
- * @returns {Promise<{ notes: string[],
- *   prompt: (options: { promptFile: string, timeoutSeconds?: number, promptRetries?: number,
- *     approveReads?: boolean, approveAll?: boolean, suppressReads?: boolean }) =>
- *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
- *   close: () => Promise<void> }>}
  */
 function harnessWritableRoots(agent) {
   const home = os.homedir();
@@ -388,6 +384,13 @@ function harnessWritableRoots(agent) {
   return roots.filter((root) => fs.existsSync(root));
 }
 
+/**
+ * @returns {Promise<{ notes: string[],
+ *   prompt: (options: { promptFile: string, timeoutSeconds?: number, promptRetries?: number,
+ *     approveReads?: boolean, approveAll?: boolean, suppressReads?: boolean }) =>
+ *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
+ *   close: () => Promise<void> }>}
+ */
 export async function openSession({
   agent,
   model = null,

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -1,6 +1,4 @@
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 
 import { UserError, warn } from "./logger.js";
 import { runCapture } from "./subprocess.js";
@@ -72,15 +70,11 @@ export class AcpxError extends Error {
  * candidate would fail on the very same argument.
  *
  * @param {string[]} args
- * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv,
- *   readOnlyRoots?: string[], writableRoots?: string[] }} [options]
+ * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv }} [options]
  */
 async function run(args, options = {}) {
   const result = await runCapture(ACPX_BIN, args, options);
   const spawnError = result.spawnError;
-  if (spawnError?.code === "ERR_READ_ONLY_ROOTS_UNAVAILABLE") {
-    throw new UserError(spawnError.message, "run synthesis on macOS or Linux with bubblewrap installed");
-  }
   if (spawnError?.code === "ERR_WINDOWS_SHIM_UNSAFE_ARG") {
     const value = spawnError.value === undefined ? "" : JSON.stringify(String(spawnError.value));
     throw new UserError(
@@ -364,47 +358,17 @@ export async function execOneShot({
  * Resolves to the handle, or throws an `AcpxError` (`unsupported: true` when the adapter
  * has no session support; `sessionPrompt` only falls back when it can preserve the requested overlays).
  *
- */
-function harnessWritableRoots(agent) {
-  const home = os.homedir();
-  const roots = [];
-  if (agent === "claude") {
-    roots.push(path.join(process.env.CLAUDE_CONFIG_DIR || path.join(home, ".claude"), "projects"));
-  } else if (agent === "codex") {
-    roots.push(path.join(process.env.CODEX_HOME || path.join(home, ".codex"), "sessions"));
-  } else if (agent === "pi") {
-    roots.push(path.join(process.env.PI_CODING_AGENT_DIR || path.join(home, ".pi", "agent"), "sessions"));
-  } else if (agent === "opencode") {
-    roots.push(path.join(process.env.XDG_DATA_HOME || path.join(home, ".local", "share"), "opencode"));
-    roots.push(path.join(process.env.XDG_STATE_HOME || path.join(home, ".local", "state"), "opencode"));
-    roots.push(path.join(process.env.XDG_CACHE_HOME || path.join(home, ".cache"), "opencode"));
-  } else if (agent === "grok") {
-    roots.push(path.join(home, ".grok"));
-  }
-  return roots.filter((root) => fs.existsSync(root));
-}
-
-/**
  * @returns {Promise<{ notes: string[],
  *   prompt: (options: { promptFile: string, timeoutSeconds?: number, promptRetries?: number,
  *     approveReads?: boolean, approveAll?: boolean, suppressReads?: boolean }) =>
  *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
  *   close: () => Promise<void> }>}
  */
-export async function openSession({
-  agent,
-  model = null,
-  effort = null,
-  sessionName,
-  cwd,
-  writeAccess = false,
-  readOnlyRoots = [],
-}) {
+export async function openSession({ agent, model = null, effort = null, sessionName, cwd, writeAccess = false }) {
   const invocation = prepareHarnessInvocation({ agent, model, effort, writeAccess });
-  const writableRoots = readOnlyRoots.length ? [cwd, ...harnessWritableRoots(agent)] : [];
   const notes = [...invocation.notes];
   const acpxAgentArgs = invocationAgentArgs(invocation, agent);
-  const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env, readOnlyRoots, writableRoots };
+  const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
   /** @type {Awaited<ReturnType<typeof run>>} */
   let created;
   try {
@@ -455,8 +419,6 @@ export async function openSession({
         timeoutMs: 30_000,
         cwd,
         env: invocation.env,
-        readOnlyRoots,
-        writableRoots,
       });
       if (result.code !== 0) warn(`could not close acpx session ${sessionName}`);
     } finally {
@@ -514,13 +476,7 @@ export async function openSession({
       "--file",
       promptFile,
     ];
-    const result = await run(args, {
-      timeoutMs: (timeoutSeconds + 30) * 1000,
-      cwd,
-      env: invocation.env,
-      readOnlyRoots,
-      writableRoots,
-    });
+    const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
     if (result.code !== 0) throw new AcpxError(`acpx ${agent} session prompt failed (exit ${result.code})`, result);
 

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -116,6 +116,7 @@ async function analyzeOne({
   memoryFile,
   config,
   repo,
+  modelCwd = null,
   slot = 0,
   openGapIndex = "(none yet)",
   skillIndex = "(this repo has no skills)",
@@ -171,7 +172,7 @@ async function analyzeOne({
       agent: pick.agent,
       model: pick.model,
       promptFile,
-      cwd: repo.root,
+      cwd: modelCwd || repo.root,
       timeoutSeconds: config.timeoutSeconds,
       promptRetries: config.promptRetries,
     };
@@ -226,6 +227,7 @@ export async function analyzeTranscripts({
   skills = [],
   config,
   repo,
+  modelCwd = null,
   memoryHash,
   force = false,
 }) {
@@ -315,6 +317,9 @@ export async function analyzeTranscripts({
         startedAt: transcript.startedAt,
         association: transcript.association,
         interaction: classifyInteraction(transcript),
+        cwd: transcript.cwd || null,
+        project: transcript.project || null,
+        projectRoot: transcript.projectRoot || null,
       },
       memoryHash,
       memoryPath: memoryFile.path,
@@ -331,7 +336,16 @@ export async function analyzeTranscripts({
     });
 
     try {
-      const result = await analyzeOne({ transcript, memoryFile, config, repo, slot, openGapIndex, skillIndex });
+      const result = await analyzeOne({
+        transcript,
+        memoryFile,
+        config,
+        repo,
+        modelCwd,
+        slot,
+        openGapIndex,
+        skillIndex,
+      });
       if (result.status === "skipped") {
         summary.skipped += 1;
         state.writeEvidence(transcript, { ...base, status: "skipped", reason: result.reason });

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -243,16 +243,27 @@ export async function analyzeTranscripts({
     staleMemoryHash: 0,
   };
   const priorHashes = new Set();
+  const transcriptMetadata = (transcript) => ({
+    harness: transcript.harness,
+    id: transcript.id,
+    identity: transcriptIdentity(transcript),
+    path: transcript.path,
+    mtimeMs: transcript.mtimeMs,
+    bytes: transcript.bytes,
+    startedAt: transcript.startedAt,
+    association: transcript.association,
+    interaction: classifyInteraction(transcript),
+    cwd: transcript.cwd || null,
+    project: transcript.project || null,
+    projectRoot: transcript.projectRoot || null,
+  });
 
   for (const transcript of transcripts) {
     const existing = state.readEvidence(transcript);
     if (!force && isEvidenceFresh(existing, transcript, memoryHash)) {
-      const interaction = classifyInteraction(transcript);
-      if (existing.transcript?.interaction !== interaction) {
-        state.writeEvidence(transcript, {
-          ...existing,
-          transcript: { ...existing.transcript, interaction },
-        });
+      const updatedTranscript = { ...existing.transcript, ...transcriptMetadata(transcript) };
+      if (JSON.stringify(existing.transcript) !== JSON.stringify(updatedTranscript)) {
+        state.writeEvidence(transcript, { ...existing, transcript: updatedTranscript });
       }
       summary.cached += 1;
       continue;
@@ -314,20 +325,7 @@ export async function analyzeTranscripts({
   const evidenceTotals = { positive: 0, negative: 0, gaps: 0 };
   await pool(pending, config.jobs, async (transcript, _index, slot) => {
     const base = {
-      transcript: {
-        harness: transcript.harness,
-        id: transcript.id,
-        identity: transcriptIdentity(transcript),
-        path: transcript.path,
-        mtimeMs: transcript.mtimeMs,
-        bytes: transcript.bytes,
-        startedAt: transcript.startedAt,
-        association: transcript.association,
-        interaction: classifyInteraction(transcript),
-        cwd: transcript.cwd || null,
-        project: transcript.project || null,
-        projectRoot: transcript.projectRoot || null,
-      },
+      transcript: transcriptMetadata(transcript),
       memoryHash,
       memoryPath: memoryFile.path,
       key: evidenceKey(transcript, memoryHash),

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -301,7 +301,14 @@ export async function analyzeTranscripts({
   // the skill index, so a mistake an existing skill's content covers is reported as a
   // failed trigger (`coveredBySkill`) instead of a brand-new gap.
   const openGapIndex = renderOpenGapIndex(state.readGapLedger(), memoryFile.path);
-  const skillIndex = renderSkillIndexForAnalysis(skills);
+  const skillIndex = renderSkillIndexForAnalysis(
+    modelCwd && path.resolve(modelCwd) !== path.resolve(repo.root)
+      ? skills.map((skill) => ({
+          ...skill,
+          path: path.isAbsolute(skill.path) ? skill.path : path.join(repo.root, skill.path),
+        }))
+      : skills,
+  );
 
   let done = 0;
   const evidenceTotals = { positive: 0, negative: 0, gaps: 0 };

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -24,6 +24,38 @@ import {
  * are part of the count, the bare file when there are none - a number shown to a person
  * must describe the thing it measures.
  */
+function resolveTarget(root, relative) {
+  if (!relative) return relative;
+  return path.isAbsolute(relative) ? relative : path.join(root, relative);
+}
+
+/** Named refusal when a user-level target is a symlink into a read-only store. */
+export function readOnlySymlinkMessage(absolute, realPath) {
+  return `${absolute} is a symlink to ${realPath}, which is not writable; edit the source that generates it`;
+}
+
+function refuseReadOnlySymlink(absolute) {
+  let lstat;
+  try {
+    lstat = fs.lstatSync(absolute);
+  } catch {
+    return null;
+  }
+  if (!lstat.isSymbolicLink()) return null;
+  let real;
+  try {
+    real = fs.realpathSync(absolute);
+  } catch {
+    return null;
+  }
+  try {
+    fs.accessSync(real, fs.constants.W_OK);
+    return null;
+  } catch {
+    return readOnlySymlinkMessage(absolute, real);
+  }
+}
+
 function surfaceLabel(memoryPath, descriptionTokens) {
   return descriptionTokens ? `the always-loaded surface (${memoryPath} + skill descriptions)` : memoryPath;
 }
@@ -86,7 +118,11 @@ function memoryFileSnapshot(proposal, repo) {
   const relative = proposal.memoryFile?.path;
   if (!relative) return { text: null };
 
-  const absolute = path.join(repo.root, relative);
+  const absolute = resolveTarget(repo.root, relative);
+  const blocked = refuseReadOnlySymlink(absolute);
+  if (blocked) {
+    return { text: null, failure: { file: relative, error: blocked } };
+  }
   if (!fs.existsSync(absolute)) {
     if (!expected) return { text: null };
     return {
@@ -232,7 +268,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     repo.root,
     proposal.config?.skillsDir || config.skillsDir || CANONICAL_SKILLS_DIR,
   ).dir;
-  const skillsNow = loadProjectSkills(repo.root, skillsDir);
+  const skillsNow = loadProjectSkills(repo.root, skillsDir, config.skillsDirs || proposal.config?.skillDirs || []);
   const descriptionTokensNow = skillDescriptionTokens(skillsNow);
 
   // Freshness for every non-memory file a decision targets, the same contract the
@@ -247,7 +283,12 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
       checkedTargets.add(relative);
       const expected = expectedTargetHashes.get(relative);
       if (!expected) continue;
-      const absolute = path.join(repo.root, relative);
+      const absolute = resolveTarget(repo.root, relative);
+      const blocked = refuseReadOnlySymlink(absolute);
+      if (blocked) {
+        results.failed.push({ file: relative, error: blocked });
+        continue;
+      }
       if (!fs.existsSync(absolute)) {
         results.failed.push({ file: relative, error: "file does not exist" });
         continue;
@@ -281,9 +322,14 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   const landed = new Set();
 
   for (const [relative, edits] of byFile) {
-    const absolute = path.join(repo.root, relative);
+    const absolute = resolveTarget(repo.root, relative);
     if (!fs.existsSync(absolute)) {
       results.failed.push({ file: relative, error: "file does not exist" });
+      continue;
+    }
+    const blocked = refuseReadOnlySymlink(absolute);
+    if (blocked) {
+      results.failed.push({ file: relative, error: blocked });
       continue;
     }
 
@@ -351,7 +397,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   for (const edit of accepted) {
     if (edit.kind !== "extract" || !landed.has(edit.id)) continue;
     for (const skill of editSkills(edit)) {
-      const absolute = path.join(repo.root, skill.path);
+      const absolute = resolveTarget(repo.root, skill.path);
       if (skillPaths.has(skill.path) || fs.existsSync(absolute)) {
         results.failed.push({
           file: skill.path,
@@ -395,8 +441,8 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     ({ skill }) => skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`),
   );
   const createdDirectoryCandidates = absentParentDirectories(repo.root, [
-    ...plannedSkills.map(({ skill }) => path.join(repo.root, skill.path)),
-    ...(canonical ? [path.join(repo.root, CLAUDE_SKILLS_LINK)] : []),
+    ...plannedSkills.map(({ skill }) => resolveTarget(repo.root, skill.path)),
+    ...(canonical ? [resolveTarget(repo.root, CLAUDE_SKILLS_LINK)] : []),
   ]);
   const skillFailures = [];
   const ownedSkillPaths = [];
@@ -487,9 +533,10 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     try {
       if (!dryRun) commit = atomicReplace(resolved, text);
     } catch (err) {
+      const blocked = refuseReadOnlySymlink(item.absolute);
       results.failed.push({
         file: relative,
-        error: `${relative} could not be written: ${err.message}`,
+        error: blocked || `${relative} could not be written: ${err.message}`,
       });
       rollbackCommitted();
       rollbackSkills();

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -206,7 +206,11 @@ function commitStillCurrent(commit) {
 function absentParentDirectories(root, files) {
   const directories = new Set();
   for (const file of files) {
-    for (let current = path.dirname(file); current !== root; current = path.dirname(current)) {
+    for (
+      let current = path.dirname(file);
+      current !== root && path.dirname(current) !== current;
+      current = path.dirname(current)
+    ) {
       if (!fs.existsSync(current)) directories.add(current);
     }
   }

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 
 import { applyEdit, filesOfEdit, sliceEditForFile } from "../proposal.js";
 import { memoryTextHash, resolveMemoryPath } from "../memory.js";
+import { userClaudeSkillsDir } from "../config.js";
 import { budgetGateKind, budgetStatus, estimateTokens, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
 import {
@@ -282,15 +283,16 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
   // The always-loaded skill layer as it exists on disk right now - the budget below
   // covers the whole surface, not the memory file alone.
+  const userScope = proposal.scope === "user";
+  const claudeSkillsLink = userScope ? userClaudeSkillsDir() : CLAUDE_SKILLS_LINK;
   const skillsDir = resolveOverflowTarget(
     repo.root,
     proposal.config?.skillsDir || config.skillsDir || CANONICAL_SKILLS_DIR,
+    { claudeSkillsDir: claudeSkillsLink },
   ).dir;
   const configuredSkillDirs =
     proposal.config?.skillsDirs || proposal.config?.skillDirs || config.skillsDirs || [];
-  const claudeSkillsLink =
-    proposal.scope === "user" ? configuredSkillDirs[1] || CLAUDE_SKILLS_LINK : CLAUDE_SKILLS_LINK;
-  const skillsNow = loadProjectSkills(repo.root, skillsDir, configuredSkillDirs);
+  const skillsNow = loadProjectSkills(repo.root, skillsDir, configuredSkillDirs, { exact: userScope });
   const descriptionTokensNow = skillDescriptionTokens(skillsNow);
 
   // Freshness for every non-memory file a decision targets, the same contract the

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 
 import { applyEdit, filesOfEdit, sliceEditForFile } from "../proposal.js";
-import { memoryTextHash } from "../memory.js";
+import { memoryTextHash, resolveMemoryPath } from "../memory.js";
 import { budgetGateKind, budgetStatus, estimateTokens, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
 import {
@@ -251,6 +251,20 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     rejected: rejected.length,
     rejectionsRecorded: false,
   };
+
+  if ((proposal.scope || "project") === "project") {
+    const targets = new Set([
+      proposal.memoryFile?.path,
+      ...[...accepted, ...rejected].flatMap((edit) => filesOfEdit(edit)),
+      ...accepted.flatMap((edit) => editSkills(edit).map((skill) => skill.path)),
+    ]);
+    try {
+      for (const target of targets) if (target) resolveMemoryPath(repo.root, target);
+    } catch (err) {
+      results.failed.push({ error: err.message });
+      return results;
+    }
+  }
 
   let memoryText = null;
   if (accepted.length || rejected.length) {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -291,8 +291,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     proposal.config?.skillsDir || config.skillsDir || CANONICAL_SKILLS_DIR,
     { claudeSkillsDir: claudeSkillsLink },
   ).dir;
-  const configuredSkillDirs =
-    proposal.config?.skillsDirs || proposal.config?.skillDirs || config.skillsDirs || [];
+  const configuredSkillDirs = proposal.config?.skillsDirs || proposal.config?.skillDirs || config.skillsDirs || [];
   const skillsNow = loadProjectSkills(repo.root, skillsDir, configuredSkillDirs, { exact: userScope });
   const descriptionTokensNow = skillDescriptionTokens(skillsNow);
 

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -51,6 +51,7 @@ function refuseReadOnlySymlink(absolute) {
   }
   try {
     fs.accessSync(real, fs.constants.W_OK);
+    fs.accessSync(path.dirname(real), fs.constants.W_OK | fs.constants.X_OK);
     return null;
   } catch {
     return readOnlySymlinkMessage(absolute, real);

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -286,7 +286,11 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
     repo.root,
     proposal.config?.skillsDir || config.skillsDir || CANONICAL_SKILLS_DIR,
   ).dir;
-  const skillsNow = loadProjectSkills(repo.root, skillsDir, config.skillsDirs || proposal.config?.skillDirs || []);
+  const configuredSkillDirs =
+    proposal.config?.skillsDirs || proposal.config?.skillDirs || config.skillsDirs || [];
+  const claudeSkillsLink =
+    proposal.scope === "user" ? configuredSkillDirs[1] || CLAUDE_SKILLS_LINK : CLAUDE_SKILLS_LINK;
+  const skillsNow = loadProjectSkills(repo.root, skillsDir, configuredSkillDirs);
   const descriptionTokensNow = skillDescriptionTokens(skillsNow);
 
   // Freshness for every non-memory file a decision targets, the same contract the
@@ -460,7 +464,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   );
   const createdDirectoryCandidates = absentParentDirectories(repo.root, [
     ...plannedSkills.map(({ skill }) => resolveTarget(repo.root, skill.path)),
-    ...(canonical ? [resolveTarget(repo.root, CLAUDE_SKILLS_LINK)] : []),
+    ...(canonical ? [resolveTarget(repo.root, claudeSkillsLink)] : []),
   ]);
   const skillFailures = [];
   const ownedSkillPaths = [];
@@ -578,12 +582,12 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
 
   if (!dryRun && canonical) {
     try {
-      const layout = ensureSkillsLayout(repo.root);
+      const layout = ensureSkillsLayout(repo.root, claudeSkillsLink);
       const result = results.skills.find(({ path: skillPath }) => skillPath === canonical.skill.path);
       result.created = [...new Set([...result.created, ...layout.created])];
       for (const w of layout.warnings) if (!results.warnings.includes(w)) results.warnings.push(w);
     } catch (err) {
-      results.failed.push({ file: CLAUDE_SKILLS_LINK, edit: canonical.edit.id, error: err.message });
+      results.failed.push({ file: claudeSkillsLink, edit: canonical.edit.id, error: err.message });
       rollbackCommitted();
       rollbackSkills();
       return results;

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,8 +4,9 @@ import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 
 import { UserError, fail, setQuiet } from "./logger.js";
-import { loadConfig, parseMaxTranscripts } from "./config.js";
+import { loadConfig, parseMaxTranscripts, parseScopeKind } from "./config.js";
 import { resolveRepo } from "./repo.js";
+import { printScopeNote, resolveScope } from "./scope.js";
 import { State } from "./state.js";
 import { AgentResolver } from "./agents.js";
 
@@ -41,6 +42,9 @@ const OPTIONS = {
   "max-transcripts": { type: "string" },
   seed: { type: "string" },
   "min-gap-evidence": { type: "string" },
+  "min-gap-projects": { type: "string" },
+  scope: { type: "string" },
+  project: { type: "string", multiple: true },
   "memory-file": { type: "string", multiple: true },
   "skills-dir": { type: "string" },
 
@@ -78,7 +82,7 @@ COMMANDS
              turning the aggregated evidence into edits (tier 2)
   apply      review the proposal and write the accepted edits (the only writer)
   status     cache state, evidence counts, and the budget bar
-  init       write .backpassrc.json and exclude .backpass/ via .git/info/exclude
+  init       write .backpassrc.json, or with --scope user the user config block
 
 COLLECT SAMPLES
   --since <dur>            only sessions newer than this (30d, 12h, 2w, all)  [30d]
@@ -110,6 +114,9 @@ BUDGET AND SHAPE
   --budget <tokens>        always-loaded budget per memory file         [5000]
   --max-edits <n>          edits per run - the learning rate            [adaptive]
   --min-gap-evidence <n>   sessions needed to add or remove instruction [2]
+  --min-gap-projects <n>    user-scope: distinct projects needed for a gap [1]
+  --scope <project|user>   which surface a run reads and writes          [project]
+  --project <glob>         user-scope: only sessions whose project/cwd matches (repeatable)
   --memory-file <path>     memory file to optimize (repeatable)
   --skills-dir <path>      where skill extractions are written          [.agents/skills]
 
@@ -134,6 +141,7 @@ or below 60 columns - stdout and --json output are identical either way.
 EXAMPLES
   backpass                                  a full run, ending with a proposal
   backpass scan --since 7d --strict         what would be collected, deterministic only
+  backpass --scope user                     train the user-level memory file and skills
   backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
 `;
@@ -159,6 +167,13 @@ function overridesFrom(values) {
   if (values.seed !== undefined) overrides.seed = toSeed(values.seed);
   if (values["min-gap-evidence"]) {
     overrides.minGapEvidence = toInt(values["min-gap-evidence"], "--min-gap-evidence");
+  }
+  if (values["min-gap-projects"]) {
+    overrides.minGapProjects = toInt(values["min-gap-projects"], "--min-gap-projects");
+  }
+  if (values.project?.length) {
+    overrides.discovery = overrides.discovery || {};
+    overrides.discovery.includeProjects = values.project;
   }
   if (values["memory-file"]?.length) overrides.memoryFiles = values["memory-file"];
   if (values["skills-dir"]) overrides.skillsDir = values["skills-dir"];
@@ -231,17 +246,35 @@ export async function main(argv) {
   }
 
   try {
-    const repo = resolveRepo(process.cwd());
-    const config = loadConfig(repo.root, overridesFrom(values));
-    config.state = new State(repo.root).ensure();
+    const kind = parseScopeKind(values.scope);
+    const overrides = overridesFrom(values);
+    let repo = null;
+    let config;
+    if (kind === "user") {
+      config = loadConfig(null, overrides, { kind: "user" });
+    } else {
+      repo = resolveRepo(process.cwd());
+      config = loadConfig(repo.root, overrides);
+    }
+    const scope = resolveScope(process.cwd(), { ...values, scope: kind, strict: Boolean(values.strict) }, config, repo);
+    printScopeNote(scope);
+    config.memoryFiles = scope.memoryFiles;
+    config.skillsDir = scope.overflowDir;
+    if (scope.skillDirs.length) config.skillsDirs = scope.skillDirs;
+    config.state = new State(scope.root, {
+      stateDir: scope.stateDir,
+      mode: kind === "user" ? 0o700 : undefined,
+      exclude: kind === "user" ? false : undefined,
+    }).ensure();
     config.agents = new AgentResolver(config, {
       state: config.state,
-      cwd: repo.root,
+      cwd: scope.modelCwd,
       bypassCache: Boolean(values.force),
     });
 
     const ctx = {
-      repo,
+      repo: scope.repo,
+      scope,
       config,
       flags: values,
       positionals: positionals.slice(1),

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import { analyzeTranscripts } from "../analyze.js";
+import { userClaudeSkillsDir } from "../config.js";
 import { UserError, color, info, json, out, warn } from "../logger.js";
 import { memorySurfaceHash, resolveMemoryFiles } from "../memory.js";
 import { loadProjectSkills, resolveOverflowTarget, skillDescriptionTokens } from "../skills.js";
@@ -52,8 +53,11 @@ export function primaryMemoryFile(repo, config, scope = null) {
     );
   }
   // Overflow-layout warnings are the synthesis stage's to print; this resolution is read-only.
-  const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
-  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || []);
+  const userScope = scope?.kind === "user";
+  const overflow = resolveOverflowTarget(repo.root, config.skillsDir, {
+    claudeSkillsDir: userScope ? userClaudeSkillsDir() : undefined,
+  });
+  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
   return {
     file: resolved.primary,
     all: resolved.all,

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -23,9 +23,15 @@ import { capTranscripts } from "../sample.js";
  * When no configured file exists, `backpass` (the default run) bootstraps one; every
  * other command fails with a pointer to that.
  */
-export function primaryMemoryFile(repo, config) {
+export function primaryMemoryFile(repo, config, scope = null) {
   const resolved = resolveMemoryFiles(repo.root, config.memoryFiles);
   if (!resolved.primary) {
+    if (scope?.kind === "user") {
+      throw new UserError(
+        `no user memory file found (looked for ${config.memoryFiles.join(", ")})`,
+        "set user.memoryFiles in ~/.config/backpass/config.json",
+      );
+    }
     throw new UserError(
       `no memory file found (looked for ${config.memoryFiles.join(", ")})`,
       "run `backpass` to bootstrap an AGENTS.md, or set memoryFiles in .backpassrc.json",
@@ -40,7 +46,7 @@ export function primaryMemoryFile(repo, config) {
   }
   // Overflow-layout warnings are the synthesis stage's to print; this resolution is read-only.
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
-  const skills = loadProjectSkills(repo.root, overflow.dir);
+  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || []);
   return {
     file: resolved.primary,
     all: resolved.all,
@@ -51,8 +57,8 @@ export function primaryMemoryFile(repo, config) {
 }
 
 export async function runAnalysis(ctx) {
-  const { repo, config } = ctx;
-  const { file, hash, skills } = primaryMemoryFile(repo, config);
+  const { repo, scope, config } = ctx;
+  const { file, hash, skills } = primaryMemoryFile(repo, config, scope);
   // Deterministic by design: tokens and units come from parsing the file, no model.
   const descriptionTokens = skillDescriptionTokens(skills);
   emitProgress("memory", {
@@ -66,7 +72,7 @@ export async function runAnalysis(ctx) {
   const { transcripts, perHarness } = capTranscripts(await discoverForRun(ctx), config);
 
   if (!transcripts.length) {
-    info(`${color.yellow("·")} no transcripts associated with this repo`);
+    info(`${color.yellow("·")} no transcripts associated with this ${scope?.kind === "user" ? "user" : "repo"}`);
     return { file, hash, skills, transcripts, perHarness, summary: null };
   }
 
@@ -76,6 +82,7 @@ export async function runAnalysis(ctx) {
     skills,
     config,
     repo,
+    modelCwd: scope?.modelCwd || repo.root,
     memoryHash: hash,
     force: Boolean(ctx.flags.force),
   });

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { analyzeTranscripts } from "../analyze.js";
 import { UserError, color, info, json, out, warn } from "../logger.js";
 import { memorySurfaceHash, resolveMemoryFiles } from "../memory.js";
@@ -24,7 +26,7 @@ import { capTranscripts } from "../sample.js";
  * other command fails with a pointer to that.
  */
 export function primaryMemoryFile(repo, config, scope = null) {
-  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles);
+  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles, { allowExternal: scope?.kind === "user" });
   if (!resolved.primary) {
     if (scope?.kind === "user") {
       throw new UserError(
@@ -38,10 +40,12 @@ export function primaryMemoryFile(repo, config, scope = null) {
     );
   }
   for (const other of resolved.separate) {
+    const relativeImport = path.relative(path.dirname(other.absolute), resolved.primary.absolute).split(path.sep).join("/");
+    const pointerImport = relativeImport;
     warn(
       `${other.path} is a separate memory file and will NOT be updated - only ${resolved.primary.path} is optimized. ` +
         `To cover both, consolidate: move its content into ${resolved.primary.path} and make ${other.path} a pointer ` +
-        `(a single line: @${resolved.primary.path}).`,
+        `(a single line: @${pointerImport}).`,
     );
   }
   // Overflow-layout warnings are the synthesis stage's to print; this resolution is read-only.

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -40,7 +40,10 @@ export function primaryMemoryFile(repo, config, scope = null) {
     );
   }
   for (const other of resolved.separate) {
-    const relativeImport = path.relative(path.dirname(other.absolute), resolved.primary.absolute).split(path.sep).join("/");
+    const relativeImport = path
+      .relative(path.dirname(other.absolute), resolved.primary.absolute)
+      .split(path.sep)
+      .join("/");
     const pointerImport = relativeImport;
     warn(
       `${other.path} is a separate memory file and will NOT be updated - only ${resolved.primary.path} is optimized. ` +

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -21,6 +21,11 @@ export async function cmdApply(ctx) {
   if (!proposal) {
     throw new UserError("no proposal to apply", "run `backpass` first to produce one");
   }
+  const proposalScope = proposal.scope || "project";
+  const runScope = ctx.scope?.kind || "project";
+  if (proposalScope !== runScope) {
+    throw new UserError(`this proposal is ${proposalScope} scope; run \`backpass apply --scope ${proposalScope}\``);
+  }
   if (proposal.violations?.length) {
     throw new UserError(
       "the saved proposal failed its mechanical gates and was never approved for apply",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -40,7 +40,7 @@ async function initUser(config, flags) {
   try {
     fs.chmodSync(stateDir, 0o700);
   } catch {
-    // mode is best-effort; the directory exists either way
+    // State.ensure already enforced 0700 before this command; this repeat is best-effort.
   }
   info(`${color.green("·")} user state ${stateDir} (0700)`);
   out("");

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,14 +1,54 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { CONFIG_FILENAME, initialConfig, repoConfigPath } from "../config.js";
-import { color, info, out, warn } from "../logger.js";
+import { CONFIG_FILENAME, initialConfig, initialUserConfig, repoConfigPath, userConfigPath } from "../config.js";
+import { UserError, color, info, out, warn } from "../logger.js";
 import { loadMemoryFiles } from "../memory.js";
 import { ensureLocalExclude } from "../repo.js";
 import { STATE_EXCLUDE_LINE as EXCLUDE_LINE } from "../state.js";
 import { budgetBar, budgetStatus, formatTokens } from "../tokens.js";
 
-export async function cmdInit({ repo, config, flags }) {
+export async function cmdInit({ repo, scope = null, config, flags }) {
+  if (scope?.kind === "user") return initUser(config, flags);
+  return initProject(repo, config, flags);
+}
+
+async function initUser(config, flags) {
+  const target = userConfigPath();
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  let existing = {};
+  if (fs.existsSync(target)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(target, "utf8"));
+    } catch (err) {
+      throw new UserError(`${target} is not valid JSON: ${err.message}`);
+    }
+    if (existing === null || typeof existing !== "object" || Array.isArray(existing)) {
+      throw new UserError(`${target} must contain a JSON object`);
+    }
+  }
+  if (existing.user && !flags.force) {
+    info(`${color.yellow("·")} ${target} already has a user block - leaving it alone (use --force to overwrite)`);
+  } else {
+    const next = { ...existing, user: initialUserConfig() };
+    fs.writeFileSync(target, `${JSON.stringify(next, null, 2)}\n`);
+    info(`${color.green("·")} wrote user block in ${target}`);
+  }
+
+  const stateDir = config.state.root;
+  fs.mkdirSync(stateDir, { recursive: true });
+  try {
+    fs.chmodSync(stateDir, 0o700);
+  } catch {
+    // mode is best-effort; the directory exists either way
+  }
+  info(`${color.green("·")} user state ${stateDir} (0700)`);
+  out("");
+  out("Next: `backpass --scope user` to run a backward pass on the user-level memory file and skills.");
+  return 0;
+}
+
+async function initProject(repo, config, flags) {
   const target = repoConfigPath(repo.root);
   const existing = fs.existsSync(target);
 

--- a/src/commands/propose.js
+++ b/src/commands/propose.js
@@ -71,6 +71,7 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], trans
     memoryPath: memoryFile.path,
     config: ctx.config,
     repo: ctx.repo,
+    modelCwd: ctx.scope?.modelCwd || ctx.repo?.root,
   });
   pruneGapLedger(ledger, { memoryFile, memoryPath: memoryFile.path, skills, maxAge: gapLedgerMaxAge });
   state.writeGapLedger(ledger);
@@ -80,6 +81,8 @@ export async function foldForRun(ctx, memoryFile, memoryHash, skills = [], trans
   );
   const summary = foldEvidence(relevant, {
     minGapEvidence,
+    minGapProjects: ctx.scope?.kind === "user" ? ctx.config.minGapProjects || 1 : 0,
+    checkProjectCoverage: ctx.scope?.kind === "user",
     memoryFile,
     gapObservations,
     skills,
@@ -100,7 +103,7 @@ export async function runProposal(ctx, precomputed = null) {
   // folding, and agent resolution can all fail before synthesis starts; none of those
   // failures may leave an older proposal available to apply as if it came from this run.
   config.state.clearProposal();
-  const { file, hash, skills } = precomputed || primaryMemoryFile(repo, config);
+  const { file, hash, skills } = precomputed || primaryMemoryFile(repo, config, ctx.scope);
   const transcripts = precomputed?.transcripts || capTranscripts(await discoverForRun(ctx), config).transcripts;
 
   const foldStarted = Date.now();
@@ -128,6 +131,7 @@ export async function runProposal(ctx, precomputed = null) {
     config,
     repo,
     transcripts,
+    scope: ctx.scope,
   });
 
   accountForConsolidationUsage(proposal, summary);
@@ -169,7 +173,11 @@ export function printProposal(proposal, { applied = false, analysisUsage = [] } 
     const delta = edit.deltaTokens || 0;
     out(
       `  ${color.cyan(edit.id)} ${kind.padEnd(8)} ${edit.title} ` +
-        color.dim(`(${delta > 0 ? "+" : ""}${delta} tok, ${edit.transcripts} transcript(s))`),
+        color.dim(
+          `(${delta > 0 ? "+" : ""}${delta} tok, ${edit.transcripts} transcript(s)` +
+            (edit.projects != null ? `, projects=${edit.projects}` : "") +
+            `)`,
+        ),
     );
   }
 

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -22,19 +22,25 @@ import { resolveMemoryFiles } from "../memory.js";
  * stdout, so piped and logged output is unchanged.
  */
 export async function cmdRun(ctx) {
-  const { repo, config } = ctx;
+  const { repo, scope, config } = ctx;
   const tui = await startTui(ctx);
 
   try {
     info(
       `${color.bold("backpass")} ${color.dim(
-        `v${ctx.version} · ${repo.name} · budget ${formatTokens(config.budgetTokens)} tok · since ${config.discovery.since}`,
+        `v${ctx.version} · ${scope?.kind === "user" ? "user scope" : repo.name} · budget ${formatTokens(config.budgetTokens)} tok · since ${config.discovery.since}`,
       )}`,
     );
 
     config.state.clearProposal();
 
     if (!resolveMemoryFiles(repo.root, config.memoryFiles).primary) {
+      if (scope?.kind === "user") {
+        throw new UserError(
+          `no user memory file found (looked for ${config.memoryFiles.join(", ")})`,
+          "set user.memoryFiles in ~/.config/backpass/config.json",
+        );
+      }
       const result = await bootstrapRun(ctx);
       tui?.stop();
       if (ctx.flags.json) bootstrapJson(result);
@@ -47,12 +53,17 @@ export async function cmdRun(ctx) {
     if (!analysis.transcripts.length) {
       tui?.stop();
       out("");
-      out("No agent transcripts are associated with this repo yet.");
-      out(
-        color.dim(
-          "  `backpass scan --since all` widens the time window; --include-cursor-ide adds the Cursor IDE store.",
-        ),
-      );
+      if (scope?.kind === "user") {
+        out("No agent transcripts found for user scope yet.");
+        out(color.dim("  `backpass scan --scope user --since all` widens the time window."));
+      } else {
+        out("No agent transcripts are associated with this repo yet.");
+        out(
+          color.dim(
+            "  `backpass scan --since all` widens the time window; --include-cursor-ide adds the Cursor IDE store.",
+          ),
+        );
+      }
       return 0;
     }
 

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -34,7 +34,7 @@ export async function cmdRun(ctx) {
 
     config.state.clearProposal();
 
-    if (!resolveMemoryFiles(repo.root, config.memoryFiles).primary) {
+    if (!resolveMemoryFiles(repo.root, config.memoryFiles, { allowExternal: scope?.kind === "user" }).primary) {
       if (scope?.kind === "user") {
         throw new UserError(
           `no user memory file found (looked for ${config.memoryFiles.join(", ")})`,

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -5,9 +5,9 @@ import { attachSiblingClones } from "../repo.js";
 
 /** Shared by every command that needs the transcript set. */
 export async function discoverForRun(ctx) {
-  const { repo, config, strict } = ctx;
-  attachSiblingClones(repo, config.discovery.cloneRoots);
-  const result = await discoverTranscripts({ repo, config, strict });
+  const { repo, scope, config, strict } = ctx;
+  if (scope?.kind !== "user") attachSiblingClones(repo, config.discovery.cloneRoots);
+  const result = await discoverTranscripts({ repo, scope, config, strict });
   if (ctx.limit && result.transcripts.length > ctx.limit) {
     result.truncated = result.transcripts.length - ctx.limit;
     result.transcripts = result.transcripts.slice(0, ctx.limit);
@@ -28,11 +28,21 @@ export async function cmdScan(ctx) {
   const mix = corpusMix(transcripts);
 
   if (ctx.flags.json) {
-    json({ repo: ctx.repo.name, perHarness, mix, transcripts });
+    json({
+      repo: ctx.repo.name,
+      ...(ctx.scope ? { scope: ctx.scope.kind } : {}),
+      perHarness,
+      mix,
+      transcripts,
+    });
     return 0;
   }
 
-  out(`${ctx.repo.name} · ${ctx.repo.worktrees.length} worktree(s) · since ${ctx.config.discovery.since}`);
+  if (ctx.scope?.kind === "user") {
+    out(`user scope · since ${ctx.config.discovery.since}`);
+  } else {
+    out(`${ctx.repo.name} · ${ctx.repo.worktrees.length} worktree(s) · since ${ctx.config.discovery.since}`);
+  }
   out("");
 
   const rows = [["HARNESS", "SCANNED", "MATCHED", "SELF", "CACHED", "NOTE"]];
@@ -53,28 +63,56 @@ export async function cmdScan(ctx) {
 
   const byTier = { 1: 0, 1.5: 0, 2: 0, 3: 0 };
   for (const t of transcripts) byTier[t.association.tier] += 1;
-  out(
-    `${transcripts.length} transcript(s) associated with this repo · ` +
-      `tier1 ${byTier[1]} (exact) · tier1.5 ${byTier[1.5]} (sibling clone) · ` +
-      `tier2 ${byTier[2]} (remote) · tier3 ${byTier[3]} (best-effort) · ` +
-      formatCorpusMix(mix),
-  );
+  if (ctx.scope?.kind === "user") {
+    const byProject = new Map();
+    for (const t of transcripts) {
+      const key = t.project || t.cwd || "(unknown)";
+      byProject.set(key, (byProject.get(key) || 0) + 1);
+    }
+    out(
+      `${transcripts.length} transcript(s) across ${byProject.size} project(s) · ` +
+        `tier1 ${byTier[1]} (git) · tier2 ${byTier[2]} (remote) · tier3 ${byTier[3]} (cwd) · ` +
+        formatCorpusMix(mix),
+    );
+  } else {
+    out(
+      `${transcripts.length} transcript(s) associated with this repo · ` +
+        `tier1 ${byTier[1]} (exact) · tier1.5 ${byTier[1.5]} (sibling clone) · ` +
+        `tier2 ${byTier[2]} (remote) · tier3 ${byTier[3]} (best-effort) · ` +
+        formatCorpusMix(mix),
+    );
+  }
   if (byTier[3] && !ctx.strict) out(color.dim("  re-run with --strict to exclude the best-effort tier"));
   if (truncated) out(color.dim(`  --limit ${ctx.limit} is hiding ${truncated} more transcript(s)`));
   out("");
 
   const preview = transcripts.slice(0, 25);
-  const detail = [["HARNESS", "SESSION", "KIND", "WHEN", "SIZE", "TIER", "HOW"]];
+  const detail =
+    ctx.scope?.kind === "user"
+      ? [["HARNESS", "SESSION", "KIND", "WHEN", "SIZE", "TIER", "PROJECT"]]
+      : [["HARNESS", "SESSION", "KIND", "WHEN", "SIZE", "TIER", "HOW"]];
   for (const t of preview) {
-    detail.push([
-      t.harness,
-      t.nativeId.slice(0, 12),
-      t.interaction,
-      ago(t.mtimeMs),
-      t.bytes ? `${Math.round(t.bytes / 1024)}KB` : "-",
-      `t${t.association.tier}`,
-      t.association.reason,
-    ]);
+    detail.push(
+      ctx.scope?.kind === "user"
+        ? [
+            t.harness,
+            t.nativeId.slice(0, 12),
+            t.interaction,
+            ago(t.mtimeMs),
+            t.bytes ? `${Math.round(t.bytes / 1024)}KB` : "-",
+            `t${t.association.tier}`,
+            String(t.project || t.cwd || "-").slice(0, 48),
+          ]
+        : [
+            t.harness,
+            t.nativeId.slice(0, 12),
+            t.interaction,
+            ago(t.mtimeMs),
+            t.bytes ? `${Math.round(t.bytes / 1024)}KB` : "-",
+            `t${t.association.tier}`,
+            t.association.reason,
+          ],
+    );
   }
   out(table(detail));
   if (transcripts.length > preview.length) {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -29,8 +29,8 @@ export async function cmdStatus(ctx) {
   const proposal = state.readProposal();
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
-  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir);
-  const skills = loadProjectSkills(repo.root, overflow.dir);
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || []);
+  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || []);
   const descriptionTokens = skillDescriptionTokens(skills);
 
   const duplicates = files
@@ -66,7 +66,7 @@ export async function cmdStatus(ctx) {
     return 0;
   }
 
-  out(`${color.bold(repo.name)} ${color.dim(repo.root)}`);
+  out(`${color.bold(ctx.scope?.kind === "user" ? "user scope" : repo.name)} ${color.dim(repo.root)}`);
   out("");
 
   out(color.dim("BUDGET (always-loaded)"));

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { userClaudeSkillsDir } from "../config.js";
 import { color, json, out } from "../logger.js";
 import { resolveMemoryFiles } from "../memory.js";
 import {
@@ -28,9 +29,12 @@ export async function cmdStatus(ctx) {
   const summary = state.readSummary();
   const proposal = state.readProposal();
   const rejections = state.readRejections();
-  const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
-  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || []);
-  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || []);
+  const userScope = scope?.kind === "user";
+  const overflow = resolveOverflowTarget(repo.root, config.skillsDir, {
+    claudeSkillsDir: userScope ? userClaudeSkillsDir() : undefined,
+  });
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
+  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
   const descriptionTokens = skillDescriptionTokens(skills);
 
   const duplicates = files

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -15,10 +15,10 @@ import { table } from "./scan.js";
 import { candidateKey, isProbeEntryFresh, resolvedEffort } from "../agents.js";
 
 export async function cmdStatus(ctx) {
-  const { repo, config } = ctx;
+  const { repo, config, scope } = ctx;
   const state = config.state;
 
-  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles);
+  const resolved = resolveMemoryFiles(repo.root, config.memoryFiles, { allowExternal: scope?.kind === "user" });
   const files = resolved.all;
   const evidence = state.listEvidence();
   const counts = { ok: 0, failed: 0, skipped: 0 };

--- a/src/config.js
+++ b/src/config.js
@@ -111,7 +111,7 @@ function userHarnessPaths() {
   const codexRoot = process.env.CODEX_HOME || ".codex";
   return {
     memoryFiles: [".agents/AGENTS.md", path.join(claudeRoot, "CLAUDE.md"), path.join(codexRoot, "AGENTS.md")],
-    skillDirs: [".agents/skills", path.join(claudeRoot, "skills"), path.join(codexRoot, "skills")],
+    skillsDirs: [".agents/skills", path.join(claudeRoot, "skills"), path.join(codexRoot, "skills")],
   };
 }
 
@@ -362,11 +362,11 @@ export function initialConfig() {
 
 /** The `user` block written by `backpass init --scope user`. */
 export function initialUserConfig() {
-  const { memoryFiles, skillDirs } = userHarnessPaths();
+  const { memoryFiles, skillsDirs } = userHarnessPaths();
   return {
     memoryFiles,
     skillsDir: USER_CONFIG_DEFAULTS.skillsDir,
-    skillsDirs: skillDirs,
+    skillsDirs,
     budgetTokens: DEFAULT_CONFIG.budgetTokens,
     minGapEvidence: DEFAULT_CONFIG.minGapEvidence,
     minGapProjects: USER_CONFIG_DEFAULTS.minGapProjects,

--- a/src/config.js
+++ b/src/config.js
@@ -100,11 +100,20 @@ export const DEFAULT_CONFIG = {
  * `~/.agents/AGENTS.md` first (AGENTS.md is the cross-harness file), then Claude Code's
  * `~/.claude/CLAUDE.md` (allowed as a pointer), then Codex `~/.codex/AGENTS.md`.
  * `minGapProjects` defaults to 1: the gate exists and is configurable, but cross-project
- * corroboration is not required. Discovery still enumerates every configured harness;
- * user-level edit targets in v1 are Claude Code and Codex (plus the shared `.agents` layout).
+ * corroboration is not required. Phase 1 discovery and user-level edit targets cover
+ * Claude Code and Codex (plus the shared `.agents` layout).
  */
 export const USER_MEMORY_FILES = [".agents/AGENTS.md", ".claude/CLAUDE.md", ".codex/AGENTS.md"];
 export const USER_SKILLS_DIRS = [".agents/skills", ".claude/skills", ".codex/skills"];
+
+function userHarnessPaths() {
+  const claudeRoot = process.env.CLAUDE_CONFIG_DIR || ".claude";
+  const codexRoot = process.env.CODEX_HOME || ".codex";
+  return {
+    memoryFiles: [".agents/AGENTS.md", path.join(claudeRoot, "CLAUDE.md"), path.join(codexRoot, "AGENTS.md")],
+    skillDirs: [".agents/skills", path.join(claudeRoot, "skills"), path.join(codexRoot, "skills")],
+  };
+}
 
 export const USER_CONFIG_DEFAULTS = {
   memoryFiles: USER_MEMORY_FILES,
@@ -112,6 +121,7 @@ export const USER_CONFIG_DEFAULTS = {
   skillsDirs: USER_SKILLS_DIRS,
   minGapProjects: 1,
   discovery: {
+    harnesses: ["claude", "codex"],
     includeProjects: [],
     excludeProjects: [],
     maxTranscriptsPerProject: null,
@@ -306,7 +316,8 @@ export function loadConfig(repoRoot, overrides = {}, { kind = "project" } = {}) 
   if (scopeKind === "user") {
     const globalFile = readJsonIfPresent(userConfigPath());
     const userBlock = isPlainObject(globalFile?.user) ? globalFile.user : {};
-    merged = [DEFAULT_CONFIG, USER_CONFIG_DEFAULTS, userBlock, overrides].reduce(
+    const harnessPaths = userHarnessPaths();
+    merged = [DEFAULT_CONFIG, { ...USER_CONFIG_DEFAULTS, ...harnessPaths }, userBlock, overrides].reduce(
       (acc, layer) => (layer ? deepMerge(acc, layer) : acc),
       {},
     );
@@ -351,15 +362,16 @@ export function initialConfig() {
 
 /** The `user` block written by `backpass init --scope user`. */
 export function initialUserConfig() {
+  const { memoryFiles, skillDirs } = userHarnessPaths();
   return {
-    memoryFiles: USER_MEMORY_FILES,
+    memoryFiles,
     skillsDir: USER_CONFIG_DEFAULTS.skillsDir,
-    skillsDirs: USER_SKILLS_DIRS,
+    skillsDirs: skillDirs,
     budgetTokens: DEFAULT_CONFIG.budgetTokens,
     minGapEvidence: DEFAULT_CONFIG.minGapEvidence,
     minGapProjects: USER_CONFIG_DEFAULTS.minGapProjects,
     discovery: {
-      harnesses: ALL_HARNESSES,
+      harnesses: USER_CONFIG_DEFAULTS.discovery.harnesses,
       since: "30d",
       includeProjects: [],
       excludeProjects: [],

--- a/src/config.js
+++ b/src/config.js
@@ -93,9 +93,45 @@ export const DEFAULT_CONFIG = {
   theme: "auto",
 };
 
-function userConfigPath() {
+/**
+ * User-scope defaults, layered on `DEFAULT_CONFIG` when `--scope user`.
+ *
+ * Canonical user memory is the first existing file in this list (captain, issue #97):
+ * `~/.agents/AGENTS.md` first (AGENTS.md is the cross-harness file), then Claude Code's
+ * `~/.claude/CLAUDE.md` (allowed as a pointer), then Codex `~/.codex/AGENTS.md`.
+ * `minGapProjects` defaults to 1: the gate exists and is configurable, but cross-project
+ * corroboration is not required. Discovery still enumerates every configured harness;
+ * user-level edit targets in v1 are Claude Code and Codex (plus the shared `.agents` layout).
+ */
+export const USER_MEMORY_FILES = [".agents/AGENTS.md", ".claude/CLAUDE.md", ".codex/AGENTS.md"];
+export const USER_SKILLS_DIRS = [".agents/skills", ".claude/skills", ".codex/skills"];
+
+export const USER_CONFIG_DEFAULTS = {
+  memoryFiles: USER_MEMORY_FILES,
+  skillsDir: ".agents/skills",
+  skillsDirs: USER_SKILLS_DIRS,
+  minGapProjects: 1,
+  discovery: {
+    includeProjects: [],
+    excludeProjects: [],
+    maxTranscriptsPerProject: null,
+  },
+};
+
+export function parseScopeKind(value) {
+  if (value === undefined || value === null || value === "") return "project";
+  if (value === "project" || value === "user") return value;
+  throw new UserError(`--scope must be "project" or "user" (got "${value}")`);
+}
+
+export function userConfigPath() {
   const base = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
   return path.join(base, "backpass", "config.json");
+}
+
+/** Isolated user-scope state: `~/.config/backpass/user/` (honours `XDG_CONFIG_HOME`). */
+export function userStateDir() {
+  return path.join(path.dirname(userConfigPath()), "user");
 }
 
 function readJsonIfPresent(file) {
@@ -162,7 +198,7 @@ export function sinceCutoff(since, now = Date.now()) {
   return window === null ? null : now - window;
 }
 
-function validate(config) {
+function validate(config, { kind = "project" } = {}) {
   if (!Array.isArray(config.memoryFiles) || config.memoryFiles.length === 0) {
     throw new UserError("config.memoryFiles must be a non-empty array");
   }
@@ -174,6 +210,38 @@ function validate(config) {
   }
   if (!Number.isInteger(config.minGapEvidence) || config.minGapEvidence < 1) {
     throw new UserError("config.minGapEvidence must be an integer >= 1");
+  }
+  if (kind === "user" || config.minGapProjects !== undefined) {
+    const minGapProjects = config.minGapProjects ?? 1;
+    if (!Number.isInteger(minGapProjects) || minGapProjects < 1) {
+      throw new UserError("config.minGapProjects must be an integer >= 1");
+    }
+    config.minGapProjects = minGapProjects;
+  }
+  if (config.skillsDirs !== undefined) {
+    if (!Array.isArray(config.skillsDirs) || config.skillsDirs.some((d) => typeof d !== "string")) {
+      throw new UserError("config.skillsDirs must be an array of paths");
+    }
+  }
+  const includeProjects = config.discovery.includeProjects;
+  const excludeProjects = config.discovery.excludeProjects;
+  if (
+    includeProjects !== undefined &&
+    (!Array.isArray(includeProjects) || includeProjects.some((g) => typeof g !== "string"))
+  ) {
+    throw new UserError("config.discovery.includeProjects must be an array of globs");
+  }
+  if (
+    excludeProjects !== undefined &&
+    (!Array.isArray(excludeProjects) || excludeProjects.some((g) => typeof g !== "string"))
+  ) {
+    throw new UserError("config.discovery.excludeProjects must be an array of globs");
+  }
+  const maxPerProject = config.discovery.maxTranscriptsPerProject;
+  if (maxPerProject != null) {
+    if (!Number.isInteger(maxPerProject) || maxPerProject < 1) {
+      throw new UserError("config.discovery.maxTranscriptsPerProject must be a positive integer or null");
+    }
   }
   config.maxTranscripts = parseMaxTranscripts(config.maxTranscripts, "config.maxTranscripts");
   try {
@@ -225,20 +293,39 @@ function validate(config) {
 }
 
 /**
- * Layered config: defaults < ~/.config/backpass/config.json < <repo>/.backpassrc.json < CLI flags.
+ * Layered config.
+ *
+ * Project: defaults < ~/.config/backpass/config.json (minus its `user` block) <
+ *   <repo>/.backpassrc.json < CLI flags.
+ * User: defaults < user-scope defaults < ~/.config/backpass/config.json `user` block <
+ *   CLI flags. `.backpassrc.json` is never read.
  */
-export function loadConfig(repoRoot, overrides = {}) {
-  const merged = [
-    readJsonIfPresent(userConfigPath()),
-    readJsonIfPresent(path.join(repoRoot, CONFIG_FILENAME)),
-    overrides,
-  ].reduce((acc, layer) => (layer ? deepMerge(acc, layer) : acc), DEFAULT_CONFIG);
+export function loadConfig(repoRoot, overrides = {}, { kind = "project" } = {}) {
+  const scopeKind = parseScopeKind(kind);
+  let merged;
+  if (scopeKind === "user") {
+    const globalFile = readJsonIfPresent(userConfigPath());
+    const userBlock = isPlainObject(globalFile?.user) ? globalFile.user : {};
+    merged = [DEFAULT_CONFIG, USER_CONFIG_DEFAULTS, userBlock, overrides].reduce(
+      (acc, layer) => (layer ? deepMerge(acc, layer) : acc),
+      {},
+    );
+  } else {
+    const globalFile = readJsonIfPresent(userConfigPath());
+    const projectGlobal = globalFile ? { ...globalFile } : null;
+    if (projectGlobal) delete projectGlobal.user;
+    merged = [
+      projectGlobal,
+      repoRoot ? readJsonIfPresent(path.join(repoRoot, CONFIG_FILENAME)) : null,
+      overrides,
+    ].reduce((acc, layer) => (layer ? deepMerge(acc, layer) : acc), DEFAULT_CONFIG);
+  }
 
   const config = structuredClone(merged);
   if (config.discovery.includeCursorIde && !config.discovery.harnesses.includes("cursor-ide")) {
     config.discovery.harnesses = [...config.discovery.harnesses, "cursor-ide"];
   }
-  return validate(config);
+  return validate(config, { kind: scopeKind });
 }
 
 export function repoConfigPath(repoRoot) {
@@ -259,5 +346,24 @@ export function initialConfig() {
     synthesis: { agent: null, model: null, effort: null },
     discovery: { harnesses: ALL_HARNESSES, since: "30d", worktreeGlobs: [], minUserTurns: 2 },
     jobs: DEFAULT_CONFIG.jobs,
+  };
+}
+
+/** The `user` block written by `backpass init --scope user`. */
+export function initialUserConfig() {
+  return {
+    memoryFiles: USER_MEMORY_FILES,
+    skillsDir: USER_CONFIG_DEFAULTS.skillsDir,
+    skillsDirs: USER_SKILLS_DIRS,
+    budgetTokens: DEFAULT_CONFIG.budgetTokens,
+    minGapEvidence: DEFAULT_CONFIG.minGapEvidence,
+    minGapProjects: USER_CONFIG_DEFAULTS.minGapProjects,
+    discovery: {
+      harnesses: ALL_HARNESSES,
+      since: "30d",
+      includeProjects: [],
+      excludeProjects: [],
+      maxTranscriptsPerProject: null,
+    },
   };
 }

--- a/src/config.js
+++ b/src/config.js
@@ -366,11 +366,8 @@ export function initialConfig() {
 
 /** The `user` block written by `backpass init --scope user`. */
 export function initialUserConfig() {
-  const { memoryFiles, skillsDirs } = userHarnessPaths();
   return {
-    memoryFiles,
     skillsDir: USER_CONFIG_DEFAULTS.skillsDir,
-    skillsDirs,
     budgetTokens: DEFAULT_CONFIG.budgetTokens,
     minGapEvidence: DEFAULT_CONFIG.minGapEvidence,
     minGapProjects: USER_CONFIG_DEFAULTS.minGapProjects,

--- a/src/config.js
+++ b/src/config.js
@@ -106,12 +106,16 @@ export const DEFAULT_CONFIG = {
 export const USER_MEMORY_FILES = [".agents/AGENTS.md", ".claude/CLAUDE.md", ".codex/AGENTS.md"];
 export const USER_SKILLS_DIRS = [".agents/skills", ".claude/skills", ".codex/skills"];
 
+export function userClaudeSkillsDir() {
+  return path.join(process.env.CLAUDE_CONFIG_DIR || ".claude", "skills");
+}
+
 function userHarnessPaths() {
   const claudeRoot = process.env.CLAUDE_CONFIG_DIR || ".claude";
   const codexRoot = process.env.CODEX_HOME || ".codex";
   return {
     memoryFiles: [".agents/AGENTS.md", path.join(claudeRoot, "CLAUDE.md"), path.join(codexRoot, "AGENTS.md")],
-    skillsDirs: [".agents/skills", path.join(claudeRoot, "skills"), path.join(codexRoot, "skills")],
+    skillsDirs: [".agents/skills", userClaudeSkillsDir(), path.join(codexRoot, "skills")],
   };
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -98,7 +98,8 @@ export const DEFAULT_CONFIG = {
  *
  * Canonical user memory is the first existing file in this list (captain, issue #97):
  * `~/.agents/AGENTS.md` first (AGENTS.md is the cross-harness file), then Claude Code's
- * `~/.claude/CLAUDE.md` (allowed as a pointer), then Codex `~/.codex/AGENTS.md`.
+ * configured `CLAUDE.md` (allowed as a pointer), then Codex's configured `AGENTS.md`.
+ * `CLAUDE_CONFIG_DIR` and `CODEX_HOME` relocate the latter two defaults.
  * `minGapProjects` defaults to 1: the gate exists and is configurable, but cross-project
  * corroboration is not required. Phase 1 discovery and user-level edit targets cover
  * Claude Code and Codex (plus the shared `.agents` layout).

--- a/src/consolidate.js
+++ b/src/consolidate.js
@@ -63,7 +63,7 @@ function firstMistake(entry) {
  * Returns `{ merged, usage }`, `{ skipped }`, or `{ failed }` - never throws for a
  * model-side failure, because a run without consolidation is still a valid run.
  */
-export async function consolidateGapLedger({ ledger, memoryPath, config, repo }) {
+export async function consolidateGapLedger({ ledger, memoryPath, config, repo, modelCwd = null }) {
   const entries = Object.values(ledger.entries).filter((e) => e.memoryPath === memoryPath);
   if (entries.length < MIN_ENTRIES) return { skipped: "fewer than two open gaps" };
   if (!config.agents) return { skipped: "no agent resolver" };
@@ -82,7 +82,7 @@ export async function consolidateGapLedger({ ledger, memoryPath, config, repo })
         agent: pick.agent,
         model: pick.model,
         promptFile,
-        cwd: repo.root,
+        cwd: modelCwd || repo.root,
         timeoutSeconds: config.timeoutSeconds,
         promptRetries: config.promptRetries,
       };

--- a/src/discovery/adapters/codex.js
+++ b/src/discovery/adapters/codex.js
@@ -24,7 +24,7 @@ import {
 export const name = "codex";
 
 export function storeRoot() {
-  return home(".codex", "sessions");
+  return process.env.CODEX_HOME ? path.join(process.env.CODEX_HOME, "sessions") : home(".codex", "sessions");
 }
 
 /**

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -134,6 +134,7 @@ export async function discoverTranscripts({
 
   if (cacheDirty) config.state.writeScanCache(cache);
 
+  scope?.normalizeProjects?.(transcripts);
   transcripts.sort((a, b) => (b.mtimeMs || 0) - (a.mtimeMs || 0));
   emitProgress("discover:done", { total: transcripts.length });
   return { transcripts, perHarness, cutoffMs };

--- a/src/discovery/index.js
+++ b/src/discovery/index.js
@@ -14,6 +14,7 @@ import { sinceCutoff } from "../config.js";
 import { emitProgress } from "../progress.js";
 import { warn } from "../logger.js";
 import { transcriptIdentity } from "../transcript.js";
+import { passesProjectFilter } from "../scope.js";
 
 export const ADAPTERS = {
   claude,
@@ -48,10 +49,22 @@ export function getAdapter(harness) {
  * files under this repo's cwd) are excluded after association and counted in
  * `perHarness[h].self` - see `./self.js`.
  */
-export async function discoverTranscripts({ repo, config, strict = false, harnesses = null, now = Date.now() }) {
+export async function discoverTranscripts({
+  repo,
+  scope = null,
+  config,
+  strict = false,
+  harnesses = null,
+  now = Date.now(),
+}) {
   const cutoffMs = sinceCutoff(config.discovery.since, now);
   const selected = harnesses || config.discovery.harnesses;
   const cache = config.state.readScanCache();
+  const associateFn =
+    scope?.associate ||
+    ((descriptor) => associate(descriptor, repo, { worktreeGlobs: config.discovery.worktreeGlobs }));
+  const stateDir = config.state?.root;
+  const userFilter = scope?.kind === "user";
 
   const transcripts = [];
   const identities = new Set();
@@ -73,7 +86,16 @@ export async function discoverTranscripts({ repo, config, strict = false, harnes
 
     try {
       const found = adapter.discover
-        ? await discoverDirect(adapter, { repo, config, cutoffMs, strict, stats })
+        ? await discoverDirect(adapter, {
+            repo,
+            config,
+            cutoffMs,
+            strict,
+            stats,
+            associateFn,
+            stateDir,
+            userFilter,
+          })
         : discoverFiles(adapter, {
             repo,
             config,
@@ -81,6 +103,9 @@ export async function discoverTranscripts({ repo, config, strict = false, harnes
             strict,
             stats,
             cache,
+            associateFn,
+            stateDir,
+            userFilter,
             markDirty: () => {
               cacheDirty = true;
             },
@@ -123,20 +148,22 @@ function tierCounts(found) {
   return tiers;
 }
 
-async function discoverDirect(adapter, { repo, config, cutoffMs, strict, stats }) {
+async function discoverDirect(adapter, { repo, config, cutoffMs, strict, stats, associateFn, stateDir, userFilter }) {
   const rows = await adapter.discover({ cutoffMs, repo, config });
   const out = [];
   for (const row of rows) {
     stats.scanned += 1;
-    const association = associate({ cwd: row.cwd, remotes: row.remotes || [], gitRoot: row.gitRoot }, repo, {
-      worktreeGlobs: config.discovery.worktreeGlobs,
-    });
+    const association = associateFn({ cwd: row.cwd, remotes: row.remotes || [], gitRoot: row.gitRoot });
     if (!passesStrict(association, strict)) {
       stats.skipped += 1;
       continue;
     }
     const transcript = toTranscript(adapter, row, association, row.id);
-    if (isSelfSession(transcript)) {
+    if (userFilter && !passesProjectFilter(transcript, config)) {
+      stats.skipped += 1;
+      continue;
+    }
+    if (isSelfSession(transcript, { stateDir })) {
       stats.self += 1;
       continue;
     }
@@ -145,7 +172,10 @@ async function discoverDirect(adapter, { repo, config, cutoffMs, strict, stats }
   return out;
 }
 
-function discoverFiles(adapter, { repo, config, cutoffMs, strict, stats, cache, markDirty }) {
+function discoverFiles(
+  adapter,
+  { repo, config, cutoffMs, strict, stats, cache, markDirty, associateFn, stateDir, userFilter },
+) {
   const candidates = adapter.enumerate({ cutoffMs, repo, config });
   const out = [];
 
@@ -186,20 +216,24 @@ function discoverFiles(adapter, { repo, config, cutoffMs, strict, stats, cache, 
       continue;
     }
 
-    const association = associate(
-      { cwd: descriptor.cwd, remotes: descriptor.remotes || [], gitRoot: descriptor.gitRoot },
-      repo,
-      { worktreeGlobs: config.discovery.worktreeGlobs },
-    );
+    const association = associateFn({
+      cwd: descriptor.cwd,
+      remotes: descriptor.remotes || [],
+      gitRoot: descriptor.gitRoot,
+    });
     if (!passesStrict(association, strict)) {
       stats.skipped += 1;
       continue;
     }
 
     const transcript = toTranscript(adapter, { ...candidate, ...descriptor }, association, descriptor.id);
+    if (userFilter && !passesProjectFilter(transcript, config)) {
+      stats.skipped += 1;
+      continue;
+    }
     // backpass's own acpx runs land in this store under this cwd; drop them here so
     // they never reach sampling or analysis (see ./self.js).
-    if (isSelfSession(transcript)) {
+    if (isSelfSession(transcript, { stateDir })) {
       stats.self += 1;
       continue;
     }
@@ -226,6 +260,8 @@ function toTranscript(adapter, row, association, id) {
     association,
     extra: row.extra || {},
     interactionSignals: row.interactionSignals ?? row.extra?.interactionSignals ?? emptyInteractionSignals(),
+    project: association?.project || null,
+    projectRoot: association?.projectRoot || null,
   };
   transcript.identity = transcriptIdentity(transcript);
   transcript.interaction = classifyInteraction(transcript);

--- a/src/discovery/self.js
+++ b/src/discovery/self.js
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 
 import { SELF_SESSION_SENTINEL } from "../prompts.js";
 
@@ -37,11 +38,29 @@ export function headHasSelfSentinel(text) {
   return SENTINEL_PATTERN.test(text || "");
 }
 
+function realpathOrResolve(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+function isUnder(child, parent) {
+  if (!child || !parent) return false;
+  const a = realpathOrResolve(child);
+  const b = realpathOrResolve(parent);
+  if (a === b) return true;
+  return a.startsWith(b.endsWith(path.sep) ? b : b + path.sep);
+}
+
 /**
- * @param {{ path?: string | null }} transcript
+ * @param {{ path?: string | null, cwd?: string | null }} transcript
+ * @param {{ stateDir?: string | null }} [options]
  * @returns {boolean}
  */
-export function isSelfSession(transcript) {
+export function isSelfSession(transcript, { stateDir } = {}) {
+  if (stateDir && isUnder(transcript?.cwd, stateDir)) return true;
   const file = transcript?.path;
   if (!file) return false;
   let fd;

--- a/src/fold.js
+++ b/src/fold.js
@@ -195,18 +195,19 @@ export function foldEvidence(
     .sort((a, b) => b.negative - a.negative || b.sessions - a.sessions || a.instruction.localeCompare(b.instruction));
 
   const decided = gapClusters.map((cluster) => {
-    const vote = clusterDomainVote(cluster.items);
+    const eligibleItems = cluster.items.filter((item) => !item.projectCovered);
+    const vote = clusterDomainVote(eligibleItems);
     return {
       proposedInstruction: cluster.proposedInstruction,
       sessions: cluster.sessions.size,
       projects: cluster.projects.size,
       projectCoveredSessions: cluster.projectCoveredSessions.size,
-      recurrenceRisk: highestRisk(cluster.items),
-      quotes: cluster.items.slice(0, 6).map((i) => ({ text: i.quote, effect: i.mistake, source: i.source })),
+      recurrenceRisk: highestRisk(eligibleItems),
+      quotes: eligibleItems.slice(0, 6).map((i) => ({ text: i.quote, effect: i.mistake, source: i.source })),
       orchestrationSightings: vote.orchestrationSightings,
       mixed: vote.mixed,
       majorityOrchestration: vote.majorityOrchestration,
-      ...failedTriggerOf(cluster.items, minGapEvidence),
+      ...failedTriggerOf(eligibleItems, minGapEvidence),
       ...projectSpecificNote(cluster, minGapProjects),
     };
   });
@@ -357,9 +358,13 @@ function isProjectCoveredSighting(obs) {
     if (!fs.existsSync(root)) return false;
     const resolved = resolveMemoryFiles(root, loadConfig(root).memoryFiles);
     if (!resolved.primary) return false;
-    return instructionUnits(resolved.primary).some((unit) =>
-      phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD),
-    );
+    return resolved.all
+      .filter((file) => !resolved.pointers.includes(file))
+      .some((file) =>
+        instructionUnits(file).some((unit) =>
+          phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD),
+        ),
+      );
   } catch {
     return false;
   }

--- a/src/fold.js
+++ b/src/fold.js
@@ -372,10 +372,15 @@ function isProjectCoveredSighting(obs) {
 
 function projectSpecificNote(cluster, minGapProjects) {
   if (minGapProjects < 2 || cluster.projects.size >= minGapProjects || cluster.sessions.size < 1) return {};
-  const only = [...cluster.projects][0];
+  const projects = [...cluster.projects];
+  if (projects.length === 1) {
+    return {
+      reportOnlyReason: `project-specific: seen in ${projects[0]} only; run \`backpass\` there`,
+    };
+  }
   return {
-    reportOnlyReason: only
-      ? `project-specific: seen in ${only} only; run \`backpass\` there`
+    reportOnlyReason: projects.length
+      ? `project-specific: seen in ${projects.length} projects; minGapProjects is ${minGapProjects}`
       : "project-specific: below minGapProjects",
   };
 }

--- a/src/fold.js
+++ b/src/fold.js
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 
+import { loadConfig } from "./config.js";
 import { classifyInteraction, INTERACTIVE, NON_INTERACTIVE } from "./interaction.js";
 import { findInstructionUnit, instructionUnits, resolveMemoryFiles, similarity } from "./memory.js";
 import { GAP_COVERED_THRESHOLD, GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
@@ -354,7 +355,7 @@ function isProjectCoveredSighting(obs) {
   if (!root || !phrasings.some(Boolean)) return false;
   try {
     if (!fs.existsSync(root)) return false;
-    const resolved = resolveMemoryFiles(root, ["AGENTS.md", "CLAUDE.md"]);
+    const resolved = resolveMemoryFiles(root, loadConfig(root).memoryFiles);
     if (!resolved.primary) return false;
     return instructionUnits(resolved.primary).some((unit) =>
       phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD),

--- a/src/fold.js
+++ b/src/fold.js
@@ -1,6 +1,8 @@
+import fs from "node:fs";
+
 import { classifyInteraction, INTERACTIVE, NON_INTERACTIVE } from "./interaction.js";
-import { findInstructionUnit, instructionUnits, similarity } from "./memory.js";
-import { GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
+import { findInstructionUnit, instructionUnits, resolveMemoryFiles, similarity } from "./memory.js";
+import { GAP_COVERED_THRESHOLD, GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
 import { crossSurfaceDuplicates } from "./overlap.js";
 
 /**
@@ -36,16 +38,28 @@ import { crossSurfaceDuplicates } from "./overlap.js";
 
 /**
  * @param {object[]} evidenceRecords
- * @param {{ minGapEvidence?: number, memoryFile?: object|null, gapObservations?: object[]|null, skills?: object[] }} [options]
+ * @param {{ minGapEvidence?: number, minGapProjects?: number, checkProjectCoverage?: boolean, memoryFile?: object|null, gapObservations?: object[]|null, skills?: object[] }} [options]
  */
 export function foldEvidence(
   evidenceRecords,
-  { minGapEvidence = 2, memoryFile = null, gapObservations = null, skills = [] } = {},
+  {
+    minGapEvidence = 2,
+    minGapProjects = 0,
+    checkProjectCoverage = false,
+    memoryFile = null,
+    gapObservations = null,
+    skills = [],
+  } = {},
 ) {
   const usable = evidenceRecords.filter((e) => e && e.status === "ok");
   const analyzedSessions = usable.length;
   const analyzedByInteraction = { [INTERACTIVE]: 0, [NON_INTERACTIVE]: 0 };
-  for (const record of usable) analyzedByInteraction[classifyInteraction(record.transcript)] += 1;
+  const analyzedByProject = new Map();
+  for (const record of usable) {
+    analyzedByInteraction[classifyInteraction(record.transcript)] += 1;
+    const projectKey = record.transcript?.project;
+    if (projectKey) analyzedByProject.set(projectKey, (analyzedByProject.get(projectKey) || 0) + 1);
+  }
 
   const instructions = new Map();
   let positiveCount = 0;
@@ -60,6 +74,7 @@ export function foldEvidence(
         negative: 0,
         sessions: new Set(),
         sessionsByInteraction: { [INTERACTIVE]: new Set(), [NON_INTERACTIVE]: new Set() },
+        sessionsByProject: new Map(),
         harmSessions: new Set(),
         nonComplianceSessions: new Set(),
         quotes: [],
@@ -81,6 +96,11 @@ export function foldEvidence(
         const category = classifyInteraction(record.transcript);
         entry.sessions.add(sessionIdentity);
         entry.sessionsByInteraction[category].add(sessionIdentity);
+        const projectKey = record.transcript.project;
+        if (projectKey) {
+          if (!entry.sessionsByProject.has(projectKey)) entry.sessionsByProject.set(projectKey, new Set());
+          entry.sessionsByProject.get(projectKey).add(sessionIdentity);
+        }
         // `class` is what a negative means (harm vs non-compliance vs irrelevant);
         // `harmSessions` is what the removal-evidence floor counts. A record from
         // before the class existed carries none and never counts as harm.
@@ -110,6 +130,8 @@ export function foldEvidence(
         source,
         sessionId: record.transcript.identity || record.transcript.id,
         domain: gap.domain === "orchestration" ? "orchestration" : "project",
+        project: record.transcript.project || null,
+        projectRoot: record.transcript.projectRoot || null,
         ...(gap.coveredBySkill ? { coveredBySkill: gap.coveredBySkill } : {}),
       });
     }
@@ -123,7 +145,7 @@ export function foldEvidence(
   const allObservations = gapObservations ?? recordObservations;
   const orchestrationGapSightings = allObservations.filter((obs) => obs?.domain === "orchestration").length;
 
-  const gapClusters = clusterGapObservations(allObservations);
+  const gapClusters = clusterGapObservations(allObservations, { checkProjectCoverage });
 
   // Instructions that exist in the file but drew no evidence at all are the strongest
   // removal / extraction candidates, so they must appear in the summary too.
@@ -156,6 +178,9 @@ export function foldEvidence(
             ? entry.sessionsByInteraction[NON_INTERACTIVE].size / analyzedByInteraction[NON_INTERACTIVE]
             : 0,
         },
+        ...(analyzedByProject.size
+          ? { relevanceByProject: relevanceByProject(entry.sessionsByProject, analyzedByProject) }
+          : {}),
         tokens: unit?.tokens ?? null,
         section: unit?.section ?? null,
         known: Boolean(unit),
@@ -173,24 +198,30 @@ export function foldEvidence(
     return {
       proposedInstruction: cluster.proposedInstruction,
       sessions: cluster.sessions.size,
+      projects: cluster.projects.size,
+      projectCoveredSessions: cluster.projectCoveredSessions.size,
       recurrenceRisk: highestRisk(cluster.items),
       quotes: cluster.items.slice(0, 6).map((i) => ({ text: i.quote, effect: i.mistake, source: i.source })),
       orchestrationSightings: vote.orchestrationSightings,
       mixed: vote.mixed,
       majorityOrchestration: vote.majorityOrchestration,
       ...failedTriggerOf(cluster.items, minGapEvidence),
+      ...projectSpecificNote(cluster, minGapProjects),
     };
   });
 
   const proposalClusters = decided.filter((cluster) => !cluster.majorityOrchestration);
+  // Default 1 means the gate exists but does not require a second project.
+  const clearsProjectGate = (cluster) => minGapProjects < 2 || cluster.projects >= minGapProjects;
   const gaps = proposalClusters
-    .filter((cluster) => cluster.sessions >= minGapEvidence)
+    .filter((cluster) => cluster.sessions >= minGapEvidence && clearsProjectGate(cluster))
     .sort((a, b) => b.sessions - a.sessions);
   const reportOnlyGaps = decided
     .filter((cluster) =>
       cluster.mixed
-        ? cluster.majorityOrchestration || cluster.sessions < minGapEvidence
-        : cluster.majorityOrchestration && cluster.sessions >= minGapEvidence,
+        ? cluster.majorityOrchestration || cluster.sessions < minGapEvidence || !clearsProjectGate(cluster)
+        : (cluster.majorityOrchestration && cluster.sessions >= minGapEvidence) ||
+          (cluster.sessions >= minGapEvidence && !clearsProjectGate(cluster) && !cluster.majorityOrchestration),
     )
     .sort((a, b) => b.sessions - a.sessions);
 
@@ -261,11 +292,14 @@ function oversizedRestructureTargets(memoryFile, nonComplianceSessions, minGapEv
 /**
  * Greedy similarity clustering over gap observations. A cluster counts each session once
  * no matter how many observations it contributed (re-analysis, duplicate reports).
+ * A user-scope sighting the session's own project memory already covers is recorded but
+ * does not count toward `sessions` or `projects`.
  */
-export function clusterGapObservations(observations) {
+export function clusterGapObservations(observations, { checkProjectCoverage = false } = {}) {
   const clusters = [];
   for (const obs of observations) {
     if (!obs || !obs.proposedInstruction) continue;
+    const projectCovered = Boolean(checkProjectCoverage && isProjectCoveredSighting(obs));
     const cluster = clusters.find(
       (c) => similarity(c.proposedInstruction, obs.proposedInstruction) >= GAP_SIMILARITY_THRESHOLD,
     );
@@ -276,33 +310,82 @@ export function clusterGapObservations(observations) {
       source: obs.source,
       sessionId: obs.sessionId,
       domain: observationDomain(obs),
+      project: obs.project || null,
+      projectCovered,
       coveredBySkills: new Set(obs.coveredBySkill ? [obs.coveredBySkill] : []),
     };
     if (cluster) {
       const sessionItem = cluster.items.find((candidate) => candidate.sessionId === obs.sessionId);
       if (sessionItem) {
         if (obs.coveredBySkill) sessionItem.coveredBySkills.add(obs.coveredBySkill);
-        // One session, one vote: a project classification from the same session
-        // keeps the cluster eligible rather than letting a later orchestration
-        // label silently win.
         if (observationDomain(obs) !== "orchestration") sessionItem.domain = "project";
+        if (projectCovered) sessionItem.projectCovered = true;
       } else {
         cluster.items.push(item);
       }
-      cluster.sessions.add(obs.sessionId);
-      // Keep the shortest phrasing: it generalizes best.
+      if (projectCovered) cluster.projectCoveredSessions.add(obs.sessionId);
+      else {
+        cluster.sessions.add(obs.sessionId);
+        if (obs.project) cluster.projects.add(obs.project);
+      }
       if (obs.proposedInstruction.length < cluster.proposedInstruction.length) {
         cluster.proposedInstruction = obs.proposedInstruction;
       }
     } else {
       clusters.push({
         proposedInstruction: obs.proposedInstruction,
-        sessions: new Set([obs.sessionId]),
+        sessions: projectCovered ? new Set() : new Set([obs.sessionId]),
+        projects: projectCovered || !obs.project ? new Set() : new Set([obs.project]),
+        projectCoveredSessions: projectCovered ? new Set([obs.sessionId]) : new Set(),
         items: [item],
       });
     }
   }
   return clusters;
+}
+
+function isProjectCoveredSighting(obs) {
+  const root = obs.projectRoot;
+  if (!root || !obs.proposedInstruction) return false;
+  try {
+    if (!fs.existsSync(root)) return false;
+    const resolved = resolveMemoryFiles(root, ["AGENTS.md", "CLAUDE.md"]);
+    if (!resolved.primary) return false;
+    return instructionUnits(resolved.primary).some(
+      (unit) => similarity(unit.text, obs.proposedInstruction) >= GAP_COVERED_THRESHOLD,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function projectSpecificNote(cluster, minGapProjects) {
+  if (minGapProjects < 2 || cluster.projects.size >= minGapProjects || cluster.sessions.size < 1) return {};
+  const only = [...cluster.projects][0];
+  return {
+    reportOnlyReason: only
+      ? `project-specific: seen in ${only} only; run \`backpass\` there`
+      : "project-specific: below minGapProjects",
+  };
+}
+
+function relevanceByProject(sessionsByProject, analyzedByProject, topK = 5) {
+  const rows = [...sessionsByProject.entries()]
+    .map(([project, sessions]) => ({
+      project,
+      relevance: analyzedByProject.get(project) ? sessions.size / analyzedByProject.get(project) : 0,
+      sessions: sessions.size,
+    }))
+    .sort((a, b) => b.sessions - a.sessions || a.project.localeCompare(b.project));
+  const top = rows.slice(0, topK);
+  const rest = rows.slice(topK);
+  const out = Object.fromEntries(top.map((row) => [row.project, row.relevance]));
+  if (rest.length) {
+    const sessions = rest.reduce((n, row) => n + row.sessions, 0);
+    const analyzed = rest.reduce((n, row) => n + (analyzedByProject.get(row.project) || 0), 0);
+    out.other = analyzed ? sessions / analyzed : 0;
+  }
+  return out;
 }
 
 function observationDomain(obs) {

--- a/src/fold.js
+++ b/src/fold.js
@@ -350,13 +350,14 @@ export function clusterGapObservations(observations, { checkProjectCoverage = fa
 
 function isProjectCoveredSighting(obs) {
   const root = obs.projectRoot;
-  if (!root || !obs.proposedInstruction) return false;
+  const phrasings = obs.phrasings?.length ? obs.phrasings : [obs.proposedInstruction];
+  if (!root || !phrasings.some(Boolean)) return false;
   try {
     if (!fs.existsSync(root)) return false;
     const resolved = resolveMemoryFiles(root, ["AGENTS.md", "CLAUDE.md"]);
     if (!resolved.primary) return false;
-    return instructionUnits(resolved.primary).some(
-      (unit) => similarity(unit.text, obs.proposedInstruction) >= GAP_COVERED_THRESHOLD,
+    return instructionUnits(resolved.primary).some((unit) =>
+      phrasings.some((phrasing) => similarity(unit.text, phrasing) >= GAP_COVERED_THRESHOLD),
     );
   } catch {
     return false;

--- a/src/fold.js
+++ b/src/fold.js
@@ -323,23 +323,27 @@ export function clusterGapObservations(observations, { checkProjectCoverage = fa
       } else {
         cluster.items.push(item);
       }
-      if (projectCovered) cluster.projectCoveredSessions.add(obs.sessionId);
-      else {
-        cluster.sessions.add(obs.sessionId);
-        if (obs.project) cluster.projects.add(obs.project);
-      }
       if (obs.proposedInstruction.length < cluster.proposedInstruction.length) {
         cluster.proposedInstruction = obs.proposedInstruction;
       }
     } else {
       clusters.push({
         proposedInstruction: obs.proposedInstruction,
-        sessions: projectCovered ? new Set() : new Set([obs.sessionId]),
-        projects: projectCovered || !obs.project ? new Set() : new Set([obs.project]),
-        projectCoveredSessions: projectCovered ? new Set([obs.sessionId]) : new Set(),
+        sessions: new Set(),
+        projects: new Set(),
+        projectCoveredSessions: new Set(),
         items: [item],
       });
     }
+  }
+  for (const cluster of clusters) {
+    cluster.sessions = new Set(cluster.items.filter((item) => !item.projectCovered).map((item) => item.sessionId));
+    cluster.projects = new Set(
+      cluster.items.filter((item) => !item.projectCovered && item.project).map((item) => item.project),
+    );
+    cluster.projectCoveredSessions = new Set(
+      cluster.items.filter((item) => item.projectCovered).map((item) => item.sessionId),
+    );
   }
   return clusters;
 }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -170,6 +170,8 @@ export function recordGapObservations(ledger, evidenceRecords, options = {}) {
         // this mistake. Absent when no skill covers it (including all pre-existing
         // observations), and absence never counts as a citation.
         ...(coveredBySkill ? { coveredBySkill } : {}),
+        ...(transcript.project ? { project: transcript.project } : {}),
+        ...(transcript.projectRoot ? { projectRoot: transcript.projectRoot } : {}),
       };
       recorded += 1;
     }
@@ -255,6 +257,8 @@ export function ledgerGapObservations(ledger, memoryPath, skills = null) {
         ...(obs.coveredBySkill && (!skillNames || skillNames.has(obs.coveredBySkill))
           ? { coveredBySkill: obs.coveredBySkill }
           : {}),
+        ...(obs.project ? { project: obs.project } : {}),
+        ...(obs.projectRoot ? { projectRoot: obs.projectRoot } : {}),
       });
     }
   }

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -157,7 +157,9 @@ export function recordGapObservations(ledger, evidenceRecords, options = {}) {
         gap.coveredBySkill || priors.find((observation) => observation.coveredBySkill)?.coveredBySkill;
       const phrasings = [
         ...new Set([
-          ...priors.flatMap((observation) => observation.phrasings || [observation.proposedInstruction].filter(Boolean)),
+          ...priors.flatMap(
+            (observation) => observation.phrasings || [observation.proposedInstruction].filter(Boolean),
+          ),
           gap.proposedInstruction,
         ]),
       ];

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -323,6 +323,8 @@ export function mergeGapEntries(ledger, groups) {
           if (earlier) prior.firstObservedAt = obs.firstObservedAt || obs.observedAt;
           if (prior.domain === "orchestration" && obs.domain !== "orchestration") prior.domain = "project";
           if (!prior.coveredBySkill && obs.coveredBySkill) prior.coveredBySkill = obs.coveredBySkill;
+          if (!prior.project && obs.project) prior.project = obs.project;
+          if (!prior.projectRoot && obs.projectRoot) prior.projectRoot = obs.projectRoot;
           prior.phrasings = [
             ...new Set([
               ...(prior.phrasings || [target.proposedInstruction]),

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -155,6 +155,12 @@ export function recordGapObservations(ledger, evidenceRecords, options = {}) {
       if (aliasPrior) delete entry.sessions[transcript.id];
       const coveredBySkill =
         gap.coveredBySkill || priors.find((observation) => observation.coveredBySkill)?.coveredBySkill;
+      const phrasings = [
+        ...new Set([
+          ...priors.flatMap((observation) => observation.phrasings || [observation.proposedInstruction].filter(Boolean)),
+          gap.proposedInstruction,
+        ]),
+      ];
       entry.sessions[sessionIdentity] = {
         firstObservedAt: firstObservedAt || observedAt,
         observedAt,
@@ -165,6 +171,7 @@ export function recordGapObservations(ledger, evidenceRecords, options = {}) {
         mistake: gap.mistake,
         quote: gap.quote,
         recurrenceRisk: gap.recurrenceRisk,
+        phrasings,
         domain: gap.domain === "orchestration" ? "orchestration" : "project",
         // A failed trigger: the analysis judged an existing skill's content to cover
         // this mistake. Absent when no skill covers it (including all pre-existing
@@ -248,6 +255,7 @@ export function ledgerGapObservations(ledger, memoryPath, skills = null) {
     for (const [sessionId, obs] of Object.entries(entry.sessions)) {
       observations.push({
         proposedInstruction: entry.proposedInstruction,
+        phrasings: obs.phrasings?.length ? obs.phrasings : [entry.proposedInstruction],
         sessionId,
         source: obs.source,
         mistake: obs.mistake,
@@ -315,6 +323,12 @@ export function mergeGapEntries(ledger, groups) {
           if (earlier) prior.firstObservedAt = obs.firstObservedAt || obs.observedAt;
           if (prior.domain === "orchestration" && obs.domain !== "orchestration") prior.domain = "project";
           if (!prior.coveredBySkill && obs.coveredBySkill) prior.coveredBySkill = obs.coveredBySkill;
+          prior.phrasings = [
+            ...new Set([
+              ...(prior.phrasings || [target.proposedInstruction]),
+              ...(obs.phrasings || [entry.proposedInstruction]),
+            ]),
+          ];
         }
       }
       target.aliases = [...new Set([...(target.aliases || []), entry.id, ...(entry.aliases || [])])];

--- a/src/memory.js
+++ b/src/memory.js
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { sha256 } from "./state.js";
@@ -294,7 +295,11 @@ export function memoryTextHash(text) {
 }
 
 export function readMemoryFile(repoRoot, relativePath) {
-  const absolute = path.join(repoRoot, relativePath);
+  const expanded =
+    relativePath === "~" || relativePath.startsWith("~/")
+      ? path.join(os.homedir(), relativePath.slice(relativePath === "~" ? 1 : 2))
+      : relativePath;
+  const absolute = path.isAbsolute(expanded) ? expanded : path.join(repoRoot, expanded);
   if (!fs.existsSync(absolute)) return null;
   const text = fs.readFileSync(absolute, "utf8");
   return {
@@ -423,15 +428,28 @@ export function reanchor(reference, file, threshold = 0.6) {
  * A file is a pointer to `target` when, ignoring blank lines and HTML comments, its
  * only content is the import line (`@AGENTS.md` or `@./AGENTS.md`).
  */
-export function isPointerTo(text, target) {
+export function isPointerTo(text, target, options = {}) {
   const lines = text
     .replace(/<!--[\s\S]*?-->/g, "")
     .split("\n")
     .map((l) => l.trim())
     .filter(Boolean);
   if (lines.length !== 1) return false;
-  const ref = lines[0].replace(/^@\.\//, "@");
-  return ref === `@${target}`;
+  const imported = lines[0].replace(/^@\.\//, "@");
+  if (!imported.startsWith("@")) return false;
+  if (imported === `@${target}`) return true;
+
+  const spec = imported.slice(1);
+  const home = options.home || os.homedir();
+  const fromDir = options.fromDir || options.root || "";
+  const expand = (p) => {
+    if (p === "~") return home;
+    if (p.startsWith("~/")) return path.join(home, p.slice(2));
+    return p;
+  };
+  const resolvedSpec = path.isAbsolute(expand(spec)) ? expand(spec) : path.resolve(fromDir || ".", spec);
+  const resolvedTarget = path.isAbsolute(expand(target)) ? expand(target) : path.resolve(fromDir || ".", target);
+  return resolvedSpec === resolvedTarget;
 }
 
 /**
@@ -449,7 +467,9 @@ export function resolveMemoryFiles(repoRoot, memoryFiles) {
   const files = loadMemoryFiles(repoRoot, memoryFiles);
   if (!files.length) return { primary: null, all: files, pointers: [], separate: [], hash: null };
   const [primary, ...others] = files;
-  const pointers = others.filter((f) => isPointerTo(f.text, primary.path));
+  const pointers = others.filter((f) =>
+    isPointerTo(f.text, primary.path, { fromDir: path.dirname(primary.absolute || path.join(repoRoot, primary.path)) }),
+  );
   const separate = others.filter((f) => !pointers.includes(f));
   return { primary, all: files, pointers, separate, hash: memorySetHash(files) };
 }

--- a/src/memory.js
+++ b/src/memory.js
@@ -491,8 +491,10 @@ export function resolveMemoryFiles(repoRoot, memoryFiles, options = {}) {
   const files = loadMemoryFiles(repoRoot, memoryFiles, options);
   if (!files.length) return { primary: null, all: files, pointers: [], separate: [], hash: null };
   const [primary, ...others] = files;
-  const pointers = others.filter((f) =>
-    isPointerTo(f.text, primary.absolute, { fromDir: path.dirname(f.absolute) }),
+  const pointers = others.filter(
+    (f) =>
+      path.basename(f.absolute).toLowerCase() === "claude.md" &&
+      isPointerTo(f.text, primary.absolute, { fromDir: path.dirname(f.absolute) }),
   );
   const separate = others.filter((f) => !pointers.includes(f));
   return { primary, all: files, pointers, separate, hash: memorySetHash(files) };

--- a/src/memory.js
+++ b/src/memory.js
@@ -437,7 +437,6 @@ export function isPointerTo(text, target, options = {}) {
   if (lines.length !== 1) return false;
   const imported = lines[0].replace(/^@\.\//, "@");
   if (!imported.startsWith("@")) return false;
-  if (imported === `@${target}`) return true;
 
   const spec = imported.slice(1);
   const home = options.home || os.homedir();
@@ -468,7 +467,7 @@ export function resolveMemoryFiles(repoRoot, memoryFiles) {
   if (!files.length) return { primary: null, all: files, pointers: [], separate: [], hash: null };
   const [primary, ...others] = files;
   const pointers = others.filter((f) =>
-    isPointerTo(f.text, primary.path, { fromDir: path.dirname(primary.absolute || path.join(repoRoot, primary.path)) }),
+    isPointerTo(f.text, primary.absolute, { fromDir: path.dirname(f.absolute) }),
   );
   const separate = others.filter((f) => !pointers.includes(f));
   return { primary, all: files, pointers, separate, hash: memorySetHash(files) };

--- a/src/memory.js
+++ b/src/memory.js
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { sha256 } from "./state.js";
 import { estimateTokens } from "./tokens.js";
+import { UserError } from "./logger.js";
 
 /**
  * Memory files are the weights. To talk about them precisely, backpass parses each
@@ -294,12 +295,36 @@ export function memoryTextHash(text) {
   return `sha256:${sha256(text).slice(0, 16)}`;
 }
 
-export function readMemoryFile(repoRoot, relativePath) {
+export function resolveMemoryPath(repoRoot, configuredPath, { allowExternal = false } = {}) {
   const expanded =
-    relativePath === "~" || relativePath.startsWith("~/")
-      ? path.join(os.homedir(), relativePath.slice(relativePath === "~" ? 1 : 2))
-      : relativePath;
-  const absolute = path.isAbsolute(expanded) ? expanded : path.join(repoRoot, expanded);
+    configuredPath === "~" || configuredPath.startsWith("~/")
+      ? path.join(os.homedir(), configuredPath.slice(configuredPath === "~" ? 1 : 2))
+      : configuredPath;
+  const root = path.resolve(repoRoot);
+  const absolute = path.resolve(root, expanded);
+  if (!allowExternal) {
+    let existing = absolute;
+    while (!fs.existsSync(existing) && path.dirname(existing) !== existing) existing = path.dirname(existing);
+    let realRoot = root;
+    let realExisting = existing;
+    try {
+      realRoot = fs.realpathSync(root);
+      realExisting = fs.realpathSync(existing);
+    } catch {
+      realRoot = root;
+      realExisting = existing;
+    }
+    const resolved = path.resolve(realExisting, path.relative(existing, absolute));
+    const relative = path.relative(realRoot, resolved);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      throw new UserError(`${configuredPath} resolves outside the project root; project scope cannot access it`);
+    }
+  }
+  return absolute;
+}
+
+export function readMemoryFile(repoRoot, relativePath, options = {}) {
+  const absolute = resolveMemoryPath(repoRoot, relativePath, options);
   if (!fs.existsSync(absolute)) return null;
   const text = fs.readFileSync(absolute, "utf8");
   return {
@@ -313,8 +338,8 @@ export function readMemoryFile(repoRoot, relativePath) {
 }
 
 /** Load every configured memory file that actually exists in the repo. */
-export function loadMemoryFiles(repoRoot, memoryFiles) {
-  return memoryFiles.map((f) => readMemoryFile(repoRoot, f)).filter(Boolean);
+export function loadMemoryFiles(repoRoot, memoryFiles, options = {}) {
+  return memoryFiles.map((f) => readMemoryFile(repoRoot, f, options)).filter(Boolean);
 }
 
 /** Combined hash across all memory files - the "weights version" evidence is keyed to. */
@@ -462,8 +487,8 @@ export function isPointerTo(text, target, options = {}) {
  * The weights hash still covers every existing file, as before, so cached evidence
  * survives this resolution unchanged.
  */
-export function resolveMemoryFiles(repoRoot, memoryFiles) {
-  const files = loadMemoryFiles(repoRoot, memoryFiles);
+export function resolveMemoryFiles(repoRoot, memoryFiles, options = {}) {
+  const files = loadMemoryFiles(repoRoot, memoryFiles, options);
   if (!files.length) return { primary: null, all: files, pointers: [], separate: [], hash: null };
   const [primary, ...others] = files;
   const pointers = others.filter((f) =>

--- a/src/memory.js
+++ b/src/memory.js
@@ -305,8 +305,8 @@ export function resolveMemoryPath(repoRoot, configuredPath, { allowExternal = fa
   if (!allowExternal) {
     let existing = absolute;
     while (!fs.existsSync(existing) && path.dirname(existing) !== existing) existing = path.dirname(existing);
-    let realRoot = root;
-    let realExisting = existing;
+    let realRoot;
+    let realExisting;
     try {
       realRoot = fs.realpathSync(root);
       realExisting = fs.realpathSync(existing);

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -19,7 +19,8 @@ Return ONE JSON object and nothing else. No prose, no markdown fence.
       "rationale": "why the evidence supports this",
       "instructions": ["AG-017"],
       "evidence": [{"polarity": "negative", "text": "the verbatim quote", "source": "claude · abc123 · turn 12"}],
-      "transcripts": 3
+      "transcripts": 3,
+      "projects": 1
     }
   ],
   "verdicts": [
@@ -39,7 +40,8 @@ Hard rules - a violation fails the whole proposal:
 3. **Every edit carries at least one verbatim quote in `evidence`**, with its source.
 4. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
    sessions.** `transcripts` is how many distinct sessions back the edit; an edit that
-   only adds text is a new instruction whatever its `kind` says.
+   only adds text is a new instruction whatever its `kind` says. `projects` is how many
+   distinct projects those sessions came from (user scope); omit it in a project-scoped run.
 5. **Removing an instruction outright needs harm evidence from at least
    {{MIN_GAP_EVIDENCE}} distinct sessions** (`harm-sessions` in the evidence). Only
    `harm` negatives argue against an instruction; `non-compliance` never justifies a

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -293,6 +293,16 @@ export function renderChangesForPrompt(measured, memoryFile) {
  * the model's annotation. Nothing textual is taken from the model: the hunks, their
  * deltas, the projected budget, and even whether an edit is an addition are measured.
  */
+function countedEvidenceProjects(edit, summary) {
+  const quoted = new Set(edit.evidence.map((item) => `${item.source || ""}\n${item.text || ""}`));
+  return Math.max(
+    0,
+    ...(summary?.gaps || [])
+      .filter((gap) => gap.quotes?.some((quote) => quoted.has(`${quote.source || ""}\n${quote.text || ""}`)))
+      .map((gap) => gap.projects || 0),
+  );
+}
+
 export function buildProposal(rawResult, context) {
   const {
     memoryFile,
@@ -504,10 +514,23 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
+    const evidenceProjects = onlyAdds && config.minGapProjects != null ? countedEvidenceProjects(edit, summary) : null;
     if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
+      );
+      continue;
+    }
+    if (
+      !preservesAlwaysLoaded(edit.kind) &&
+      onlyAdds &&
+      config.minGapProjects != null &&
+      evidenceProjects < config.minGapProjects
+    ) {
+      violations.push(
+        `edit ${edit.id} ("${edit.title}") adds a new instruction backed by evidence from ${evidenceProjects} project(s); ` +
+          `${config.minGapProjects} are required`,
       );
       continue;
     }
@@ -571,7 +594,7 @@ export function buildProposal(rawResult, context) {
       instructions: edit.instructions,
       evidence: edit.evidence,
       transcripts: edit.transcripts,
-      ...(edit.projects != null ? { projects: edit.projects } : {}),
+      ...(evidenceProjects != null ? { projects: evidenceProjects } : {}),
       skills: created.map((c) => c.skill),
       hunks: hunks.map((h) => ({
         id: h.id,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -272,7 +272,7 @@ export function renderChangesForPrompt(measured, memoryFile) {
   };
   return measured.changes
     .map((change) => {
-      const head = `[${describeChange(change)}${unitsAt(change)}]`;
+      const head = `[${describeChange({ ...change, file: change.workspaceFile || change.file })}${unitsAt(change)}]`;
       if (change.kind === "deleted") return head;
       if (change.kind === "created") {
         return `${head}\n${renderHunkLines(

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -514,7 +514,8 @@ export function buildProposal(rawResult, context) {
 
     // An addition is measured, not declared: text that only goes in is a new instruction.
     const onlyAdds = hunks.every((h) => h.removed === 0);
-    const evidenceProjects = onlyAdds && config.minGapProjects != null ? countedEvidenceProjects(edit, summary) : null;
+    const projectGate = scope?.kind === "user" && config.minGapProjects != null;
+    const evidenceProjects = onlyAdds && projectGate ? countedEvidenceProjects(edit, summary) : null;
     if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
@@ -525,7 +526,7 @@ export function buildProposal(rawResult, context) {
     if (
       !preservesAlwaysLoaded(edit.kind) &&
       onlyAdds &&
-      config.minGapProjects != null &&
+      projectGate &&
       evidenceProjects < config.minGapProjects
     ) {
       violations.push(

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -523,12 +523,7 @@ export function buildProposal(rawResult, context) {
       );
       continue;
     }
-    if (
-      !preservesAlwaysLoaded(edit.kind) &&
-      onlyAdds &&
-      projectGate &&
-      evidenceProjects < config.minGapProjects
-    ) {
+    if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && projectGate && evidenceProjects < config.minGapProjects) {
       violations.push(
         `edit ${edit.id} ("${edit.title}") adds a new instruction backed by evidence from ${evidenceProjects} project(s); ` +
           `${config.minGapProjects} are required`,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -113,6 +113,7 @@ function normalizeEdit(raw, index) {
     instructions: Array.isArray(raw?.instructions) ? raw.instructions.map(String) : [],
     evidence: normalizeEvidence(raw?.evidence),
     transcripts: Number.isFinite(raw?.transcripts) ? Number(raw.transcripts) : countSources(raw?.evidence),
+    projects: Number.isFinite(raw?.projects) ? Number(raw.projects) : undefined,
   };
 }
 
@@ -303,6 +304,7 @@ export function buildProposal(rawResult, context) {
     rejections = { entries: {} },
     isSuppressed = () => false,
     skillFiles = [],
+    scope = null,
   } = context;
 
   const violations = [];
@@ -569,6 +571,7 @@ export function buildProposal(rawResult, context) {
       instructions: edit.instructions,
       evidence: edit.evidence,
       transcripts: edit.transcripts,
+      ...(edit.projects != null ? { projects: edit.projects } : {}),
       skills: created.map((c) => c.skill),
       hunks: hunks.map((h) => ({
         id: h.id,
@@ -582,6 +585,9 @@ export function buildProposal(rawResult, context) {
         lines: h.lines,
       })),
       targetsMemoryFile: file === memoryFile.path,
+      applicable: true,
+      deltaTokens: 0,
+      descriptionDelta: 0,
     };
 
     if (isSuppressed(proposed, rejections)) {
@@ -690,6 +696,7 @@ export function buildProposal(rawResult, context) {
     tool: "backpass",
     generatedAt: new Date().toISOString(),
     repo: { name: repo.name, root: repo.root },
+    scope: scope?.kind || "project",
     memoryFile: { path: memoryFile.path, hash: memoryFile.hash, tokens: memoryFile.tokens },
     targetFiles,
     budget,
@@ -697,6 +704,7 @@ export function buildProposal(rawResult, context) {
       budgetTokens: config.budgetTokens,
       maxEditsPerRun: maxEdits,
       minGapEvidence: config.minGapEvidence,
+      ...(config.minGapProjects != null ? { minGapProjects: config.minGapProjects } : {}),
       skillsDir: config.skillsDir,
       skillDirs: config.skillDirs,
       analysis: config.analysis,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -729,7 +729,7 @@ export function buildProposal(rawResult, context) {
       minGapEvidence: config.minGapEvidence,
       ...(config.minGapProjects != null ? { minGapProjects: config.minGapProjects } : {}),
       skillsDir: config.skillsDir,
-      skillDirs: config.skillDirs,
+      skillsDirs: config.skillsDirs,
       analysis: config.analysis,
       synthesis: config.synthesis,
     },

--- a/src/repo.js
+++ b/src/repo.js
@@ -119,6 +119,7 @@ function listRemoteUrls(root) {
     return [];
   }
 
+  names.sort((a, b) => (a === "origin" ? -1 : b === "origin" ? 1 : a.localeCompare(b)));
   const urls = new Set();
   for (const name of names) {
     for (const args of [
@@ -142,7 +143,7 @@ function listRemotes(root) {
 }
 
 export function gitProjectIdentity(root) {
-  const remote = listRemotes(root).sort()[0];
+  const remote = listRemotes(root)[0];
   if (remote) return remote;
 
   try {

--- a/src/repo.js
+++ b/src/repo.js
@@ -141,8 +141,17 @@ function listRemotes(root) {
   return [...new Set(listRemoteUrls(root).map(normalizeRemote).filter(Boolean))];
 }
 
-export function gitRemoteIdentity(root) {
-  return listRemotes(root).sort()[0] || null;
+export function gitProjectIdentity(root) {
+  const remote = listRemotes(root).sort()[0];
+  if (remote) return remote;
+
+  try {
+    const commonDir = git(["rev-parse", "--git-common-dir"], root);
+    const absolute = realpathOrSelf(path.isAbsolute(commonDir) ? commonDir : path.resolve(root, commonDir));
+    return path.basename(absolute) === ".git" ? path.dirname(absolute) : `git:${absolute}`;
+  } catch {
+    return realpathOrSelf(root);
+  }
 }
 
 function listCloneRemotes(root) {

--- a/src/repo.js
+++ b/src/repo.js
@@ -36,6 +36,20 @@ export function normalizeRemote(remote) {
   return s.toLowerCase() || null;
 }
 
+/**
+ * Live git toplevel for a cwd, or null when the path is missing or not a checkout.
+ * User-scope association uses this as the project key when the worktree still exists.
+ */
+export function gitToplevel(cwd) {
+  if (!cwd) return null;
+  try {
+    if (!fs.existsSync(cwd)) return null;
+    return realpathOrSelf(git(["rev-parse", "--show-toplevel"], cwd));
+  } catch {
+    return null;
+  }
+}
+
 /** Worktree paths for the repo, realpath-normalized (design section 2.1, tier 1). */
 function listWorktrees(root) {
   let raw;

--- a/src/repo.js
+++ b/src/repo.js
@@ -141,6 +141,10 @@ function listRemotes(root) {
   return [...new Set(listRemoteUrls(root).map(normalizeRemote).filter(Boolean))];
 }
 
+export function gitRemoteIdentity(root) {
+  return listRemotes(root).sort()[0] || null;
+}
+
 function listCloneRemotes(root) {
   return [
     ...new Set(

--- a/src/repo.js
+++ b/src/repo.js
@@ -51,7 +51,7 @@ export function gitToplevel(cwd) {
 }
 
 /** Worktree paths for the repo, realpath-normalized (design section 2.1, tier 1). */
-function listWorktrees(root) {
+export function listWorktrees(root) {
   let raw;
   try {
     raw = git(["worktree", "list", "--porcelain"], root);

--- a/src/sample.js
+++ b/src/sample.js
@@ -180,19 +180,42 @@ export function sampleTranscripts(
 }
 
 /**
+ * Cap each project's transcripts before the global cap, so one hot repo cannot fill
+ * the sample. Uses the same sticky recency-weighted draw as the global cap.
+ */
+export function capPerProject(transcripts, maxPerProject, options = {}) {
+  if (!Number.isInteger(maxPerProject) || maxPerProject < 1) return transcripts;
+  const groups = new Map();
+  for (const transcript of transcripts) {
+    const key = transcript.project || transcript.cwd || transcriptIdentity(transcript);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(transcript);
+  }
+  const kept = new Set();
+  for (const group of groups.values()) {
+    for (const transcript of sampleTranscripts(group, maxPerProject, options)) kept.add(transcript);
+  }
+  return transcripts.filter((transcript) => kept.has(transcript));
+}
+
+/**
  * Apply the configured cap to a discovery result, reporting it on stderr when sampling
  * actually happened. Under the cap the set passes through untouched and nothing is
  * printed.
  */
 export function capTranscripts(result, config, { now = Date.now() } = {}) {
+  const options = { seed: config.seed ?? undefined, now, halfLife: config.sampleHalfLife };
+  let transcripts = result.transcripts;
+  const perProject = config.discovery?.maxTranscriptsPerProject;
+  if (Number.isInteger(perProject) && perProject > 0) {
+    transcripts = capPerProject(transcripts, perProject, options);
+  }
   const cap = parseMaxTranscripts(config.maxTranscripts);
   const discovered = result.transcripts.length;
-  if (cap === null || discovered <= cap) return result;
-  const sampled = sampleTranscripts(result.transcripts, cap, {
-    seed: config.seed ?? undefined,
-    now,
-    halfLife: config.sampleHalfLife,
-  });
+  if (cap === null || transcripts.length <= cap) {
+    return transcripts === result.transcripts ? result : { ...result, transcripts };
+  }
+  const sampled = sampleTranscripts(transcripts, cap, options);
   const sampledMix = corpusMix(sampled);
   const discoveredMix = corpusMix(result.transcripts);
   const mixed = discoveredMix.interactive > 0 && discoveredMix.nonInteractive > 0;

--- a/src/scope.js
+++ b/src/scope.js
@@ -12,7 +12,7 @@ import { gitToplevel, normalizeRemote } from "./repo.js";
  *
  * Project scope is today's behaviour: git checkout, `<repo>/.backpass/`, sessions
  * associated with this repo. User scope trains the always-loaded user file and
- * user-level skills from every session on the machine, with state isolated under
+ * user-level skills from Claude and Codex sessions across projects, with state isolated under
  * `~/.config/backpass/user/` (0700). A run is exactly one scope, chosen by `--scope`.
  */
 
@@ -153,11 +153,7 @@ function resolveProjectScope(repo, config) {
   };
 }
 
-function resolveUserScope(
-  cwd,
-  config,
-  { strict = false, home = os.homedir(), associateUserFn = associateUser } = {},
-) {
+function resolveUserScope(cwd, config, { strict = false, home = os.homedir(), associateUserFn = associateUser } = {}) {
   const root = home;
   const memoryFiles = (config.memoryFiles || []).map((file) => pathInRoot(file, root, home));
   const overflowDir = pathInRoot(config.skillsDir || ".agents/skills", root, home);
@@ -196,7 +192,7 @@ function resolveUserScope(
  * @param {{ scope?: string, strict?: boolean }} flags
  * @param {object} config
  * @param {object | null} [repo] required for project scope
- * @param {{ home?: string }} [options]
+ * @param {{ home?: string, associateUserFn?: (descriptor: any, options?: { strict?: boolean }) => any }} [options]
  */
 export function resolveScope(cwd, flags, config, repo = null, options = {}) {
   const kind = parseScopeKind(flags?.scope);

--- a/src/scope.js
+++ b/src/scope.js
@@ -5,7 +5,7 @@ import path from "node:path";
 import { parseScopeKind, userStateDir } from "./config.js";
 import { associate as associateProject, globToRegExp } from "./discovery/association.js";
 import { UserError, info } from "./logger.js";
-import { gitToplevel, normalizeRemote } from "./repo.js";
+import { gitRemoteIdentity, gitToplevel, normalizeRemote } from "./repo.js";
 
 /**
  * A run scope is the triple (weights surface, session corpus, state directory).
@@ -64,16 +64,17 @@ export function associateUser(descriptor, { strict = false } = {}) {
 
   const liveRoot = gitToplevel(cwd);
   if (liveRoot) {
+    const remote = gitRemoteIdentity(liveRoot);
     return {
       tier: 1,
       confidence: "git",
       reason: `cwd is in ${liveRoot}`,
-      project: liveRoot,
+      project: remote || liveRoot,
       projectRoot: liveRoot,
     };
   }
 
-  const remote = (descriptor.remotes || []).map(normalizeRemote).find(Boolean);
+  const remote = (descriptor.remotes || []).map(normalizeRemote).filter(Boolean).sort()[0];
   if (remote) {
     return {
       tier: 2,

--- a/src/scope.js
+++ b/src/scope.js
@@ -153,13 +153,25 @@ function resolveProjectScope(repo, config) {
   };
 }
 
-function resolveUserScope(cwd, config, { strict = false, home = os.homedir() } = {}) {
+function resolveUserScope(
+  cwd,
+  config,
+  { strict = false, home = os.homedir(), associateUserFn = associateUser } = {},
+) {
   const root = home;
   const memoryFiles = (config.memoryFiles || []).map((file) => pathInRoot(file, root, home));
   const overflowDir = pathInRoot(config.skillsDir || ".agents/skills", root, home);
   const skillDirs = (config.skillsDirs || []).map((dir) => pathInRoot(dir, root, home));
   const repo = syntheticUserRepo(root);
   const stateDir = userStateDir();
+  const associationCache = new Map();
+  const associate = (descriptor) => {
+    const key = JSON.stringify([descriptor?.cwd || null, descriptor?.remotes || []]);
+    if (!associationCache.has(key)) {
+      associationCache.set(key, associateUserFn(descriptor, { strict }));
+    }
+    return associationCache.get(key);
+  };
   return {
     kind: "user",
     repo,
@@ -170,7 +182,7 @@ function resolveUserScope(cwd, config, { strict = false, home = os.homedir() } =
     memoryFiles,
     skillDirs,
     overflowDir,
-    associate: (descriptor) => associateUser(descriptor, { strict }),
+    associate,
     cwdNote: gitToplevel(cwd)
       ? "user scope: this checkout is not a write target; edits go to the user-level memory file and skills"
       : null,
@@ -190,7 +202,11 @@ export function resolveScope(cwd, flags, config, repo = null, options = {}) {
   const kind = parseScopeKind(flags?.scope);
   if (kind === "user") {
     const home = options.home || os.homedir();
-    return resolveUserScope(cwd, config, { strict: Boolean(flags?.strict), home });
+    return resolveUserScope(cwd, config, {
+      strict: Boolean(flags?.strict),
+      home,
+      associateUserFn: options.associateUserFn,
+    });
   }
   if (!repo) {
     throw new UserError("backpass runs per-repo; cd into a repo and retry", "or pass --scope user");

--- a/src/scope.js
+++ b/src/scope.js
@@ -5,7 +5,7 @@ import path from "node:path";
 import { parseScopeKind, userStateDir } from "./config.js";
 import { associate as associateProject, globToRegExp } from "./discovery/association.js";
 import { UserError, info } from "./logger.js";
-import { gitRemoteIdentity, gitToplevel, normalizeRemote } from "./repo.js";
+import { gitProjectIdentity, gitToplevel, normalizeRemote } from "./repo.js";
 
 /**
  * A run scope is the triple (weights surface, session corpus, state directory).
@@ -64,12 +64,11 @@ export function associateUser(descriptor, { strict = false } = {}) {
 
   const liveRoot = gitToplevel(cwd);
   if (liveRoot) {
-    const remote = gitRemoteIdentity(liveRoot);
     return {
       tier: 1,
       confidence: "git",
       reason: `cwd is in ${liveRoot}`,
-      project: remote || liveRoot,
+      project: gitProjectIdentity(liveRoot),
       projectRoot: liveRoot,
     };
   }

--- a/src/scope.js
+++ b/src/scope.js
@@ -73,7 +73,7 @@ export function associateUser(descriptor, { strict = false } = {}) {
     };
   }
 
-  const remote = (descriptor.remotes || []).map(normalizeRemote).filter(Boolean).sort()[0];
+  const remote = (descriptor.remotes || []).map(normalizeRemote).find(Boolean);
   if (remote) {
     return {
       tier: 2,

--- a/src/scope.js
+++ b/src/scope.js
@@ -5,7 +5,7 @@ import path from "node:path";
 import { parseScopeKind, userStateDir } from "./config.js";
 import { associate as associateProject, globToRegExp } from "./discovery/association.js";
 import { UserError, info } from "./logger.js";
-import { gitProjectIdentity, gitToplevel, normalizeRemote } from "./repo.js";
+import { gitProjectIdentity, gitToplevel, listWorktrees, normalizeRemote } from "./repo.js";
 
 /**
  * A run scope is the triple (weights surface, session corpus, state directory).
@@ -44,10 +44,19 @@ export function resolveInRoot(root, p) {
 }
 
 function realpathOrResolve(p) {
+  const absolute = path.resolve(p);
+  let existing = absolute;
+  const tail = [];
+  while (!fs.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) return absolute;
+    tail.unshift(path.basename(existing));
+    existing = parent;
+  }
   try {
-    return fs.realpathSync(p);
+    return path.join(fs.realpathSync(existing), ...tail);
   } catch {
-    return path.resolve(p);
+    return absolute;
   }
 }
 
@@ -161,12 +170,37 @@ function resolveUserScope(cwd, config, { strict = false, home = os.homedir(), as
   const repo = syntheticUserRepo(root);
   const stateDir = userStateDir();
   const associationCache = new Map();
+  const knownWorktrees = new Map();
+  const indexedRoots = new Set();
   const associate = (descriptor) => {
     const key = JSON.stringify([descriptor?.cwd || null, descriptor?.remotes || []]);
     if (!associationCache.has(key)) {
-      associationCache.set(key, associateUserFn(descriptor, { strict }));
+      const association = associateUserFn(descriptor, { strict });
+      associationCache.set(key, association);
+      if (association?.tier === 1 && association.projectRoot && !indexedRoots.has(association.projectRoot)) {
+        indexedRoots.add(association.projectRoot);
+        for (const worktree of listWorktrees(association.projectRoot)) {
+          knownWorktrees.set(realpathOrResolve(worktree), association.project);
+        }
+      }
     }
     return associationCache.get(key);
+  };
+  const normalizeProjects = (transcripts) => {
+    for (const transcript of transcripts) {
+      if (transcript.association?.tier !== 3 || !transcript.cwd) continue;
+      const cwdPath = realpathOrResolve(transcript.cwd);
+      const match = [...knownWorktrees.entries()]
+        .filter(([worktree]) => cwdPath === worktree || cwdPath.startsWith(`${worktree}${path.sep}`))
+        .sort(([a], [b]) => b.length - a.length)[0];
+      if (!match) continue;
+      const [worktree, project] = match;
+      transcript.project = project;
+      transcript.association.project = project;
+      transcript.association.confidence = "git";
+      transcript.association.reason = `cwd is in registered worktree ${worktree}`;
+    }
+    return transcripts;
   };
   return {
     kind: "user",
@@ -179,6 +213,7 @@ function resolveUserScope(cwd, config, { strict = false, home = os.homedir(), as
     skillDirs,
     overflowDir,
     associate,
+    normalizeProjects,
     cwdNote: gitToplevel(cwd)
       ? "user scope: this checkout is not a write target; edits go to the user-level memory file and skills"
       : null,

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,203 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { parseScopeKind, userStateDir } from "./config.js";
+import { associate as associateProject, globToRegExp } from "./discovery/association.js";
+import { UserError, info } from "./logger.js";
+import { gitToplevel, normalizeRemote } from "./repo.js";
+
+/**
+ * A run scope is the triple (weights surface, session corpus, state directory).
+ *
+ * Project scope is today's behaviour: git checkout, `<repo>/.backpass/`, sessions
+ * associated with this repo. User scope trains the always-loaded user file and
+ * user-level skills from every session on the machine, with state isolated under
+ * `~/.config/backpass/user/` (0700). A run is exactly one scope, chosen by `--scope`.
+ */
+
+export function expandUserPath(p, home = os.homedir()) {
+  if (typeof p !== "string") return p;
+  if (p === "~") return home;
+  if (p.startsWith("~/")) return path.join(home, p.slice(2));
+  return p;
+}
+
+/**
+ * Path relative to `root` when it sits under it, otherwise the absolute path.
+ * Staging and apply both use this spelling, so a file outside home still has one name.
+ */
+export function pathInRoot(p, root, home = os.homedir()) {
+  const expanded = expandUserPath(p, home);
+  const absolute = path.isAbsolute(expanded) ? expanded : path.join(root, expanded);
+  const rel = path.relative(root, absolute);
+  if (rel && !rel.startsWith("..") && !path.isAbsolute(rel)) {
+    return rel.split(path.sep).join("/");
+  }
+  return absolute;
+}
+
+export function resolveInRoot(root, p) {
+  if (!p) return p;
+  const expanded = expandUserPath(p);
+  return path.isAbsolute(expanded) ? expanded : path.join(root, expanded);
+}
+
+function realpathOrResolve(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/**
+ * User-scope association: keep every session with a cwd, stamp a project key.
+ *
+ *   tier 1  live git toplevel (passes --strict)
+ *   tier 2  recorded remote, for deleted worktrees (codex, grok)
+ *   tier 3  cwd string; excluded by --strict
+ */
+export function associateUser(descriptor, { strict = false } = {}) {
+  const cwd = descriptor?.cwd;
+  if (!cwd) return null;
+
+  const liveRoot = gitToplevel(cwd);
+  if (liveRoot) {
+    return {
+      tier: 1,
+      confidence: "git",
+      reason: `cwd is in ${liveRoot}`,
+      project: liveRoot,
+      projectRoot: liveRoot,
+    };
+  }
+
+  const remote = (descriptor.remotes || []).map(normalizeRemote).find(Boolean);
+  if (remote) {
+    return {
+      tier: 2,
+      confidence: "remote",
+      reason: `remote ${remote}`,
+      project: remote,
+      projectRoot: null,
+    };
+  }
+
+  if (strict) return null;
+
+  const key = realpathOrResolve(cwd);
+  return {
+    tier: 3,
+    confidence: "cwd",
+    reason: `cwd ${key}`,
+    project: key,
+    projectRoot: null,
+  };
+}
+
+function matchesAnyGlob(values, globs) {
+  if (!globs?.length) return false;
+  return values.some((value) => globs.some((glob) => globToRegExp(glob).test(value)));
+}
+
+/** Include/exclude globs over project keys and cwds. Applied only in user scope. */
+export function passesProjectFilter(transcript, config) {
+  const include = config.discovery?.includeProjects || [];
+  const exclude = config.discovery?.excludeProjects || [];
+  const haystacks = [transcript.project, transcript.cwd].filter(Boolean);
+  if (exclude.length && matchesAnyGlob(haystacks, exclude)) return false;
+  if (include.length && !matchesAnyGlob(haystacks, include)) return false;
+  return true;
+}
+
+function syntheticUserRepo(home) {
+  let realRoot;
+  try {
+    realRoot = fs.realpathSync(home);
+  } catch {
+    realRoot = path.resolve(home);
+  }
+  return {
+    root: home,
+    realRoot,
+    name: "user",
+    worktrees: [],
+    remotes: [],
+    cloneRemotes: [],
+    siblingWorktrees: [],
+  };
+}
+
+function resolveProjectScope(repo, config) {
+  return {
+    kind: "project",
+    repo,
+    root: repo.root,
+    name: repo.name,
+    stateDir: path.join(repo.root, ".backpass"),
+    modelCwd: repo.root,
+    memoryFiles: config.memoryFiles,
+    skillDirs: config.skillsDirs || [],
+    overflowDir: config.skillsDir,
+    associate: (descriptor, options = {}) => {
+      const result = associateProject(descriptor, repo, {
+        worktreeGlobs: options.worktreeGlobs || config.discovery?.worktreeGlobs || [],
+      });
+      if (result) {
+        result.project = repo.root;
+        result.projectRoot = repo.root;
+      }
+      return result;
+    },
+  };
+}
+
+function resolveUserScope(cwd, config, { strict = false, home = os.homedir() } = {}) {
+  const root = home;
+  const memoryFiles = (config.memoryFiles || []).map((file) => pathInRoot(file, root, home));
+  const overflowDir = pathInRoot(config.skillsDir || ".agents/skills", root, home);
+  const skillDirs = (config.skillsDirs || []).map((dir) => pathInRoot(dir, root, home));
+  const repo = syntheticUserRepo(root);
+  const stateDir = userStateDir();
+  return {
+    kind: "user",
+    repo,
+    root,
+    name: "user",
+    stateDir,
+    modelCwd: stateDir,
+    memoryFiles,
+    skillDirs,
+    overflowDir,
+    associate: (descriptor) => associateUser(descriptor, { strict }),
+    cwdNote: gitToplevel(cwd)
+      ? "user scope: this checkout is not a write target; edits go to the user-level memory file and skills"
+      : null,
+  };
+}
+
+/**
+ * Build the run scope. `config` is already loaded for this kind.
+ *
+ * @param {string} cwd
+ * @param {{ scope?: string, strict?: boolean }} flags
+ * @param {object} config
+ * @param {object | null} [repo] required for project scope
+ * @param {{ home?: string }} [options]
+ */
+export function resolveScope(cwd, flags, config, repo = null, options = {}) {
+  const kind = parseScopeKind(flags?.scope);
+  if (kind === "user") {
+    const home = options.home || os.homedir();
+    return resolveUserScope(cwd, config, { strict: Boolean(flags?.strict), home });
+  }
+  if (!repo) {
+    throw new UserError("backpass runs per-repo; cd into a repo and retry", "or pass --scope user");
+  }
+  return resolveProjectScope(repo, config);
+}
+
+export function printScopeNote(scope) {
+  if (scope.kind === "user" && scope.cwdNote) info(scope.cwdNote);
+}

--- a/src/skills.js
+++ b/src/skills.js
@@ -23,7 +23,7 @@ export const BROAD_RELEVANCE_THRESHOLD = 0.2;
 
 /** Read the existing skills so synthesis can tune a description instead of duplicating it. */
 export function loadSkills(repoRoot, skillsDir) {
-  const root = path.join(repoRoot, skillsDir);
+  const root = path.isAbsolute(skillsDir) ? skillsDir : path.join(repoRoot, skillsDir);
   if (!fs.existsSync(root)) return [];
 
   const skills = [];
@@ -66,10 +66,10 @@ export function loadSkills(repoRoot, skillsDir) {
  * included even when custom-configured, and roots resolving to the same directory (the
  * normal `.claude/skills` symlink) are counted only once.
  */
-export function resolveProjectSkillDirs(repoRoot, overflowDir = CANONICAL_SKILLS_DIR) {
+export function resolveProjectSkillDirs(repoRoot, overflowDir = CANONICAL_SKILLS_DIR, extraDirs = []) {
   const dirs = [];
   const seen = new Set();
-  for (const dir of [overflowDir, CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK]) {
+  for (const dir of [overflowDir, CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK, ...extraDirs]) {
     if (!dir) continue;
     const absolute = path.join(repoRoot, dir);
     const exists = fs.existsSync(absolute);
@@ -90,8 +90,8 @@ export function resolveProjectSkillDirs(repoRoot, overflowDir = CANONICAL_SKILLS
 }
 
 /** Load generated and human-authored project skills across every supported root. */
-export function loadProjectSkills(repoRoot, overflowDir = CANONICAL_SKILLS_DIR) {
-  return resolveProjectSkillDirs(repoRoot, overflowDir)
+export function loadProjectSkills(repoRoot, overflowDir = CANONICAL_SKILLS_DIR, extraDirs = []) {
+  return resolveProjectSkillDirs(repoRoot, overflowDir, extraDirs)
     .flatMap((dir) => loadSkills(repoRoot, dir))
     .sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -273,7 +273,8 @@ export function resolveOverflowTarget(repoRoot, skillsDir = CANONICAL_SKILLS_DIR
   if (claude.state === "dir") warnings.push(claudeSkillsDirWarning());
 
   const explicit = skillsDir && skillsDir !== CANONICAL_SKILLS_DIR && skillsDir !== CLAUDE_SKILLS_LINK;
-  if (explicit && fs.existsSync(path.join(repoRoot, skillsDir))) {
+  const resolvedSkillsDir = path.isAbsolute(skillsDir) ? skillsDir : path.join(repoRoot, skillsDir);
+  if (explicit && fs.existsSync(resolvedSkillsDir)) {
     return { kind: "skills", dir: skillsDir, warnings };
   }
   return { kind: "skills", dir: CANONICAL_SKILLS_DIR, warnings };
@@ -435,7 +436,7 @@ export function writeSkill(repoRoot, skill, { exclusive = false, ensureLayout = 
   const inCanonical = skill.path === CANONICAL_SKILLS_DIR || skill.path.startsWith(`${CANONICAL_SKILLS_DIR}/`);
   const layout = inCanonical && ensureLayout ? ensureSkillsLayout(repoRoot) : { created: [], warnings: [] };
   const canonicalWasMissing = inCanonical && !fs.existsSync(path.join(repoRoot, CANONICAL_SKILLS_DIR));
-  const target = path.join(repoRoot, skill.path);
+  const target = path.isAbsolute(skill.path) ? skill.path : path.join(repoRoot, skill.path);
   fs.mkdirSync(path.dirname(target), { recursive: true });
   if (!ensureLayout && canonicalWasMissing) layout.created.push(CANONICAL_SKILLS_DIR);
   const text = renderSkillFile(skill);

--- a/src/skills.js
+++ b/src/skills.js
@@ -183,7 +183,7 @@ export function renderSkillIndex(skills) {
   return skills
     .map(
       (s) =>
-        `- ${s.name} (${s.bodyTokens} tok body, ${s.descriptionTokens} tok description) :: ${s.description || "(no description)"}`,
+        `- ${s.name} (${s.path}; ${s.bodyTokens} tok body, ${s.descriptionTokens} tok description) :: ${s.description || "(no description)"}`,
     )
     .join("\n");
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -51,7 +51,10 @@ export function loadSkills(repoRoot, skillsDir) {
     skills.push({
       name: frontmatter.name || entry.name.replace(/\.md$/, ""),
       description: frontmatter.description || "",
-      path: path.relative(repoRoot, file),
+      path: (() => {
+        const relative = path.relative(repoRoot, file);
+        return relative.startsWith("..") || path.isAbsolute(relative) ? file : relative;
+      })(),
       body: skillBody(text),
       bodyTokens: estimateTokens(text),
       descriptionTokens: estimateTokens(frontmatter.description || ""),
@@ -71,7 +74,7 @@ export function resolveProjectSkillDirs(repoRoot, overflowDir = CANONICAL_SKILLS
   const seen = new Set();
   for (const dir of [overflowDir, CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK, ...extraDirs]) {
     if (!dir) continue;
-    const absolute = path.join(repoRoot, dir);
+    const absolute = path.isAbsolute(dir) ? dir : path.join(repoRoot, dir);
     const exists = fs.existsSync(absolute);
     if (!exists && dir !== overflowDir) continue;
     let identity = path.resolve(absolute);

--- a/src/skills.js
+++ b/src/skills.js
@@ -280,18 +280,19 @@ export function resolveOverflowTarget(repoRoot, skillsDir = CANONICAL_SKILLS_DIR
   return { kind: "skills", dir: CANONICAL_SKILLS_DIR, warnings };
 }
 
-function claudeSkillsDirWarning() {
+function claudeSkillsDirWarning(claudeSkillsDir = CLAUDE_SKILLS_LINK, target = CLAUDE_SKILLS_LINK_TARGET) {
   return (
-    `${CLAUDE_SKILLS_LINK} is a real directory, not a symlink to ${CLAUDE_SKILLS_LINK_TARGET}; ` +
+    `${claudeSkillsDir} is a real directory, not a symlink to ${target}; ` +
     `left untouched. Claude will not see skills written to ${CANONICAL_SKILLS_DIR} until you ` +
-    `merge it in and replace it with the symlink (ln -s ${CLAUDE_SKILLS_LINK_TARGET} ${CLAUDE_SKILLS_LINK}).`
+    `merge it in and replace it with the symlink (ln -s ${target} ${claudeSkillsDir}).`
   );
 }
 
-function inspectClaudeSkillsLink(repoRoot) {
+function inspectClaudeSkillsLink(repoRoot, claudeSkillsDir = CLAUDE_SKILLS_LINK) {
+  const link = path.isAbsolute(claudeSkillsDir) ? claudeSkillsDir : path.join(repoRoot, claudeSkillsDir);
   let stat;
   try {
-    stat = fs.lstatSync(path.join(repoRoot, CLAUDE_SKILLS_LINK));
+    stat = fs.lstatSync(link);
   } catch {
     return { state: "missing" };
   }
@@ -410,7 +411,7 @@ export function removeOwnedSkillPaths(paths) {
  * `.claude/skills` is never clobbered: a symlink (to anywhere) is left as is, and a real
  * directory is reported so the user can merge it by hand.
  */
-export function ensureSkillsLayout(repoRoot) {
+export function ensureSkillsLayout(repoRoot, claudeSkillsDir = CLAUDE_SKILLS_LINK) {
   const created = [];
   const warnings = [];
   const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
@@ -419,14 +420,15 @@ export function ensureSkillsLayout(repoRoot) {
     created.push(CANONICAL_SKILLS_DIR);
   }
 
-  const claude = inspectClaudeSkillsLink(repoRoot);
+  const link = path.isAbsolute(claudeSkillsDir) ? claudeSkillsDir : path.join(repoRoot, claudeSkillsDir);
+  const target = path.relative(path.dirname(link), canonical) || ".";
+  const claude = inspectClaudeSkillsLink(repoRoot, claudeSkillsDir);
   if (claude.state === "missing") {
-    const link = path.join(repoRoot, CLAUDE_SKILLS_LINK);
     fs.mkdirSync(path.dirname(link), { recursive: true });
-    fs.symlinkSync(CLAUDE_SKILLS_LINK_TARGET, link, "dir");
-    created.push(`${CLAUDE_SKILLS_LINK} -> ${CLAUDE_SKILLS_LINK_TARGET}`);
+    fs.symlinkSync(target, link, "dir");
+    created.push(`${claudeSkillsDir} -> ${target}`);
   } else if (claude.state === "dir") {
-    warnings.push(claudeSkillsDirWarning());
+    warnings.push(claudeSkillsDirWarning(claudeSkillsDir, target));
   }
   return { created, warnings };
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -65,14 +65,22 @@ export function loadSkills(repoRoot, skillsDir) {
 }
 
 /**
- * Every project-level skill root a supported harness can load. The overflow target is
- * included even when custom-configured, and roots resolving to the same directory (the
- * normal `.claude/skills` symlink) are counted only once.
+ * Resolve supported skill roots without double-counting directories reached by symlink.
+ * Project scope includes the conventional roots; exact mode uses only the configured
+ * harness roots and overflow target.
  */
-export function resolveProjectSkillDirs(repoRoot, overflowDir = CANONICAL_SKILLS_DIR, extraDirs = []) {
+export function resolveProjectSkillDirs(
+  repoRoot,
+  overflowDir = CANONICAL_SKILLS_DIR,
+  extraDirs = [],
+  { exact = false } = {},
+) {
   const dirs = [];
   const seen = new Set();
-  for (const dir of [overflowDir, CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK, ...extraDirs]) {
+  const candidates = exact
+    ? [overflowDir, ...extraDirs]
+    : [overflowDir, CANONICAL_SKILLS_DIR, CLAUDE_SKILLS_LINK, ...extraDirs];
+  for (const dir of candidates) {
     if (!dir) continue;
     const absolute = path.isAbsolute(dir) ? dir : path.join(repoRoot, dir);
     const exists = fs.existsSync(absolute);
@@ -93,8 +101,8 @@ export function resolveProjectSkillDirs(repoRoot, overflowDir = CANONICAL_SKILLS
 }
 
 /** Load generated and human-authored project skills across every supported root. */
-export function loadProjectSkills(repoRoot, overflowDir = CANONICAL_SKILLS_DIR, extraDirs = []) {
-  return resolveProjectSkillDirs(repoRoot, overflowDir, extraDirs)
+export function loadProjectSkills(repoRoot, overflowDir = CANONICAL_SKILLS_DIR, extraDirs = [], options = {}) {
+  return resolveProjectSkillDirs(repoRoot, overflowDir, extraDirs, options)
     .flatMap((dir) => loadSkills(repoRoot, dir))
     .sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
 }
@@ -267,10 +275,17 @@ export const CLAUDE_SKILLS_LINK_TARGET = path.posix.join("..", CANONICAL_SKILLS_
  * created at write time (`ensureSkillsLayout`), which keeps every pre-apply stage
  * side-effect free.
  */
-export function resolveOverflowTarget(repoRoot, skillsDir = CANONICAL_SKILLS_DIR) {
+export function resolveOverflowTarget(
+  repoRoot,
+  skillsDir = CANONICAL_SKILLS_DIR,
+  { claudeSkillsDir = CLAUDE_SKILLS_LINK } = {},
+) {
   const warnings = [];
-  const claude = inspectClaudeSkillsLink(repoRoot);
-  if (claude.state === "dir") warnings.push(claudeSkillsDirWarning());
+  const canonical = path.join(repoRoot, CANONICAL_SKILLS_DIR);
+  const claudeLink = path.isAbsolute(claudeSkillsDir) ? claudeSkillsDir : path.join(repoRoot, claudeSkillsDir);
+  const target = path.relative(path.dirname(claudeLink), canonical) || ".";
+  const claude = inspectClaudeSkillsLink(repoRoot, claudeSkillsDir);
+  if (claude.state === "dir") warnings.push(claudeSkillsDirWarning(claudeSkillsDir, target));
 
   const explicit = skillsDir && skillsDir !== CANONICAL_SKILLS_DIR && skillsDir !== CLAUDE_SKILLS_LINK;
   const resolvedSkillsDir = path.isAbsolute(skillsDir) ? skillsDir : path.join(repoRoot, skillsDir);

--- a/src/state.js
+++ b/src/state.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 import { STATE_DIRNAME } from "./config.js";
-import { warn } from "./logger.js";
+import { UserError, warn } from "./logger.js";
 import { ensureLocalExclude } from "./repo.js";
 import { transcriptIdentity } from "./transcript.js";
 
@@ -52,12 +52,20 @@ export class State {
    * state is created 0700 and is never git-excluded (it does not live in a checkout).
    */
   ensure() {
-    fs.mkdirSync(this.root, { recursive: true });
+    fs.mkdirSync(this.root, { recursive: true, ...(this.dirMode ? { mode: this.dirMode } : {}) });
     if (this.dirMode) {
       try {
         fs.chmodSync(this.root, this.dirMode);
-      } catch {
-        // A filesystem that ignores mode still has the directory; keep going.
+      } catch (err) {
+        throw new UserError(
+          `could not secure state directory ${this.root} as mode ${this.dirMode.toString(8)}: ${err.message}`,
+        );
+      }
+      const actualMode = fs.statSync(this.root).mode & 0o777;
+      if (actualMode !== this.dirMode) {
+        throw new UserError(
+          `could not secure state directory ${this.root} as mode ${this.dirMode.toString(8)} (got ${actualMode.toString(8)})`,
+        );
       }
     }
     fs.mkdirSync(this.evidenceDir, { recursive: true });

--- a/src/state.js
+++ b/src/state.js
@@ -28,8 +28,14 @@ export const STATE_EXCLUDE_LINE = `${STATE_DIRNAME}/`;
  *   apply/                 the rendered Lavish apply surface
  */
 export class State {
-  constructor(repoRoot) {
-    this.root = path.join(repoRoot, STATE_DIRNAME);
+  /**
+   * @param {string} repoRoot project checkout, or ignored when `options.stateDir` is set
+   * @param {{ stateDir?: string, mode?: number, exclude?: boolean }} [options]
+   */
+  constructor(repoRoot, options = {}) {
+    this.root = options.stateDir || path.join(repoRoot, STATE_DIRNAME);
+    this.dirMode = options.mode;
+    this.skipExclude = options.exclude === false;
     this.evidenceDir = path.join(this.root, "evidence");
     this.applyDir = path.join(this.root, "apply");
     this.scanCachePath = path.join(this.root, "scan-cache.json");
@@ -42,12 +48,23 @@ export class State {
 
   /**
    * Creates the state dir and excludes it from git in the same step. The exclude is
-   * local-only and fail-soft: a non-git directory is silently left alone.
+   * local-only and fail-soft: a non-git directory is silently left alone. User-scope
+   * state is created 0700 and is never git-excluded (it does not live in a checkout).
    */
   ensure() {
+    fs.mkdirSync(this.root, { recursive: true });
+    if (this.dirMode) {
+      try {
+        fs.chmodSync(this.root, this.dirMode);
+      } catch {
+        // A filesystem that ignores mode still has the directory; keep going.
+      }
+    }
     fs.mkdirSync(this.evidenceDir, { recursive: true });
     fs.mkdirSync(this.applyDir, { recursive: true });
-    this.exclude = ensureLocalExclude(path.dirname(this.root), STATE_EXCLUDE_LINE);
+    this.exclude = this.skipExclude
+      ? { status: "skipped" }
+      : ensureLocalExclude(path.dirname(this.root), STATE_EXCLUDE_LINE);
     return this;
   }
 

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -19,30 +19,17 @@ import path from "node:path";
  * @param {string} bin
  * @param {string[]} args
  * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv,
- *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv, readOnlyRoots?: string[], writableRoots?: string[],
+ *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv,
  *   spawnFn?: (file: string, args: string[], options: object) => any }} [options]
  * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: ShimError }>}
  */
 export function runCapture(
   bin,
   args,
-  {
-    timeoutMs,
-    cwd,
-    input,
-    env,
-    platform = process.platform,
-    lookupEnv = process.env,
-    readOnlyRoots = [],
-    writableRoots = [],
-    spawnFn = spawn,
-  } = {},
+  { timeoutMs, cwd, input, env, platform = process.platform, lookupEnv = process.env, spawnFn = spawn } = {},
 ) {
   return new Promise((resolve) => {
-    let launch = windowsShimLaunch(bin, args, { platform, env: lookupEnv });
-    if (!launch.error && readOnlyRoots.length) {
-      launch = readOnlyLaunch(launch, readOnlyRoots, { platform, env: lookupEnv, writableRoots });
-    }
+    const launch = windowsShimLaunch(bin, args, { platform, env: lookupEnv });
     if (launch.error) {
       // Loud and named: an argument no quoting can neutralise must not reach a shim
       // where cmd.exe would silently rewrite it into several arguments or commands.
@@ -101,77 +88,6 @@ export function runCapture(
     if (input !== undefined) child.stdin.end(input);
     else child.stdin.end();
   });
-}
-
-export function supportsReadOnlyLaunch({ platform = process.platform, env = process.env } = {}) {
-  if (platform === "darwin") return fs.existsSync("/usr/bin/sandbox-exec");
-  if (platform === "linux") {
-    const bwrap = resolveOnPath("bwrap", { platform, env });
-    if (!bwrap) return false;
-    const probe = spawnSync(bwrap, ["--ro-bind", "/", "/", "--", process.execPath, "-e", ""], {
-      env,
-      stdio: "ignore",
-      timeout: 5000,
-    });
-    return probe.status === 0;
-  }
-  return false;
-}
-
-export function readOnlyLaunch(
-  launch,
-  roots,
-  { platform = process.platform, env = process.env, writableRoots = [] } = {},
-) {
-  const canonical = (root) => {
-    try {
-      return fs.realpathSync(root);
-    } catch {
-      return path.resolve(root);
-    }
-  };
-  const unique = [...new Set(roots.map(canonical))];
-  const writable = [...new Set(writableRoots.map(canonical))].filter(
-    (candidate) =>
-      !unique.some((readOnly) => {
-        const relative = path.relative(candidate, readOnly);
-        return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-      }),
-  );
-  if (!unique.length) return launch;
-  if (platform === "darwin" && supportsReadOnlyLaunch({ platform, env })) {
-    const profile = `(version 1)(allow default)${unique
-      .map((root) => `(deny file-write* (subpath ${JSON.stringify(root)}))`)
-      .join("")}${writable.map((root) => `(allow file-write* (subpath ${JSON.stringify(root)}))`).join("")}`;
-    return {
-      file: "/usr/bin/sandbox-exec",
-      args: ["-p", profile, launch.file, ...launch.args],
-      verbatim: false,
-    };
-  }
-  if (platform === "linux") {
-    const bwrap = resolveOnPath("bwrap", { platform, env });
-    if (bwrap) {
-      return {
-        file: bwrap,
-        args: [
-          "--bind",
-          "/",
-          "/",
-          ...unique.flatMap((root) => ["--ro-bind", root, root]),
-          ...writable.flatMap((root) => ["--bind", root, root]),
-          "--",
-          launch.file,
-          ...launch.args,
-        ],
-        verbatim: false,
-      };
-    }
-  }
-  const error = Object.assign(new Error(`read-only grounding is unavailable on ${platform}`), {
-    code: "ERR_READ_ONLY_ROOTS_UNAVAILABLE",
-  });
-  return { ...launch, error };
 }
 
 /**

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -103,13 +103,35 @@ export function runCapture(
   });
 }
 
+export function supportsReadOnlyLaunch({ platform = process.platform, env = process.env } = {}) {
+  if (platform === "darwin") return fs.existsSync("/usr/bin/sandbox-exec");
+  if (platform === "linux") {
+    const bwrap = resolveOnPath("bwrap", { platform, env });
+    if (!bwrap) return false;
+    const probe = spawnSync(bwrap, ["--ro-bind", "/", "/", "--", process.execPath, "-e", ""], {
+      env,
+      stdio: "ignore",
+      timeout: 5000,
+    });
+    return probe.status === 0;
+  }
+  return false;
+}
+
 export function readOnlyLaunch(
   launch,
   roots,
   { platform = process.platform, env = process.env, writableRoots = [] } = {},
 ) {
-  const unique = [...new Set(roots.map((root) => path.resolve(root)))];
-  const writable = [...new Set(writableRoots.map((root) => path.resolve(root)))].filter(
+  const canonical = (root) => {
+    try {
+      return fs.realpathSync(root);
+    } catch {
+      return path.resolve(root);
+    }
+  };
+  const unique = [...new Set(roots.map(canonical))];
+  const writable = [...new Set(writableRoots.map(canonical))].filter(
     (candidate) =>
       !unique.some((readOnly) => {
         const relative = path.relative(candidate, readOnly);
@@ -117,7 +139,7 @@ export function readOnlyLaunch(
       }),
   );
   if (!unique.length) return launch;
-  if (platform === "darwin") {
+  if (platform === "darwin" && supportsReadOnlyLaunch({ platform, env })) {
     const profile = `(version 1)(allow default)${unique
       .map((root) => `(deny file-write* (subpath ${JSON.stringify(root)}))`)
       .join("")}${writable.map((root) => `(allow file-write* (subpath ${JSON.stringify(root)}))`).join("")}`;

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -19,7 +19,7 @@ import path from "node:path";
  * @param {string} bin
  * @param {string[]} args
  * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv,
- *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv, readOnlyRoots?: string[],
+ *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv, readOnlyRoots?: string[], writableRoots?: string[],
  *   spawnFn?: (file: string, args: string[], options: object) => any }} [options]
  * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: ShimError }>}
  */
@@ -34,13 +34,14 @@ export function runCapture(
     platform = process.platform,
     lookupEnv = process.env,
     readOnlyRoots = [],
+    writableRoots = [],
     spawnFn = spawn,
   } = {},
 ) {
   return new Promise((resolve) => {
     let launch = windowsShimLaunch(bin, args, { platform, env: lookupEnv });
     if (!launch.error && readOnlyRoots.length) {
-      launch = readOnlyLaunch(launch, readOnlyRoots, { platform, env: lookupEnv });
+      launch = readOnlyLaunch(launch, readOnlyRoots, { platform, env: lookupEnv, writableRoots });
     }
     if (launch.error) {
       // Loud and named: an argument no quoting can neutralise must not reach a shim
@@ -102,13 +103,18 @@ export function runCapture(
   });
 }
 
-export function readOnlyLaunch(launch, roots, { platform = process.platform, env = process.env } = {}) {
+export function readOnlyLaunch(
+  launch,
+  roots,
+  { platform = process.platform, env = process.env, writableRoots = [] } = {},
+) {
   const unique = [...new Set(roots.map((root) => path.resolve(root)))];
+  const writable = [...new Set(writableRoots.map((root) => path.resolve(root)))];
   if (!unique.length) return launch;
   if (platform === "darwin") {
     const profile = `(version 1)(allow default)${unique
       .map((root) => `(deny file-write* (subpath ${JSON.stringify(root)}))`)
-      .join("")}`;
+      .join("")}${writable.map((root) => `(allow file-write* (subpath ${JSON.stringify(root)}))`).join("")}`;
     return {
       file: "/usr/bin/sandbox-exec",
       args: ["-p", profile, launch.file, ...launch.args],
@@ -120,7 +126,16 @@ export function readOnlyLaunch(launch, roots, { platform = process.platform, env
     if (bwrap) {
       return {
         file: bwrap,
-        args: ["--bind", "/", "/", ...unique.flatMap((root) => ["--ro-bind", root, root]), "--", launch.file, ...launch.args],
+        args: [
+          "--bind",
+          "/",
+          "/",
+          ...unique.flatMap((root) => ["--ro-bind", root, root]),
+          ...writable.flatMap((root) => ["--bind", root, root]),
+          "--",
+          launch.file,
+          ...launch.args,
+        ],
         verbatim: false,
       };
     }

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -109,7 +109,13 @@ export function readOnlyLaunch(
   { platform = process.platform, env = process.env, writableRoots = [] } = {},
 ) {
   const unique = [...new Set(roots.map((root) => path.resolve(root)))];
-  const writable = [...new Set(writableRoots.map((root) => path.resolve(root)))];
+  const writable = [...new Set(writableRoots.map((root) => path.resolve(root)))].filter(
+    (candidate) =>
+      !unique.some((readOnly) => {
+        const relative = path.relative(candidate, readOnly);
+        return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+      }),
+  );
   if (!unique.length) return launch;
   if (platform === "darwin") {
     const profile = `(version 1)(allow default)${unique

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -168,8 +168,9 @@ export function readOnlyLaunch(
       };
     }
   }
-  const error = new Error(`read-only grounding is unavailable on ${platform}`);
-  error.code = "ERR_READ_ONLY_ROOTS_UNAVAILABLE";
+  const error = Object.assign(new Error(`read-only grounding is unavailable on ${platform}`), {
+    code: "ERR_READ_ONLY_ROOTS_UNAVAILABLE",
+  });
   return { ...launch, error };
 }
 

--- a/src/subprocess.js
+++ b/src/subprocess.js
@@ -19,17 +19,29 @@ import path from "node:path";
  * @param {string} bin
  * @param {string[]} args
  * @param {{ timeoutMs?: number, cwd?: string, input?: string, env?: NodeJS.ProcessEnv,
- *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv,
+ *   platform?: NodeJS.Platform, lookupEnv?: NodeJS.ProcessEnv, readOnlyRoots?: string[],
  *   spawnFn?: (file: string, args: string[], options: object) => any }} [options]
  * @returns {Promise<{ code: number | null, stdout: string, stderr: string, timedOut?: boolean, spawnError?: ShimError }>}
  */
 export function runCapture(
   bin,
   args,
-  { timeoutMs, cwd, input, env, platform = process.platform, lookupEnv = process.env, spawnFn = spawn } = {},
+  {
+    timeoutMs,
+    cwd,
+    input,
+    env,
+    platform = process.platform,
+    lookupEnv = process.env,
+    readOnlyRoots = [],
+    spawnFn = spawn,
+  } = {},
 ) {
   return new Promise((resolve) => {
-    const launch = windowsShimLaunch(bin, args, { platform, env: lookupEnv });
+    let launch = windowsShimLaunch(bin, args, { platform, env: lookupEnv });
+    if (!launch.error && readOnlyRoots.length) {
+      launch = readOnlyLaunch(launch, readOnlyRoots, { platform, env: lookupEnv });
+    }
     if (launch.error) {
       // Loud and named: an argument no quoting can neutralise must not reach a shim
       // where cmd.exe would silently rewrite it into several arguments or commands.
@@ -88,6 +100,34 @@ export function runCapture(
     if (input !== undefined) child.stdin.end(input);
     else child.stdin.end();
   });
+}
+
+export function readOnlyLaunch(launch, roots, { platform = process.platform, env = process.env } = {}) {
+  const unique = [...new Set(roots.map((root) => path.resolve(root)))];
+  if (!unique.length) return launch;
+  if (platform === "darwin") {
+    const profile = `(version 1)(allow default)${unique
+      .map((root) => `(deny file-write* (subpath ${JSON.stringify(root)}))`)
+      .join("")}`;
+    return {
+      file: "/usr/bin/sandbox-exec",
+      args: ["-p", profile, launch.file, ...launch.args],
+      verbatim: false,
+    };
+  }
+  if (platform === "linux") {
+    const bwrap = resolveOnPath("bwrap", { platform, env });
+    if (bwrap) {
+      return {
+        file: bwrap,
+        args: ["--bind", "/", "/", ...unique.flatMap((root) => ["--ro-bind", root, root]), "--", launch.file, ...launch.args],
+        verbatim: false,
+      };
+    }
+  }
+  const error = new Error(`read-only grounding is unavailable on ${platform}`);
+  error.code = "ERR_READ_ONLY_ROOTS_UNAVAILABLE";
+  return { ...launch, error };
 }
 
 /**

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -149,13 +149,13 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
  * Everything the edit and annotation turns need: prompt values, the `buildProposal`
  * context, and the overflow target.
  */
-function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
+function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scope = null }) {
   const state = config.state;
   const rejections = state.readRejections();
   const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
   for (const w of overflow.warnings) warn(w);
-  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir);
-  const skillFiles = loadProjectSkills(repo.root, overflow.dir);
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || []);
+  const skillFiles = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || []);
   const descriptionTokens = skillDescriptionTokens(skillFiles);
   const maxEdits = effectiveMaxEdits(memoryFile, config, descriptionTokens);
 
@@ -170,6 +170,7 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
     memoryFile,
     config: { ...config, skillsDir: overflow.dir, skillDirs },
     repo,
+    scope,
     summary,
     harnessCounts,
     rejections,
@@ -200,11 +201,17 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts }) {
  * fresh session used after an empty reply would otherwise be asked to quote evidence it
  * has never been shown.
  */
-function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0 }) {
+function groundingRoot(repo, transcripts, scope) {
+  if (scope?.kind !== "user") return repo.root;
+  const roots = [...new Set((transcripts || []).map((t) => t.projectRoot).filter(Boolean))].slice(0, 8);
+  return roots.length ? roots.join("\n") : "(no live project checkouts in this sample)";
+}
+
+function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0, grounding = null }) {
   return render(loadPrompt("annotate-preface"), {
     MEMORY_PATH: memoryFile.path,
     REPO_NAME: repo.name,
-    REPO_ROOT: repo.root,
+    REPO_ROOT: grounding || repo.root,
     WORKSPACE_ROOT: workspaceRoot,
     CURRENT_TOKENS: String(memoryFile.tokens + descriptionTokens),
     BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
@@ -387,7 +394,15 @@ async function annotateLoop({
   });
 }
 
-export async function synthesizeProposal({ memoryFile, summary, config, repo, transcripts, runNote = "" }) {
+export async function synthesizeProposal({
+  memoryFile,
+  summary,
+  config,
+  repo,
+  transcripts,
+  runNote = "",
+  scope = null,
+}) {
   config.state.clearProposal();
   const harnessCounts = harnessCountsOf(transcripts);
   const {
@@ -407,12 +422,15 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
     config,
     repo,
     harnessCounts,
+    scope,
   });
+
+  const repoRoot = groundingRoot(repo, transcripts, scope);
 
   const editValues = {
     ...common,
     REPO_NAME: repo.name,
-    REPO_ROOT: repo.root,
+    REPO_ROOT: repoRoot,
     TRANSCRIPT_COUNT: String(summary.analyzedSessions),
     RUN_NOTE: runNote,
     HARNESS_SUMMARY:
@@ -541,7 +559,15 @@ export async function synthesizeProposal({ memoryFile, summary, config, repo, tr
       overflow,
       progress,
       renderPreface: () =>
-        prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root, descriptionTokens }),
+        prefaceFor({
+          memoryFile,
+          summary,
+          config,
+          repo,
+          workspaceRoot: workspace.root,
+          descriptionTokens,
+          grounding: repoRoot,
+        }),
     });
   } finally {
     await holder.session.close();

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -431,6 +431,13 @@ export async function synthesizeProposal({
 
   const readOnlyGroundingRoots = groundingRoots(transcripts, scope);
   const repoRoot = groundingRoot(repo, readOnlyGroundingRoots, scope);
+  let workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, skillDirs });
+  const stagedSkillsDir =
+    workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged || workspacePathFor(overflow.dir);
+  const stagedSkillFiles = skillFiles.map((skill) => ({
+    ...skill,
+    path: workspace.stagedPaths.get(skill.path) || workspacePathFor(skill.path),
+  }));
 
   const editValues = {
     ...common,
@@ -446,8 +453,8 @@ export async function synthesizeProposal({
     BUDGET_TOKENS: String(config.budgetTokens),
     BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
-    SKILLS_DIR: overflow.dir,
-    SKILL_INDEX: renderSkillIndex(skillFiles.map((skill) => ({ ...skill, path: workspacePathFor(skill.path) }))),
+    SKILLS_DIR: stagedSkillsDir,
+    SKILL_INDEX: renderSkillIndex(stagedSkillFiles),
     EVIDENCE: renderEvidenceForPrompt(summary),
     REJECTIONS: renderRejections(rejections),
   };
@@ -502,8 +509,6 @@ export async function synthesizeProposal({
       return this.session.prompt(args);
     },
   };
-  /** @type {ReturnType<typeof prepareWorkspace>} */
-  let workspace = null;
   const editResult = await config.agents.withFallthrough("synthesis", async (current) => {
     ranWith = current.agent;
     holder.ranWith = current.agent;

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -449,7 +449,8 @@ export async function synthesizeProposal({
   const repoRoot = groundingRoot(repo, liveGroundingRoots, scope, groundingAvailable);
   let workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, skillDirs });
   const stagedSkillsDir =
-    workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged || workspacePathFor(overflow.dir);
+    workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged ||
+    workspacePathFor(overflow.dir);
   const stagedSkillFiles = skillFiles.map((skill) => ({
     ...skill,
     path: workspace.stagedPaths.get(skill.path) || workspacePathFor(skill.path),

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -15,7 +15,7 @@ import {
 } from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
-import { measureWorkspace, prepareWorkspace, repoFingerprint, treeFingerprint } from "./workspace.js";
+import { measureWorkspace, prepareWorkspace, repoFingerprint, workspacePathFor } from "./workspace.js";
 import { UserError, color, info, warn } from "./logger.js";
 
 /**
@@ -135,13 +135,11 @@ function harnessCountsOf(transcripts) {
 
 /** The repo must be exactly as fingerprinted; the staging copy is the only place to write. */
 function assertRepoUntouched(repo, before, workspaceRoot) {
-  const after = repoFingerprint(repo, Object.keys(before.repo));
-  const moved = Object.keys(before.repo).filter((file) => before.repo[file] !== after[file]);
-  const groundingChanged = before.grounding !== treeFingerprint(before.groundingRoots);
-  if (!moved.length && !groundingChanged) return;
-  const changed = [...moved, ...(groundingChanged ? before.groundingRoots : [])];
+  const after = repoFingerprint(repo, Object.keys(before));
+  const moved = Object.keys(before).filter((file) => before[file] !== after[file]);
+  if (!moved.length) return;
   throw new UserError(
-    `synthesis changed ${changed.join(", ")} in the repository directly instead of the staging copy ` +
+    `synthesis changed ${moved.join(", ")} in the repository directly instead of the staging copy ` +
       `(${workspaceRoot}); nothing was proposed`,
     `inspect the change with \`git diff\`, restore the file, and re-run - a harness that edits outside its cwd cannot be trusted with the synthesis role`,
   );
@@ -162,7 +160,7 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
   const maxEdits = effectiveMaxEdits(memoryFile, config, descriptionTokens);
 
   const common = {
-    MEMORY_PATH: memoryFile.path,
+    MEMORY_PATH: workspacePathFor(memoryFile.path),
     BUDGET_RULE: budgetRule(memoryFile, config, maxEdits, descriptionTokens),
     MAX_EDITS: String(maxEdits),
     MIN_GAP_EVIDENCE: String(config.minGapEvidence),
@@ -215,7 +213,7 @@ function groundingRoot(repo, roots, scope) {
 
 function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0, grounding = null }) {
   return render(loadPrompt("annotate-preface"), {
-    MEMORY_PATH: memoryFile.path,
+    MEMORY_PATH: workspacePathFor(memoryFile.path),
     REPO_NAME: repo.name,
     REPO_ROOT: grounding || repo.root,
     WORKSPACE_ROOT: workspaceRoot,
@@ -449,7 +447,7 @@ export async function synthesizeProposal({
     BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
     SKILLS_DIR: overflow.dir,
-    SKILL_INDEX: renderSkillIndex(skillFiles),
+    SKILL_INDEX: renderSkillIndex(skillFiles.map((skill) => ({ ...skill, path: workspacePathFor(skill.path) }))),
     EVIDENCE: renderEvidenceForPrompt(summary),
     REJECTIONS: renderRejections(rejections),
   };
@@ -457,11 +455,7 @@ export async function synthesizeProposal({
   const editPromptFile = path.join(promptDir, "synthesis-edit.md");
   fs.writeFileSync(editPromptFile, renderPrompt("synthesis", editValues));
 
-  const fingerprint = {
-    repo: repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]),
-    groundingRoots: readOnlyGroundingRoots,
-    grounding: treeFingerprint(readOnlyGroundingRoots),
-  };
+  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
   const sessionName = `backpass-synth-${process.pid}`;
   const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
   const usage = [];
@@ -524,6 +518,7 @@ export async function synthesizeProposal({
       sessionName,
       cwd: workspace.root,
       writeAccess: true,
+      readOnlyRoots: readOnlyGroundingRoots,
     });
     try {
       return await holder.session.prompt({
@@ -550,6 +545,7 @@ export async function synthesizeProposal({
       sessionName: `${sessionName}-r${(serial += 1)}`,
       cwd: workspace.root,
       writeAccess: true,
+      readOnlyRoots: readOnlyGroundingRoots,
     });
 
   try {

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -18,7 +18,6 @@ import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
 import { measureWorkspace, prepareWorkspace, repoFingerprint, workspacePathFor } from "./workspace.js";
 import { UserError, color, info, warn } from "./logger.js";
-import { supportsReadOnlyLaunch } from "./subprocess.js";
 
 /**
  * Stage 3 of the pipeline (design section 3): high-reasoning synthesis that turns folded
@@ -206,34 +205,11 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
  * fresh session used after an empty reply would otherwise be asked to quote evidence it
  * has never been shown.
  */
-function groundingRoots(transcripts, scope) {
-  if (scope?.kind !== "user") return [];
-  const roots = [];
-  for (const transcript of transcripts || []) {
-    const candidate = transcript.projectRoot || transcript.cwd;
-    if (!candidate || !fs.existsSync(candidate)) continue;
-    let root;
-    try {
-      root = fs.realpathSync(candidate);
-    } catch {
-      continue;
-    }
-    if (fs.statSync(root).isDirectory() && !roots.includes(root)) roots.push(root);
-  }
-  return roots;
-}
-
-function groundingRoot(repo, roots, scope, available = true) {
-  if (scope?.kind !== "user") return repo.root;
-  if (!available) return "(live project paths withheld: read-only containment unavailable)";
-  return roots.length ? roots.join("\n") : "(no live project checkouts in this sample)";
-}
-
-function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0, grounding = null }) {
+function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0 }) {
   return render(loadPrompt("annotate-preface"), {
     MEMORY_PATH: workspacePathFor(memoryFile.path),
     REPO_NAME: repo.name,
-    REPO_ROOT: grounding || repo.root,
+    REPO_ROOT: repo.root,
     WORKSPACE_ROOT: workspaceRoot,
     CURRENT_TOKENS: String(memoryFile.tokens + descriptionTokens),
     BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
@@ -447,10 +423,6 @@ export async function synthesizeProposal({
     scope,
   });
 
-  const liveGroundingRoots = groundingRoots(transcripts, scope);
-  const groundingAvailable = !liveGroundingRoots.length || supportsReadOnlyLaunch();
-  const readOnlyGroundingRoots = groundingAvailable ? liveGroundingRoots : [];
-  const repoRoot = groundingRoot(repo, liveGroundingRoots, scope, groundingAvailable);
   let workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, skillDirs });
   const stagedSkillsDir =
     workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged ||
@@ -463,7 +435,7 @@ export async function synthesizeProposal({
   const editValues = {
     ...common,
     REPO_NAME: repo.name,
-    REPO_ROOT: repoRoot,
+    REPO_ROOT: repo.root,
     TRANSCRIPT_COUNT: String(summary.analyzedSessions),
     RUN_NOTE: runNote,
     HARNESS_SUMMARY:
@@ -544,7 +516,6 @@ export async function synthesizeProposal({
       sessionName,
       cwd: workspace.root,
       writeAccess: true,
-      readOnlyRoots: readOnlyGroundingRoots,
     });
     try {
       return await holder.session.prompt({
@@ -571,7 +542,6 @@ export async function synthesizeProposal({
       sessionName: `${sessionName}-r${(serial += 1)}`,
       cwd: workspace.root,
       writeAccess: true,
-      readOnlyRoots: readOnlyGroundingRoots,
     });
 
   try {
@@ -592,15 +562,7 @@ export async function synthesizeProposal({
       overflow,
       progress,
       renderPreface: () =>
-        prefaceFor({
-          memoryFile,
-          summary,
-          config,
-          repo,
-          workspaceRoot: workspace.root,
-          descriptionTokens,
-          grounding: repoRoot,
-        }),
+        prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root, descriptionTokens }),
     });
   } finally {
     await holder.session.close();

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -17,6 +17,7 @@ import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
 import { measureWorkspace, prepareWorkspace, repoFingerprint, workspacePathFor } from "./workspace.js";
 import { UserError, color, info, warn } from "./logger.js";
+import { supportsReadOnlyLaunch } from "./subprocess.js";
 
 /**
  * Stage 3 of the pipeline (design section 3): high-reasoning synthesis that turns folded
@@ -203,11 +204,24 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
  */
 function groundingRoots(transcripts, scope) {
   if (scope?.kind !== "user") return [];
-  return [...new Set((transcripts || []).map((t) => t.projectRoot).filter(Boolean))].slice(0, 8);
+  const roots = [];
+  for (const transcript of transcripts || []) {
+    const candidate = transcript.projectRoot || transcript.cwd;
+    if (!candidate || !fs.existsSync(candidate)) continue;
+    let root;
+    try {
+      root = fs.realpathSync(candidate);
+    } catch {
+      continue;
+    }
+    if (fs.statSync(root).isDirectory() && !roots.includes(root)) roots.push(root);
+  }
+  return roots;
 }
 
-function groundingRoot(repo, roots, scope) {
+function groundingRoot(repo, roots, scope, available = true) {
   if (scope?.kind !== "user") return repo.root;
+  if (!available) return "(live project paths withheld: read-only containment unavailable)";
   return roots.length ? roots.join("\n") : "(no live project checkouts in this sample)";
 }
 
@@ -429,8 +443,10 @@ export async function synthesizeProposal({
     scope,
   });
 
-  const readOnlyGroundingRoots = groundingRoots(transcripts, scope);
-  const repoRoot = groundingRoot(repo, readOnlyGroundingRoots, scope);
+  const liveGroundingRoots = groundingRoots(transcripts, scope);
+  const groundingAvailable = !liveGroundingRoots.length || supportsReadOnlyLaunch();
+  const readOnlyGroundingRoots = groundingAvailable ? liveGroundingRoots : [];
+  const repoRoot = groundingRoot(repo, liveGroundingRoots, scope, groundingAvailable);
   let workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, skillDirs });
   const stagedSkillsDir =
     workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged || workspacePathFor(overflow.dir);

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { extractJson, openSession, usageRecord } from "./acpx.js";
+import { userClaudeSkillsDir } from "./config.js";
 import { renderEvidenceForPrompt } from "./fold.js";
 import { renderInstructionIndex } from "./memory.js";
 import { renderPrompt, render, loadPrompt } from "./prompts.js";
@@ -153,10 +154,13 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
 function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scope = null }) {
   const state = config.state;
   const rejections = state.readRejections();
-  const overflow = resolveOverflowTarget(repo.root, config.skillsDir);
+  const userScope = scope?.kind === "user";
+  const overflow = resolveOverflowTarget(repo.root, config.skillsDir, {
+    claudeSkillsDir: userScope ? userClaudeSkillsDir() : undefined,
+  });
   for (const w of overflow.warnings) warn(w);
-  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || []);
-  const skillFiles = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || []);
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
+  const skillFiles = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
   const descriptionTokens = skillDescriptionTokens(skillFiles);
   const maxEdits = effectiveMaxEdits(memoryFile, config, descriptionTokens);
 

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -15,7 +15,7 @@ import {
 } from "./skills.js";
 import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
-import { measureWorkspace, prepareWorkspace, repoFingerprint } from "./workspace.js";
+import { measureWorkspace, prepareWorkspace, repoFingerprint, treeFingerprint } from "./workspace.js";
 import { UserError, color, info, warn } from "./logger.js";
 
 /**
@@ -135,11 +135,13 @@ function harnessCountsOf(transcripts) {
 
 /** The repo must be exactly as fingerprinted; the staging copy is the only place to write. */
 function assertRepoUntouched(repo, before, workspaceRoot) {
-  const after = repoFingerprint(repo, Object.keys(before));
-  const moved = Object.keys(before).filter((file) => before[file] !== after[file]);
-  if (!moved.length) return;
+  const after = repoFingerprint(repo, Object.keys(before.repo));
+  const moved = Object.keys(before.repo).filter((file) => before.repo[file] !== after[file]);
+  const groundingChanged = before.grounding !== treeFingerprint(before.groundingRoots);
+  if (!moved.length && !groundingChanged) return;
+  const changed = [...moved, ...(groundingChanged ? before.groundingRoots : [])];
   throw new UserError(
-    `synthesis changed ${moved.join(", ")} in the repository directly instead of the staging copy ` +
+    `synthesis changed ${changed.join(", ")} in the repository directly instead of the staging copy ` +
       `(${workspaceRoot}); nothing was proposed`,
     `inspect the change with \`git diff\`, restore the file, and re-run - a harness that edits outside its cwd cannot be trusted with the synthesis role`,
   );
@@ -201,9 +203,13 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
  * fresh session used after an empty reply would otherwise be asked to quote evidence it
  * has never been shown.
  */
-function groundingRoot(repo, transcripts, scope) {
+function groundingRoots(transcripts, scope) {
+  if (scope?.kind !== "user") return [];
+  return [...new Set((transcripts || []).map((t) => t.projectRoot).filter(Boolean))].slice(0, 8);
+}
+
+function groundingRoot(repo, roots, scope) {
   if (scope?.kind !== "user") return repo.root;
-  const roots = [...new Set((transcripts || []).map((t) => t.projectRoot).filter(Boolean))].slice(0, 8);
   return roots.length ? roots.join("\n") : "(no live project checkouts in this sample)";
 }
 
@@ -425,7 +431,8 @@ export async function synthesizeProposal({
     scope,
   });
 
-  const repoRoot = groundingRoot(repo, transcripts, scope);
+  const readOnlyGroundingRoots = groundingRoots(transcripts, scope);
+  const repoRoot = groundingRoot(repo, readOnlyGroundingRoots, scope);
 
   const editValues = {
     ...common,
@@ -450,7 +457,11 @@ export async function synthesizeProposal({
   const editPromptFile = path.join(promptDir, "synthesis-edit.md");
   fs.writeFileSync(editPromptFile, renderPrompt("synthesis", editValues));
 
-  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
+  const fingerprint = {
+    repo: repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]),
+    groundingRoots: readOnlyGroundingRoots,
+    grounding: treeFingerprint(readOnlyGroundingRoots),
+  };
   const sessionName = `backpass-synth-${process.pid}`;
   const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
   const usage = [];

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -290,6 +290,34 @@ function signatureOf(changes) {
   ).slice(0, 16);
 }
 
+export function treeFingerprint(roots) {
+  const entries = [];
+  const visit = (root, current = root) => {
+    let children;
+    try {
+      children = fs.readdirSync(current, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+    } catch (err) {
+      entries.push([root, path.relative(root, current), "error", err.code || err.message]);
+      return;
+    }
+    for (const child of children) {
+      if (current === root && child.name === ".git") continue;
+      const absolute = path.join(current, child.name);
+      const relative = path.relative(root, absolute);
+      if (child.isDirectory()) {
+        entries.push([root, relative, "dir"]);
+        visit(root, absolute);
+      } else if (child.isSymbolicLink()) {
+        entries.push([root, relative, "link", fs.readlinkSync(absolute)]);
+      } else if (child.isFile()) {
+        entries.push([root, relative, "file", sha256(fs.readFileSync(absolute))]);
+      }
+    }
+  };
+  for (const root of [...new Set(roots)].sort()) visit(root);
+  return sha256(JSON.stringify(entries));
+}
+
 /** The files backpass must find untouched in the repo after synthesis: a moved write is a bug, loudly. */
 export function repoFingerprint(repo, files) {
   const out = {};

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -323,7 +323,16 @@ export function measureWorkspace(workspace) {
         continue;
       }
       const subHunks = splitRemovalHunk(change, { oldText, oldLines, recovered });
-      if (subHunks) measured.push(...subHunks.map((sub) => ({ kind: "hunk", file: memoryPath, ...sub })));
+      if (subHunks) {
+        measured.push(
+          ...subHunks.map((sub) => ({
+            kind: "hunk",
+            file: memoryPath,
+            workspaceFile: change.workspaceFile,
+            ...sub,
+          })),
+        );
+      }
       else measured.push(change);
     }
     changes.splice(0, changes.length, ...measured);

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -274,9 +274,7 @@ export function measureWorkspace(workspace) {
   const knownStaged = new Set(stagedPaths.values());
   for (const staged of [...present].sort()) {
     if (knownStaged.has(staged)) continue;
-    const mapping = skillMappings.find(
-      ({ staged: dir }) => staged === dir || staged.startsWith(`${dir}/`),
-    );
+    const mapping = skillMappings.find(({ staged: dir }) => staged === dir || staged.startsWith(`${dir}/`));
     if (!mapping) {
       stray.push(staged);
       continue;
@@ -332,8 +330,7 @@ export function measureWorkspace(workspace) {
             ...sub,
           })),
         );
-      }
-      else measured.push(change);
+      } else measured.push(change);
     }
     changes.splice(0, changes.length, ...measured);
   }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -25,6 +25,11 @@ export function workspaceRoot(state) {
   return path.join(state.root, WORKSPACE_DIRNAME);
 }
 
+export function workspacePathFor(file) {
+  if (!path.isAbsolute(file)) return file.split(path.sep).join("/");
+  return path.posix.join(".external", sha256(file).slice(0, 16), path.basename(file));
+}
+
 /**
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
@@ -35,25 +40,43 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs
   fs.mkdirSync(root, { recursive: true });
 
   const originals = new Map();
-  const memoryTarget = path.join(root, memoryFile.path);
+  const stagedPaths = new Map();
+  const memoryWorkspacePath = workspacePathFor(memoryFile.path);
+  const memoryTarget = path.join(root, memoryWorkspacePath);
   fs.mkdirSync(path.dirname(memoryTarget), { recursive: true });
   fs.writeFileSync(memoryTarget, memoryFile.text);
   originals.set(memoryFile.path, memoryFile.text);
+  stagedPaths.set(memoryFile.path, memoryWorkspacePath);
 
-  for (const sourceDir of skillDirs) {
-    const skillsSource = path.join(repo.root, sourceDir);
+  const skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) }));
+  for (const { logical: sourceDir, staged: stagedDir } of skillMappings) {
+    const skillsSource = path.isAbsolute(sourceDir) ? sourceDir : path.join(repo.root, sourceDir);
     if (!fs.existsSync(skillsSource) || !fs.statSync(skillsSource).isDirectory()) continue;
     for (const relative of walkFiles(skillsSource)) {
       const from = path.join(skillsSource, relative);
-      const to = path.join(root, sourceDir, relative);
+      const logical = path.isAbsolute(sourceDir)
+        ? path.join(sourceDir, relative)
+        : path.posix.join(sourceDir, relative);
+      const staged = path.posix.join(stagedDir, relative);
+      const to = path.join(root, staged);
       fs.mkdirSync(path.dirname(to), { recursive: true });
       fs.copyFileSync(from, to);
-      originals.set(path.posix.join(sourceDir, relative), fs.readFileSync(from, "utf8"));
+      originals.set(logical, fs.readFileSync(from, "utf8"));
+      stagedPaths.set(logical, staged);
     }
   }
-  fs.mkdirSync(path.join(root, skillsDir), { recursive: true });
+  fs.mkdirSync(path.join(root, workspacePathFor(skillsDir)), { recursive: true });
 
-  return { root, memoryPath: memoryFile.path, skillsDir, skillDirs, originals };
+  return {
+    root,
+    memoryPath: memoryFile.path,
+    memoryWorkspacePath,
+    skillsDir,
+    skillDirs,
+    skillMappings,
+    stagedPaths,
+    originals,
+  };
 }
 
 function walkFiles(dir, prefix = "") {
@@ -217,7 +240,15 @@ export function splitRemovalHunk(hunk, { oldText, oldLines, recovered }) {
  * workspace yields identical ids.
  */
 export function measureWorkspace(workspace) {
-  const { root, memoryPath, skillsDir, skillDirs = [skillsDir], originals } = workspace;
+  const {
+    root,
+    memoryPath,
+    skillsDir,
+    skillDirs = [skillsDir],
+    skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) })),
+    stagedPaths = new Map([...workspace.originals.keys()].map((file) => [file, workspacePathFor(file)])),
+    originals,
+  } = workspace;
   /** @type {any[]} */
   const changes = [];
   const stray = [];
@@ -226,26 +257,47 @@ export function measureWorkspace(workspace) {
   const present = new Set(walkFiles(root).map((p) => p.split(path.sep).join("/")));
 
   const ordered = [memoryPath, ...[...originals.keys()].filter((f) => f !== memoryPath).sort()];
-  for (const relative of ordered) {
-    const original = originals.get(relative);
-    if (!present.has(relative)) {
-      changes.push({ kind: "deleted", file: relative });
+  for (const logical of ordered) {
+    const original = originals.get(logical);
+    const staged = stagedPaths.get(logical) || workspacePathFor(logical);
+    if (!present.has(staged)) {
+      changes.push({ kind: "deleted", file: logical, workspaceFile: staged });
       continue;
     }
-    const text = fs.readFileSync(path.join(root, relative), "utf8");
-    texts.set(relative, text);
-    for (const hunk of anchoredHunks(original, text)) changes.push({ kind: "hunk", file: relative, ...hunk });
+    const text = fs.readFileSync(path.join(root, staged), "utf8");
+    texts.set(logical, text);
+    for (const hunk of anchoredHunks(original, text)) {
+      changes.push({ kind: "hunk", file: logical, workspaceFile: staged, ...hunk });
+    }
   }
 
-  for (const relative of [...present].sort()) {
-    if (originals.has(relative)) continue;
-    if (!isSkillFilePath(relative, skillDirs)) {
-      stray.push(relative);
+  const knownStaged = new Set(stagedPaths.values());
+  for (const staged of [...present].sort()) {
+    if (knownStaged.has(staged)) continue;
+    const mapping = skillMappings.find(
+      ({ staged: dir }) => staged === dir || staged.startsWith(`${dir}/`),
+    );
+    if (!mapping) {
+      stray.push(staged);
       continue;
     }
-    const text = fs.readFileSync(path.join(root, relative), "utf8");
-    texts.set(relative, text);
-    changes.push({ kind: "created", file: relative, text, skill: parseSkillFile(relative, text) });
+    const inside = staged.slice(mapping.staged.length).replace(/^\//, "");
+    const logical = path.isAbsolute(mapping.logical)
+      ? path.join(mapping.logical, inside)
+      : path.posix.join(mapping.logical, inside);
+    if (!isSkillFilePath(logical, skillDirs)) {
+      stray.push(staged);
+      continue;
+    }
+    const text = fs.readFileSync(path.join(root, staged), "utf8");
+    texts.set(logical, text);
+    changes.push({
+      kind: "created",
+      file: logical,
+      workspaceFile: staged,
+      text,
+      skill: parseSkillFile(logical, text),
+    });
   }
 
   // Split any memory-file removal that mixes extracted text (recovered in a created
@@ -290,39 +342,11 @@ function signatureOf(changes) {
   ).slice(0, 16);
 }
 
-export function treeFingerprint(roots) {
-  const entries = [];
-  const visit = (root, current = root) => {
-    let children;
-    try {
-      children = fs.readdirSync(current, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
-    } catch (err) {
-      entries.push([root, path.relative(root, current), "error", err.code || err.message]);
-      return;
-    }
-    for (const child of children) {
-      if (current === root && child.name === ".git") continue;
-      const absolute = path.join(current, child.name);
-      const relative = path.relative(root, absolute);
-      if (child.isDirectory()) {
-        entries.push([root, relative, "dir"]);
-        visit(root, absolute);
-      } else if (child.isSymbolicLink()) {
-        entries.push([root, relative, "link", fs.readlinkSync(absolute)]);
-      } else if (child.isFile()) {
-        entries.push([root, relative, "file", sha256(fs.readFileSync(absolute))]);
-      }
-    }
-  };
-  for (const root of [...new Set(roots)].sort()) visit(root);
-  return sha256(JSON.stringify(entries));
-}
-
 /** The files backpass must find untouched in the repo after synthesis: a moved write is a bug, loudly. */
 export function repoFingerprint(repo, files) {
   const out = {};
   for (const relative of files) {
-    const absolute = path.join(repo.root, relative);
+    const absolute = path.isAbsolute(relative) ? relative : path.join(repo.root, relative);
     out[relative] = fs.existsSync(absolute) ? sha256(fs.readFileSync(absolute, "utf8")) : null;
   }
   return out;

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -99,10 +99,12 @@ function walkFiles(dir, prefix = "") {
 export function isSkillFilePath(relative, skillsDir) {
   const dirs = Array.isArray(skillsDir) ? skillsDir : [skillsDir];
   return dirs.some((dir) => {
-    const prefix = `${dir}/`;
-    if (!relative.startsWith(prefix)) return false;
-    const inside = relative.slice(prefix.length);
-    const parts = inside.split("/");
+    if (!relative || !dir) return false;
+    const windows = relative.includes("\\") || dir.includes("\\") || path.win32.isAbsolute(relative);
+    const paths = windows ? path.win32 : path;
+    const inside = paths.relative(dir, relative);
+    if (!inside || inside === ".." || inside.startsWith(`..${paths.sep}`) || paths.isAbsolute(inside)) return false;
+    const parts = inside.split(paths.sep);
     if (parts.length === 1) return parts[0].endsWith(".md");
     return parts.length === 2 && parts[1] === "SKILL.md";
   });

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -93,6 +93,18 @@ test("claude adapter enumerates the default store and CLAUDE_CONFIG_DIR, without
   assert.deepEqual(enumerateClaude(fakeHome, defaultRoot), ["personal.jsonl"]);
 });
 
+test("codex adapter honors CODEX_HOME", () => {
+  const previous = process.env.CODEX_HOME;
+  const relocated = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-codex-home-"));
+  process.env.CODEX_HOME = relocated;
+  try {
+    assert.equal(codex.storeRoot(), path.join(relocated, "sessions"));
+  } finally {
+    if (previous === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previous;
+  }
+});
+
 test("codex adapter reads the recorded git remote, enabling tier-2 association", () => {
   const file = path.join(FIXTURES, "codex-rollout.jsonl");
   const descriptor = codex.classify(candidateFor(file));

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { CONFIG_FILENAME, loadConfig, parseSince, sinceCutoff } from "../src/config.js";
+import { CONFIG_FILENAME, loadConfig, parseScopeKind, parseSince, sinceCutoff } from "../src/config.js";
 import { evidenceKey, isEvidenceFresh, safeFileName, State } from "../src/state.js";
 import { UserError } from "../src/logger.js";
 
@@ -184,4 +184,26 @@ test("an interrupted legacy evidence migration remains stale under the current a
 test("transcript ids are turned into safe filenames", () => {
   assert.equal(safeFileName("claude-abc/../../etc/passwd"), "claude-abc_.._.._etc_passwd");
   assert.equal(safeFileName("opencode:ses_25de1e"), "opencode_ses_25de1e");
+});
+
+test("user-scope config ignores a checkout .backpassrc.json and defaults minGapProjects to 1", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-user-cfg-"));
+  const repo = tempRepo({ budgetTokens: 1111, minGapProjects: 9 });
+  const prev = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+  try {
+    const user = loadConfig(repo, {}, { kind: "user" });
+    assert.equal(user.budgetTokens, 5000);
+    assert.equal(user.minGapProjects, 1);
+    assert.deepEqual(user.memoryFiles[0], ".agents/AGENTS.md");
+    const project = loadConfig(repo);
+    assert.equal(project.budgetTokens, 1111);
+    assert.equal(project.minGapProjects, 9);
+    assert.throws(() => loadConfig(tempRepo({ minGapProjects: 0 })), UserError);
+    assert.throws(() => parseScopeKind("global"), UserError);
+    assert.equal(parseScopeKind(""), "project");
+  } finally {
+    if (prev === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prev;
+  }
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -4,7 +4,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { CONFIG_FILENAME, loadConfig, parseScopeKind, parseSince, sinceCutoff } from "../src/config.js";
+import {
+  CONFIG_FILENAME,
+  initialUserConfig,
+  loadConfig,
+  parseScopeKind,
+  parseSince,
+  sinceCutoff,
+} from "../src/config.js";
 import { evidenceKey, isEvidenceFresh, safeFileName, State } from "../src/state.js";
 import { UserError } from "../src/logger.js";
 
@@ -196,6 +203,8 @@ test("user-scope config ignores a checkout .backpassrc.json and defaults minGapP
     assert.equal(user.budgetTokens, 5000);
     assert.equal(user.minGapProjects, 1);
     assert.deepEqual(user.memoryFiles[0], ".agents/AGENTS.md");
+    assert.deepEqual(user.discovery.harnesses, ["claude", "codex"]);
+    assert.deepEqual(initialUserConfig().discovery.harnesses, ["claude", "codex"]);
     const project = loadConfig(repo);
     assert.equal(project.budgetTokens, 1111);
     assert.equal(project.minGapProjects, 9);
@@ -205,5 +214,31 @@ test("user-scope config ignores a checkout .backpassrc.json and defaults minGapP
   } finally {
     if (prev === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = prev;
+  }
+});
+
+test("user-scope defaults honor relocated Claude and Codex homes", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-relocated-homes-"));
+  const previous = {
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+    CODEX_HOME: process.env.CODEX_HOME,
+  };
+  process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+  process.env.CLAUDE_CONFIG_DIR = path.join(home, "claude-work");
+  process.env.CODEX_HOME = path.join(home, "codex-work");
+  try {
+    const config = loadConfig(null, {}, { kind: "user" });
+    assert.deepEqual(config.memoryFiles, [
+      ".agents/AGENTS.md",
+      path.join(home, "claude-work", "CLAUDE.md"),
+      path.join(home, "codex-work", "AGENTS.md"),
+    ]);
+    assert.deepEqual(initialUserConfig().memoryFiles, config.memoryFiles);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -239,8 +239,15 @@ test("user-scope defaults honor relocated Claude and Codex homes", () => {
       path.join(home, "claude-work", "skills"),
       path.join(home, "codex-work", "skills"),
     ]);
-    assert.deepEqual(initialUserConfig().memoryFiles, config.memoryFiles);
-    assert.deepEqual(initialUserConfig().skillsDirs, config.skillsDirs);
+    const initialized = initialUserConfig();
+    assert.equal("memoryFiles" in initialized, false);
+    assert.equal("skillsDirs" in initialized, false);
+    const configPath = path.join(home, ".config", "backpass", "config.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ user: initialized }));
+    const reloaded = loadConfig(null, {}, { kind: "user" });
+    assert.deepEqual(reloaded.memoryFiles, config.memoryFiles);
+    assert.deepEqual(reloaded.skillsDirs, config.skillsDirs);
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -234,7 +234,13 @@ test("user-scope defaults honor relocated Claude and Codex homes", () => {
       path.join(home, "claude-work", "CLAUDE.md"),
       path.join(home, "codex-work", "AGENTS.md"),
     ]);
+    assert.deepEqual(config.skillsDirs, [
+      ".agents/skills",
+      path.join(home, "claude-work", "skills"),
+      path.join(home, "codex-work", "skills"),
+    ]);
     assert.deepEqual(initialUserConfig().memoryFiles, config.memoryFiles);
+    assert.deepEqual(initialUserConfig().skillsDirs, config.skillsDirs);
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) delete process.env[key];

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -662,7 +662,10 @@ test("project-covered sightings do not control eligible cluster metadata", () =>
   assert.equal(summary.gaps[0].orchestrationSightings, 0);
   assert.equal(summary.gaps[0].majorityOrchestration, false);
   assert.equal(summary.gaps[0].recurrenceRisk, "medium");
-  assert.deepEqual(summary.gaps[0].quotes.map((quote) => quote.text), ["eligible one", "eligible two"]);
+  assert.deepEqual(
+    summary.gaps[0].quotes.map((quote) => quote.text),
+    ["eligible one", "eligible two"],
+  );
   assert.equal(summary.gaps[0].failedTriggerSkill, undefined);
 });
 

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { parseMemoryUnits } from "../src/memory.js";
@@ -531,4 +534,106 @@ test("an oversized high-non-compliance paragraph attributes per sentence and inv
   assert.match(rendered, /- AG-001 is \d+ tokens as one paragraph \(attribution: \[AG-001\.1\]/);
   assert.doesNotMatch(rendered, /\[AG-001\](?!\.)/);
   assert.doesNotMatch(rendered, /\[AG-001\] \+0 -0/);
+});
+
+test("minGapProjects 2 keeps a single-project cluster report-only", () => {
+  const phrasing = "Always vendor the lockfile.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        transcript: { id: "s1", harness: "claude", project: "/repos/alpha" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        transcript: { id: "s2", harness: "claude", project: "/repos/alpha" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "high" }],
+      }),
+    ],
+    { minGapEvidence: 2, minGapProjects: 2 },
+  );
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.equal(summary.reportOnlyGaps[0].sessions, 2);
+  assert.equal(summary.reportOnlyGaps[0].projects, 1);
+  assert.match(summary.reportOnlyGaps[0].reportOnlyReason, /project-specific/);
+});
+
+test("minGapProjects 2 admits a cluster seen in two projects", () => {
+  const phrasing = "Always vendor the lockfile.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        transcript: { id: "s1", harness: "claude", project: "/repos/alpha" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        transcript: { id: "s2", harness: "claude", project: "/repos/beta" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "high" }],
+      }),
+    ],
+    { minGapEvidence: 2, minGapProjects: 2 },
+  );
+  assert.equal(summary.gaps.length, 1);
+  assert.equal(summary.gaps[0].projects, 2);
+  assert.equal(summary.reportOnlyGaps.length, 0);
+});
+
+test("the default minGapProjects of 1 does not require a second project", () => {
+  const phrasing = "Always vendor the lockfile.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        transcript: { id: "s1", harness: "claude", project: "/repos/alpha" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        transcript: { id: "s2", harness: "claude", project: "/repos/alpha" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "high" }],
+      }),
+    ],
+    { minGapEvidence: 2, minGapProjects: 1 },
+  );
+  assert.equal(summary.gaps.length, 1);
+  assert.equal(summary.gaps[0].projects, 1);
+});
+
+test("a project-covered sighting does not count toward gap sessions", () => {
+  const coveredRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fold-covered-"));
+  const phrasing = "Always pin the Node version with nvm.";
+  fs.writeFileSync(path.join(coveredRoot, "AGENTS.md"), `# T\n\n- ${phrasing}\n`);
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        transcript: { id: "s1", harness: "claude", project: coveredRoot, projectRoot: coveredRoot },
+        gaps: [{ proposedInstruction: phrasing, quote: "q", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        transcript: { id: "s2", harness: "claude", project: "/repos/other", projectRoot: null },
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "high" }],
+      }),
+    ],
+    { minGapEvidence: 2, checkProjectCoverage: true },
+  );
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.totals.droppedGapSingletons, 1);
+  const cluster = [...summary.gaps, ...summary.reportOnlyGaps];
+  assert.equal(cluster.length, 0);
+  // Re-fold at minGapEvidence 1 so the uncovered session is eligible, and the covered one is not.
+  const uncovered = foldEvidence(
+    [
+      record("s1", {
+        transcript: { id: "s1", harness: "claude", project: coveredRoot, projectRoot: coveredRoot },
+        gaps: [{ proposedInstruction: phrasing, quote: "q", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        transcript: { id: "s2", harness: "claude", project: "/repos/other", projectRoot: null },
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "high" }],
+      }),
+    ],
+    { minGapEvidence: 1, checkProjectCoverage: true },
+  );
+  assert.equal(uncovered.gaps.length, 1);
+  assert.equal(uncovered.gaps[0].sessions, 1);
+  assert.equal(uncovered.gaps[0].projectCoveredSessions, 1);
+  assert.equal(uncovered.gaps[0].projects, 1);
 });

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -597,6 +597,36 @@ test("the default minGapProjects of 1 does not require a second project", () => 
   assert.equal(summary.gaps[0].projects, 1);
 });
 
+test("duplicate sightings from a covered session do not count toward gap sessions", () => {
+  const coveredRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fold-duplicate-covered-"));
+  const covered = "Always pin the Node version with nvm.";
+  const similarUncovered = "Pin the Node version using nvm.";
+  fs.writeFileSync(path.join(coveredRoot, "AGENTS.md"), `# T\n\n- ${covered}\n`);
+  const records = [
+    record("s1", {
+      transcript: { id: "s1", harness: "claude", project: coveredRoot, projectRoot: coveredRoot },
+      gaps: [
+        { proposedInstruction: similarUncovered, quote: "q1", recurrenceRisk: "high" },
+        { proposedInstruction: covered, quote: "q2", recurrenceRisk: "high" },
+      ],
+    }),
+    record("s2", {
+      transcript: { id: "s2", harness: "claude", project: "/repos/other", projectRoot: null },
+      gaps: [{ proposedInstruction: similarUncovered, quote: "q3", recurrenceRisk: "high" }],
+    }),
+  ];
+
+  const belowFloor = foldEvidence(records, { minGapEvidence: 2, checkProjectCoverage: true });
+  assert.equal(belowFloor.gaps.length, 0);
+  assert.equal(belowFloor.totals.droppedGapSingletons, 1);
+
+  const eligible = foldEvidence(records, { minGapEvidence: 1, checkProjectCoverage: true });
+  assert.equal(eligible.gaps.length, 1);
+  assert.equal(eligible.gaps[0].sessions, 1);
+  assert.equal(eligible.gaps[0].projectCoveredSessions, 1);
+  assert.equal(eligible.gaps[0].projects, 1);
+});
+
 test("a project-covered sighting does not count toward gap sessions", () => {
   const coveredRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fold-covered-"));
   const phrasing = "Always pin the Node version with nvm.";

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -558,6 +558,28 @@ test("minGapProjects 2 keeps a single-project cluster report-only", () => {
   assert.match(summary.reportOnlyGaps[0].reportOnlyReason, /project-specific/);
 });
 
+test("report-only gaps name the actual number of observed projects", () => {
+  const phrasing = "Always vendor the lockfile.";
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        transcript: { id: "s1", harness: "claude", project: "/repos/alpha" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        transcript: { id: "s2", harness: "claude", project: "/repos/beta" },
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "high" }],
+      }),
+    ],
+    { minGapEvidence: 2, minGapProjects: 3 },
+  );
+
+  assert.equal(summary.reportOnlyGaps.length, 1);
+  assert.equal(summary.reportOnlyGaps[0].projects, 2);
+  assert.match(summary.reportOnlyGaps[0].reportOnlyReason, /seen in 2 projects; minGapProjects is 3/);
+  assert.doesNotMatch(summary.reportOnlyGaps[0].reportOnlyReason, /only/);
+});
+
 test("minGapProjects 2 admits a cluster seen in two projects", () => {
   const phrasing = "Always vendor the lockfile.";
   const summary = foldEvidence(

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -627,12 +627,55 @@ test("duplicate sightings from a covered session do not count toward gap session
   assert.equal(eligible.gaps[0].projects, 1);
 });
 
+test("project-covered sightings do not control eligible cluster metadata", () => {
+  const coveredRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fold-covered-votes-"));
+  const phrasing = "Always pin deployment artifact digests.";
+  fs.writeFileSync(path.join(coveredRoot, "AGENTS.md"), `# T\n\n- ${phrasing}\n`);
+  const records = [
+    record("p1", {
+      transcript: { id: "p1", harness: "claude", project: "/repos/one", projectRoot: null },
+      gaps: [{ proposedInstruction: phrasing, quote: "eligible one", recurrenceRisk: "medium" }],
+    }),
+    record("p2", {
+      transcript: { id: "p2", harness: "claude", project: "/repos/two", projectRoot: null },
+      gaps: [{ proposedInstruction: phrasing, quote: "eligible two", recurrenceRisk: "medium" }],
+    }),
+    ...["c1", "c2", "c3"].map((id) =>
+      record(id, {
+        transcript: { id, harness: "claude", project: coveredRoot, projectRoot: coveredRoot },
+        gaps: [
+          {
+            proposedInstruction: phrasing,
+            quote: `covered ${id}`,
+            recurrenceRisk: "high",
+            domain: "orchestration",
+            coveredBySkill: "deploy",
+          },
+        ],
+      }),
+    ),
+  ];
+  const summary = foldEvidence(records, { minGapEvidence: 2, checkProjectCoverage: true });
+  assert.equal(summary.gaps.length, 1);
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(summary.gaps[0].projectCoveredSessions, 3);
+  assert.equal(summary.gaps[0].orchestrationSightings, 0);
+  assert.equal(summary.gaps[0].majorityOrchestration, false);
+  assert.equal(summary.gaps[0].recurrenceRisk, "medium");
+  assert.deepEqual(summary.gaps[0].quotes.map((quote) => quote.text), ["eligible one", "eligible two"]);
+  assert.equal(summary.gaps[0].failedTriggerSkill, undefined);
+});
+
 test("project coverage honors the project's configured memory file", () => {
   const coveredRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fold-custom-memory-"));
   const phrasing = "Always read the deployment guide before releasing.";
   fs.mkdirSync(path.join(coveredRoot, "docs"), { recursive: true });
+  fs.writeFileSync(path.join(coveredRoot, "AGENTS.md"), "# T\n\n- Keep releases reproducible.\n");
   fs.writeFileSync(path.join(coveredRoot, "docs/AI.md"), `# T\n\n- ${phrasing}\n`);
-  fs.writeFileSync(path.join(coveredRoot, ".backpassrc.json"), JSON.stringify({ memoryFiles: ["docs/AI.md"] }));
+  fs.writeFileSync(
+    path.join(coveredRoot, ".backpassrc.json"),
+    JSON.stringify({ memoryFiles: ["AGENTS.md", "docs/AI.md"] }),
+  );
   const summary = foldEvidence(
     [
       record("s1", {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -627,6 +627,29 @@ test("duplicate sightings from a covered session do not count toward gap session
   assert.equal(eligible.gaps[0].projects, 1);
 });
 
+test("project coverage honors the project's configured memory file", () => {
+  const coveredRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fold-custom-memory-"));
+  const phrasing = "Always read the deployment guide before releasing.";
+  fs.mkdirSync(path.join(coveredRoot, "docs"), { recursive: true });
+  fs.writeFileSync(path.join(coveredRoot, "docs/AI.md"), `# T\n\n- ${phrasing}\n`);
+  fs.writeFileSync(path.join(coveredRoot, ".backpassrc.json"), JSON.stringify({ memoryFiles: ["docs/AI.md"] }));
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        transcript: { id: "s1", harness: "claude", project: coveredRoot, projectRoot: coveredRoot },
+        gaps: [{ proposedInstruction: phrasing, quote: "q", recurrenceRisk: "high" }],
+      }),
+      record("s2", {
+        transcript: { id: "s2", harness: "claude", project: "/repos/other", projectRoot: null },
+        gaps: [{ proposedInstruction: phrasing, quote: "q2", recurrenceRisk: "high" }],
+      }),
+    ],
+    { minGapEvidence: 2, checkProjectCoverage: true },
+  );
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.totals.droppedGapSingletons, 1);
+});
+
 test("a project-covered sighting does not count toward gap sessions", () => {
   const coveredRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fold-covered-"));
   const phrasing = "Always pin the Node version with nvm.";

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -390,14 +390,25 @@ test("mergeGapEntries preserves absorbed citations for duplicate sessions", () =
     { id: targetId, text: "Check the database contract before changing queries.", sessions: ["s1", "s2"] },
     { id: absorbedId, text: "Read schema docs before SQL edits.", sessions: ["s1", "s2"] },
   );
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-merged-project-"));
+  fs.writeFileSync(path.join(projectRoot, "AGENTS.md"), "# T\n\n- Read schema docs before SQL edits.\n");
   ledger.entries[absorbedId].sessions.s1.coveredBySkill = "db-schema";
+  ledger.entries[absorbedId].sessions.s1.project = projectRoot;
+  ledger.entries[absorbedId].sessions.s1.projectRoot = projectRoot;
   ledger.entries[absorbedId].sessions.s2.coveredBySkill = "db-schema";
 
   mergeGapEntries(ledger, [[targetId, absorbedId]]);
   const observations = ledgerGapObservations(ledger, MEMORY_PATH, [{ name: "db-schema" }]);
-  const summary = foldEvidence([], { gapObservations: observations, minGapEvidence: 2 });
+  const summary = foldEvidence([], {
+    gapObservations: observations,
+    minGapEvidence: 1,
+    checkProjectCoverage: true,
+  });
 
   assert.equal(observations.length, 2, "each session remains one observation");
+  assert.equal(observations.find((observation) => observation.sessionId === "s1").projectRoot, projectRoot);
+  assert.equal(summary.gaps[0].sessions, 1);
+  assert.equal(summary.gaps[0].projectCoveredSessions, 1);
   assert.equal(summary.gaps[0].failedTriggerSkill, "db-schema");
   assert.equal(summary.gaps[0].failedTriggerSessions, 2);
 });

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -156,6 +156,33 @@ function age(h, days) {
   h.state.writeGapLedger(ledger);
 }
 
+test("ledger preserves covered duplicate phrasings for each session", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-ledger-covered-"));
+  const covered = "Always pin the Node version with nvm.";
+  const uncovered = "Pin the Node version using nvm.";
+  fs.writeFileSync(path.join(root, "AGENTS.md"), `# T\n\n- ${covered}\n`);
+  const first = record("s1", [uncovered, covered]);
+  first.transcript.project = root;
+  first.transcript.projectRoot = root;
+  const second = record("s2", [uncovered]);
+  second.transcript.project = "/repos/other";
+  const ledger = { version: 1, entries: {} };
+
+  recordGapObservations(ledger, [first, second]);
+  const observations = ledgerGapObservations(ledger, MEMORY_PATH);
+  const summary = foldEvidence([], {
+    gapObservations: observations,
+    minGapEvidence: 2,
+    minGapProjects: 2,
+    checkProjectCoverage: true,
+  });
+
+  const persisted = observations.find((observation) => observation.sessionId === "s1");
+  assert.deepEqual(persisted.phrasings, [uncovered, covered]);
+  assert.equal(summary.gaps.length, 0);
+  assert.equal(summary.totals.droppedGapSingletons, 1);
+});
+
 test("a later uncited observation preserves the session's failed-trigger citation", () => {
   const phrasing = "Wrap migrations in a transaction.";
   const citedThenUncited = (id) =>

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -410,7 +410,7 @@ test("mergeGapEntries preserves absorbed citations for duplicate sessions", () =
   assert.equal(summary.gaps[0].sessions, 1);
   assert.equal(summary.gaps[0].projectCoveredSessions, 1);
   assert.equal(summary.gaps[0].failedTriggerSkill, "db-schema");
-  assert.equal(summary.gaps[0].failedTriggerSessions, 2);
+  assert.equal(summary.gaps[0].failedTriggerSessions, 1);
 });
 
 test("merged gap identities remain durable as the canonical phrasing changes", () => {

--- a/test/interaction.test.js
+++ b/test/interaction.test.js
@@ -384,11 +384,24 @@ test("cached evidence is upgraded with the current interaction category", async 
     bytes: 200,
     interactionSignals: { originator: "codex_exec", source: "exec" },
     interaction: NON_INTERACTIVE,
+    startedAt: "2026-09-02T10:00:00.000Z",
+    cwd: "/repos/restored",
+    project: "github.com/acme/restored",
+    projectRoot: "/repos/restored",
+    association: { tier: 1, confidence: "git", reason: "restored checkout" },
   };
   const memoryHash = "sha256:memory";
   state.writeEvidence(transcript, {
     status: "ok",
-    transcript: { harness: "codex", id: transcript.id, identity: "codex:robot-1" },
+    transcript: {
+      harness: "codex",
+      id: transcript.id,
+      identity: "codex:robot-1",
+      cwd: "/repos/deleted",
+      project: "github.com/acme/restored",
+      projectRoot: null,
+      association: { tier: 2, confidence: "remote", reason: "checkout absent" },
+    },
     memoryHash,
     memoryPath: "AGENTS.md",
     key: evidenceKey(transcript, memoryHash),
@@ -412,6 +425,11 @@ test("cached evidence is upgraded with the current interaction category", async 
   assert.deepEqual([summary.cached, summary.analyzed], [1, 0]);
   const [upgraded] = state.listEvidence();
   assert.equal(upgraded.transcript.interaction, NON_INTERACTIVE);
+  assert.equal(upgraded.transcript.cwd, transcript.cwd);
+  assert.equal(upgraded.transcript.project, transcript.project);
+  assert.equal(upgraded.transcript.projectRoot, transcript.projectRoot);
+  assert.deepEqual(upgraded.transcript.association, transcript.association);
+  assert.equal(upgraded.transcript.startedAt, transcript.startedAt);
   assert.deepEqual(foldEvidence([upgraded]).analyzedByInteraction, {
     [INTERACTIVE]: 0,
     [NON_INTERACTIVE]: 1,

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -107,6 +107,14 @@ test("a relative pointer resolves from the importing file's directory", () => {
   assert.equal(absolute.separate.length, 0);
 });
 
+test("only CLAUDE.md can cover a secondary memory file by import", () => {
+  const repo = repoWith({ ".claude/CLAUDE.md": AGENTS, ".codex/AGENTS.md": "@placeholder\n" });
+  fs.writeFileSync(path.join(repo.root, ".codex/AGENTS.md"), `@${path.join(repo.root, ".claude/CLAUDE.md")}\n`);
+  const resolved = resolveMemoryFiles(repo.root, [".claude/CLAUDE.md", ".codex/AGENTS.md"]);
+  assert.equal(resolved.pointers.length, 0);
+  assert.deepEqual(resolved.separate.map((file) => file.path), [".codex/AGENTS.md"]);
+});
+
 test("CLAUDE.md as a pointer resolves AGENTS.md silently and only AGENTS.md is written", () => {
   const repo = repoWith({ "AGENTS.md": AGENTS, "CLAUDE.md": renderPointer("AGENTS.md") });
   const config = loadConfig(repo.root);

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -92,6 +92,14 @@ test("a relative pointer resolves from the importing file's directory", () => {
   const relative = resolveMemoryFiles(repo.root, [".agents/AGENTS.md", ".claude/CLAUDE.md"]);
   assert.equal(relative.pointers.length, 0);
   assert.equal(relative.separate.length, 1);
+  const { warnings } = captureWarnings(() =>
+    primaryMemoryFile(
+      repo,
+      { memoryFiles: [".agents/AGENTS.md", ".claude/CLAUDE.md"], skillsDir: ".agents/skills" },
+      { kind: "user" },
+    ),
+  );
+  assert.match(warnings[0], /@\.\.\/\.agents\/AGENTS\.md/);
 
   fs.writeFileSync(path.join(repo.root, ".claude/CLAUDE.md"), `@${path.join(repo.root, ".agents/AGENTS.md")}\n`);
   const absolute = resolveMemoryFiles(repo.root, [".agents/AGENTS.md", ".claude/CLAUDE.md"]);
@@ -144,6 +152,15 @@ test("a single AGENTS.md or a single CLAUDE.md resolves as before, without warni
     assert.deepEqual(warnings, []);
     assert.equal(result.all.length, 1);
   }
+});
+
+test("project memory resolution rejects external paths while user resolution permits them", () => {
+  const repo = repoWith({ "AGENTS.md": AGENTS });
+  const external = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-memory-")), "AGENTS.md");
+  fs.writeFileSync(external, AGENTS);
+
+  assert.throws(() => resolveMemoryFiles(repo.root, [external]), /outside the project root/);
+  assert.equal(resolveMemoryFiles(repo.root, [external], { allowExternal: true }).primary.absolute, external);
 });
 
 test("a configured memoryFiles override still picks its own primary", () => {

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -83,6 +83,22 @@ test("isPointerTo accepts the @AGENTS.md import forms and nothing else", () => {
   assert.equal(isPointerTo("", "AGENTS.md"), false);
 });
 
+test("a relative pointer resolves from the importing file's directory", () => {
+  const repo = repoWith({
+    ".agents/AGENTS.md": AGENTS,
+    ".claude/CLAUDE.md": renderPointer("AGENTS.md"),
+  });
+
+  const relative = resolveMemoryFiles(repo.root, [".agents/AGENTS.md", ".claude/CLAUDE.md"]);
+  assert.equal(relative.pointers.length, 0);
+  assert.equal(relative.separate.length, 1);
+
+  fs.writeFileSync(path.join(repo.root, ".claude/CLAUDE.md"), `@${path.join(repo.root, ".agents/AGENTS.md")}\n`);
+  const absolute = resolveMemoryFiles(repo.root, [".agents/AGENTS.md", ".claude/CLAUDE.md"]);
+  assert.equal(absolute.pointers.length, 1);
+  assert.equal(absolute.separate.length, 0);
+});
+
 test("CLAUDE.md as a pointer resolves AGENTS.md silently and only AGENTS.md is written", () => {
   const repo = repoWith({ "AGENTS.md": AGENTS, "CLAUDE.md": renderPointer("AGENTS.md") });
   const config = loadConfig(repo.root);

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -112,7 +112,10 @@ test("only CLAUDE.md can cover a secondary memory file by import", () => {
   fs.writeFileSync(path.join(repo.root, ".codex/AGENTS.md"), `@${path.join(repo.root, ".claude/CLAUDE.md")}\n`);
   const resolved = resolveMemoryFiles(repo.root, [".claude/CLAUDE.md", ".codex/AGENTS.md"]);
   assert.equal(resolved.pointers.length, 0);
-  assert.deepEqual(resolved.separate.map((file) => file.path), [".codex/AGENTS.md"]);
+  assert.deepEqual(
+    resolved.separate.map((file) => file.path),
+    [".codex/AGENTS.md"],
+  );
 });
 
 test("CLAUDE.md as a pointer resolves AGENTS.md silently and only AGENTS.md is written", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -713,6 +713,15 @@ test("addition project counts come from folded gap evidence", () => {
   });
   assert.deepEqual(twoProjects.violations, []);
   assert.equal(twoProjects.proposal.edits[0].projects, 2);
+
+  const projectScope = gate({
+    edit,
+    annotation,
+    config: config({ minGapProjects: 2 }),
+    context: { summary: summary(1), scope: { kind: "project" } },
+  });
+  assert.deepEqual(projectScope.violations, []);
+  assert.equal(projectScope.proposal.edits[0].projects, undefined);
 });
 
 test("a move repositions verbatim memory-file text without the harm floor", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -680,6 +680,41 @@ test("an extract cannot bypass addition evidence without removing memory text", 
   );
 });
 
+test("addition project counts come from folded gap evidence", () => {
+  const edit = memoryEdit((text) => `${text}- Include the full pull request URL.\n`);
+  const annotation = { edits: [claim(["H1"], { kind: "add", projects: 99 })] };
+  const summary = (projects) => ({
+    analyzedSessions: 3,
+    totals: { positive: 0, negative: 0, gapClusters: 1 },
+    instructions: [],
+    gaps: [
+      {
+        proposedInstruction: "Include the full pull request URL.",
+        sessions: 3,
+        projects,
+        quotes: [{ text: QUOTE[0].text, source: QUOTE[0].source }],
+      },
+    ],
+  });
+
+  const oneProject = gate({
+    edit,
+    annotation,
+    config: config({ minGapProjects: 2 }),
+    context: { summary: summary(1), scope: { kind: "user" } },
+  });
+  assert.ok(oneProject.violations.some((violation) => /evidence from 1 project/.test(violation)));
+
+  const twoProjects = gate({
+    edit,
+    annotation,
+    config: config({ minGapProjects: 2 }),
+    context: { summary: summary(2), scope: { kind: "user" } },
+  });
+  assert.deepEqual(twoProjects.violations, []);
+  assert.equal(twoProjects.proposal.edits[0].projects, 2);
+});
+
 test("a move repositions verbatim memory-file text without the harm floor", () => {
   const text = `${MEMORY_TEXT}\n## Later\n\n- Keep this nearby.\n`;
   const node = "- Use Node 18 via nvm before running any script.";

--- a/test/sample.test.js
+++ b/test/sample.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { capTranscripts, recencyWeight, sampleTranscripts, sampleUnit } from "../src/sample.js";
+import { capPerProject, capTranscripts, recencyWeight, sampleTranscripts, sampleUnit } from "../src/sample.js";
 import { CONFIG_FILENAME, loadConfig, parseMaxTranscripts } from "../src/config.js";
 import { transcriptIdentity } from "../src/transcript.js";
 import { UserError, setLoggerSink } from "../src/logger.js";
@@ -360,4 +360,28 @@ test("maxTranscripts is configurable and 0 / all disable the cap", () => {
   assert.deepEqual(lines, [], "no sampling line when the cap is disabled");
   const seven = loadConfig(tempDir(), { maxTranscripts: 7, seed: 1 });
   captureInfo(() => assert.equal(capTranscripts(big, seven, { now: NOW }).transcripts.length, 7));
+});
+
+test("capPerProject keeps at most N transcripts from each project before the global cap", () => {
+  const set = [
+    ...transcripts(6, 10).map((t, i) => ({ ...t, id: `a${i}`, project: "alpha" })),
+    ...transcripts(6, 10).map((t, i) => ({ ...t, id: `b${i}`, project: "beta" })),
+  ];
+  const limited = capPerProject(set, 2, { seed: 1, now: NOW });
+  assert.equal(limited.length, 4);
+  const counts = { alpha: 0, beta: 0 };
+  for (const transcript of limited) counts[transcript.project] += 1;
+  assert.equal(counts.alpha, 2);
+  assert.equal(counts.beta, 2);
+
+  const config = loadConfig(tempDir(), {
+    maxTranscripts: 100,
+    seed: 1,
+    discovery: { maxTranscriptsPerProject: 2 },
+  });
+  let result = { transcripts: [] };
+  captureInfo(() => {
+    result = capTranscripts({ transcripts: set, perHarness: {} }, config, { now: NOW });
+  });
+  assert.equal(result.transcripts.length, 4);
 });

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { loadConfig } from "../src/config.js";
+import { associateUser, passesProjectFilter, resolveScope } from "../src/scope.js";
+
+function git(args, cwd) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function initRepo(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `backpass-scope-${name}-`));
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  return fs.realpathSync(dir);
+}
+
+test("resolveScope project uses the checkout and .backpass state", () => {
+  const root = initRepo("proj");
+  const repo = { root, realRoot: root, name: path.basename(root), worktrees: [root], remotes: [] };
+  const config = loadConfig(root);
+  const scope = resolveScope(root, { scope: "project" }, config, repo);
+  assert.equal(scope.kind, "project");
+  assert.equal(scope.root, root);
+  assert.equal(scope.stateDir, path.join(root, ".backpass"));
+  assert.equal(scope.modelCwd, root);
+  assert.equal(scope.associate({ cwd: root }).tier, 1);
+});
+
+test("resolveScope user uses homedir weights and isolated config state", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-user-home-"));
+  const prevXdg = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+  try {
+    const config = loadConfig(null, {}, { kind: "user" });
+    const scope = resolveScope(home, { scope: "user" }, config, null, { home });
+    assert.equal(scope.kind, "user");
+    assert.equal(scope.root, home);
+    assert.equal(scope.name, "user");
+    assert.equal(scope.stateDir, path.join(home, ".config", "backpass", "user"));
+    assert.equal(scope.modelCwd, scope.stateDir);
+    assert.deepEqual(scope.memoryFiles, [".agents/AGENTS.md", ".claude/CLAUDE.md", ".codex/AGENTS.md"]);
+    assert.equal(scope.overflowDir, ".agents/skills");
+    assert.deepEqual(scope.skillDirs, [".agents/skills", ".claude/skills", ".codex/skills"]);
+    assert.equal(config.minGapProjects, 1);
+  } finally {
+    if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdg;
+  }
+});
+
+test("user association stamps a live git toplevel as the project key", () => {
+  const root = initRepo("live");
+  const nested = path.join(root, "src");
+  fs.mkdirSync(nested);
+  const result = associateUser({ cwd: nested });
+  assert.equal(result.tier, 1);
+  assert.equal(result.project, root);
+  assert.equal(result.projectRoot, root);
+});
+
+test("user association groups a deleted worktree by recorded remote", () => {
+  const result = associateUser({
+    cwd: "/vanished/worktree/demo",
+    remotes: ["https://github.com/acme/other.git"],
+  });
+  assert.equal(result.tier, 2);
+  assert.equal(result.project, "github.com/acme/other");
+  assert.equal(result.projectRoot, null);
+});
+
+test("user --strict drops sessions with only a dead unrecognisable cwd", () => {
+  assert.equal(associateUser({ cwd: "/vanished/no-remote" }, { strict: true }), null);
+  const kept = associateUser({ cwd: "/vanished/no-remote" }, { strict: false });
+  assert.equal(kept.tier, 3);
+  assert.ok(kept.project);
+});
+
+test("passesProjectFilter includes and excludes by project key or cwd", () => {
+  const transcript = { project: "/repos/alpha", cwd: "/repos/alpha" };
+  assert.equal(passesProjectFilter(transcript, { discovery: {} }), true);
+  assert.equal(passesProjectFilter(transcript, { discovery: { includeProjects: ["**/alpha"] } }), true);
+  assert.equal(passesProjectFilter(transcript, { discovery: { includeProjects: ["**/beta"] } }), false);
+  assert.equal(passesProjectFilter(transcript, { discovery: { excludeProjects: ["**/alpha"] } }), false);
+});

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -95,10 +95,7 @@ test("user association groups worktrees and deleted sessions by the origin remot
 
 test("user association groups local worktrees by their shared git directory", () => {
   const root = initRepo("local-worktree");
-  const sibling = path.join(
-    fs.mkdtempSync(path.join(os.tmpdir(), "backpass-scope-local-worktree-parent-")),
-    "sibling",
-  );
+  const sibling = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-scope-local-worktree-parent-")), "sibling");
   git(["worktree", "add", "-q", "-b", "local-sibling", sibling], root);
 
   const first = associateUser({ cwd: root });

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -77,16 +77,19 @@ test("user association stamps a live git toplevel as the project key", () => {
   assert.equal(result.projectRoot, root);
 });
 
-test("user association groups worktrees by normalized remote identity", () => {
+test("user association groups worktrees and deleted sessions by the origin remote", () => {
   const root = initRepo("worktree");
   const sibling = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-scope-worktree-parent-")), "sibling");
+  git(["remote", "add", "upstream", "https://github.com/aaa/upstream.git"], root);
   git(["remote", "add", "origin", "git@github.com:acme/example.git"], root);
   git(["worktree", "add", "-q", "-b", "sibling", sibling], root);
 
   const first = associateUser({ cwd: root });
   const second = associateUser({ cwd: sibling });
+  const deleted = associateUser({ cwd: "/deleted/example", remotes: ["git@github.com:acme/example.git"] });
   assert.equal(first.project, "github.com/acme/example");
   assert.equal(second.project, first.project);
+  assert.equal(deleted.project, first.project);
   assert.notEqual(first.projectRoot, second.projectRoot);
 });
 

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -39,7 +39,12 @@ test("resolveScope user uses homedir weights and isolated config state", () => {
   process.env.XDG_CONFIG_HOME = path.join(home, ".config");
   try {
     const config = loadConfig(null, {}, { kind: "user" });
-    const scope = resolveScope(home, { scope: "user" }, config, null, { home });
+    let associationCalls = 0;
+    const associateUserFn = (descriptor) => {
+      associationCalls += 1;
+      return { tier: 2, project: descriptor.remotes?.[0] || descriptor.cwd };
+    };
+    const scope = resolveScope(home, { scope: "user" }, config, null, { home, associateUserFn });
     assert.equal(scope.kind, "user");
     assert.equal(scope.root, home);
     assert.equal(scope.name, "user");
@@ -49,6 +54,13 @@ test("resolveScope user uses homedir weights and isolated config state", () => {
     assert.equal(scope.overflowDir, ".agents/skills");
     assert.deepEqual(scope.skillDirs, [".agents/skills", ".claude/skills", ".codex/skills"]);
     assert.equal(config.minGapProjects, 1);
+
+    const descriptor = { cwd: "/repos/alpha", remotes: ["https://example.com/alpha.git"] };
+    assert.equal(scope.associate(descriptor).project, descriptor.remotes[0]);
+    assert.equal(scope.associate({ ...descriptor, remotes: [...descriptor.remotes] }).project, descriptor.remotes[0]);
+    assert.equal(associationCalls, 1);
+    scope.associate({ ...descriptor, remotes: ["https://example.com/fork.git"] });
+    assert.equal(associationCalls, 2);
   } finally {
     if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = prevXdg;

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -77,6 +77,19 @@ test("user association stamps a live git toplevel as the project key", () => {
   assert.equal(result.projectRoot, root);
 });
 
+test("user association groups worktrees by normalized remote identity", () => {
+  const root = initRepo("worktree");
+  const sibling = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-scope-worktree-parent-")), "sibling");
+  git(["remote", "add", "origin", "git@github.com:acme/example.git"], root);
+  git(["worktree", "add", "-q", "-b", "sibling", sibling], root);
+
+  const first = associateUser({ cwd: root });
+  const second = associateUser({ cwd: sibling });
+  assert.equal(first.project, "github.com/acme/example");
+  assert.equal(second.project, first.project);
+  assert.notEqual(first.projectRoot, second.projectRoot);
+});
+
 test("user association groups a deleted worktree by recorded remote", () => {
   const result = associateUser({
     cwd: "/vanished/worktree/demo",

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -90,6 +90,21 @@ test("user association groups worktrees by normalized remote identity", () => {
   assert.notEqual(first.projectRoot, second.projectRoot);
 });
 
+test("user association groups local worktrees by their shared git directory", () => {
+  const root = initRepo("local-worktree");
+  const sibling = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "backpass-scope-local-worktree-parent-")),
+    "sibling",
+  );
+  git(["worktree", "add", "-q", "-b", "local-sibling", sibling], root);
+
+  const first = associateUser({ cwd: root });
+  const second = associateUser({ cwd: sibling });
+  assert.equal(first.project, root);
+  assert.equal(second.project, first.project);
+  assert.notEqual(first.projectRoot, second.projectRoot);
+});
+
 test("user association groups a deleted worktree by recorded remote", () => {
   const result = associateUser({
     cwd: "/vanished/worktree/demo",

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -143,6 +143,24 @@ test("resolveOverflowTarget prefers .agents/skills and never auto-picks bare ski
   assert.equal(resolveOverflowTarget(bare, "nope/skills").dir, CANONICAL_SKILLS_DIR);
 });
 
+test("user skill discovery uses only configured harness roots", () => {
+  const root = tmpRepo();
+  const relocated = path.join(root, "claude-config", "skills");
+  const stale = path.join(root, CLAUDE_SKILLS_LINK, "stale", "SKILL.md");
+  const active = path.join(relocated, "active", "SKILL.md");
+  fs.mkdirSync(path.dirname(stale), { recursive: true });
+  fs.mkdirSync(path.dirname(active), { recursive: true });
+  fs.writeFileSync(stale, "---\nname: stale\ndescription: stale trigger\n---\n\nbody\n");
+  fs.writeFileSync(active, "---\nname: active\ndescription: active trigger\n---\n\nbody\n");
+
+  assert.deepEqual(
+    loadProjectSkills(root, CANONICAL_SKILLS_DIR, [CANONICAL_SKILLS_DIR, relocated], { exact: true }).map(
+      (skill) => skill.name,
+    ),
+    ["active"],
+  );
+});
+
 test("project skill discovery includes separate canonical and Claude roots without double-counting symlinks", () => {
   const root = tmpRepo();
   const canonical = path.join(root, CANONICAL_SKILLS_DIR, "generated", "SKILL.md");
@@ -247,32 +265,44 @@ test("applyDecisions writes accepted extractions through the skills layout and s
   assert.ok(fs.existsSync(path.join(root, CLAUDE_SKILLS_LINK, "release-signing", "SKILL.md")));
 });
 
-test("user apply links relocated Claude skills to the canonical directory", () => {
+test("user apply links relocated Claude skills without relying on directory order", () => {
   const root = tmpRepo();
-  const relocated = path.join(root, "claude-config", "skills");
-  fs.writeFileSync(path.join(root, "AGENTS.md"), "# Memory\n\n- Sign releases with the key.\n");
-  const edit = {
-    id: "e1",
-    kind: "extract",
-    file: "AGENTS.md",
-    find: "- Sign releases with the key.",
-    replace: "- Release signing: see the release-signing skill.",
-    skill: SKILL,
-  };
-  const results = applyDecisions({
-    proposal: { scope: "user", memoryFile: { path: "AGENTS.md" }, edits: [edit] },
-    decisions: { e1: "accepted" },
-    repo: { root },
-    state: { readRejections: () => [], writeRejections: () => {} },
-    config: {
-      budgetTokens: 5000,
-      skillsDirs: [CANONICAL_SKILLS_DIR, relocated, path.join(root, ".codex", "skills")],
-    },
-  });
+  const claudeRoot = path.join(root, "claude-config");
+  const relocated = path.join(claudeRoot, "skills");
+  const previous = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = claudeRoot;
+  try {
+    fs.writeFileSync(path.join(root, "AGENTS.md"), "# Memory\n\n- Sign releases with the key.\n");
+    const edit = {
+      id: "e1",
+      kind: "extract",
+      file: "AGENTS.md",
+      find: "- Sign releases with the key.",
+      replace: "- Release signing: see the release-signing skill.",
+      skill: SKILL,
+    };
+    const skillsDirs = [path.join(root, "custom-skills"), path.join(root, ".codex", "skills"), CANONICAL_SKILLS_DIR];
+    const results = applyDecisions({
+      proposal: {
+        scope: "user",
+        memoryFile: { path: "AGENTS.md" },
+        edits: [edit],
+        config: { skillsDirs },
+      },
+      decisions: { e1: "accepted" },
+      repo: { root },
+      state: { readRejections: () => [], writeRejections: () => {} },
+      config: { budgetTokens: 5000, skillsDirs },
+    });
 
-  assert.equal(results.failed.length, 0);
-  assert.ok(fs.lstatSync(relocated).isSymbolicLink());
-  assert.equal(fs.realpathSync(relocated), fs.realpathSync(path.join(root, CANONICAL_SKILLS_DIR)));
-  assert.ok(fs.existsSync(path.join(relocated, "release-signing", "SKILL.md")));
-  assert.equal(fs.existsSync(path.join(root, CLAUDE_SKILLS_LINK)), false);
+    assert.equal(results.failed.length, 0);
+    assert.ok(fs.lstatSync(relocated).isSymbolicLink());
+    assert.equal(fs.realpathSync(relocated), fs.realpathSync(path.join(root, CANONICAL_SKILLS_DIR)));
+    assert.ok(fs.existsSync(path.join(relocated, "release-signing", "SKILL.md")));
+    assert.equal(fs.existsSync(path.join(root, CLAUDE_SKILLS_LINK)), false);
+    assert.equal(fs.existsSync(path.join(root, ".codex", "skills")), false);
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previous;
+  }
 });

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -246,3 +246,33 @@ test("applyDecisions writes accepted extractions through the skills layout and s
   ]);
   assert.ok(fs.existsSync(path.join(root, CLAUDE_SKILLS_LINK, "release-signing", "SKILL.md")));
 });
+
+test("user apply links relocated Claude skills to the canonical directory", () => {
+  const root = tmpRepo();
+  const relocated = path.join(root, "claude-config", "skills");
+  fs.writeFileSync(path.join(root, "AGENTS.md"), "# Memory\n\n- Sign releases with the key.\n");
+  const edit = {
+    id: "e1",
+    kind: "extract",
+    file: "AGENTS.md",
+    find: "- Sign releases with the key.",
+    replace: "- Release signing: see the release-signing skill.",
+    skill: SKILL,
+  };
+  const results = applyDecisions({
+    proposal: { scope: "user", memoryFile: { path: "AGENTS.md" }, edits: [edit] },
+    decisions: { e1: "accepted" },
+    repo: { root },
+    state: { readRejections: () => [], writeRejections: () => {} },
+    config: {
+      budgetTokens: 5000,
+      skillsDirs: [CANONICAL_SKILLS_DIR, relocated, path.join(root, ".codex", "skills")],
+    },
+  });
+
+  assert.equal(results.failed.length, 0);
+  assert.ok(fs.lstatSync(relocated).isSymbolicLink());
+  assert.equal(fs.realpathSync(relocated), fs.realpathSync(path.join(root, CANONICAL_SKILLS_DIR)));
+  assert.ok(fs.existsSync(path.join(relocated, "release-signing", "SKILL.md")));
+  assert.equal(fs.existsSync(path.join(root, CLAUDE_SKILLS_LINK)), false);
+});

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -6,37 +6,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { classifyAcpxFailure } from "../src/acpx.js";
-import { quoteShimArg, runCapture, supportsReadOnlyLaunch } from "../src/subprocess.js";
-
-test(
-  "read-only sandbox blocks grounding writes despite a writable parent",
-  { skip: !supportsReadOnlyLaunch() && "read-only sandbox unavailable" },
-  async () => {
-    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-sandbox-parent-"));
-    const project = path.join(parent, "project");
-    const workspace = path.join(project, "workspace");
-    const protectedFile = path.join(project, ".git/config");
-    const workspaceFile = path.join(workspace, "result.txt");
-    fs.mkdirSync(path.dirname(protectedFile), { recursive: true });
-    fs.mkdirSync(workspace, { recursive: true });
-    fs.writeFileSync(protectedFile, "original");
-    const script = `
-      const fs = require("node:fs");
-      let denied = false;
-      try { fs.writeFileSync(${JSON.stringify(protectedFile)}, "changed"); } catch { denied = true; }
-      fs.writeFileSync(${JSON.stringify(workspaceFile)}, "written");
-      process.stdout.write(JSON.stringify({ denied }));
-    `;
-    const result = await runCapture(process.execPath, ["-e", script], {
-      readOnlyRoots: [project],
-      writableRoots: [parent, workspace],
-    });
-    assert.equal(result.code, 0, result.stderr);
-    assert.deepEqual(JSON.parse(result.stdout), { denied: true });
-    assert.equal(fs.readFileSync(protectedFile, "utf8"), "original");
-    assert.equal(fs.readFileSync(workspaceFile, "utf8"), "written");
-  },
-);
+import { quoteShimArg, runCapture } from "../src/subprocess.js";
 
 test(
   "a timed leader close still kills a descendant that ignores termination",

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -6,22 +6,37 @@ import path from "node:path";
 import test from "node:test";
 
 import { classifyAcpxFailure } from "../src/acpx.js";
-import { quoteShimArg, readOnlyLaunch, runCapture } from "../src/subprocess.js";
+import { quoteShimArg, runCapture, supportsReadOnlyLaunch } from "../src/subprocess.js";
 
-test("read-only launch never grants a writable ancestor of a grounding root", () => {
-  const launch = readOnlyLaunch(
-    { file: "tool", args: [], verbatim: false },
-    ["/sandbox/tmp/project"],
-    {
-      platform: "darwin",
-      writableRoots: ["/sandbox/tmp", "/sandbox/tmp/project/workspace", "/sandbox/state"],
-    },
-  );
-  const profile = launch.args[1];
-  assert.doesNotMatch(profile, /allow file-write\* \(subpath "\/sandbox\/tmp"\)/);
-  assert.match(profile, /allow file-write\* \(subpath "\/sandbox\/tmp\/project\/workspace"\)/);
-  assert.match(profile, /allow file-write\* \(subpath "\/sandbox\/state"\)/);
-});
+test(
+  "read-only sandbox blocks grounding writes despite a writable parent",
+  { skip: !supportsReadOnlyLaunch() && "read-only sandbox unavailable" },
+  async () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-sandbox-parent-"));
+    const project = path.join(parent, "project");
+    const workspace = path.join(project, "workspace");
+    const protectedFile = path.join(project, ".git/config");
+    const workspaceFile = path.join(workspace, "result.txt");
+    fs.mkdirSync(path.dirname(protectedFile), { recursive: true });
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.writeFileSync(protectedFile, "original");
+    const script = `
+      const fs = require("node:fs");
+      let denied = false;
+      try { fs.writeFileSync(${JSON.stringify(protectedFile)}, "changed"); } catch { denied = true; }
+      fs.writeFileSync(${JSON.stringify(workspaceFile)}, "written");
+      process.stdout.write(JSON.stringify({ denied }));
+    `;
+    const result = await runCapture(process.execPath, ["-e", script], {
+      readOnlyRoots: [project],
+      writableRoots: [parent, workspace],
+    });
+    assert.equal(result.code, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { denied: true });
+    assert.equal(fs.readFileSync(protectedFile, "utf8"), "original");
+    assert.equal(fs.readFileSync(workspaceFile, "utf8"), "written");
+  },
+);
 
 test(
   "a timed leader close still kills a descendant that ignores termination",

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -6,7 +6,22 @@ import path from "node:path";
 import test from "node:test";
 
 import { classifyAcpxFailure } from "../src/acpx.js";
-import { quoteShimArg, runCapture } from "../src/subprocess.js";
+import { quoteShimArg, readOnlyLaunch, runCapture } from "../src/subprocess.js";
+
+test("read-only launch never grants a writable ancestor of a grounding root", () => {
+  const launch = readOnlyLaunch(
+    { file: "tool", args: [], verbatim: false },
+    ["/sandbox/tmp/project"],
+    {
+      platform: "darwin",
+      writableRoots: ["/sandbox/tmp", "/sandbox/tmp/project/workspace", "/sandbox/state"],
+    },
+  );
+  const profile = launch.args[1];
+  assert.doesNotMatch(profile, /allow file-write\* \(subpath "\/sandbox\/tmp"\)/);
+  assert.match(profile, /allow file-write\* \(subpath "\/sandbox\/tmp\/project\/workspace"\)/);
+  assert.match(profile, /allow file-write\* \(subpath "\/sandbox\/state"\)/);
+});
 
 test(
   "a timed leader close still kills a descendant that ignores termination",

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -81,6 +81,7 @@ const { ProposalViolation } = await import("../src/proposal.js");
 const { State } = await import("../src/state.js");
 const { UserError, setLoggerSink } = await import("../src/logger.js");
 const { workspacePathFor } = await import("../src/workspace.js");
+const { supportsReadOnlyLaunch } = await import("../src/subprocess.js");
 const { makeRepo } = await import("./helpers/staging.js");
 
 setLoggerSink(() => {});
@@ -403,26 +404,54 @@ test("a harness that writes to the repository instead of the staging copy is ref
   });
 });
 
-test("user synthesis makes grounding project roots read-only", async () => {
-  const grounding = makeRepo({ ".git/config": "[core]\n", "README.md": "# Grounding\n" });
-  const setupResult = setup(
-    { edit: {}, annotations: [{ reply: { edits: [] } }] },
-    {
-      scope: { kind: "user" },
-      transcripts: [{ harness: "claude", projectRoot: grounding.root }],
-    },
-  );
-  fs.writeFileSync(
-    process.env.FAKE_ACPX_SCRIPT,
-    JSON.stringify({
-      edit: { [path.join(grounding.root, ".git/config")]: "[changed]\n" },
-      annotations: [{ reply: { edits: [] } }],
-    }),
-  );
+test(
+  "user synthesis makes every live grounding root read-only",
+  { skip: !supportsReadOnlyLaunch() && "read-only sandbox unavailable" },
+  async () => {
+    const projects = Array.from({ length: 9 }, () => makeRepo({ ".git/config": "[core]\n" }));
+    const tierThree = makeRepo({ ".git/config": "[core]\n" });
+    const setupResult = setup(
+      { edit: {}, annotations: [{ reply: { edits: [] } }] },
+      {
+        scope: { kind: "user" },
+        transcripts: [
+          ...projects.map((project) => ({ harness: "claude", projectRoot: project.root })),
+          { harness: "claude", cwd: tierThree.root, projectRoot: null },
+        ],
+      },
+    );
+    fs.writeFileSync(
+      process.env.FAKE_ACPX_SCRIPT,
+      JSON.stringify({
+        edit: { [path.join(tierThree.root, ".git/config")]: "[changed]\n" },
+        annotations: [{ reply: { edits: [] } }],
+      }),
+    );
 
-  await assert.rejects(setupResult.run());
-  assert.equal(fs.readFileSync(path.join(grounding.root, ".git/config"), "utf8"), "[core]\n");
-});
+    await assert.rejects(setupResult.run());
+    assert.equal(fs.readFileSync(path.join(tierThree.root, ".git/config"), "utf8"), "[core]\n");
+  },
+);
+
+test(
+  "user synthesis withholds grounding paths when containment is unavailable",
+  { skip: supportsReadOnlyLaunch() && "read-only sandbox available" },
+  async () => {
+    const grounding = makeRepo({ "README.md": "# Grounding\n" });
+    const setupResult = setup(
+      { edit: {}, annotations: [{ reply: { edits: [] } }] },
+      {
+        scope: { kind: "user" },
+        transcripts: [{ harness: "claude", projectRoot: grounding.root }],
+      },
+    );
+    const { proposal } = await setupResult.run();
+    assert.equal(proposal.edits.length, 0);
+    const prompt = fs.readFileSync(path.join(setupResult.config.state.root, "prompts/synthesis-edit.md"), "utf8");
+    assert.equal(prompt.includes(grounding.root), false);
+    assert.match(prompt, /live project paths withheld/);
+  },
+);
 
 test("a home-rooted grounding project leaves the synthesis workspace writable", async () => {
   const setupResult = setup(

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -81,7 +81,6 @@ const { ProposalViolation } = await import("../src/proposal.js");
 const { State } = await import("../src/state.js");
 const { UserError, setLoggerSink } = await import("../src/logger.js");
 const { workspacePathFor } = await import("../src/workspace.js");
-const { supportsReadOnlyLaunch } = await import("../src/subprocess.js");
 const { makeRepo } = await import("./helpers/staging.js");
 
 setLoggerSink(() => {});
@@ -149,10 +148,8 @@ function setup(
     overrides = {},
     summary = summaryFor(),
     scope = null,
-    transcripts = null,
     externalMemory = false,
     externalSkills = false,
-    groundInRepo = false,
   } = {},
 ) {
   const repo = makeRepo(externalMemory ? {} : { "AGENTS.md": text });
@@ -189,7 +186,7 @@ function setup(
       summary,
       config,
       repo,
-      transcripts: transcripts || [{ harness: "claude", ...(groundInRepo ? { projectRoot: repo.root } : {}) }],
+      transcripts: [{ harness: "claude" }],
       scope,
     });
   const calls = () =>
@@ -400,66 +397,6 @@ test("a harness that writes to the repository instead of the staging copy is ref
     assert.match(err.message, /synthesis changed AGENTS\.md in the repository directly/);
     return true;
   });
-});
-
-test(
-  "user synthesis makes every live grounding root read-only",
-  { skip: !supportsReadOnlyLaunch() && "read-only sandbox unavailable" },
-  async () => {
-    const projects = Array.from({ length: 9 }, () => makeRepo({ ".git/config": "[core]\n" }));
-    const tierThree = makeRepo({ ".git/config": "[core]\n" });
-    const setupResult = setup(
-      { edit: {}, annotations: [{ reply: { edits: [] } }] },
-      {
-        scope: { kind: "user" },
-        transcripts: [
-          ...projects.map((project) => ({ harness: "claude", projectRoot: project.root })),
-          { harness: "claude", cwd: tierThree.root, projectRoot: null },
-        ],
-      },
-    );
-    fs.writeFileSync(
-      process.env.FAKE_ACPX_SCRIPT,
-      JSON.stringify({
-        edit: { [path.join(tierThree.root, ".git/config")]: "[changed]\n" },
-        annotations: [{ reply: { edits: [] } }],
-      }),
-    );
-
-    await assert.rejects(setupResult.run());
-    assert.equal(fs.readFileSync(path.join(tierThree.root, ".git/config"), "utf8"), "[core]\n");
-  },
-);
-
-test(
-  "user synthesis withholds grounding paths when containment is unavailable",
-  { skip: supportsReadOnlyLaunch() && "read-only sandbox available" },
-  async () => {
-    const grounding = makeRepo({ "README.md": "# Grounding\n" });
-    const setupResult = setup(
-      { edit: {}, annotations: [{ reply: { edits: [] } }] },
-      {
-        scope: { kind: "user" },
-        transcripts: [{ harness: "claude", projectRoot: grounding.root }],
-      },
-    );
-    const { proposal } = await setupResult.run();
-    assert.equal(proposal.edits.length, 0);
-    const prompt = fs.readFileSync(path.join(setupResult.config.state.root, "prompts/synthesis-edit.md"), "utf8");
-    assert.equal(prompt.includes(grounding.root), false);
-    assert.match(prompt, /live project paths withheld/);
-  },
-);
-
-test("a home-rooted grounding project leaves the synthesis workspace writable", async () => {
-  const setupResult = setup(
-    { edit: {}, annotations: [{ reply: { edits: [] } }] },
-    { scope: { kind: "user" }, groundInRepo: true },
-  );
-  process.env.FAKE_ACPX_STATE = path.join(setupResult.repo.root, ".backpass/synthesis/fake-state.json");
-  const { proposal, violations } = await setupResult.run();
-  assert.deepEqual(violations, []);
-  assert.equal(proposal.edits.length, 0);
 });
 
 test("user synthesis can propose against relocated external memory", async () => {

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -80,6 +80,7 @@ const { foldEvidence } = await import("../src/fold.js");
 const { ProposalViolation } = await import("../src/proposal.js");
 const { State } = await import("../src/state.js");
 const { UserError, setLoggerSink } = await import("../src/logger.js");
+const { workspacePathFor } = await import("../src/workspace.js");
 const { makeRepo } = await import("./helpers/staging.js");
 
 setLoggerSink(() => {});
@@ -142,10 +143,34 @@ const agents = { resolve: async () => pick, withFallthrough: async (_role, fn) =
 
 function setup(
   script,
-  { text = AGENTS, overrides = {}, summary = summaryFor(), scope = null, transcripts = null, externalMemory = false } = {},
+  {
+    text = AGENTS,
+    overrides = {},
+    summary = summaryFor(),
+    scope = null,
+    transcripts = null,
+    externalMemory = false,
+    externalSkills = false,
+    groundInRepo = false,
+  } = {},
 ) {
   const repo = makeRepo(externalMemory ? {} : { "AGENTS.md": text });
-  const config = loadConfig(repo.root, overrides);
+  const externalSkillsDir = externalSkills
+    ? path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-skills-")), "skills")
+    : null;
+  if (externalSkillsDir) {
+    fs.mkdirSync(path.join(externalSkillsDir, "db"), { recursive: true });
+    fs.writeFileSync(
+      path.join(externalSkillsDir, "db/SKILL.md"),
+      "---\nname: db\ndescription: Load for database work.\n---\n\n- Keep transactions short.\n",
+    );
+  }
+  const config = loadConfig(
+    repo.root,
+    externalSkillsDir
+      ? { ...overrides, skillsDir: externalSkillsDir, skillsDirs: [externalSkillsDir] }
+      : overrides,
+  );
   config.state = new State(repo.root).ensure();
   config.agents = agents;
   const log = path.join(fakeDir, `log-${Date.now()}-${Math.random().toString(16).slice(2)}.jsonl`);
@@ -165,7 +190,7 @@ function setup(
       summary,
       config,
       repo,
-      transcripts: transcripts || [{ harness: "claude" }],
+      transcripts: transcripts || [{ harness: "claude", ...(groundInRepo ? { projectRoot: repo.root } : {}) }],
       scope,
     });
   const calls = () =>
@@ -175,7 +200,7 @@ function setup(
       .split("\n")
       .filter(Boolean)
       .map((l) => JSON.parse(l));
-  return { repo, config, memoryFile, run, calls };
+  return { repo, config, memoryFile, externalSkillsDir, run, calls };
 }
 
 test("synthesis edits the staging copy natively; measured hunks anchor to the raw file and nothing touches the repo until apply", async () => {
@@ -399,6 +424,17 @@ test("user synthesis makes grounding project roots read-only", async () => {
   assert.equal(fs.readFileSync(path.join(grounding.root, ".git/config"), "utf8"), "[core]\n");
 });
 
+test("a home-rooted grounding project leaves the synthesis workspace writable", async () => {
+  const setupResult = setup(
+    { edit: {}, annotations: [{ reply: { edits: [] } }] },
+    { scope: { kind: "user" }, groundInRepo: true },
+  );
+  process.env.FAKE_ACPX_STATE = path.join(setupResult.repo.root, ".backpass/synthesis/fake-state.json");
+  const { proposal, violations } = await setupResult.run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits.length, 0);
+});
+
 test("user synthesis can propose against relocated external memory", async () => {
   const { run, memoryFile } = setup(
     { edit: {}, annotations: [{ reply: { edits: [] } }] },
@@ -408,6 +444,18 @@ test("user synthesis can propose against relocated external memory", async () =>
   assert.deepEqual(violations, []);
   assert.equal(proposal.memoryFile.path, memoryFile.path);
   assert.equal(proposal.edits.length, 0);
+});
+
+test("relocated skill prompts use their actual staged paths", async () => {
+  const setupResult = setup(
+    { edit: {}, annotations: [{ reply: { edits: [] } }] },
+    { scope: { kind: "user" }, externalSkills: true },
+  );
+  await setupResult.run();
+  const prompt = fs.readFileSync(path.join(setupResult.config.state.root, "prompts/synthesis-edit.md"), "utf8");
+  const stagedDir = workspacePathFor(setupResult.externalSkillsDir);
+  assert.ok(prompt.includes(stagedDir));
+  assert.ok(prompt.includes(`${stagedDir}/db/SKILL.md`));
 });
 
 test("an agent that changes nothing yields an empty proposal, never an invented edit", async () => {

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -168,9 +168,7 @@ function setup(
   }
   const config = loadConfig(
     repo.root,
-    externalSkillsDir
-      ? { ...overrides, skillsDir: externalSkillsDir, skillsDirs: [externalSkillsDir] }
-      : overrides,
+    externalSkillsDir ? { ...overrides, skillsDir: externalSkillsDir, skillsDirs: [externalSkillsDir] } : overrides,
   );
   config.state = new State(repo.root).ensure();
   config.agents = agents;

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -140,7 +140,7 @@ function summaryFor(sessions = 3) {
 const pick = { agent: "claude", model: "claude-opus-5", effort: "high", pinned: true };
 const agents = { resolve: async () => pick, withFallthrough: async (_role, fn) => fn(pick) };
 
-function setup(script, { text = AGENTS, overrides = {}, summary = summaryFor() } = {}) {
+function setup(script, { text = AGENTS, overrides = {}, summary = summaryFor(), scope = null, transcripts = null } = {}) {
   const repo = makeRepo({ "AGENTS.md": text });
   const config = loadConfig(repo.root, overrides);
   config.state = new State(repo.root).ensure();
@@ -152,7 +152,15 @@ function setup(script, { text = AGENTS, overrides = {}, summary = summaryFor() }
   process.env.FAKE_ACPX_STATE = path.join(repo.root, "fake-state.json");
   fs.writeFileSync(process.env.FAKE_ACPX_SCRIPT, JSON.stringify(script));
   const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
-  const run = () => synthesizeProposal({ memoryFile, summary, config, repo, transcripts: [{ harness: "claude" }] });
+  const run = () =>
+    synthesizeProposal({
+      memoryFile,
+      summary,
+      config,
+      repo,
+      transcripts: transcripts || [{ harness: "claude" }],
+      scope,
+    });
   const calls = () =>
     fs
       .readFileSync(log, "utf8")
@@ -359,6 +367,30 @@ test("a harness that writes to the repository instead of the staging copy is ref
   await assert.rejects(run(), (err) => {
     assert.ok(err instanceof UserError);
     assert.match(err.message, /synthesis changed AGENTS\.md in the repository directly/);
+    return true;
+  });
+});
+
+test("user synthesis refuses changes to grounding project roots", async () => {
+  const grounding = makeRepo({ "README.md": "# Grounding\n" });
+  const setupResult = setup(
+    { edit: {}, annotations: [{ reply: { edits: [] } }] },
+    {
+      scope: { kind: "user" },
+      transcripts: [{ harness: "claude", projectRoot: grounding.root }],
+    },
+  );
+  fs.writeFileSync(
+    process.env.FAKE_ACPX_SCRIPT,
+    JSON.stringify({
+      edit: { [path.join(grounding.root, "README.md")]: "# Changed\n" },
+      annotations: [{ reply: { edits: [] } }],
+    }),
+  );
+
+  await assert.rejects(setupResult.run(), (err) => {
+    assert.ok(err instanceof UserError);
+    assert.match(err.message, new RegExp(grounding.root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     return true;
   });
 });

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -140,8 +140,11 @@ function summaryFor(sessions = 3) {
 const pick = { agent: "claude", model: "claude-opus-5", effort: "high", pinned: true };
 const agents = { resolve: async () => pick, withFallthrough: async (_role, fn) => fn(pick) };
 
-function setup(script, { text = AGENTS, overrides = {}, summary = summaryFor(), scope = null, transcripts = null } = {}) {
-  const repo = makeRepo({ "AGENTS.md": text });
+function setup(
+  script,
+  { text = AGENTS, overrides = {}, summary = summaryFor(), scope = null, transcripts = null, externalMemory = false } = {},
+) {
+  const repo = makeRepo(externalMemory ? {} : { "AGENTS.md": text });
   const config = loadConfig(repo.root, overrides);
   config.state = new State(repo.root).ensure();
   config.agents = agents;
@@ -151,7 +154,11 @@ function setup(script, { text = AGENTS, overrides = {}, summary = summaryFor(), 
   process.env.FAKE_ACPX_SCRIPT = path.join(repo.root, "fake-script.json");
   process.env.FAKE_ACPX_STATE = path.join(repo.root, "fake-state.json");
   fs.writeFileSync(process.env.FAKE_ACPX_SCRIPT, JSON.stringify(script));
-  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const memoryPath = externalMemory
+    ? path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-synth-")), "CLAUDE.md")
+    : "AGENTS.md";
+  if (externalMemory) fs.writeFileSync(memoryPath, text);
+  const memoryFile = readMemoryFile(repo.root, memoryPath, { allowExternal: externalMemory });
   const run = () =>
     synthesizeProposal({
       memoryFile,
@@ -371,8 +378,8 @@ test("a harness that writes to the repository instead of the staging copy is ref
   });
 });
 
-test("user synthesis refuses changes to grounding project roots", async () => {
-  const grounding = makeRepo({ "README.md": "# Grounding\n" });
+test("user synthesis makes grounding project roots read-only", async () => {
+  const grounding = makeRepo({ ".git/config": "[core]\n", "README.md": "# Grounding\n" });
   const setupResult = setup(
     { edit: {}, annotations: [{ reply: { edits: [] } }] },
     {
@@ -383,16 +390,24 @@ test("user synthesis refuses changes to grounding project roots", async () => {
   fs.writeFileSync(
     process.env.FAKE_ACPX_SCRIPT,
     JSON.stringify({
-      edit: { [path.join(grounding.root, "README.md")]: "# Changed\n" },
+      edit: { [path.join(grounding.root, ".git/config")]: "[changed]\n" },
       annotations: [{ reply: { edits: [] } }],
     }),
   );
 
-  await assert.rejects(setupResult.run(), (err) => {
-    assert.ok(err instanceof UserError);
-    assert.match(err.message, new RegExp(grounding.root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-    return true;
-  });
+  await assert.rejects(setupResult.run());
+  assert.equal(fs.readFileSync(path.join(grounding.root, ".git/config"), "utf8"), "[core]\n");
+});
+
+test("user synthesis can propose against relocated external memory", async () => {
+  const { run, memoryFile } = setup(
+    { edit: {}, annotations: [{ reply: { edits: [] } }] },
+    { scope: { kind: "user" }, externalMemory: true },
+  );
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.memoryFile.path, memoryFile.path);
+  assert.equal(proposal.edits.length, 0);
 });
 
 test("an agent that changes nothing yields an empty proposal, never an invented edit", async () => {

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -162,7 +162,8 @@ test("init --scope user writes the user block and a 0700 state directory", async
     const target = path.join(home, ".config", "backpass", "config.json");
     const parsed = JSON.parse(fs.readFileSync(target, "utf8"));
     assert.equal(parsed.user.minGapProjects, 1);
-    assert.deepEqual(parsed.user.memoryFiles[0], ".agents/AGENTS.md");
+    assert.equal("memoryFiles" in parsed.user, false);
+    assert.equal("skillsDirs" in parsed.user, false);
     assert.equal(fs.statSync(scope.stateDir).mode & 0o777, 0o700);
     assert.equal(config.state.exclude.status, "skipped");
   });

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -60,6 +60,30 @@ test("apply refuses a user-level memory file that is a symlink to a read-only pa
   assert.equal(fs.readlinkSync(link), source);
 });
 
+test("project apply refuses an external memory target", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-project-apply-"));
+  const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-apply-"));
+  const external = path.join(externalRoot, "AGENTS.md");
+  const text = "# External\n";
+  fs.writeFileSync(external, text);
+  const state = new State(repoRoot).ensure();
+  const results = applyDecisions({
+    proposal: {
+      scope: "project",
+      memoryFile: { path: external, hash: memoryTextHash(text), tokens: 2 },
+      edits: [{ id: "e1", kind: "rewrite", file: external, hunks: [] }],
+      config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+    },
+    decisions: { e1: "accepted" },
+    repo: { root: repoRoot, name: "project" },
+    state,
+    config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+  });
+  assert.equal(results.written.length, 0);
+  assert.match(results.failed[0].error, /outside the project root/);
+  assert.equal(fs.readFileSync(external, "utf8"), text);
+});
+
 test("apply refuses a proposal from the other scope", async () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-scope-"));
   const state = {

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -71,6 +71,44 @@ test("apply refuses a user-level memory file that is a symlink to a read-only pa
   assert.equal(fs.readlinkSync(link), source);
 });
 
+test("apply names a symlink whose writable file is in a read-only store", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-store-"));
+  const store = path.join(home, "readonly-store");
+  const source = path.join(store, "AGENTS.md");
+  const link = path.join(home, ".agents", "AGENTS.md");
+  const text = "# User memory\n\n- Keep secrets out of prompts.\n";
+  fs.mkdirSync(store, { recursive: true });
+  fs.mkdirSync(path.dirname(link), { recursive: true });
+  fs.writeFileSync(source, text, { mode: 0o644 });
+  fs.symlinkSync(source, link);
+  fs.chmodSync(store, 0o555);
+
+  try {
+    const state = new State(home, {
+      stateDir: path.join(home, ".config", "backpass", "user"),
+      mode: 0o700,
+      exclude: false,
+    }).ensure();
+    const results = applyDecisions({
+      proposal: {
+        memoryFile: { path: ".agents/AGENTS.md", hash: memoryTextHash(text), tokens: 20 },
+        edits: [{ id: "e1", kind: "rewrite", file: ".agents/AGENTS.md" }],
+        config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+      },
+      decisions: { e1: "accepted" },
+      repo: { root: home, name: "user" },
+      state,
+      config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+    });
+
+    assert.equal(results.written.length, 0);
+    assert.equal(results.failed[0].error, readOnlySymlinkMessage(link, fs.realpathSync(source)));
+    assert.equal(fs.readFileSync(source, "utf8"), text);
+  } finally {
+    fs.chmodSync(store, 0o755);
+  }
+});
+
 test("project apply refuses an external memory target", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-project-apply-"));
   const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-apply-"));

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { applyDecisions, readOnlySymlinkMessage } from "../src/apply/writer.js";
+import { cmdApply } from "../src/commands/apply.js";
+import { cmdInit } from "../src/commands/init.js";
+import { loadConfig } from "../src/config.js";
+import { UserError } from "../src/logger.js";
+import { memoryTextHash } from "../src/memory.js";
+import { resolveScope } from "../src/scope.js";
+import { State } from "../src/state.js";
+
+async function withXdg(home, fn) {
+  const prev = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prev;
+  }
+}
+
+test("apply refuses a user-level memory file that is a symlink to a read-only path", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-home-"));
+  const source = path.join(home, "dotfiles", "AGENTS.md");
+  const link = path.join(home, ".agents", "AGENTS.md");
+  const text = "# User memory\n\n- Keep secrets out of prompts.\n";
+  fs.mkdirSync(path.dirname(source), { recursive: true });
+  fs.mkdirSync(path.dirname(link), { recursive: true });
+  fs.writeFileSync(source, text);
+  fs.chmodSync(source, 0o444);
+  fs.symlinkSync(source, link);
+
+  const state = new State(home, {
+    stateDir: path.join(home, ".config", "backpass", "user"),
+    mode: 0o700,
+    exclude: false,
+  }).ensure();
+  const results = applyDecisions({
+    proposal: {
+      memoryFile: { path: ".agents/AGENTS.md", hash: memoryTextHash(text), tokens: 20 },
+      edits: [{ id: "e1", kind: "rewrite", file: ".agents/AGENTS.md" }],
+      config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+    },
+    decisions: { e1: "accepted" },
+    repo: { root: home, name: "user" },
+    state,
+    config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+  });
+
+  assert.equal(results.written.length, 0);
+  assert.equal(results.rejectionsRecorded, false);
+  assert.equal(results.failed[0].error, readOnlySymlinkMessage(link, fs.realpathSync(source)));
+  assert.match(results.failed[0].error, /is a symlink to .+ which is not writable; edit the source that generates it/);
+  assert.equal(fs.readFileSync(source, "utf8"), text);
+  assert.equal(fs.readlinkSync(link), source);
+});
+
+test("apply refuses a proposal from the other scope", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-scope-"));
+  const state = {
+    readProposal: () => ({ scope: "user", edits: [{ id: "e1" }] }),
+  };
+  await assert.rejects(
+    () => cmdApply({ repo: { root: home, name: "demo" }, scope: { kind: "project" }, config: { state }, flags: {} }),
+    (err) => {
+      assert.ok(err instanceof UserError);
+      assert.match(err.message, /this proposal is user scope; run `backpass apply --scope user`/);
+      return true;
+    },
+  );
+});
+
+test("init --scope user writes the user block and a 0700 state directory", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uinit-"));
+  await withXdg(home, async () => {
+    const config = loadConfig(null, {}, { kind: "user" });
+    const scope = resolveScope(home, { scope: "user" }, config, null, { home });
+    config.state = new State(scope.root, {
+      stateDir: scope.stateDir,
+      mode: 0o700,
+      exclude: false,
+    }).ensure();
+    await cmdInit({ repo: scope.repo, scope, config, flags: {} });
+    const target = path.join(home, ".config", "backpass", "config.json");
+    const parsed = JSON.parse(fs.readFileSync(target, "utf8"));
+    assert.equal(parsed.user.minGapProjects, 1);
+    assert.deepEqual(parsed.user.memoryFiles[0], ".agents/AGENTS.md");
+    assert.equal(fs.statSync(scope.stateDir).mode & 0o777, 0o700);
+    assert.equal(config.state.exclude.status, "skipped");
+  });
+});

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -24,6 +24,17 @@ async function withXdg(home, fn) {
   }
 }
 
+test("user state creation tightens an existing directory to mode 0700", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-user-state-mode-"));
+  const stateDir = path.join(home, ".config", "backpass", "user");
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.chmodSync(stateDir, 0o777);
+
+  new State(home, { stateDir, mode: 0o700, exclude: false }).ensure();
+
+  assert.equal(fs.statSync(stateDir).mode & 0o777, 0o700);
+});
+
 test("apply refuses a user-level memory file that is a symlink to a read-only path", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-home-"));
   const source = path.join(home, "dotfiles", "AGENTS.md");

--- a/test/user-discovery.test.js
+++ b/test/user-discovery.test.js
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { loadConfig } from "../src/config.js";
 import { discoverTranscripts } from "../src/discovery/index.js";
 import { SELF_SESSION_SENTINEL } from "../src/prompts.js";
+import { capTranscripts } from "../src/sample.js";
 import { resolveScope } from "../src/scope.js";
 import { State } from "../src/state.js";
 
@@ -110,6 +111,28 @@ test("user-scope discovery keeps Claude and Codex sessions from different projec
   );
   assert.equal(scope.stateDir, path.join(home, ".config", "backpass", "user"));
   assert.equal(fs.statSync(scope.stateDir).mode & 0o777, 0o700);
+});
+
+test("user-scope discovery gives live and deleted registered worktrees one project identity", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-udisc-worktrees-"));
+  const root = initRepo("worktrees");
+  const sibling = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-udisc-parent-")), "deleted");
+  git(["remote", "add", "origin", "https://github.com/acme/shared.git"], root);
+  git(["worktree", "add", "-q", "-b", "deleted", sibling], root);
+
+  writeFixture(path.join(home, ".claude", "projects", "a-deleted", "deleted.jsonl"), "claude-session.jsonl", sibling);
+  writeFixture(path.join(home, ".claude", "projects", "z-live", "live.jsonl"), "claude-session.jsonl", root, {
+    "11111111-2222-3333-4444-555555555555": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  });
+  fs.rmSync(sibling, { recursive: true, force: true });
+
+  const { result, config } = await userDiscovery(home, { discovery: { maxTranscriptsPerProject: 1 } });
+  assert.equal(result.transcripts.length, 2);
+  assert.deepEqual(
+    new Set(result.transcripts.map((transcript) => transcript.project)),
+    new Set(["github.com/acme/shared"]),
+  );
+  assert.equal(capTranscripts(result, config).transcripts.length, 1);
 });
 
 test("user-scope discovery drops self-sessions by sentinel and by cwd under the user state dir", async () => {

--- a/test/user-discovery.test.js
+++ b/test/user-discovery.test.js
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { loadConfig } from "../src/config.js";
+import { discoverTranscripts } from "../src/discovery/index.js";
+import { SELF_SESSION_SENTINEL } from "../src/prompts.js";
+import { resolveScope } from "../src/scope.js";
+import { State } from "../src/state.js";
+
+const FIXTURES = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
+
+function git(args, cwd) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function initRepo(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `backpass-udisc-${name}-`));
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  git(["commit", "--allow-empty", "-q", "-m", "init"], dir);
+  return fs.realpathSync(dir);
+}
+
+async function withEnv(overrides, fn) {
+  const keys = Object.keys(overrides);
+  const previous = {};
+  for (const key of keys) previous[key] = process.env[key];
+  try {
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return await fn();
+  } finally {
+    for (const key of keys) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+    }
+  }
+}
+
+function writeFixture(target, fixtureName, cwd, rewrite = {}) {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  let text = fs.readFileSync(path.join(FIXTURES, fixtureName), "utf8");
+  text = text.replaceAll("/repo/demo", cwd);
+  for (const [from, to] of Object.entries(rewrite)) text = text.replaceAll(from, to);
+  fs.writeFileSync(target, text);
+}
+
+function userDiscovery(home, overrides = {}) {
+  const xdg = path.join(home, ".config");
+  return withEnv(
+    {
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: xdg,
+      CLAUDE_CONFIG_DIR: undefined,
+      HERMES_HOME: path.join(home, ".hermes-absent"),
+    },
+    async () => {
+      const config = loadConfig(
+        null,
+        { discovery: { since: "all", harnesses: ["claude", "codex"], ...overrides.discovery } },
+        { kind: "user" },
+      );
+      const scope = resolveScope(home, { scope: "user", strict: Boolean(overrides.strict) }, config, null, { home });
+      config.state = new State(scope.root, {
+        stateDir: scope.stateDir,
+        mode: 0o700,
+        exclude: false,
+      }).ensure();
+      const result = await discoverTranscripts({
+        repo: scope.repo,
+        scope,
+        config,
+        strict: Boolean(overrides.strict),
+      });
+      return { result, scope, config };
+    },
+  );
+}
+
+test("user-scope discovery keeps Claude and Codex sessions from different project cwds", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-udisc-home-"));
+  const alpha = initRepo("alpha");
+  const beta = initRepo("beta");
+  writeFixture(path.join(home, ".claude", "projects", "alpha", "alpha.jsonl"), "claude-session.jsonl", alpha);
+  writeFixture(
+    path.join(home, ".codex", "sessions", "2026", "08", "02", "rollout-2026-08-02T09-00-00-beta.jsonl"),
+    "codex-rollout.jsonl",
+    beta,
+  );
+
+  const { result, scope } = await userDiscovery(home);
+  const harnesses = result.transcripts.map((t) => t.harness).sort();
+  assert.deepEqual(harnesses, ["claude", "codex"]);
+  const projects = new Set(result.transcripts.map((t) => t.project));
+  assert.ok(projects.has(alpha), "Claude session stamps the live git toplevel");
+  assert.ok(projects.has(beta), "Codex session stamps the other checkout");
+  assert.equal(
+    result.transcripts.every((t) => t.association.tier === 1),
+    true,
+  );
+  assert.equal(scope.stateDir, path.join(home, ".config", "backpass", "user"));
+  assert.equal(fs.statSync(scope.stateDir).mode & 0o777, 0o700);
+});
+
+test("user-scope discovery drops self-sessions by sentinel and by cwd under the user state dir", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-udisc-self-"));
+  const alpha = initRepo("alpha");
+  const stateDir = path.join(home, ".config", "backpass", "user");
+  writeFixture(path.join(home, ".claude", "projects", "alpha", "real.jsonl"), "claude-session.jsonl", alpha);
+  writeFixture(path.join(home, ".claude", "projects", "state", "under-state.jsonl"), "claude-session.jsonl", stateDir, {
+    "11111111-2222-3333-4444-555555555555": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  });
+  const sentinelFile = path.join(home, ".claude", "projects", "alpha", "self.jsonl");
+  fs.mkdirSync(path.dirname(sentinelFile), { recursive: true });
+  fs.writeFileSync(
+    sentinelFile,
+    `${JSON.stringify({
+      parentUuid: null,
+      isSidechain: false,
+      type: "user",
+      message: { role: "user", content: `${SELF_SESSION_SENTINEL}\nanalyze this` },
+      uuid: "u1",
+      timestamp: "2026-08-01T10:00:00.000Z",
+      cwd: alpha,
+      sessionId: "self-sess-0000-0000-0000-000000000001",
+      entrypoint: "cli",
+    })}\n`,
+  );
+
+  const { result } = await userDiscovery(home);
+  assert.equal(result.transcripts.length, 1);
+  assert.equal(result.transcripts[0].harness, "claude");
+  assert.equal(result.transcripts[0].project, alpha);
+  assert.ok(result.perHarness.claude.self >= 2);
+});
+
+test("user-scope --strict drops a dead cwd with no recorded remote", async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-udisc-strict-"));
+  writeFixture(
+    path.join(home, ".claude", "projects", "gone", "dead.jsonl"),
+    "claude-session.jsonl",
+    "/vanished/no-remote",
+  );
+  const kept = await userDiscovery(home);
+  assert.equal(kept.result.transcripts.length, 1);
+  assert.equal(kept.result.transcripts[0].association.tier, 3);
+  const dropped = await userDiscovery(home, { strict: true });
+  assert.equal(dropped.result.transcripts.length, 0);
+});

--- a/test/user-discovery.test.js
+++ b/test/user-discovery.test.js
@@ -61,6 +61,7 @@ function userDiscovery(home, overrides = {}) {
       USERPROFILE: home,
       XDG_CONFIG_HOME: xdg,
       CLAUDE_CONFIG_DIR: undefined,
+      CODEX_HOME: undefined,
       HERMES_HOME: path.join(home, ".hermes-absent"),
     },
     async () => {

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { readMemoryFile } from "../src/memory.js";
@@ -11,6 +12,7 @@ import {
   parseSkillFile,
   prepareWorkspace,
   repoFingerprint,
+  workspacePathFor,
 } from "../src/workspace.js";
 import { makeRepo, writeIn } from "./helpers/staging.js";
 
@@ -74,6 +76,35 @@ test("an untouched workspace measures as no change, and ids are stable across re
   assert.equal(a.signature, b.signature);
   assert.equal(a.changes[1].skill.name, "new");
   assert.notEqual(first.signature, a.signature);
+});
+
+test("external user memory and skills use workspace-relative staging paths", () => {
+  const repo = makeRepo({});
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-workspace-"));
+  const memoryPath = path.join(external, "CLAUDE.md");
+  const skillsDir = path.join(external, "skills");
+  fs.mkdirSync(path.join(skillsDir, "db"), { recursive: true });
+  fs.writeFileSync(memoryPath, AGENTS);
+  fs.writeFileSync(path.join(skillsDir, "db/SKILL.md"), SKILL);
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile: readMemoryFile(repo.root, memoryPath, { allowExternal: true }),
+    skillsDir,
+    skillDirs: [skillsDir],
+  });
+
+  assert.equal(path.isAbsolute(workspace.memoryWorkspacePath), false);
+  writeIn(workspace.root, workspace.memoryWorkspacePath, (text) => text.replace("- two", "- 2"));
+  writeIn(path.join(workspace.root, workspacePathFor(skillsDir)), "new/SKILL.md", SKILL.replace("db", "new"));
+  const measured = measureWorkspace(workspace);
+  assert.deepEqual(
+    measured.changes.map((change) => [change.kind, change.file]),
+    [
+      ["hunk", memoryPath],
+      ["created", path.join(skillsDir, "new/SKILL.md")],
+    ],
+  );
 });
 
 test("only the skill layouts a harness loads count as created skills; anything else is stray", () => {

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -129,7 +129,10 @@ test("split external memory hunks retain their staged path", () => {
 
   const hunks = measureWorkspace(workspace).changes.filter((change) => change.kind === "hunk");
   assert.equal(hunks.length, 2);
-  assert.equal(hunks.every((hunk) => hunk.workspaceFile === workspace.memoryWorkspacePath), true);
+  assert.equal(
+    hunks.every((hunk) => hunk.workspaceFile === workspace.memoryWorkspacePath),
+    true,
+  );
 });
 
 test("only the skill layouts a harness loads count as created skills; anything else is stray", () => {

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -141,6 +141,9 @@ test("only the skill layouts a harness loads count as created skills; anything e
   assert.equal(isSkillFilePath(".agents/skills/db/reference.md", ".agents/skills"), false);
   assert.equal(isSkillFilePath(".agents/skills/a/b/SKILL.md", ".agents/skills"), false);
   assert.equal(isSkillFilePath("skills/db/SKILL.md", ".agents/skills"), false);
+  assert.equal(isSkillFilePath("C:\\cfg\\skills\\db\\SKILL.md", "C:\\cfg\\skills"), true);
+  assert.equal(isSkillFilePath("C:\\cfg\\skills\\db.md", "C:\\cfg\\skills"), true);
+  assert.equal(isSkillFilePath("C:\\cfg\\other\\db\\SKILL.md", "C:\\cfg\\skills"), false);
 
   assert.deepEqual(parseSkillFile("x/SKILL.md", SKILL), {
     name: "db",

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -107,6 +107,31 @@ test("external user memory and skills use workspace-relative staging paths", () 
   );
 });
 
+test("split external memory hunks retain their staged path", () => {
+  const repo = makeRepo({});
+  const external = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-split-"));
+  const memoryPath = path.join(external, "CLAUDE.md");
+  const skillsDir = path.join(external, "skills");
+  fs.writeFileSync(memoryPath, "# M\n\n- carry\n- delete\n- keep\n");
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile: readMemoryFile(repo.root, memoryPath, { allowExternal: true }),
+    skillsDir,
+    skillDirs: [skillsDir],
+  });
+  writeIn(workspace.root, workspace.memoryWorkspacePath, (text) => text.replace("- carry\n- delete\n", ""));
+  writeIn(
+    path.join(workspace.root, workspacePathFor(skillsDir)),
+    "carry/SKILL.md",
+    "---\nname: carry\ndescription: Load for carry rules.\n---\n\n- carry\n",
+  );
+
+  const hunks = measureWorkspace(workspace).changes.filter((change) => change.kind === "hunk");
+  assert.equal(hunks.length, 2);
+  assert.equal(hunks.every((hunk) => hunk.workspaceFile === workspace.memoryWorkspacePath), true);
+});
+
 test("only the skill layouts a harness loads count as created skills; anything else is stray", () => {
   assert.equal(isSkillFilePath(".agents/skills/db/SKILL.md", ".agents/skills"), true);
   assert.equal(isSkillFilePath(".agents/skills/db.md", ".agents/skills"), true);


### PR DESCRIPTION
## Intent

Phase 1 of issue #97: smallest useful cut of --scope user. A run is exactly one scope, chosen by --scope; default stays project. User scope discovers Claude and Codex sessions across projects, excludes self-sessions, and edits only user-level memory files and skills. Project-scope fixture behavior must stay unchanged. No cross-scope writes. User state is ~/.config/backpass/user/ (mode 0700, honour XDG_CONFIG_HOME), isolated from every project's .backpass/ (evidence, ledgers, rejections, apply surfaces). Apply refuses a symlink into a read-only store with the named message: "{absolute} is a symlink to {real}, which is not writable; edit the source that generates it".

Captain answers on issue #97 (2026-09-02): (1) vision already amended in Phase 0 (H-13; H-8 stays off-mission for a project-scoped write to a user-level file); (2) canonical user memory is first-existing with divergence warnings; (3) minGapProjects default 1 so the gate exists but cross-project corroboration is not required, and section 8's "more than one project" is not folded into VISION.md; (4) isolate project vs user state as much as possible; (5) user state under ~/.config/backpass/, not XDG_STATE_HOME; (6) pre-image backups follow project scope (atomicReplace + rollback only, no new backup dir); (7) extraction target follows project (.agents/skills plus a warning if .claude/skills is a real directory); (8) AGENTS.md is canonical; CLAUDE.md may be a pointer (verified: Claude Code inlines @ imports including ~/ and absolute; Codex follows AGENTS.md and is not assumed to honour @ imports).

Captain 2026-09-02 (containment): no hard containment; edit scope is instruction-based. Do not add a write allowlist, deny-default sandbox, or further OS containment machinery for the user-scope synthesis invariant.

Out of scope for this PR: Phase 2/3 (cross-scope UG/PG ids, SK ids, status overlap report, other harness user surfaces, multi-machine pooling). Tests must be offline and behavioral. Required coverage: resolveScope fixtures; user discovery over existing claude/codex fixtures with differing cwds; fold minGapProjects + project-covered; writer vs temp home + read-only symlink; sample per-project cap.

## What Changed

- Add `--scope user` across the CLI to manage canonical user memory and skills with isolated, XDG-aware state.
- Discover Claude and Codex sessions across projects with project filters, self-session exclusion, sticky per-project sampling, and project-aware gap folding.
- Keep writes scoped to the selected surface, support user memory pointers and relocated skill directories, and refuse read-only symlink targets with actionable errors.

## Risk Assessment

✅ Low: The implementation matches the stated Phase 1 scope and prior decisions, with no material source-verifiable defects found.

## Testing

Targeted behavioral tests and an end-to-end CLI scan validated user-scope resolution, cross-project Claude/Codex discovery, self-session exclusion, per-project sampling, project coverage and gap gating, isolated 0700 state, relocated memory and skills, scope-safe apply, and the named read-only symlink refusal. The reviewer-visible CLI transcript confirms the intended user experience and state isolation. No visual UI changed, so screenshot evidence was not applicable.

<details>
<summary>Evidence: End-to-end user-scope scan across two projects with state isolation checks</summary>

Source: [End-to-end user-scope scan across two projects with state isolation checks](https://github.com/kunchenguid/backpass/blob/fe9c8f6eef659cafbd60374c79eef3bc095829aa/.no-mistakes/evidence/fm/backpass-user-level-scope-p1-r1/user-scope-scan.txt)

```text
COMMAND: backpass scan --scope user --since all --harness claude,codex

user scope: this checkout is not a write target; edits go to the user-level memory file and skills
user scope · since all

HARNESS  SCANNED  MATCHED  SELF  CACHED  NOTE
claude   1        1        0     0
codex    1        1        0     0

2 transcript(s) across 2 project(s) · tier1 2 (git) · tier2 0 (remote) · tier3 0 (cwd) · interactive 0 · non-interactive 2

HARNESS  SESSION       KIND             WHEN   SIZE  TIER  PROJECT
codex    aaaa-bbbb     non-interactive  today  2KB   t1    ~/.no-mistakes/worktrees/26c81f7411
claude   11111111-222  non-interactive  today  2KB   t1    ~/.no-mistakes/worktrees/26c81f7411

STATE DIRECTORY MODE: 700 ~/.no-mistakes/worktrees/26c81f74111f/01M1GP6BEEPGHNQ6Y3EEG6GAC9/.test-user-scope-e2e/home/xdg/backpass/user
PROJECT .backpass DIRECTORIES CREATED: none
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"45c238dc60c8a0ade5d1a0a2e6c482b8e6f30717","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (7) ✅</summary>

- 🚨 `src/subprocess.js:121` - The intent explicitly says: &#34;no hard containment&#34; and &#34;Do not add a write allowlist, deny-default sandbox, or further OS containment machinery.&#34; This branch adds sandbox-exec/bubblewrap launch policy and wires it into user synthesis. It also withholds grounding paths when containment is unavailable. Revert this pipeline-added containment machinery and retain instruction-based edit scope only.
- 🚨 `src/analyze.js:249` - Fresh cached evidence updates only `interaction`, leaving the newly significant `project`, `projectRoot`, `cwd`, and association fields stale. For example, analyze a Codex session while its checkout is absent, then restore that checkout with project memory covering the gap: discovery finds the live root, but fold receives the cached null `projectRoot` and incorrectly counts the covered gap. Refresh the non-judgment transcript metadata from the current descriptor whenever cached evidence is reused.
- 🚨 `src/scope.js:65` - Live sessions use each git worktree path as `project`, while deleted sessions use a normalized remote. Two worktrees of one repository therefore count as two projects at `fold.js:343`, incorrectly satisfying `minGapProjects=2` and independently evading the per-project sample cap. Establish a stable repository identity at the user-association boundary, using normalized live remotes when available and a path fallback only when no repository identity exists.
- 🚨 `src/state.js:55` - The required criterion says user state is mode 0700, but `ensure()` creates it with the process default mode and silently continues when chmod fails. A filesystem or permission state that rejects chmod therefore leaves evidence, prompts, proposals, and apply surfaces under a potentially broader directory mode. Create with 0700 and fail clearly if the existing directory cannot be secured rather than treating the requirement as best effort.

🔧 Fix: Refresh cached associations and unify worktree project identity
2 errors still open:

- 🚨 `src/state.js:55` - Intent requires user state to be mode 0700, but the directory is initially created with the process default mode and chmod failures are silently ignored. It can therefore remain broadly readable while holding evidence, prompts, proposals, and apply surfaces. Create it with mode 0700 and fail clearly if an existing directory cannot be secured.
- 🚨 `src/scope.js:72` - The worktree-identity fix still uses each toplevel path when a repository has no remote. Two worktrees of the same local repository therefore receive different project keys, can independently evade maxTranscriptsPerProject, and can incorrectly satisfy minGapProjects=2. At the association boundary, use the shared git-common-dir identity before falling back to the worktree path.

🔧 Fix: Unify local worktrees by shared Git identity
3 errors still open:

- 🚨 `src/subprocess.js:106` - The authoritative intent says &#34;no hard containment&#34; and explicitly forbids &#34;a write allowlist, deny-default sandbox, or further OS containment machinery.&#34; This change adds sandbox-exec/bubblewrap probing and launch policies at lines 106-174, then conditionally withholds grounding paths in synthesis. Revert this pipeline-added machinery to the smallest instruction-based edit-scope implementation required by the intent.
- 🚨 `src/state.js:55` - Intent requires user state to be mode 0700, but ensure() creates it with the process default mode and silently ignores chmod failure. The directory can therefore remain broadly accessible while holding evidence, prompts, proposals, and apply surfaces. Create it with mode 0700 and fail clearly if an existing directory cannot be secured.
- 🚨 `src/apply/writer.js:581` - With CLAUDE_CONFIG_DIR=/custom/claude, discovery and synthesis correctly use /custom/claude/skills, but applying an extraction still calls ensureSkillsLayout(repo.root), which creates ~/.claude/skills rather than /custom/claude/skills. The new skill lands in ~/.agents/skills and remains invisible to relocated Claude. Pass the configured Claude skills location through the apply layout boundary and create or validate its link to the canonical directory.

🔧 Fix: Link relocated Claude skills during user apply
4 issues (3 errors, 1 warning) still open:

- 🚨 `src/state.js:55` - The required user-state mode is not enforced. `ensure()` creates the directory with the process default mode and silently ignores `chmod` failure, so evidence, prompts, proposals, and apply surfaces can remain accessible beyond mode 0700. Create with mode 0700 and fail clearly when an existing directory cannot be secured.
- 🚨 `src/repo.js:145` - Live repositories use the lexicographically first of every configured remote, while deleted Codex sessions use their single recorded `git.repository_url`. In a fork checkout with `origin=user/fork` and `upstream=org/repo`, live and deleted sessions from the same repository can receive different project keys, bypass the per-project cap, and incorrectly satisfy `minGapProjects=2`. Establish one identity compatible with the recorded remote at this association boundary, such as preferring the repository&#39;s authoritative origin before other remotes.
- 🚨 `src/skills.js:75` - Skill resolution always injects `.claude/skills`, even when `CLAUDE_CONFIG_DIR` relocates Claude and `extraDirs` contains the actual directory. An old default skill can therefore affect budgets, be reported as covering a gap, or be edited even though the active Claude installation cannot load it. User scope should resolve exactly its configured harness skill roots rather than unconditionally adding the default Claude root.
- ⚠️ `src/apply/writer.js:291` - User apply assumes `skillsDirs[1]` is Claude&#39;s directory, but validation and documentation expose `skillsDirs` as a general path list with no positional contract. Reordering or prepending a custom directory can make apply create a symlink at the wrong user path while leaving relocated Claude disconnected. Persist or otherwise carry the semantic Claude skills target instead of inferring it from list position; adding that explicit persisted contract needs authorization.

🔧 Fix: Enforce user state, project identity, and skill roots
2 issues (1 error, 1 warning) still open:

- 🚨 `src/apply/writer.js:53` - The required named symlink refusal checks only whether the resolved file is writable. If the source file is mode 0644 but its containing store directory is not writable, this check passes, then atomicReplace cannot create its temporary sibling and returns a generic write error instead of the required message. Check writability needed by the actual replacement operation, including the resolved target&#39;s parent directory, before applying.
- ⚠️ `src/fold.js:386` - With minGapProjects=3 and an eligible gap observed in two projects, projectSpecificNote selects the first project and reports `seen in &lt;project&gt; only`, incorrectly hiding the second project. Report the actual project count or list rather than claiming a single-project observation.

🔧 Fix: Detect read-only symlink stores and report project counts
1 error still open:

- 🚨 `src/subprocess.js:43` - Authoritative intent says: &#34;no hard containment; edit scope is instruction-based&#34; and &#34;Do not add a write allowlist, deny-default sandbox, or further OS containment machinery.&#34; This hunk routes synthesis subprocesses through the new sandbox-exec/bubblewrap policy in `readOnlyLaunch`, with `src/synthesize.js:450-574` probing and supplying grounding roots. Revert this prior fixer machinery and retain the required instruction-based edit scope.

🔧 Fix: Remove forbidden synthesis OS containment
3 issues (1 error, 2 warnings) still open:

- 🚨 `src/workspace.js:102` - Skill membership is checked with hard-coded &#34;/&#34; separators. On Windows, an external CLAUDE_CONFIG_DIR or CODEX_HOME produces logical paths such as `C:\cfg\skills\db\SKILL.md`, which do not start with `C:\cfg\skills/`. Changes to relocated existing skills are therefore silently classified as stray and omitted from proposals. Use path-relative component checks or normalize both paths before comparison.
- ⚠️ `src/config.js:371` - `init --scope user` persists the currently derived memoryFiles and skillsDirs. After initializing under defaults, running with CODEX_HOME or CLAUDE_CONFIG_DIR relocated still uses the stored default memory and skill paths, while discovery follows the new environment. This can analyze relocated sessions against inactive memory. Keep environment-derived defaults implicit in the generated user block so explicit user configuration can still override them.
- ⚠️ `src/proposal.js:517` - The minGapProjects proposal gate runs whenever the config contains the field, regardless of scope, although folding enables it only for user scope and the CLI documents it as user-only. A project config or `backpass --min-gap-projects 2` admits a one-project gap during folding and then repeatedly rejects its addition during synthesis. Gate project counts only when `scope.kind === &#34;user&#34;`, or reject the flag in project scope.

🔧 Fix: Fix Windows skill paths and scope-specific defaults
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/scope.test.js test/user-discovery.test.js test/fold.test.js test/user-apply.test.js test/sample.test.js test/config.test.js test/skills.test.js test/workspace.test.js test/proposal.test.js`
- `node --test test/memory-resolution.test.js test/gap-ledger.test.js test/synthesize.test.js`
- `node --test test/adapters.test.js test/association.test.js test/repo.test.js test/self-session.test.js test/sibling-clone-discovery.test.js`
- <code>Created isolated Claude and Codex fixture stores pointing to two live git projects, then ran `node bin/backpass.js scan --scope user --since all --harness claude,codex` with isolated `HOME` and `XDG_CONFIG_HOME`.</code>
- <code>Verified the CLI reported two transcripts across two projects, created user state with mode 0700, and created no project `.backpass` directories.</code>
- <code>Removed the temporary `.test-user-scope-e2e` fixture and confirmed the worktree remained clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
