### PR TITLE
fix: require corroboration for every always-loaded edit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,16 +149,14 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   placement table stays prompt guidance by the captain's explicit decision - do not harden it.
 - **One session floor covers the whole always-loaded surface.** Every edit whose kind is
   not `extract` or `move` must quote `minGapEvidence` distinct sessions - add, rewrite and
-  remove alike. `buildProposal` counts them from the edit's own `evidence` sources
-  (`countSources` in `src/proposal.js`); the model's `transcripts` field is not read at all.
-  There is deliberately NO shape predicate separating an additive rewrite from a tightening:
-  https://github.com/kunchenguid/backpass/pull/79 spent 20 commits proving every lexical
-  proxy for it (net token growth, word coverage, bigram overlap) has a mirror-image
-  failure, so a one-session tightening is refused too - the captain's accepted cost. Never
-  reintroduce a text classifier here. In user scope the same edits also clear
-  `minGapProjects`, counted by `countedEvidenceProjects` from cited gap clusters and from
-  `summary.sourceProjects`, the fold's source -> project map that lets instruction-row
-  evidence (which carries no project of its own) answer for a rewrite.
+  remove alike. `buildProposal` discards empty quote text, then counts canonical non-empty
+  source labels from the edit's own `evidence`; the model's `transcripts` field is not read.
+  Sourceless quotes remain visible as `unknown source` but do not count. There is no shape
+  predicate separating an additive rewrite from a tightening, so a one-session tightening
+  is refused too. Never reintroduce a lexical-overlap, token-growth, or other text classifier
+  here. In user scope the same edits also clear `minGapProjects`, counted by
+  `countedEvidenceProjects` from cited gap clusters and from `summary.sourceProjects`, the
+  fold's source -> project map that lets instruction-row evidence answer for a rewrite.
 - **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other
   values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,18 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   pure deletion inside a skill file is refused outright - skill content is rewritten or
   extracted, never dropped. Non-compliance never satisfies the floor; the >= 20%-relevance
   placement table stays prompt guidance by the captain's explicit decision - do not harden it.
+- **One session floor covers the whole always-loaded surface.** Every edit whose kind is
+  not `extract` or `move` must quote `minGapEvidence` distinct sessions - add, rewrite and
+  remove alike. `buildProposal` counts them from the edit's own `evidence` sources
+  (`countSources` in `src/proposal.js`); the model's `transcripts` field is not read at all.
+  There is deliberately NO shape predicate separating an additive rewrite from a tightening:
+  https://github.com/kunchenguid/backpass/pull/79 spent 20 commits proving every lexical
+  proxy for it (net token growth, word coverage, bigram overlap) has a mirror-image
+  failure, so a one-session tightening is refused too - the captain's accepted cost. Never
+  reintroduce a text classifier here. In user scope the same edits also clear
+  `minGapProjects`, counted by `countedEvidenceProjects` from cited gap clusters and from
+  `summary.sourceProjects`, the fold's source -> project map that lets instruction-row
+  evidence (which carries no project of its own) answer for a rewrite.
 - **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other
   values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each
@@ -165,8 +177,9 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   unsplit. The instruction index and fold use those parts so evidence cannot smear across a
   blob, and synthesis is told to restructure repeated non-compliance into list items rather
   than bold-label it. See `src/memory.js` and `renderEvidenceForPrompt` in `src/fold.js`.
-- **Never trust model-reported numbers.** Token deltas and budget projections are measured
-  in `src/proposal.js` from the actual text; the synthesis model's own figures are ignored.
+- **Never trust model-reported numbers.** Token deltas, budget projections and an edit's
+  session count are measured in `src/proposal.js` from the actual text and quotes; the
+  synthesis model's own figures are ignored.
   Usage accounting comes from acpx's `[acpx] tokens:` stderr line, which acpx prints
   when the ACP adapter returns usage (codex, claude do; pi-acp does not), with one
   harness-store fallback: pi's per-turn usage is read back from its own session file,

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ memory file and project skills - under a token budget, gated by you.
 - **Local-first** - Reads the transcript stores of seven agent harnesses directly from disk.
   No API, no upload; transcripts never leave your machine except into an agent you already
   authenticated, and obvious secrets are redacted before they do.
-- **Evidence-gated** - Every proposed edit carries verbatim quotes from real sessions, a
-  new instruction needs evidence from at least two independent sessions, and one run
-  proposes at most five edits. Small, noisy, repeated steps - not a rewrite.
+- **Evidence-gated** - Every proposed edit carries verbatim quotes from real sessions,
+  and every `add`, `rewrite`, or `remove` edit needs evidence from at least two distinct
+  sessions. Small, noisy, bounded steps - not a rewrite.
 - **Human in the loop** - Analysis never writes. `backpass apply` is the only writing
   command, and it shows each edit with its evidence for you to accept or reject.
 
@@ -51,8 +51,7 @@ AGENTS.md / CLAUDE.md + skills (the weights)
   → back to the weights
 ```
 
-One run is one gradient step: at most five edits, and a new instruction needs evidence
-from at least two independent sessions.
+One run is one bounded gradient step.
 
 ## Quick Start
 
@@ -87,9 +86,10 @@ Canonical user memory is the first existing file in this order: `~/.agents/AGENT
 follow the project layout at `~/.agents/skills`, with a warning if Claude's active
 `skills` path is a real directory rather than the usual symlink.
 
-In user scope every edit also clears `minGapProjects` (default `1`): the distinct
-projects behind its own quotes, counted from the gap clusters it cites and from the
-session-to-project map behind the instruction evidence rows.
+In user scope every `add`, `rewrite`, or `remove` edit also clears `minGapProjects`
+(default `1`): the distinct projects behind its own quotes, counted from the gap
+clusters it cites and from the session-to-project map behind the instruction evidence
+rows. `extract` and `move` edits remain exempt.
 
 State lives in `$XDG_CONFIG_HOME/backpass/user/` (default
 `~/.config/backpass/user/`) with mode 0700, isolated from every project's

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Canonical user memory is the first existing file in this order: `~/.agents/AGENT
 follow the project layout at `~/.agents/skills`, with a warning if Claude's active
 `skills` path is a real directory rather than the usual symlink.
 
+In user scope every edit also clears `minGapProjects` (default `1`): the distinct
+projects behind its own quotes, counted from the gap clusters it cites and from the
+session-to-project map behind the instruction evidence rows.
+
 State lives in `$XDG_CONFIG_HOME/backpass/user/` (default
 `~/.config/backpass/user/`) with mode 0700, isolated from every project's
 `.backpass/`. User-scope evidence, ledgers, proposals, and apply surfaces stay in
@@ -311,8 +315,12 @@ Then mechanical gates run, and they are not negotiable:
   An explicit `--max-edits` or config value always pins it.
 - every measured change belongs to exactly one annotated edit - an unexplained change
   is a violation, so is an edit that names no change
-- new instructions need evidence from `minGapEvidence` distinct sessions (an edit that
-  only adds text is a new instruction, whatever the model calls it)
+- every edit that changes the always-loaded surface - adding, rewriting or removing text -
+  needs quotes from `minGapEvidence` distinct sessions. The count is measured from the
+  edit's own quote sources; a session count the model reports is ignored. Rewrites are not
+  classified by shape: a one-session tightening is refused along with a one-session
+  append, because deciding which is which is a question about meaning that a line diff
+  cannot answer. `extract` and `move` are exempt - they keep every always-loaded line.
 - removing a memory-file instruction outright needs harm-class negatives from
   `minGapEvidence` distinct sessions - non-compliance never counts, because a rule that
   was skipped needs reinforcement, not deletion. A pure deletion in a skill file is also

--- a/VISION.md
+++ b/VISION.md
@@ -12,7 +12,7 @@ It owns exactly one thing: the backward pass from session transcripts to a propo
 Every claim a model makes carries a verbatim quote copied from the trace, and a claim without one is discarded rather than softened.
 A signal extracted mechanically, with no judgment applied to it, is noise until a quote anchors it to a real moment, so there is no quoteless path into the file.
 A visible violation outranks any number of "it went fine" observations, because negative evidence is what proves the file was steering anything at all.
-Changing the always-loaded surface at all - adding an instruction, rewording one, or deleting one - needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
+Adding, rewording, or deleting instruction content needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed; extraction and movement are exempt because they preserve that content.
 That bar is drawn on sessions rather than on the shape of the change, because whether a reworded line carries new instruction is a question about meaning that no measurement of the text can settle.
 The bar is sessions, not repositories: a gap does not also have to appear in more than one project.
 Removing an instruction takes the same corroboration adding one does, and only harm from following it counts, because a rule that was merely skipped argues for reinforcement rather than deletion.

--- a/VISION.md
+++ b/VISION.md
@@ -12,7 +12,8 @@ It owns exactly one thing: the backward pass from session transcripts to a propo
 Every claim a model makes carries a verbatim quote copied from the trace, and a claim without one is discarded rather than softened.
 A signal extracted mechanically, with no judgment applied to it, is noise until a quote anchors it to a real moment, so there is no quoteless path into the file.
 A visible violation outranks any number of "it went fine" observations, because negative evidence is what proves the file was steering anything at all.
-A new instruction needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
+Changing the always-loaded surface at all - adding an instruction, rewording one, or deleting one - needs corroboration from at least two distinct sessions, and one session never counts twice however often it is re-analyzed.
+That bar is drawn on sessions rather than on the shape of the change, because whether a reworded line carries new instruction is a question about meaning that no measurement of the text can settle.
 The bar is sessions, not repositories: a gap does not also have to appear in more than one project.
 Removing an instruction takes the same corroboration adding one does, and only harm from following it counts, because a rule that was merely skipped argues for reinforcement rather than deletion.
 Corroboration accumulates across runs in a ledger rather than resetting each run, so a gap seen today and again next week still graduates.

--- a/src/fold.js
+++ b/src/fold.js
@@ -85,9 +85,14 @@ export function foldEvidence(
   };
 
   const recordObservations = [];
+  // Which project each quote's source label came from. Instruction-row quotes carry no
+  // project of their own, so this is what lets the user-scope project floor count a
+  // rewrite's evidence instead of only a gap cluster's.
+  const sourceProjects = {};
   for (const record of usable) {
     if (record.usedRawTranscript) usedRawCount += 1;
     const source = gapSource(record.transcript);
+    if (record.transcript.project) sourceProjects[source] = record.transcript.project;
 
     for (const polarity of ["positive", "negative"]) {
       for (const item of record[polarity] || []) {
@@ -249,6 +254,7 @@ export function foldEvidence(
       crossSurfaceDuplicates: duplicates.length,
     },
     instructions: instructionRows,
+    sourceProjects,
     parentHarmSessions,
     gaps,
     crossSurfaceDuplicates: duplicates,

--- a/src/fold.js
+++ b/src/fold.js
@@ -3,12 +3,7 @@ import fs from "node:fs";
 import { loadConfig } from "./config.js";
 import { classifyInteraction, INTERACTIVE, NON_INTERACTIVE } from "./interaction.js";
 import { findInstructionUnit, instructionUnits, resolveMemoryFiles, similarity } from "./memory.js";
-import {
-  GAP_COVERED_THRESHOLD,
-  GAP_SIMILARITY_THRESHOLD,
-  gapSource,
-  normalizeSourceLabel,
-} from "./gap-ledger.js";
+import { GAP_COVERED_THRESHOLD, GAP_SIMILARITY_THRESHOLD, gapSource, normalizeSourceLabel } from "./gap-ledger.js";
 import { crossSurfaceDuplicates } from "./overlap.js";
 
 /**

--- a/src/fold.js
+++ b/src/fold.js
@@ -3,7 +3,12 @@ import fs from "node:fs";
 import { loadConfig } from "./config.js";
 import { classifyInteraction, INTERACTIVE, NON_INTERACTIVE } from "./interaction.js";
 import { findInstructionUnit, instructionUnits, resolveMemoryFiles, similarity } from "./memory.js";
-import { GAP_COVERED_THRESHOLD, GAP_SIMILARITY_THRESHOLD, gapSource } from "./gap-ledger.js";
+import {
+  GAP_COVERED_THRESHOLD,
+  GAP_SIMILARITY_THRESHOLD,
+  gapSource,
+  normalizeSourceLabel,
+} from "./gap-ledger.js";
 import { crossSurfaceDuplicates } from "./overlap.js";
 
 /**
@@ -91,7 +96,7 @@ export function foldEvidence(
   const sourceProjects = {};
   for (const record of usable) {
     if (record.usedRawTranscript) usedRawCount += 1;
-    const source = gapSource(record.transcript);
+    const source = normalizeSourceLabel(gapSource(record.transcript));
     if (record.transcript.project) sourceProjects[source] = record.transcript.project;
 
     for (const polarity of ["positive", "negative"]) {

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -67,6 +67,10 @@ export function gapSource(transcript = {}) {
     .slice(0, 8)} · ${date}`;
 }
 
+export function normalizeSourceLabel(source) {
+  return String(source || "").trim().replace(/\s+/g, " ");
+}
+
 function normalize(text) {
   return String(text || "")
     .toLowerCase()

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -68,7 +68,9 @@ export function gapSource(transcript = {}) {
 }
 
 export function normalizeSourceLabel(source) {
-  return String(source || "").trim().replace(/\s+/g, " ");
+  return String(source || "")
+    .trim()
+    .replace(/\s+/g, " ");
 }
 
 function normalize(text) {

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -18,9 +18,7 @@ Return ONE JSON object and nothing else. No prose, no markdown fence.
       "title": "one line a human can decide on",
       "rationale": "why the evidence supports this",
       "instructions": ["AG-017"],
-      "evidence": [{"polarity": "negative", "text": "the verbatim quote", "source": "claude · abc123 · turn 12"}],
-      "transcripts": 3,
-      "projects": 1
+      "evidence": [{"polarity": "negative", "text": "the verbatim quote", "source": "claude · abc123 · turn 12"}]
     }
   ],
   "verdicts": [
@@ -38,10 +36,14 @@ Hard rules - a violation fails the whole proposal:
    file first.
 2. **At most {{MAX_EDITS}} edits** - the learning rate. Regroup or revert if you are over.
 3. **Every edit carries at least one verbatim quote in `evidence`**, with its source.
-4. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
-   sessions.** `transcripts` is how many distinct sessions back the edit; an edit that
-   only adds text is a new instruction whatever its `kind` says. `projects` is how many
-   distinct projects those sessions came from (user scope); omit it in a project-scoped run.
+4. **Every `add`, `rewrite` and `remove` - of {{MEMORY_PATH}} or of a skill file - carries
+   quotes from at least {{MIN_GAP_EVIDENCE}} distinct sessions.** Backpass counts the
+   distinct `source` values in your `evidence`; do not report a count of your own, it is
+   not read. This covers
+   rewrites of every shape, a tightening included - one session is not enough to change
+   text that loads on every future run. `extract` and `move` are exempt, because they keep
+   every line. If you have only one session for a change, revert it in the file, or cite a
+   second session's quote from the evidence rows you were shown.
 5. **Removing an instruction outright needs harm evidence from at least
    {{MIN_GAP_EVIDENCE}} distinct sessions** (`harm-sessions` in the evidence). Only
    `harm` negatives argue against an instruction; `non-compliance` never justifies a

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -73,8 +73,12 @@ signal.
 1. **At most {{MAX_EDITS}} edits.** This is the learning rate. An edit is one change a
    human can decide on; pick the highest-signal ones. A small correct step beats a large
    speculative one.
-2. **New instructions need evidence from at least {{MIN_GAP_EVIDENCE}} distinct
-   sessions.** One bad session never rewrites the weights.
+2. **Every change to this always-loaded file needs evidence from at least
+   {{MIN_GAP_EVIDENCE}} distinct sessions** - adding text, rewriting text and removing
+   text alike, whatever the shape of the change. One bad session never rewrites the
+   weights. Extracting text into a skill and moving text within the file are exempt:
+   they keep every line. If only one session supports a wording change, leave the
+   wording alone.
 3. **Removing an instruction outright needs harm evidence from at least
    {{MIN_GAP_EVIDENCE}} distinct sessions** (`harm-sessions` in the evidence rows).
    Only `harm` negatives - following the instruction caused damage - argue against an

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -118,9 +118,8 @@ function normalizeEdit(raw, index) {
     rationale: String(raw?.rationale || "").trim(),
     instructions: Array.isArray(raw?.instructions) ? raw.instructions.map(String) : [],
     evidence,
-    // Corroboration is measured from the edit's own quotes, never taken from the model's
-    // own count: a dry run produced edits declaring 11 and 20 sessions over quotes drawn
-    // from 3 and 2. Same rule as every other number here - see AGENTS.md.
+    // Corroboration is measured from the edit's normalized quotes, never from a
+    // model-reported count.
     transcripts: countSources(normalizedEvidence),
   };
 }
@@ -529,13 +528,11 @@ export function buildProposal(rawResult, context) {
 
     // Corroboration is measured, not declared, and it covers the whole always-loaded
     // surface: adding, rewriting and removing text all clear the same session floor.
-    // Asking instead whether a rewrite "really" adds an instruction means classifying
-    // text - a question about meaning that a line diff cannot answer, which is why every
-    // lexical proxy for it (net growth, word coverage, bigram overlap) had a mirror-image
-    // failure. Counting the distinct sessions behind an edit's own quotes asks nothing of
-    // the text, so there is no shape to game. Extract and move keep every line on the
-    // always-loaded surface, so they stay exempt; a removal keeps the harm floor below on
-    // top of this one.
+    // Asking instead whether a rewrite "really" adds an instruction requires a semantic
+    // text classifier. Counting the distinct sessions behind an edit's own quotes asks
+    // nothing of the text, so there is no shape to game. Extract and move keep every line
+    // on the always-loaded surface, so they stay exempt; a removal keeps the harm floor
+    // below on top of this one.
     const onlyAdds = hunks.every((h) => h.removed === 0);
     const changed = onlyAdds ? "adds a new instruction" : `changes ${files[0] ?? memoryFile.path}`;
     const projectGate = scope?.kind === "user" && config.minGapProjects != null;

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -104,6 +104,7 @@ export class ProposalViolation extends Error {
 function normalizeEdit(raw, index) {
   const kind = String(raw?.kind || "").toLowerCase();
   const refs = Array.isArray(raw?.changes) ? raw.changes : Array.isArray(raw?.hunks) ? raw.hunks : [];
+  const evidence = normalizeEvidence(raw?.evidence);
   return {
     id: `e${index + 1}`,
     kind,
@@ -111,11 +112,11 @@ function normalizeEdit(raw, index) {
     title: String(raw?.title || "").trim() || "(untitled edit)",
     rationale: String(raw?.rationale || "").trim(),
     instructions: Array.isArray(raw?.instructions) ? raw.instructions.map(String) : [],
-    evidence: normalizeEvidence(raw?.evidence),
+    evidence,
     // Corroboration is measured from the edit's own quotes, never taken from the model's
     // own count: a dry run produced edits declaring 11 and 20 sessions over quotes drawn
     // from 3 and 2. Same rule as every other number here - see AGENTS.md.
-    transcripts: countSources(raw?.evidence),
+    transcripts: countSources(evidence),
   };
 }
 
@@ -132,7 +133,11 @@ function normalizeEvidence(evidence) {
 
 function countSources(evidence) {
   if (!Array.isArray(evidence)) return 0;
-  return new Set(evidence.map((e) => e?.source).filter(Boolean)).size;
+  return new Set(
+    evidence
+      .map((e) => String(e?.source || "").trim().replace(/\s+/g, " "))
+      .filter(Boolean),
+  ).size;
 }
 
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -112,8 +112,10 @@ function normalizeEdit(raw, index) {
     rationale: String(raw?.rationale || "").trim(),
     instructions: Array.isArray(raw?.instructions) ? raw.instructions.map(String) : [],
     evidence: normalizeEvidence(raw?.evidence),
-    transcripts: Number.isFinite(raw?.transcripts) ? Number(raw.transcripts) : countSources(raw?.evidence),
-    projects: Number.isFinite(raw?.projects) ? Number(raw.projects) : undefined,
+    // Corroboration is measured from the edit's own quotes, never taken from the model's
+    // own count: a dry run produced edits declaring 11 and 20 sessions over quotes drawn
+    // from 3 and 2. Same rule as every other number here - see AGENTS.md.
+    transcripts: countSources(raw?.evidence),
   };
 }
 
@@ -295,12 +297,17 @@ export function renderChangesForPrompt(measured, memoryFile) {
  */
 function countedEvidenceProjects(edit, summary) {
   const quoted = new Set(edit.evidence.map((item) => `${item.source || ""}\n${item.text || ""}`));
-  return Math.max(
-    0,
-    ...(summary?.gaps || [])
-      .filter((gap) => gap.quotes?.some((quote) => quoted.has(`${quote.source || ""}\n${quote.text || ""}`)))
-      .map((gap) => gap.projects || 0),
-  );
+  const byGap = (summary?.gaps || [])
+    .filter((gap) => gap.quotes?.some((quote) => quoted.has(`${quote.source || ""}\n${quote.text || ""}`)))
+    .map((gap) => gap.projects || 0);
+  // Gap clusters carry their own project count, but an edit that rewrites or reinforces
+  // an existing instruction quotes instruction-row evidence, which carries none. The fold
+  // hands over the session -> project map behind those rows, so the edit's own quote
+  // sources answer for themselves. A run whose evidence predates the map (or a
+  // project-scoped one, which has no projects) still has the gap count.
+  const sourceProjects = summary?.sourceProjects || {};
+  const byQuoteSource = new Set(edit.evidence.map((item) => sourceProjects[item.source]).filter(Boolean));
+  return Math.max(0, byQuoteSource.size, ...byGap);
 }
 
 export function buildProposal(rawResult, context) {
@@ -512,20 +519,29 @@ export function buildProposal(rawResult, context) {
       }
     }
 
-    // An addition is measured, not declared: text that only goes in is a new instruction.
+    // Corroboration is measured, not declared, and it covers the whole always-loaded
+    // surface: adding, rewriting and removing text all clear the same session floor.
+    // Asking instead whether a rewrite "really" adds an instruction means classifying
+    // text - a question about meaning that a line diff cannot answer, which is why every
+    // lexical proxy for it (net growth, word coverage, bigram overlap) had a mirror-image
+    // failure. Counting the distinct sessions behind an edit's own quotes asks nothing of
+    // the text, so there is no shape to game. Extract and move keep every line on the
+    // always-loaded surface, so they stay exempt; a removal keeps the harm floor below on
+    // top of this one.
     const onlyAdds = hunks.every((h) => h.removed === 0);
+    const changed = onlyAdds ? "adds a new instruction" : `changes ${files[0] ?? memoryFile.path}`;
     const projectGate = scope?.kind === "user" && config.minGapProjects != null;
-    const evidenceProjects = onlyAdds && projectGate ? countedEvidenceProjects(edit, summary) : null;
-    if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && edit.transcripts < config.minGapEvidence) {
+    const evidenceProjects = projectGate ? countedEvidenceProjects(edit, summary) : null;
+    if (!preservesAlwaysLoaded(edit.kind) && edit.transcripts < config.minGapEvidence) {
       violations.push(
-        `edit ${edit.id} ("${edit.title}") adds a new instruction backed by ${edit.transcripts} session(s); ` +
+        `edit ${edit.id} ("${edit.title}") ${changed} backed by ${edit.transcripts} session(s); ` +
           `${config.minGapEvidence} are required`,
       );
       continue;
     }
-    if (!preservesAlwaysLoaded(edit.kind) && onlyAdds && projectGate && evidenceProjects < config.minGapProjects) {
+    if (!preservesAlwaysLoaded(edit.kind) && projectGate && evidenceProjects < config.minGapProjects) {
       violations.push(
-        `edit ${edit.id} ("${edit.title}") adds a new instruction backed by evidence from ${evidenceProjects} project(s); ` +
+        `edit ${edit.id} ("${edit.title}") ${changed} backed by evidence from ${evidenceProjects} project(s); ` +
           `${config.minGapProjects} are required`,
       );
       continue;

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -104,7 +104,11 @@ export class ProposalViolation extends Error {
 function normalizeEdit(raw, index) {
   const kind = String(raw?.kind || "").toLowerCase();
   const refs = Array.isArray(raw?.changes) ? raw.changes : Array.isArray(raw?.hunks) ? raw.hunks : [];
-  const evidence = normalizeEvidence(raw?.evidence);
+  const normalizedEvidence = normalizeEvidence(raw?.evidence);
+  const evidence = normalizedEvidence.map((item) => ({
+    ...item,
+    source: item.source.trim() || "unknown source",
+  }));
   return {
     id: `e${index + 1}`,
     kind,
@@ -116,7 +120,7 @@ function normalizeEdit(raw, index) {
     // Corroboration is measured from the edit's own quotes, never taken from the model's
     // own count: a dry run produced edits declaring 11 and 20 sessions over quotes drawn
     // from 3 and 2. Same rule as every other number here - see AGENTS.md.
-    transcripts: countSources(evidence),
+    transcripts: countSources(normalizedEvidence),
   };
 }
 
@@ -127,7 +131,7 @@ function normalizeEvidence(evidence) {
     .map((e) => ({
       polarity: e.polarity === "positive" ? "positive" : e.polarity === "neutral" ? "neutral" : "negative",
       text: String(e.text).trim().slice(0, 600),
-      source: String(e.source || "unknown source").slice(0, 120),
+      source: String(e.source || "").slice(0, 120),
     }));
 }
 

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,4 +1,5 @@
 import { renderHunkLines } from "./diff.js";
+import { normalizeSourceLabel } from "./gap-ledger.js";
 import { mixFromCounts } from "./interaction.js";
 import { memoryTextHash } from "./memory.js";
 import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
@@ -137,11 +138,7 @@ function normalizeEvidence(evidence) {
 
 function countSources(evidence) {
   if (!Array.isArray(evidence)) return 0;
-  return new Set(
-    evidence
-      .map((e) => String(e?.source || "").trim().replace(/\s+/g, " "))
-      .filter(Boolean),
-  ).size;
+  return new Set(evidence.map((e) => normalizeSourceLabel(e?.source)).filter(Boolean)).size;
 }
 
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
@@ -315,7 +312,9 @@ function countedEvidenceProjects(edit, summary) {
   // sources answer for themselves. A run whose evidence predates the map (or a
   // project-scoped one, which has no projects) still has the gap count.
   const sourceProjects = summary?.sourceProjects || {};
-  const byQuoteSource = new Set(edit.evidence.map((item) => sourceProjects[item.source]).filter(Boolean));
+  const byQuoteSource = new Set(
+    edit.evidence.map((item) => sourceProjects[normalizeSourceLabel(item.source)]).filter(Boolean),
+  );
   return Math.max(0, byQuoteSource.size, ...byGap);
 }
 

--- a/test/memory-resolution.test.js
+++ b/test/memory-resolution.test.js
@@ -61,8 +61,10 @@ function applyOneEdit(repo, config) {
           changes: ["H1"],
           kind: "rewrite",
           title: "tighten",
-          evidence: [{ polarity: "negative", text: "skipped tests", source: "claude · s1 · turn 2" }],
-          transcripts: 2,
+          evidence: [
+            { polarity: "negative", text: "skipped tests", source: "claude · s1 · turn 2" },
+            { polarity: "negative", text: "pushed without running tests", source: "codex · s2 · turn 5" },
+          ],
         },
       ],
     },

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -352,6 +352,40 @@ test("a single-session rewrite is refused whatever shape it takes, and the model
   }
 });
 
+test("empty evidence cannot pad a single-session rewrite", () => {
+  const { proposal, violations } = gate({
+    edit: memoryEdit(REWRITE_SHAPES["append a sentence"]),
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "rewrite",
+          evidence: [...ONE_SESSION, { polarity: "negative", text: "  ", source: "fake-session" }],
+        }),
+      ],
+    },
+  });
+  assert.equal(proposal.edits.length, 0);
+  assert.ok(
+    violations.some((v) => /backed by 1 session/.test(v)),
+    violations.join("\n"),
+  );
+});
+
+test("source-label whitespace cannot pad a single-session rewrite", () => {
+  const repeated = { ...ONE_SESSION[0], source: "claude  ·  abc · turn 3" };
+  const { proposal, violations } = gate({
+    edit: memoryEdit(REWRITE_SHAPES["append a sentence"]),
+    annotation: {
+      edits: [claim(["H1"], { kind: "rewrite", evidence: [...ONE_SESSION, repeated] })],
+    },
+  });
+  assert.equal(proposal.edits.length, 0);
+  assert.ok(
+    violations.some((v) => /backed by 1 session/.test(v)),
+    violations.join("\n"),
+  );
+});
+
 test("a rewrite spread over two hunks cannot pay for itself with one session", () => {
   const { proposal, violations } = gate({
     edit: memoryEdit((t) =>

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -34,7 +34,13 @@ const MEMORY_TEXT = [
   "",
 ].join("\n");
 
-const QUOTE = [{ polarity: "negative", text: "it used a bare #2731 reference", source: "claude · abc · turn 3" }];
+// Two sources, because every edit that changes the always-loaded surface now clears the
+// session floor. Tests whose subject is that floor pass their own evidence.
+const QUOTE = [
+  { polarity: "negative", text: "it used a bare #2731 reference", source: "claude · abc · turn 3" },
+  { polarity: "negative", text: "the PR was named without a link", source: "codex · def · turn 8" },
+];
+const ONE_SESSION = [QUOTE[0]];
 
 function config(overrides = {}) {
   return {
@@ -88,7 +94,6 @@ const claim = (changes, extra = {}) => ({
   kind: "rewrite",
   title: "t",
   evidence: QUOTE,
-  transcripts: 3,
   ...extra,
 });
 
@@ -242,22 +247,14 @@ test("folded domain votes separate synthesis evidence from report-only diagnosti
     );
   const propose = (summary, minGapEvidence) => {
     const displayed = summary.gaps[0] || summary.reportOnlyGaps[0];
-    const evidence = displayed.quotes.slice(0, 1).map((quote) => ({
+    const evidence = displayed.quotes.slice(0, minGapEvidence).map((quote) => ({
       polarity: "negative",
       text: quote.text,
       source: quote.source,
     }));
     return gate({
       edit: memoryEdit((text) => `${text}- ${phrasing}\n`),
-      annotation: {
-        edits: [
-          claim(["H1"], {
-            kind: "add",
-            evidence,
-            transcripts: Math.max(displayed.sessions, minGapEvidence),
-          }),
-        ],
-      },
+      annotation: { edits: [claim(["H1"], { kind: "add", evidence })] },
       config: config({ minGapEvidence }),
       context: { summary },
     });
@@ -296,11 +293,223 @@ test("a new instruction backed by too few sessions is rejected, whatever kind th
   for (const kind of ["add", "rewrite"]) {
     const { proposal, violations } = gate({
       edit: insert,
-      annotation: { edits: [claim(["H1"], { kind, title: "new rule from one session", transcripts: 1 })] },
+      annotation: { edits: [claim(["H1"], { kind, title: "new rule from one session", evidence: ONE_SESSION })] },
     });
     assert.equal(proposal.edits.length, 0, `${kind}: measured as an addition`);
     assert.ok(violations.some((v) => /backed by 1 session/.test(v)));
   }
+});
+
+// The always-loaded session floor. Its whole point is that it asks nothing of the text:
+// a rewrite is not classified as "really an addition" or "really a tightening" - the
+// only question is how many distinct sessions the edit's own quotes come from. The
+// shapes below are the ones that broke every lexical proxy tried before it.
+const REWRITE_SHAPES = {
+  "append a sentence": (t) =>
+    t.replace(
+      "- Whenever a PR is mentioned, include its URL.",
+      "- Whenever a PR is mentioned, include its URL. Check for and replace every bare number.",
+    ),
+  "append four tokens": (t) => t.replace("- Prefer small commits.", "- Prefer small commits. Same for PRs."),
+  "pure tightening, shared words": (t) =>
+    t.replace("- Use Node 18 via nvm before running any script.", "- Use Node 18 with nvm."),
+  "paraphrase tightening, few shared words": (t) =>
+    t.replace("- Use Node 18 via nvm before running any script.", "- Run every script under nvm's Node 18."),
+  negation: (t) => t.replace("- Prefer small commits.", "- Never prefer small commits."),
+  "version bump": (t) => t.replace("Node 18", "Node 22"),
+  "unrelated net-negative substitution": (t) =>
+    t.replace("- Use Node 18 via nvm before running any script.", "- Route SSH through the bastion."),
+  "split one rule into two bullets": (t) =>
+    t.replace(
+      "- Use Node 18 via nvm before running any script.",
+      "- Use Node 18 via nvm.\n- Do it before running any script.",
+    ),
+  "reword and extend": (t) =>
+    t.replace("- Prefer small commits.", "- Keep commits small and focused, and squash fixups before review."),
+  "append plus an innocent word fix in the same line": (t) =>
+    t.replace(
+      "- Whenever a PR is mentioned, include its URL.",
+      "- Whenever a PR is mentioned, include its full URL. Check for and replace every bare number.",
+    ),
+};
+
+test("a single-session rewrite is refused whatever shape it takes, and the model's own session count is ignored", () => {
+  for (const [name, rewrite] of Object.entries(REWRITE_SHAPES)) {
+    const { proposal, violations } = gate({
+      edit: memoryEdit(rewrite),
+      annotation: {
+        edits: [
+          // 20 declared sessions over one quoted source: the declared number is not read.
+          claim(["H1"], { kind: "rewrite", title: name, evidence: ONE_SESSION, transcripts: 20 }),
+        ],
+      },
+    });
+    assert.equal(proposal.edits.length, 0, `${name} was accepted on one session`);
+    assert.ok(
+      violations.some((v) => /changes AGENTS\.md backed by 1 session\(s\); 2 are required/.test(v)),
+      `${name}: ${violations.join("\n")}`,
+    );
+  }
+});
+
+test("a rewrite spread over two hunks cannot pay for itself with one session", () => {
+  const { proposal, violations } = gate({
+    edit: memoryEdit((t) =>
+      t
+        .replace("- Use Node 18 via nvm before running any script.", "- Use Node 18 with nvm.")
+        .replace(
+          "- Whenever a PR is mentioned, include its URL.",
+          "- Whenever a PR is mentioned, include its URL. Always.",
+        ),
+    ),
+    annotation: { edits: [claim(["H1", "H2"], { kind: "rewrite", title: "two hunks", evidence: ONE_SESSION })] },
+  });
+  assert.equal(proposal.edits.length, 0);
+  assert.ok(
+    violations.some((v) => /backed by 1 session/.test(v)),
+    violations.join("\n"),
+  );
+});
+
+test("two quoted sessions carry a rewrite of any shape, including a pure tightening", () => {
+  for (const [name, rewrite] of Object.entries(REWRITE_SHAPES)) {
+    const { proposal, violations } = gate({
+      edit: memoryEdit(rewrite),
+      // `claim` quotes two sources; `transcripts` is deliberately absent from the annotation.
+      annotation: { edits: [claim(["H1"], { kind: "rewrite", title: name })] },
+    });
+    assert.deepEqual(violations, [], `${name}: ${violations.join("\n")}`);
+    assert.equal(proposal.edits.length, 1, name);
+    assert.equal(proposal.edits[0].transcripts, 2, `${name}: the count is measured from the quotes`);
+  }
+});
+
+test("the dry run's three appends still pass on their real quote-source counts", () => {
+  // e1 to e3 of the user-scope dry run: 1-removed/1-added appends backed by 3, 2 and 2
+  // distinct sources, over models that declared 11, 20 and 2.
+  const source = (n) => ({ polarity: "negative", text: `quote ${n}`, source: `claude · s${n} · 2026-08-0${n}` });
+  const appends = [
+    {
+      name: "e1 em dash",
+      sources: 3,
+      declared: 11,
+      edit: (t) =>
+        t.replace(
+          "include its URL.",
+          "include its URL. Before sending prose, check for and replace every bare reference.",
+        ),
+    },
+    {
+      name: "e2 repro before fix",
+      sources: 2,
+      declared: 20,
+      edit: (t) =>
+        t.replace(
+          "- Prefer small commits.",
+          "- Prefer small commits. Reproduce before implementing the fix, then repeat the same check after.",
+        ),
+    },
+    {
+      name: "e3 lint warnings",
+      sources: 2,
+      declared: 2,
+      edit: (t) =>
+        t.replace(
+          "before running any script.",
+          "before running any script. Treat warnings as issues rather than dismissing them.",
+        ),
+    },
+  ];
+  for (const append of appends) {
+    const evidence = Array.from({ length: append.sources }, (_, i) => source(i + 1));
+    const { proposal, violations } = gate({
+      edit: memoryEdit(append.edit),
+      annotation: {
+        edits: [claim(["H1"], { kind: "rewrite", title: append.name, evidence, transcripts: append.declared })],
+      },
+    });
+    assert.deepEqual(violations, [], `${append.name}: ${violations.join("\n")}`);
+    assert.equal(proposal.edits[0].transcripts, append.sources, append.name);
+  }
+});
+
+test("extract and move stay exempt from the session floor: they keep every always-loaded line", () => {
+  const extracted = "- Use Node 18 via nvm before running any script.";
+  const extract = gate({
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (t) => t.replace(`${extracted}\n`, ""));
+      writeIn(
+        root,
+        ".agents/skills/setup/SKILL.md",
+        `---\nname: setup\ndescription: setting up the toolchain\n---\n\n${extracted}\n`,
+      );
+    },
+    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "extract setup", evidence: ONE_SESSION })] },
+  });
+  assert.deepEqual(extract.violations, [], extract.violations.join("\n"));
+
+  const moved = gate({
+    text: `${MEMORY_TEXT}\n## Later\n\n- Keep this nearby.\n`,
+    edit: memoryEdit((t) =>
+      t.replace(`${extracted}\n`, "").replace("- Keep this nearby.", `${extracted}\n- Keep this nearby.`),
+    ),
+    annotation: { edits: [claim(["H1", "H2"], { kind: "move", title: "reposition setup", evidence: ONE_SESSION })] },
+  });
+  assert.deepEqual(moved.violations, [], moved.violations.join("\n"));
+});
+
+test("the user-scope project floor counts instruction evidence, not only gap quotes", () => {
+  // A rewrite reinforcing an existing instruction quotes instruction-row evidence, which
+  // carries no project of its own. The fold hands the gate the session -> project map so
+  // those quotes still answer the "how many projects" question.
+  const record = (id, project) => ({
+    status: "ok",
+    transcript: { id, harness: "claude", project, startedAt: Date.parse("2026-08-01T00:00:00Z") },
+    positive: [],
+    negative: [
+      { instruction: "AG-001", quote: `quote from ${id}`, effect: "the URL was omitted", class: "non-compliance" },
+    ],
+    gaps: [],
+  });
+  const foldFor = (projects) =>
+    foldEvidence(
+      projects.map((project, i) => record(`s${i + 1}`, project)),
+      { minGapEvidence: 2 },
+    );
+
+  const rewrite = memoryEdit((t) => t.replace("include its URL.", "include its full https:// URL."));
+  const proposeWith = (summary, minGapProjects) => {
+    const evidence = summary.instructions[0].quotes.map((quote) => ({
+      polarity: "negative",
+      text: quote.text,
+      source: quote.source,
+    }));
+    return gate({
+      edit: rewrite,
+      annotation: { edits: [claim(["H1"], { kind: "rewrite", title: "spell out the URL", evidence })] },
+      config: config({ minGapProjects }),
+      context: { summary, scope: { kind: "user" } },
+    });
+  };
+
+  const oneProject = proposeWith(foldFor(["repo-a", "repo-a"]), 2);
+  assert.ok(
+    oneProject.violations.some((v) => /evidence from 1 project\(s\); 2 are required/.test(v)),
+    oneProject.violations.join("\n"),
+  );
+
+  const twoProjects = proposeWith(foldFor(["repo-a", "repo-b"]), 2);
+  assert.deepEqual(twoProjects.violations, [], twoProjects.violations.join("\n"));
+  assert.equal(twoProjects.proposal.edits[0].projects, 2);
+
+  // Same evidence in a project-scoped run: no project gate at all.
+  const projectScope = gate({
+    edit: rewrite,
+    annotation: { edits: [claim(["H1"], { kind: "rewrite", title: "spell out the URL" })] },
+    config: config({ minGapProjects: 2 }),
+    context: { summary: foldFor(["repo-a", "repo-a"]), scope: { kind: "project" } },
+  });
+  assert.deepEqual(projectScope.violations, [], projectScope.violations.join("\n"));
 });
 
 test("an edit with no verbatim quote is rejected", () => {
@@ -662,7 +871,9 @@ test("an extract cannot bypass addition evidence without removing memory text", 
   const unsupported = gate({
     files,
     edit: addOnly,
-    annotation: { edits: [claim(["H1", "H2"], { kind: "extract", title: "add setup guidance", transcripts: 1 })] },
+    annotation: {
+      edits: [claim(["H1", "H2"], { kind: "extract", title: "add setup guidance", evidence: ONE_SESSION })],
+    },
   });
   assert.ok(
     unsupported.violations.some((violation) => /adds a new instruction backed by 1 session/.test(violation)),
@@ -682,7 +893,7 @@ test("an extract cannot bypass addition evidence without removing memory text", 
 
 test("addition project counts come from folded gap evidence", () => {
   const edit = memoryEdit((text) => `${text}- Include the full pull request URL.\n`);
-  const annotation = { edits: [claim(["H1"], { kind: "add", projects: 99 })] };
+  const annotation = { edits: [claim(["H1"], { kind: "add" })] };
   const summary = (projects) => ({
     analyzedSessions: 3,
     totals: { positive: 0, negative: 0, gapClusters: 1 },
@@ -893,7 +1104,18 @@ test("a previously rejected edit is suppressed until new evidence arrives", () =
 
   const revived = gate({
     edit,
-    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin", transcripts: 9 })] },
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "remove",
+          title: "drop the stale Node pin",
+          evidence: [
+            ...QUOTE,
+            { polarity: "negative", text: "a third session hit the same pin", source: "pi · ghi · turn 2" },
+          ],
+        }),
+      ],
+    },
     context: { rejections, isSuppressed: isSuppressedByRejection },
   });
   assert.equal(revived.proposal.edits.length, 1, "materially new evidence revives the edit");

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -547,11 +547,15 @@ test("the user-scope project floor counts instruction evidence, not only gap quo
     );
 
   const rewrite = memoryEdit((t) => t.replace("include its URL.", "include its full https:// URL."));
-  const proposeWith = (summary, minGapProjects) => {
-    const evidence = summary.instructions[0].quotes.map((quote) => ({
+  const proposeWith = (summary, minGapProjects, varySourceWhitespace = false) => {
+    const evidence = summary.instructions[0].quotes.map((quote, index) => ({
       polarity: "negative",
       text: quote.text,
-      source: quote.source,
+      source: varySourceWhitespace
+        ? index === 0
+          ? `  ${quote.source}  `
+          : quote.source.replaceAll(" · ", "  ·   ")
+        : quote.source,
     }));
     return gate({
       edit: rewrite,
@@ -567,7 +571,7 @@ test("the user-scope project floor counts instruction evidence, not only gap quo
     oneProject.violations.join("\n"),
   );
 
-  const twoProjects = proposeWith(foldFor(["repo-a", "repo-b"]), 2);
+  const twoProjects = proposeWith(foldFor(["repo-a", "repo-b"]), 2, true);
   assert.deepEqual(twoProjects.violations, [], twoProjects.violations.join("\n"));
   assert.equal(twoProjects.proposal.edits[0].projects, 2);
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -371,6 +371,41 @@ test("empty evidence cannot pad a single-session rewrite", () => {
   );
 });
 
+test("sourceless evidence cannot pad a single-session rewrite and remains visible", () => {
+  for (const source of [undefined, "", "   "]) {
+    const sourceless = { polarity: "negative", text: "another quote", ...(source === undefined ? {} : { source }) };
+    const { proposal, violations } = gate({
+      edit: memoryEdit(REWRITE_SHAPES["append a sentence"]),
+      annotation: {
+        edits: [claim(["H1"], { kind: "rewrite", evidence: [...ONE_SESSION, sourceless] })],
+      },
+    });
+    assert.equal(proposal.edits.length, 0);
+    assert.ok(
+      violations.some((v) => /backed by 1 session/.test(v)),
+      violations.join("\n"),
+    );
+  }
+
+  const { proposal, violations } = gate({
+    edit: memoryEdit(REWRITE_SHAPES["append a sentence"]),
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "rewrite",
+          evidence: [...QUOTE, { polarity: "negative", text: "visible quote" }],
+        }),
+      ],
+    },
+  });
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits[0].transcripts, 2);
+  assert.deepEqual(
+    proposal.edits[0].evidence.find((item) => item.text === "visible quote"),
+    { polarity: "negative", text: "visible quote", source: "unknown source" },
+  );
+});
+
 test("source-label whitespace cannot pad a single-session rewrite", () => {
   const repeated = { ...ONE_SESSION[0], source: "claude  ·  abc · turn 3" };
   const { proposal, violations } = gate({

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -108,19 +108,24 @@ const QUOTE = {
   text: "the agent re-read the adapter fixture instead",
   source: "claude · s1 · turn 4",
 };
+// Every edit to the always-loaded surface clears the session floor, so the fixtures
+// quote two sessions; the count is measured from these, not declared.
+const QUOTE2 = {
+  polarity: "negative",
+  text: "and here it re-read the same fixture a second time",
+  source: "codex · s2 · turn 9",
+};
 const removal = (changes) => ({
   changes,
   kind: "remove",
   title: "drop two sharp edges nobody hits",
-  evidence: [QUOTE],
-  transcripts: 3,
+  evidence: [QUOTE, QUOTE2],
 });
 const tighten = (changes) => ({
   changes,
   kind: "rewrite",
   title: "sharpen the brevity rule",
-  evidence: [QUOTE],
-  transcripts: 2,
+  evidence: [QUOTE, QUOTE2],
 });
 
 function summaryFor(sessions = 3) {
@@ -494,8 +499,12 @@ test("an oversized non-compliance blob synthesizes as a list-item restructure, n
                     text: "skipped the second sentence of the blob entirely here",
                     source: "claude · s1 · turn 4",
                   },
+                  {
+                    polarity: "negative",
+                    text: "the same blob's second sentence was skipped again",
+                    source: "codex · s2 · turn 9",
+                  },
                 ],
-                transcripts: 2,
                 instructions: ["AG-001.2"],
               },
             ],


### PR DESCRIPTION
## Intent

Close backpass's single-session rewrite loophole: today an edit that appends a sentence to an existing memory-file line measures as a "rewrite", so it skips the two-session add floor entirely and one session can grow the always-loaded surface.

The captain chose option B on 2026-09-02, after a scout report on the failed earlier attempt (closed PR https://github.com/kunchenguid/backpass/pull/79). The required design:

- Floor EVERY add, rewrite, and remove of always-loaded memory on quote-backed distinct session count, using the same minGapEvidence as today's add floor. extract and move stay exempt because they keep every always-loaded line.
- Measure the session count from the edit's own quote sources; never read the model-reported `transcripts` field (a dry run had the model declare 11 and 20 sessions over quotes drawn from 3 and 2).
- HARD CONSTRAINT: do NOT use lexical overlap, Dice similarity, net-token growth, or any tightening-vs-replacement text classifier. That is exactly the failed PR #79 path - 20 commits and 10 review rounds proved every lexical proxy has a mirror-image failure, because whether reworded text carries a new instruction is a question about meaning that a line diff cannot answer. Do not retry PR #79's overlap detector.
- The user-scope project floor must count instruction evidence, not only gap quotes: on main an append reclassified as an add is refused with "backed by evidence from 0 project(s)" because countedEvidenceProjects reads only summary.gaps.

Accepted costs and deliberate decisions the captain already made (these are choices, not oversights):
- A pure one-session tightening is now REFUSED. This reverses PR #79's brief, which had said pure tightenings stay at one session. The captain explicitly accepted that cost: the bar becomes symmetric, so the file is no easier to grow than to shrink.
- The floor is drawn on sessions, not on the shape of the change. There is deliberately NO predicate distinguishing an additive rewrite from a tightening, and none should be added.
- The gate is left uniform across files rather than adding a memory-file-only carve-out, so a skill-file rewrite is floored too (a skill description line is part of the always-loaded surface).
- Delete-via-rewrite backed by two non-compliance sessions is knowingly still open; it is the semantic question again and is out of scope, left to the human reviewer who sees the diff.

Acceptance criteria:
- A single-session rewrite of any shape is refused.
- Dry-run shaped e1-e3 (3, 2, 2 quote sources) still pass.
- Pure one-session tightenings are refused.
- User-scope project floor counts instruction evidence.
- Behavioral tests go through the real proposal path (buildProposal over real staged workspaces); no source-text-only tests.
- Docs/VISION/AGENTS updated only as needed for the new floor.

What was implemented: the onlyAdds condition was removed from the corroboration gate in src/proposal.js so the floor covers every non-extract/move edit; normalizeEdit now always counts distinct sources from the edit's evidence and the model's `transcripts`/`projects` fields were dropped from both normalizeEdit and the annotate prompt shape; src/fold.js emits a `sourceProjects` map (quote source label -> project) so countedEvidenceProjects can count distinct projects over the edit's own quote sources, taking the max with the existing gap-cluster count; the user-scope project gate now also applies to rewrites and removes. Prompts (annotate rule 4, synthesis rule 2), README's gate list and user-scope section, VISION's corroboration line, and an AGENTS.md sharp edge were updated to state the new floor and to forbid reintroducing a text classifier. Existing test fixtures that declared a session count while quoting one source were given a second quote source, since the declared number is no longer read.

## What Changed

- Apply the `minGapEvidence` session floor to all add, rewrite, and remove edits, using normalized quote sources instead of model-reported counts; extract and move remain exempt.
- Count user-scope project corroboration from instruction evidence as well as gap clusters.
- Update prompts, documentation, and proposal-path tests for rewrites, tightenings, source normalization, and project evidence.

## Risk Assessment

⚠️ Medium: The intended floor is implemented, but using truncated display labels as identities can incorrectly collapse distinct sessions and reject valid proposals.

## Testing

Inspected the target changes, ran the focused proposal tests, and exercised real staged workspaces to verify single-session rewrites are refused despite inflated model counts, two-session tightenings pass, and whitespace-varied instruction evidence counts two user-scope projects. All checks succeeded and the worktree remained clean.

<details>
<summary>Evidence: Real proposal-gate outcomes for session and project floors</summary>

Source: [Real proposal-gate outcomes for session and project floors](https://github.com/kunchenguid/backpass/blob/dea6a7000a07e4866617bf5efca315c6d52d36e7/.no-mistakes/evidence/fm/backpass-rewrite-session-floor-b-r1/rewrite-session-floor.json)

```text
{
  "singleSessionAppend": {
    "acceptedEdits": 0,
    "declaredSessions": 20,
    "measuredViolation": "edit e1 (\"Strengthen PR rule\") changes AGENTS.md backed by 1 session(s); 2 are required"
  },
  "twoSessionTightening": {
    "acceptedEdits": 1,
    "declaredSessions": 1,
    "measuredSessions": 2,
    "violations": []
  },
  "userScopeInstructionEvidence": {
    "acceptedEdits": 1,
    "measuredSessions": 2,
    "measuredProjects": 2,
    "violations": []
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fb651a92ff77ffc1d43b45412163092b9f4386a0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- 🚨 `src/proposal.js:118` - This contradicts the required criterion &#34;A single-session rewrite of any shape is refused.&#34; `transcripts` counts raw evidence entries before `normalizeEvidence` removes invalid quotes. A rewrite with one valid quote plus `{ &#34;source&#34;: &#34;fake-session&#34;, &#34;text&#34;: &#34;&#34; }` gets `transcripts: 2`, retains only one quote, and passes the floor at line 535. Distinct source strings are also never verified against folded evidence, so fabricated or whitespace-altered labels can produce the same bypass. Resolve evidence pairs against the folded evidence at the proposal boundary and count only distinct matched session sources.

🔧 Fix: Count only normalized distinct evidence sources
1 error still open:

- 🚨 `src/proposal.js:119` - The required criterion says a single-session rewrite must be refused, but counting normalized evidence now makes a missing source count as a second session: `normalizeEvidence` converts an absent source to `&#34;unknown source&#34;` at line 130. Evidence containing one real sourced quote plus one non-empty quote with no `source` therefore yields `transcripts: 2` and passes. Preserve a missing source as empty or otherwise exclude it from `countSources`; this does not require matching quotes against folded evidence.

🔧 Fix: Exclude sourceless evidence from session counts
1 error still open:

- 🚨 `src/proposal.js:318` - The required criterion &#34;User-scope project floor counts instruction evidence&#34; still fails when a quote source has harmless whitespace variation. Session counting canonicalizes `&#34;claude  ·  s1&#34;`, but `countedEvidenceProjects` looks up the unnormalized displayed label in `summary.sourceProjects`, whose key is `&#34;claude · s1&#34;`. Two valid instruction quotes from separate projects can therefore clear the session floor but report 0 projects and be refused. Use the same source-label normalization for both the folded map keys and this lookup.

🔧 Fix: Canonicalize evidence source identity across gates
1 warning still open:

- ⚠️ `src/proposal.js:141` - Distinct-session counting now treats the human-facing source label as the session identity, but `gapSource` truncates IDs to eight characters. Two real sessions with the same harness, date, and ID prefix, such as IDs `12345678-a` and `12345678-b`, therefore produce one source label, count as one session, and wrongly refuse a corroborated rewrite. Fixing this requires authorization because it must either change the source-label contract or add a separate stable session identity, both beyond the explicitly approved narrow normalization change.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/proposal.test.js`
- <code>`node --input-type=module` behavioral harness invoking real `stageAndMeasure`, `buildProposal`, and `foldEvidence` paths</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
