### PR TITLE
feat(apply): unify funnel from findings to proposed edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,8 +179,8 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   `templates/apply.html` draws one band from findings to edits proposed on one scale, in two
   lanes (an existing instruction, a missing one), each drop named in plain words. It is fed by
   display-only counters - `reportOnlyByReason` and `instructionsWithNegatives` in the fold's
-  `totals`, `instructionsLeftAlone`/`leftAloneMaxSessions` in `buildProposal` - that no gate
-  may ever read; changing what the band shows must never change what is proposed or refused.
+  `totals`, plus the instruction-outcome counters in `buildProposal` - that no gate may ever
+  read; changing what the band shows must never change what is proposed or refused.
   A proposal lacking them falls back to the classic stat row rather than inventing zeros.
 - **Never trust model-reported numbers.** Token deltas, budget projections and an edit's
   session count are measured in `src/proposal.js` from the actual text and quotes; the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,13 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   unsplit. The instruction index and fold use those parts so evidence cannot smear across a
   blob, and synthesis is told to restructure repeated non-compliance into list items rather
   than bold-label it. See `src/memory.js` and `renderEvidenceForPrompt` in `src/fold.js`.
+- **The apply surface's funnel band is presentation, and its counters must stay that way.**
+  `templates/apply.html` draws one band from findings to edits proposed on one scale, in two
+  lanes (an existing instruction, a missing one), each drop named in plain words. It is fed by
+  display-only counters - `reportOnlyByReason` and `instructionsWithNegatives` in the fold's
+  `totals`, `instructionsLeftAlone`/`leftAloneMaxSessions` in `buildProposal` - that no gate
+  may ever read; changing what the band shows must never change what is proposed or refused.
+  A proposal lacking them falls back to the classic stat row rather than inventing zeros.
 - **Never trust model-reported numbers.** Token deltas, budget projections and an edit's
   session count are measured in `src/proposal.js` from the actual text and quotes; the
   synthesis model's own figures are ignored.

--- a/README.md
+++ b/README.md
@@ -423,9 +423,11 @@ changed since the proposal measured it, exactly as it refuses a drifted memory f
 
 `backpass apply` is the only command that writes. It serves a review surface through
 [`lavish-axi`](https://github.com/kunchenguid/lavish-axi): one card per edit with the diff,
-the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT. A compact
-gap funnel summarizes recorded gap evidence and proposal eligibility; older proposals
-without recorded funnel counts omit it.
+the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT. Above them
+one funnel band runs from every finding the analysis recorded down to the edits proposed,
+with each row split into the two lanes a finding sorts into - one about an instruction that
+already exists, one about a missing instruction - and each drop between two rows named in
+plain words. Older proposals without the recorded funnel counts fall back to a stat row.
 
 The surface is a static template shipped in the package - the CLI injects one JSON payload,
 so it is instant, deterministic, and identical every run. Nothing there is model-generated.

--- a/README.md
+++ b/README.md
@@ -424,10 +424,11 @@ changed since the proposal measured it, exactly as it refuses a drifted memory f
 `backpass apply` is the only command that writes. It serves a review surface through
 [`lavish-axi`](https://github.com/kunchenguid/lavish-axi): one card per edit with the diff,
 the evidence quotes and their sources, a live budget gauge, and ACCEPT / REJECT. Above them
-one funnel band runs from every finding the analysis recorded down to the edits proposed,
-with each row split into the two lanes a finding sorts into - one about an instruction that
-already exists, one about a missing instruction - and each drop between two rows named in
-plain words. Older proposals without the recorded funnel counts fall back to a stat row.
+one funnel band runs from every finding the analysis recorded down to the edits proposed.
+Blue and amber lanes distinguish existing-instruction work from missing-instruction work;
+the final row counts edits by their measured shape, while the earlier rows count findings
+or candidates. Each drop between two rows is named in plain words. Older proposals without
+the recorded funnel counts fall back to a stat row.
 
 The surface is a static template shipped in the package - the CLI injects one JSON payload,
 so it is instant, deterministic, and identical every run. Nothing there is model-generated.

--- a/src/fold.js
+++ b/src/fold.js
@@ -234,6 +234,16 @@ export function foldEvidence(
 
   const droppedGapSingletons = decided.filter((cluster) => cluster.sessions < minGapEvidence && !cluster.mixed).length;
 
+  // Why each report-only cluster is report-only, in the same priority the filter above
+  // uses. Display only: the apply surface names the reason on its own drop line instead
+  // of lumping three different refusals under one count. Nothing here gates anything.
+  const reportOnlyByReason = { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 0 };
+  for (const cluster of reportOnlyGaps) {
+    if (cluster.majorityOrchestration) reportOnlyByReason.majorityOrchestration += 1;
+    else if (cluster.sessions < minGapEvidence) reportOnlyByReason.belowFloorMixed += 1;
+    else reportOnlyByReason.tooFewProjects += 1;
+  }
+
   return {
     version: 1,
     generatedAt: new Date().toISOString(),
@@ -248,8 +258,12 @@ export function foldEvidence(
       gapSightings: allObservations.length,
       gapClusters: gaps.length,
       reportOnlyGapClusters: reportOnlyGaps.length,
+      reportOnlyByReason,
       droppedGapSingletons,
       orchestrationGapSightings,
+      // The existing-instruction lane's candidate count: how many instructions the
+      // negatives land on. Display only; no gate reads it.
+      instructionsWithNegatives: instructionRows.filter((row) => row.negative > 0).length,
       usedRawTranscript: usedRawCount,
       crossSurfaceDuplicates: duplicates.length,
     },

--- a/src/fold.js
+++ b/src/fold.js
@@ -252,9 +252,9 @@ export function foldEvidence(
     totals: {
       positive: positiveCount,
       negative: negativeCount,
-      // The gap funnel's top: every sighting this fold clustered over (the pruned ledger
-      // when one is passed, this run's records otherwise). Orchestration sightings are
-      // per-sighting votes; cluster domain is decided after grouping.
+      // The missing-instruction lane's findings count: every sighting this fold clustered
+      // over (the pruned ledger when one is passed, this run's records otherwise).
+      // Orchestration sightings are per-sighting votes; cluster domain is decided after grouping.
       gapSightings: allObservations.length,
       gapClusters: gaps.length,
       reportOnlyGapClusters: reportOnlyGaps.length,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -731,6 +731,11 @@ export function buildProposal(rawResult, context) {
     .filter((file) => measured.originals?.has(file))
     .map((file) => ({ file, hash: memoryTextHash(measured.originals.get(file)) }));
 
+  // Instructions the evidence named as candidates that no accepted edit touches: the
+  // model was shown them and chose not to edit. Counted here, not in the fold, because
+  // it depends on the accepted edit list. Display only; nothing downstream reads it.
+  const leftAlone = leftAloneInstructions(summary, accepted);
+
   const proposal = {
     version: 2,
     tool: "backpass",
@@ -764,7 +769,13 @@ export function buildProposal(rawResult, context) {
       gapSightings: summary?.totals?.gapSightings ?? null,
       orchestrationGapSightings: summary?.totals?.orchestrationGapSightings ?? null,
       reportOnlyGapClusters: summary?.totals?.reportOnlyGapClusters ?? null,
+      reportOnlyByReason: summary?.totals?.reportOnlyByReason ?? null,
       droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,
+      // The existing-instruction lane of the apply surface's funnel: how many
+      // instructions the negatives land on, and how many of those no edit touched.
+      instructionsWithNegatives: summary?.totals?.instructionsWithNegatives ?? null,
+      instructionsLeftAlone: leftAlone?.count ?? null,
+      leftAloneMaxSessions: leftAlone?.maxSessions ?? null,
       skillExtractions: accepted.reduce((n, e) => {
         if (e.kind !== "extract") return n;
         const createdSkills = editSkills(e).length;
@@ -778,6 +789,20 @@ export function buildProposal(rawResult, context) {
   };
 
   return { proposal, violations };
+}
+
+// Display counter for the apply surface's funnel: the instructions that drew a negative
+// finding and that no accepted edit names. `maxSessions` lets the surface say "ignored in
+// only 1 session each" when that is true of all of them, and stay silent otherwise. A
+// summary from before the instruction rows existed yields null, never an invented zero.
+function leftAloneInstructions(summary, accepted) {
+  if (!Array.isArray(summary?.instructions)) return null;
+  const touched = new Set(accepted.flatMap((edit) => edit.instructions || []));
+  const rows = summary.instructions.filter((row) => row.negative > 0 && !touched.has(row.instruction));
+  return {
+    count: rows.length,
+    maxSessions: rows.reduce((n, row) => Math.max(n, row.nonComplianceSessions ?? row.sessions ?? 0), 0),
+  };
 }
 
 export function slug(text) {

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -733,9 +733,9 @@ export function buildProposal(rawResult, context) {
     .filter((file) => measured.originals?.has(file))
     .map((file) => ({ file, hash: memoryTextHash(measured.originals.get(file)) }));
 
-  // Instructions the evidence named as candidates that no accepted edit touches: the
-  // model was shown them and chose not to edit. Counted here, not in the fold, because
-  // it depends on the accepted edit list. Display only; nothing downstream reads it.
+  // Instructions the evidence named as candidates that no accepted edit names.
+  // Counted here, not in the fold, because it depends on the accepted edit list.
+  // Display only; nothing downstream reads it.
   const funnelOutcome = funnelInstructionOutcome(summary, accepted, suppressed);
 
   const proposal = {
@@ -774,7 +774,7 @@ export function buildProposal(rawResult, context) {
       reportOnlyByReason: summary?.totals?.reportOnlyByReason ?? null,
       droppedGapSingletons: summary?.totals?.droppedGapSingletons ?? null,
       // The existing-instruction lane of the apply surface's funnel: how many
-      // instructions the negatives land on, and how many of those no edit touched.
+      // instructions the negatives land on, and how many no accepted edit names.
       instructionsWithNegatives: summary?.totals?.instructionsWithNegatives ?? null,
       instructionsLeftAlone: funnelOutcome?.instructionsLeftAlone ?? null,
       leftAloneMaxSessions: funnelOutcome?.leftAloneMaxSessions ?? null,
@@ -809,17 +809,14 @@ function funnelInstructionOutcome(summary, accepted, suppressed) {
   const candidateIds = new Set(candidates.map((row) => row.instruction));
   const acceptedIds = new Set(accepted.flatMap((edit) => edit.instructions || []).filter((id) => candidateIds.has(id)));
   const suppressedIds = new Set(
-    suppressed
-      .flatMap((edit) => edit.instructions || [])
-      .filter((id) => candidateIds.has(id) && !acceptedIds.has(id)),
+    suppressed.flatMap((edit) => edit.instructions || []).filter((id) => candidateIds.has(id) && !acceptedIds.has(id)),
   );
-  const untouched = candidates.filter((row) => !acceptedIds.has(row.instruction) && !suppressedIds.has(row.instruction));
+  const untouched = candidates.filter(
+    (row) => !acceptedIds.has(row.instruction) && !suppressedIds.has(row.instruction),
+  );
   return {
     instructionsLeftAlone: untouched.length,
-    leftAloneMaxSessions: untouched.reduce(
-      (n, row) => Math.max(n, row.nonComplianceSessions ?? row.sessions ?? 0),
-      0,
-    ),
+    leftAloneMaxSessions: untouched.reduce((n, row) => Math.max(n, row.nonComplianceSessions ?? row.sessions ?? 0), 0),
     suppressed: suppressedIds.size,
   };
 }

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -777,10 +777,8 @@ export function buildProposal(rawResult, context) {
       // instructions the negatives land on, and how many of those no edit touched.
       instructionsWithNegatives: summary?.totals?.instructionsWithNegatives ?? null,
       instructionsLeftAlone: funnelOutcome?.instructionsLeftAlone ?? null,
-      candidatesLeftAlone: funnelOutcome?.candidatesLeftAlone ?? null,
       leftAloneMaxSessions: funnelOutcome?.leftAloneMaxSessions ?? null,
       instructionsSuppressed: funnelOutcome?.suppressed ?? null,
-      candidatesCombined: funnelOutcome?.combined ?? null,
       skillExtractions: accepted.reduce((n, e) => {
         if (e.kind !== "extract") return n;
         const createdSkills = editSkills(e).length;
@@ -811,22 +809,13 @@ function funnelInstructionOutcome(summary, accepted, suppressed) {
       .filter((id) => candidateIds.has(id) && !acceptedIds.has(id)),
   );
   const untouched = candidates.filter((row) => !acceptedIds.has(row.instruction) && !suppressedIds.has(row.instruction));
-  const measuredAddition = (edit) => edit.hunks.length > 0 && edit.hunks.every((hunk) => hunk.removed === 0);
-  const acceptedAdds = accepted.filter(measuredAddition).length;
-  const suppressedAdds = suppressed.filter(measuredAddition).length;
-  const missingLeftAlone = Math.max(0, (summary?.totals?.gapClusters ?? 0) - acceptedAdds - suppressedAdds);
-  const sent = candidates.length + (summary?.totals?.gapClusters ?? 0);
-  const leftAlone = untouched.length + missingLeftAlone;
-  const suppressedCount = suppressedIds.size + suppressedAdds;
   return {
     instructionsLeftAlone: untouched.length,
-    candidatesLeftAlone: leftAlone,
     leftAloneMaxSessions: untouched.reduce(
       (n, row) => Math.max(n, row.nonComplianceSessions ?? row.sessions ?? 0),
       0,
     ),
-    suppressed: suppressedCount,
-    combined: Math.max(0, sent - leftAlone - suppressedCount - accepted.length),
+    suppressed: suppressedIds.size,
   };
 }
 

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -373,6 +373,7 @@ export function buildProposal(rawResult, context) {
   }
 
   const accepted = [];
+  const suppressed = [];
   for (const edit of edits) {
     const changes = edit.changeIds.map((id) => changesById.get(id)).filter(Boolean);
     const created = changes.filter((c) => c.kind === "created");
@@ -632,6 +633,7 @@ export function buildProposal(rawResult, context) {
 
     if (isSuppressed(proposed, rejections)) {
       // Rejections are respected until materially new evidence arrives (captain tweak 3).
+      suppressed.push(proposed);
       continue;
     }
     accepted.push(proposed);
@@ -734,7 +736,7 @@ export function buildProposal(rawResult, context) {
   // Instructions the evidence named as candidates that no accepted edit touches: the
   // model was shown them and chose not to edit. Counted here, not in the fold, because
   // it depends on the accepted edit list. Display only; nothing downstream reads it.
-  const leftAlone = leftAloneInstructions(summary, accepted);
+  const funnelOutcome = funnelInstructionOutcome(summary, accepted, suppressed);
 
   const proposal = {
     version: 2,
@@ -774,8 +776,11 @@ export function buildProposal(rawResult, context) {
       // The existing-instruction lane of the apply surface's funnel: how many
       // instructions the negatives land on, and how many of those no edit touched.
       instructionsWithNegatives: summary?.totals?.instructionsWithNegatives ?? null,
-      instructionsLeftAlone: leftAlone?.count ?? null,
-      leftAloneMaxSessions: leftAlone?.maxSessions ?? null,
+      instructionsLeftAlone: funnelOutcome?.instructionsLeftAlone ?? null,
+      candidatesLeftAlone: funnelOutcome?.candidatesLeftAlone ?? null,
+      leftAloneMaxSessions: funnelOutcome?.leftAloneMaxSessions ?? null,
+      instructionsSuppressed: funnelOutcome?.suppressed ?? null,
+      candidatesCombined: funnelOutcome?.combined ?? null,
       skillExtractions: accepted.reduce((n, e) => {
         if (e.kind !== "extract") return n;
         const createdSkills = editSkills(e).length;
@@ -795,13 +800,33 @@ export function buildProposal(rawResult, context) {
 // finding and that no accepted edit names. `maxSessions` lets the surface say "ignored in
 // only 1 session each" when that is true of all of them, and stay silent otherwise. A
 // summary from before the instruction rows existed yields null, never an invented zero.
-function leftAloneInstructions(summary, accepted) {
+function funnelInstructionOutcome(summary, accepted, suppressed) {
   if (!Array.isArray(summary?.instructions)) return null;
-  const touched = new Set(accepted.flatMap((edit) => edit.instructions || []));
-  const rows = summary.instructions.filter((row) => row.negative > 0 && !touched.has(row.instruction));
+  const candidates = summary.instructions.filter((row) => row.negative > 0);
+  const candidateIds = new Set(candidates.map((row) => row.instruction));
+  const acceptedIds = new Set(accepted.flatMap((edit) => edit.instructions || []).filter((id) => candidateIds.has(id)));
+  const suppressedIds = new Set(
+    suppressed
+      .flatMap((edit) => edit.instructions || [])
+      .filter((id) => candidateIds.has(id) && !acceptedIds.has(id)),
+  );
+  const untouched = candidates.filter((row) => !acceptedIds.has(row.instruction) && !suppressedIds.has(row.instruction));
+  const measuredAddition = (edit) => edit.hunks.length > 0 && edit.hunks.every((hunk) => hunk.removed === 0);
+  const acceptedAdds = accepted.filter(measuredAddition).length;
+  const suppressedAdds = suppressed.filter(measuredAddition).length;
+  const missingLeftAlone = Math.max(0, (summary?.totals?.gapClusters ?? 0) - acceptedAdds - suppressedAdds);
+  const sent = candidates.length + (summary?.totals?.gapClusters ?? 0);
+  const leftAlone = untouched.length + missingLeftAlone;
+  const suppressedCount = suppressedIds.size + suppressedAdds;
   return {
-    count: rows.length,
-    maxSessions: rows.reduce((n, row) => Math.max(n, row.nonComplianceSessions ?? row.sessions ?? 0), 0),
+    instructionsLeftAlone: untouched.length,
+    candidatesLeftAlone: leftAlone,
+    leftAloneMaxSessions: untouched.reduce(
+      (n, row) => Math.max(n, row.nonComplianceSessions ?? row.sessions ?? 0),
+      0,
+    ),
+    suppressed: suppressedCount,
+    combined: Math.max(0, sent - leftAlone - suppressedCount - accepted.length),
   };
 }
 

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -795,11 +795,16 @@ export function buildProposal(rawResult, context) {
 }
 
 // Display counter for the apply surface's funnel: the instructions that drew a negative
-// finding and that no accepted edit names. `maxSessions` lets the surface say "ignored in
-// only 1 session each" when that is true of all of them, and stay silent otherwise. A
-// summary from before the instruction rows existed yields null, never an invented zero.
+// finding and that no accepted edit names. A summary from before the funnel counters
+// existed yields null, never an invented zero.
 function funnelInstructionOutcome(summary, accepted, suppressed) {
-  if (!Array.isArray(summary?.instructions)) return null;
+  if (
+    !Array.isArray(summary?.instructions) ||
+    typeof summary?.totals?.instructionsWithNegatives !== "number" ||
+    !summary?.totals?.reportOnlyByReason ||
+    typeof summary.totals.reportOnlyByReason !== "object"
+  )
+    return null;
   const candidates = summary.instructions.filter((row) => row.negative > 0);
   const candidateIds = new Set(candidates.map((row) => row.instruction));
   const acceptedIds = new Set(accepted.flatMap((edit) => edit.instructions || []).filter((id) => candidateIds.has(id)));

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -902,9 +902,12 @@
           var distinctGaps = eligible + reportOnly + singletons;
           var candidates = s.instructionsWithNegatives;
           var adds = edits.filter(function (e) {
-            return e.hunks.length > 0 && e.hunks.every(function (hunk) {
-              return hunk.removed === 0;
-            });
+            return (
+              e.hunks.length > 0 &&
+              e.hunks.every(function (hunk) {
+                return hunk.removed === 0;
+              })
+            );
           }).length;
           return {
             floor: Number((P.config || {}).minGapEvidence) || 2,
@@ -1003,9 +1006,7 @@
             funnel.tooFewProjects,
             funnel.projectFloor === 2
               ? "seen in too few projects: the same mistake has to show up in another project"
-              : "seen in too few projects: the same mistake has to show up in " +
-                  funnel.projectFloor +
-                  " projects",
+              : "seen in too few projects: the same mistake has to show up in " + funnel.projectFloor + " projects",
           );
           funnelBar(bars, "sent to synthesis", funnel.sent, scale);
           funnelDrop(bars, funnel.leftAlone, "no accepted edit named these candidates");

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -21,6 +21,10 @@
         --defer: #ffc857;
         --defer-dim: rgba(255, 200, 87, 0.1);
         --blue: #6ea8ff;
+        /* The funnel's two lanes: a finding about an existing instruction, and one
+           about a missing instruction. Used by the legend swatches and the bars. */
+        --lane-a: rgba(110, 168, 255, 0.4);
+        --lane-b: rgba(255, 200, 87, 0.38);
         --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
         --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
       }
@@ -126,7 +130,7 @@
         margin-top: 3px;
       }
 
-      /* ---------- gap funnel ---------- */
+      /* ---------- run funnel ---------- */
       /* The template's own display rules (.statrow's grid) would beat the UA
          stylesheet's [hidden]; this keeps the hidden attribute authoritative. */
       [hidden] {
@@ -136,20 +140,13 @@
         border: 1px solid var(--line);
         background: var(--line);
         display: grid;
-        grid-template-columns: minmax(0, 3fr) minmax(280px, 2fr);
+        grid-template-columns: minmax(0, 1fr);
         gap: 1px;
         margin-bottom: 36px;
       }
       .ctx-funnel {
         background: var(--panel);
-        padding: 13px 18px 14px;
-        min-width: 0;
-      }
-      .ctx-stats {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        grid-auto-rows: 1fr;
-        gap: 1px;
+        padding: 13px 18px 12px;
         min-width: 0;
       }
       .funnel-head {
@@ -173,6 +170,29 @@
         color: var(--text);
         font-weight: 500;
       }
+      /* Lane key. Blue is a finding about an instruction that already exists, amber a
+         finding about one that is missing; the same two colours run left to right on
+         every bar, so a lane can be followed from the findings row to the last bar. */
+      .funnel-head .legend {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--faint);
+      }
+      .funnel-head .legend i {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        margin: 0 5px 0 10px;
+        vertical-align: 0;
+      }
+      .lane-a {
+        background: var(--lane-a);
+        border: 1px solid var(--blue);
+      }
+      .lane-b {
+        background: var(--lane-b);
+        border: 1px solid var(--defer);
+      }
       .frow {
         display: flex;
         align-items: center;
@@ -180,7 +200,7 @@
         margin: 4px 0;
       }
       .frow .fl {
-        width: 148px;
+        width: 160px;
         flex: none;
         font-family: var(--mono);
         font-size: 10px;
@@ -192,6 +212,7 @@
         text-overflow: ellipsis;
       }
       .frow .fb {
+        position: relative;
         flex: 1;
         min-width: 0;
         display: flex;
@@ -203,22 +224,55 @@
       .frow .fb i {
         display: block;
         height: 100%;
-        background: rgba(110, 168, 255, 0.38);
-        border-right: 1px solid rgba(110, 168, 255, 0.75);
       }
-      .frow.lit .fb i {
-        background: rgba(79, 227, 193, 0.4);
-        border-right-color: var(--accent);
+      .frow .fb i.a {
+        background: var(--lane-a);
+        border-right: 1px solid var(--blue);
+      }
+      .frow .fb i.b {
+        background: var(--lane-b);
+        border-right: 1px solid var(--defer);
+      }
+      .frow.lit .fb i.a {
+        background: rgba(110, 168, 255, 0.62);
+      }
+      .frow.lit .fb i.b {
+        background: rgba(255, 200, 87, 0.62);
       }
       .frow.zero .fb i {
         border-right: none;
       }
+      /* The learning-rate cap, on the same scale as the bar it sits over. */
+      .frow .fb .capline {
+        position: absolute;
+        top: -3px;
+        bottom: -3px;
+        width: 2px;
+        background: var(--reject);
+      }
+      .frow .fb .capline::after {
+        content: attr(data-l);
+        position: absolute;
+        left: 5px;
+        top: 0;
+        font-family: var(--mono);
+        font-size: 9.5px;
+        letter-spacing: 0.08em;
+        color: var(--reject);
+        white-space: nowrap;
+      }
       .frow .fv {
         flex: none;
-        width: 34px;
+        width: 58px;
+        text-align: right;
+        white-space: nowrap;
         font-family: var(--mono);
         font-size: 12.5px;
         color: var(--text);
+      }
+      .frow .fv small {
+        color: var(--faint);
+        font-size: 10.5px;
       }
       .frow.zero .fv {
         color: var(--faint);
@@ -227,7 +281,7 @@
         color: var(--accent);
       }
       .fdrop {
-        margin: 1px 0 6px 160px;
+        margin: 1px 0 7px 172px;
         font-size: 12px;
         color: var(--dim);
       }
@@ -696,11 +750,8 @@
           padding: 12px 16px;
           gap: 12px;
         }
-        .run-context {
-          grid-template-columns: minmax(0, 1fr);
-        }
         .frow .fl {
-          width: 92px;
+          width: 124px;
         }
         .fdrop {
           margin-left: 0;
@@ -722,13 +773,17 @@
       <div class="run-context" id="ctx" hidden>
         <div class="ctx-funnel">
           <div class="funnel-head">
-            <span class="t">Gap funnel · counted across runs</span>
-            <span class="facts num" id="funnel-floor"></span>
+            <span class="t"
+              >Funnel · this run
+              <span class="legend"
+                ><i class="lane-a"></i>existing instruction<i class="lane-b"></i>missing instruction</span
+              ></span
+            >
+            <span class="facts num" id="funnel-facts"></span>
           </div>
           <div id="funnel-bars"></div>
           <div class="funnel-note" id="funnel-note" hidden></div>
         </div>
-        <div class="ctx-stats" id="ctx-stats"></div>
       </div>
 
       <div class="gauge-block">
@@ -821,90 +876,136 @@
           );
         }
 
-        // ---- run context: one frame, the gap funnel beside the run stats ----
-        // A single bordered band. The left pane tells the gap story as proportional
-        // bars - sightings recorded by analysis -> distinct gaps after clustering ->
-        // eligible to propose - with each drop-off explained in plain words. Domain is
-        // voted after clustering, so orchestration sightings are not subtracted before
-        // the distinct-gap stage. The right pane holds the run facts (edits, evidence,
-        // skills) as stat cells. Every count is recorded by the fold (`totals` in
-        // evidence-summary.json); a proposal saved before the counts existed falls
-        // back to the classic stat row rather than showing zeros nobody measured.
+        // ---- run context: one funnel, analyzed transcripts to proposed edits ----
+        // One band on one scale (findings = 100%), read top to bottom. Every finding the
+        // analysis produced enters at the findings bar and is sorted into two lanes that
+        // stay side by side to the last row: blue is a finding about an instruction that
+        // already exists, amber a finding about one that is missing. Between two bars sit
+        // the drops that explain the difference, in everyday words; a drop that removed
+        // nothing is not drawn. Every count is recorded by the fold (`totals` in
+        // evidence-summary.json) or read off the accepted edits - nothing is estimated,
+        // and nothing drawn here decides which edits are proposed. A proposal saved
+        // before these counts existed falls back to the classic stat row rather than
+        // showing zeros nobody measured.
         function funnelCounts() {
-          if (typeof (P.stats || {}).gapSightings !== "number") return null;
-          var eligible = P.stats.gapClusters || 0;
-          var dropped = P.stats.droppedGapSingletons || 0;
-          var reportOnly = P.stats.reportOnlyGapClusters || 0;
-          var distinct = eligible + reportOnly + dropped;
+          var s = P.stats || {};
+          var byReason = s.reportOnlyByReason;
+          if (typeof s.gapSightings !== "number") return null;
+          if (typeof s.instructionsWithNegatives !== "number") return null;
+          if (!byReason || typeof byReason !== "object") return null;
+          var eligible = s.gapClusters || 0;
+          var singletons = s.droppedGapSingletons || 0;
+          var reportOnly = s.reportOnlyGapClusters || 0;
+          // Distinct missing instructions: what the sightings clustered into, before any
+          // gate. The three parts are the only outcomes a cluster can have.
+          var distinctGaps = eligible + reportOnly + singletons;
+          var candidates = s.instructionsWithNegatives;
+          var adds = edits.filter(function (e) {
+            return e.kind === "add";
+          }).length;
           return {
             floor: Number((P.config || {}).minGapEvidence) || 2,
-            sighted: P.stats.gapSightings,
-            distinct: distinct,
-            merged: Math.max(0, P.stats.gapSightings - distinct),
-            dropped: dropped,
-            reportOnly: reportOnly,
+            cap: Number((P.config || {}).maxEditsPerRun) || edits.length,
+            findings: [(s.positive || 0) + (s.negative || 0), s.gapSightings],
+            followed: s.positive || 0,
+            // A finding is not a candidate: several negatives can name one instruction,
+            // and several sightings can be the same missing instruction seen again.
+            duplicates: Math.max(0, (s.negative || 0) - candidates) + Math.max(0, s.gapSightings - distinctGaps),
+            candidates: [candidates, distinctGaps],
+            // A mixed cluster held back by the floor is the same story as a singleton.
+            seenOnce: singletons + (byReason.belowFloorMixed || 0),
+            orchestration: byReason.majorityOrchestration || 0,
+            tooFewProjects: byReason.tooFewProjects || 0,
+            sent: [candidates, eligible],
+            leftAlone: s.instructionsLeftAlone || 0,
+            leftAloneMaxSessions: s.leftAloneMaxSessions,
+            proposed: [edits.length - adds, adds],
+            sighted: s.gapSightings,
             eligible: eligible,
+            dropped: singletons,
+            reportOnly: reportOnly,
           };
         }
-        function funnelBar(host, value, label, max, lit) {
-          var row = el("div", "frow" + (value === 0 ? " zero" : lit ? " lit" : ""));
+        function funnelBar(host, label, lanes, scale, opts) {
+          var o = opts || {};
+          var total = lanes[0] + lanes[1];
+          var row = el("div", "frow" + (total === 0 ? " zero" : o.lit ? " lit" : ""));
           row.appendChild(el("span", "fl", label));
           var track = el("div", "fb");
-          var fill = el("i");
-          fill.style.width = max > 0 ? Math.max((value / max) * 100, value > 0 ? 2 : 0) + "%" : "0%";
-          track.appendChild(fill);
+          ["a", "b"].forEach(function (lane, i) {
+            var fill = el("i", lane);
+            // A lane that counted something keeps a hairline of width so it is never
+            // invisible next to a lane that dwarfs it.
+            fill.style.width = scale > 0 ? Math.max((lanes[i] / scale) * 100, lanes[i] > 0 ? 0.6 : 0) + "%" : "0%";
+            track.appendChild(fill);
+          });
+          if (o.cap != null && scale > 0) {
+            var tick = el("span", "capline");
+            tick.style.left = Math.min((o.cap / scale) * 100, 100) + "%";
+            tick.setAttribute("data-l", "cap");
+            track.appendChild(tick);
+          }
           row.appendChild(track);
-          row.appendChild(el("span", "fv num", fmt(value)));
+          var value = el("span", "fv num", fmt(total));
+          if (o.small) value.appendChild(el("small", null, " " + o.small));
+          row.appendChild(value);
           host.appendChild(row);
         }
         function funnelDrop(host, n, text) {
           if (!n) return;
           var line = el("div", "fdrop");
-          line.appendChild(el("b", null, "− " + fmt(n) + " "));
-          line.appendChild(document.createTextNode(text));
+          line.appendChild(el("b", null, fmt(n) + " dropped"));
+          line.appendChild(document.createTextNode(" - " + text));
           host.appendChild(line);
         }
         var funnelNote = null;
         var funnel = funnelCounts();
         if (funnel) {
           var bars = document.getElementById("funnel-bars");
-          funnelBar(bars, funnel.sighted, "sightings", funnel.sighted);
+          var scale = funnel.findings[0] + funnel.findings[1];
+          funnelBar(bars, "findings", funnel.findings, scale);
+          funnelDrop(bars, funnel.followed, "the instruction was followed: nothing to fix");
           funnelDrop(
             bars,
-            funnel.merged,
-            "merged: repeat sightings of a gap already counted - they corroborate it rather than add a new one",
+            funnel.duplicates,
+            "duplicates: the same instruction or the same mistake, reported more than once",
           );
-          funnelBar(bars, funnel.distinct, "distinct gaps", funnel.sighted);
+          funnelBar(bars, "candidates", funnel.candidates, scale);
           funnelDrop(
             bars,
-            funnel.dropped,
-            "below the corroboration floor: seen in fewer than " +
-              funnel.floor +
-              " sessions so far - more transcripts can corroborate them",
+            funnel.seenOnce,
+            "seen only once: a second session has to confirm them (kept for later runs)",
           );
           funnelDrop(
             bars,
-            funnel.reportOnly,
-            "report only: mixed clusters below the floor or clusters excluded by a majority orchestration vote",
+            funnel.orchestration,
+            "not this project's fault: the tooling that ran the session caused it",
           );
-          funnelBar(bars, funnel.eligible, "eligible to propose", funnel.sighted, true);
-
-          document.getElementById("funnel-floor").textContent = "corroboration floor · " + funnel.floor + " sessions";
-          var statHost = document.getElementById("ctx-stats");
-          [
-            [
-              String(edits.length) + "/" + String((P.config || {}).maxEditsPerRun || edits.length),
-              "edits proposed / cap",
-            ],
-            [fmt(P.stats.positive), "positive evidence"],
-            [fmt(P.stats.negative), "negative evidence"],
-            [fmt(P.stats.skillExtractions), "skill extractions"],
-          ].forEach(function (s) {
-            var box = el("div", "stat");
-            box.appendChild(el("div", "v num", s[0]));
-            box.appendChild(el("div", "k", s[1]));
-            statHost.appendChild(box);
+          funnelDrop(
+            bars,
+            funnel.tooFewProjects,
+            "seen in too few projects: the same mistake has to show up in another project",
+          );
+          funnelBar(bars, "sent to synthesis", funnel.sent, scale);
+          funnelDrop(
+            bars,
+            funnel.leftAlone,
+            "the model chose not to edit" +
+              (funnel.leftAloneMaxSessions === 1 ? ": ignored in only 1 session each" : ""),
+          );
+          funnelBar(bars, "edits proposed", funnel.proposed, scale, {
+            lit: true,
+            small: "of " + fmt(funnel.cap),
+            cap: funnel.cap,
           });
+
+          var facts = document.getElementById("funnel-facts");
+          facts.appendChild(el("b", null, fmt(P.stats.transcripts)));
+          facts.appendChild(document.createTextNode(" transcripts · corroboration floor · "));
+          facts.appendChild(el("b", null, fmt(funnel.floor)));
+          facts.appendChild(document.createTextNode(" sessions · cap · "));
+          facts.appendChild(el("b", null, fmt(funnel.cap)));
+          facts.appendChild(document.createTextNode(" edits"));
 
           // The drop lines carry the takeaway; the visible note only speaks when there
           // are no bars to read. funnelNote itself still feeds the zero-edit empty state.

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -979,9 +979,15 @@
           funnelDrop(
             bars,
             funnel.seenOnce,
-            funnel.floor === 2
+            funnel.floor === 2 && P.scope !== "user"
               ? "seen only once: a second session has to confirm them (kept for later runs)"
-              : "seen in fewer than " +
+              : P.scope === "user"
+                ? "fewer than " +
+                  funnel.floor +
+                  " sessions count toward corroboration: " +
+                  funnel.floor +
+                  " qualifying sessions are required (kept for later runs)"
+                : "seen in fewer than " +
                   funnel.floor +
                   " sessions: " +
                   funnel.floor +
@@ -1002,12 +1008,7 @@
                   " projects",
           );
           funnelBar(bars, "sent to synthesis", funnel.sent, scale);
-          funnelDrop(
-            bars,
-            funnel.leftAlone,
-            "the model chose not to edit" +
-              (funnel.leftAloneMaxSessions === 1 ? ": ignored in only 1 session each" : ""),
-          );
+          funnelDrop(bars, funnel.leftAlone, "the model chose not to edit");
           funnelDrop(bars, funnel.suppressed, "a previous review rejected the same edit");
           funnelBar(bars, "edits proposed", funnel.proposed, scale, {
             lit: true,

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -908,6 +908,7 @@
           }).length;
           return {
             floor: Number((P.config || {}).minGapEvidence) || 2,
+            projectFloor: Number((P.config || {}).minGapProjects) || 1,
             cap: Number((P.config || {}).maxEditsPerRun) || edits.length,
             findings: [(s.positive || 0) + (s.negative || 0), s.gapSightings],
             followed: s.positive || 0,
@@ -994,7 +995,11 @@
           funnelDrop(
             bars,
             funnel.tooFewProjects,
-            "seen in too few projects: the same mistake has to show up in another project",
+            funnel.projectFloor === 2
+              ? "seen in too few projects: the same mistake has to show up in another project"
+              : "seen in too few projects: the same mistake has to show up in " +
+                  funnel.projectFloor +
+                  " projects",
           );
           funnelBar(bars, "sent to synthesis", funnel.sent, scale);
           funnelDrop(

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -1008,7 +1008,7 @@
                   " projects",
           );
           funnelBar(bars, "sent to synthesis", funnel.sent, scale);
-          funnelDrop(bars, funnel.leftAlone, "the model chose not to edit");
+          funnelDrop(bars, funnel.leftAlone, "no accepted edit named these candidates");
           funnelDrop(bars, funnel.suppressed, "a previous review rejected the same edit");
           funnelBar(bars, "edits proposed", funnel.proposed, scale, {
             lit: true,

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -901,7 +901,9 @@
           var distinctGaps = eligible + reportOnly + singletons;
           var candidates = s.instructionsWithNegatives;
           var adds = edits.filter(function (e) {
-            return e.kind === "add";
+            return e.hunks.length > 0 && e.hunks.every(function (hunk) {
+              return hunk.removed === 0;
+            });
           }).length;
           return {
             floor: Number((P.config || {}).minGapEvidence) || 2,
@@ -917,8 +919,13 @@
             orchestration: byReason.majorityOrchestration || 0,
             tooFewProjects: byReason.tooFewProjects || 0,
             sent: [candidates, eligible],
-            leftAlone: s.instructionsLeftAlone || 0,
-            leftAloneMaxSessions: s.leftAloneMaxSessions,
+            leftAlone: s.candidatesLeftAlone == null ? s.instructionsLeftAlone || 0 : s.candidatesLeftAlone,
+            leftAloneMaxSessions:
+              s.candidatesLeftAlone == null || s.candidatesLeftAlone === s.instructionsLeftAlone
+                ? s.leftAloneMaxSessions
+                : null,
+            suppressed: s.instructionsSuppressed || 0,
+            combined: s.candidatesCombined || 0,
             proposed: [edits.length - adds, adds],
             sighted: s.gapSightings,
             eligible: eligible,
@@ -974,7 +981,13 @@
           funnelDrop(
             bars,
             funnel.seenOnce,
-            "seen only once: a second session has to confirm them (kept for later runs)",
+            funnel.floor === 2
+              ? "seen only once: a second session has to confirm them (kept for later runs)"
+              : "seen in fewer than " +
+                  funnel.floor +
+                  " sessions: " +
+                  funnel.floor +
+                  " sessions have to confirm them (kept for later runs)",
           );
           funnelDrop(
             bars,
@@ -993,6 +1006,8 @@
             "the model chose not to edit" +
               (funnel.leftAloneMaxSessions === 1 ? ": ignored in only 1 session each" : ""),
           );
+          funnelDrop(bars, funnel.suppressed, "a previous review rejected the same edit");
+          funnelDrop(bars, funnel.combined, "combined with another candidate in the same edit");
           funnelBar(bars, "edits proposed", funnel.proposed, scale, {
             lit: true,
             small: "of " + fmt(funnel.cap),

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -298,6 +298,15 @@
         font-weight: 500;
         color: var(--faint);
       }
+      .fconvert {
+        margin: 2px 58px 7px 172px;
+        padding-top: 5px;
+        border-top: 1px solid var(--line);
+        font-family: var(--mono);
+        font-size: 10px;
+        color: var(--faint);
+        text-align: right;
+      }
       .funnel-note {
         margin-top: 10px;
         padding-top: 9px;
@@ -764,6 +773,9 @@
         .fdrop {
           margin-left: 0;
         }
+        .fconvert {
+          margin-left: 0;
+        }
       }
     </style>
   </head>
@@ -894,8 +906,10 @@
         // evidence-summary.json) or read off the accepted edits - nothing is estimated,
         // and nothing drawn here decides which edits are proposed. A proposal saved
         // before these counts existed falls back to the classic stat row rather than
-        // showing zeros nobody measured. The last step deliberately changes units from
-        // candidate instructions to edits, so its counts are measured rather than reconciled.
+        // showing zeros nobody measured. Synthesis is a many-to-many boundary: an edit can
+        // address several candidates, one candidate can produce several edits, and an edit
+        // can carry no existing-instruction id. The conversion line names that unit change
+        // explicitly instead of presenting candidate and edit counts as a conserved drop.
         function funnelCounts() {
           var s = P.stats || {};
           var byReason = s.reportOnlyByReason;
@@ -985,6 +999,14 @@
           line.appendChild(document.createTextNode(" - " + text));
           host.appendChild(line);
         }
+        function funnelConversion(host, candidates, proposed) {
+          var line = el("div", "fconvert");
+          line.appendChild(document.createTextNode("counting changes here: "));
+          line.appendChild(el("b", null, fmt(candidates) + " candidate" + (candidates === 1 ? "" : "s")));
+          line.appendChild(document.createTextNode(" · "));
+          line.appendChild(el("b", null, fmt(proposed) + " proposed edit" + (proposed === 1 ? "" : "s")));
+          host.appendChild(line);
+        }
         var funnelNote = null;
         var funnel = funnelCounts();
         if (funnel) {
@@ -1030,6 +1052,11 @@
           funnelBar(bars, "sent to synthesis", funnel.sent, scale);
           funnelDrop(bars, funnel.leftAlone, "no accepted edit named these candidates");
           funnelDrop(bars, funnel.suppressed, "a previous review rejected the same edit");
+          funnelConversion(
+            bars,
+            funnel.sent[0] + funnel.sent[1] - funnel.leftAlone - funnel.suppressed,
+            funnel.proposed[0] + funnel.proposed[1],
+          );
           funnelBar(bars, "edits proposed", funnel.proposed, scale, {
             lit: true,
             small: "of " + fmt(funnel.cap),

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -223,6 +223,7 @@
       }
       .frow .fb i {
         display: block;
+        flex-shrink: 0;
         height: 100%;
       }
       .frow .fb i.a {
@@ -241,6 +242,13 @@
       }
       .frow.zero .fb i {
         border-right: none;
+      }
+      .frow .fb .overscale {
+        position: absolute;
+        inset: -1px 0 -1px auto;
+        width: 9px;
+        border-right: 2px solid var(--reject);
+        background: repeating-linear-gradient(135deg, transparent 0 2px, var(--reject) 2px 3px);
       }
       /* The learning-rate cap, on the same scale as the bar it sits over. */
       .frow .fb .capline {
@@ -940,13 +948,24 @@
           var row = el("div", "frow" + (total === 0 ? " zero" : o.lit ? " lit" : ""));
           row.appendChild(el("span", "fl", label));
           var track = el("div", "fb");
+          var overScale = scale > 0 && total > scale;
+          var widths = lanes.map(function (value) {
+            return scale > 0 ? Math.max((value / (overScale ? total : scale)) * 100, value > 0 ? 0.6 : 0) : 0;
+          });
+          if (overScale && lanes[0] > 0 && lanes[1] > 0) {
+            widths[0] = Math.min(widths[0], 99.4);
+            widths[1] = 100 - widths[0];
+          }
           ["a", "b"].forEach(function (lane, i) {
             var fill = el("i", lane);
-            // A lane that counted something keeps a hairline of width so it is never
-            // invisible next to a lane that dwarfs it.
-            fill.style.width = scale > 0 ? Math.max((lanes[i] / scale) * 100, lanes[i] > 0 ? 0.6 : 0) + "%" : "0%";
+            fill.style.width = widths[i] + "%";
             track.appendChild(fill);
           });
+          if (overScale) {
+            var overflow = el("span", "overscale");
+            overflow.setAttribute("data-l", fmt(total - scale) + " over scale");
+            track.appendChild(overflow);
+          }
           if (o.cap != null && scale > 0 && o.cap <= scale) {
             var tick = el("span", "capline");
             tick.style.left = (o.cap / scale) * 100 + "%";

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -886,7 +886,8 @@
         // evidence-summary.json) or read off the accepted edits - nothing is estimated,
         // and nothing drawn here decides which edits are proposed. A proposal saved
         // before these counts existed falls back to the classic stat row rather than
-        // showing zeros nobody measured.
+        // showing zeros nobody measured. The last step deliberately changes units from
+        // candidate instructions to edits, so its counts are measured rather than reconciled.
         function funnelCounts() {
           var s = P.stats || {};
           var byReason = s.reportOnlyByReason;
@@ -919,13 +920,9 @@
             orchestration: byReason.majorityOrchestration || 0,
             tooFewProjects: byReason.tooFewProjects || 0,
             sent: [candidates, eligible],
-            leftAlone: s.candidatesLeftAlone == null ? s.instructionsLeftAlone || 0 : s.candidatesLeftAlone,
-            leftAloneMaxSessions:
-              s.candidatesLeftAlone == null || s.candidatesLeftAlone === s.instructionsLeftAlone
-                ? s.leftAloneMaxSessions
-                : null,
+            leftAlone: s.instructionsLeftAlone || 0,
+            leftAloneMaxSessions: s.leftAloneMaxSessions,
             suppressed: s.instructionsSuppressed || 0,
-            combined: s.candidatesCombined || 0,
             proposed: [edits.length - adds, adds],
             sighted: s.gapSightings,
             eligible: eligible,
@@ -946,9 +943,9 @@
             fill.style.width = scale > 0 ? Math.max((lanes[i] / scale) * 100, lanes[i] > 0 ? 0.6 : 0) + "%" : "0%";
             track.appendChild(fill);
           });
-          if (o.cap != null && scale > 0) {
+          if (o.cap != null && scale > 0 && o.cap <= scale) {
             var tick = el("span", "capline");
-            tick.style.left = Math.min((o.cap / scale) * 100, 100) + "%";
+            tick.style.left = (o.cap / scale) * 100 + "%";
             tick.setAttribute("data-l", "cap");
             track.appendChild(tick);
           }
@@ -1007,7 +1004,6 @@
               (funnel.leftAloneMaxSessions === 1 ? ": ignored in only 1 session each" : ""),
           );
           funnelDrop(bars, funnel.suppressed, "a previous review rejected the same edit");
-          funnelDrop(bars, funnel.combined, "combined with another candidate in the same edit");
           funnelBar(bars, "edits proposed", funnel.proposed, scale, {
             lit: true,
             small: "of " + fmt(funnel.cap),

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -140,6 +140,79 @@ test("the fold records the sightings it clustered over - the gap funnel's top", 
   );
 });
 
+test("the fold counts the funnel's display splits: candidate instructions and why report-only", () => {
+  const summary = foldEvidence(
+    [
+      record("s1", {
+        positive: [{ instruction: "AG-003", quote: "followed it" }],
+        negative: [{ instruction: "AG-001", quote: "n1", class: "non-compliance" }],
+      }),
+      record("s2", {
+        negative: [
+          { instruction: "AG-001", quote: "n2", class: "non-compliance" },
+          { instruction: "AG-002", quote: "n3", class: "non-compliance" },
+        ],
+      }),
+    ],
+    {
+      memoryFile,
+      minGapEvidence: 3,
+      minGapProjects: 2,
+      gapObservations: [
+        // Eligible: three sessions, two projects, nobody blamed the tooling.
+        { proposedInstruction: "Always vendor the lockfile.", sessionId: "a", domain: "project", project: "p1" },
+        { proposedInstruction: "Always vendor the lockfile.", sessionId: "b", domain: "project", project: "p2" },
+        { proposedInstruction: "Always vendor the lockfile.", sessionId: "c", domain: "project", project: "p2" },
+        // Report only, majority orchestration: every sighting blamed the tooling.
+        {
+          proposedInstruction: "Never bypass the release gate.",
+          sessionId: "a",
+          domain: "orchestration",
+          project: "p1",
+        },
+        {
+          proposedInstruction: "Never bypass the release gate.",
+          sessionId: "b",
+          domain: "orchestration",
+          project: "p2",
+        },
+        {
+          proposedInstruction: "Never bypass the release gate.",
+          sessionId: "c",
+          domain: "orchestration",
+          project: "p2",
+        },
+        // Report only, too few projects: corroborated, but only ever in one project.
+        { proposedInstruction: "Pin the schema version.", sessionId: "a", domain: "project", project: "p1" },
+        { proposedInstruction: "Pin the schema version.", sessionId: "b", domain: "project", project: "p1" },
+        { proposedInstruction: "Pin the schema version.", sessionId: "c", domain: "project", project: "p1" },
+        // Report only, mixed and still below the floor: two sessions, one vote each way.
+        { proposedInstruction: "Rotate the deploy token.", sessionId: "a", domain: "project", project: "p1" },
+        { proposedInstruction: "Rotate the deploy token.", sessionId: "b", domain: "orchestration", project: "p2" },
+        // Dropped singleton: one session, no orchestration vote to make it mixed.
+        { proposedInstruction: "Tag the release commit.", sessionId: "c", domain: "project", project: "p3" },
+      ],
+    },
+  );
+
+  assert.equal(summary.totals.instructionsWithNegatives, 2, "AG-001 and AG-002 drew a negative; AG-003 only positives");
+  assert.equal(summary.totals.gapClusters, 1);
+  assert.equal(summary.totals.reportOnlyGapClusters, 3);
+  assert.equal(summary.totals.droppedGapSingletons, 1);
+  assert.deepEqual(summary.totals.reportOnlyByReason, {
+    majorityOrchestration: 1,
+    belowFloorMixed: 1,
+    tooFewProjects: 1,
+  });
+  assert.equal(
+    summary.totals.reportOnlyByReason.majorityOrchestration +
+      summary.totals.reportOnlyByReason.belowFloorMixed +
+      summary.totals.reportOnlyByReason.tooFewProjects,
+    summary.totals.reportOnlyGapClusters,
+    "every report-only cluster is attributed to exactly one reason",
+  );
+});
+
 test("a two-sighting cluster with one orchestration vote survives instead of dropping below the floor", () => {
   const phrasing = "Read docs/sshhip.md before changing the tunnel.";
   const summary = foldEvidence(

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -679,9 +679,7 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   assert.equal(legacy.proposal.stats.droppedGapSingletons, null);
   assert.equal(legacy.proposal.stats.instructionsWithNegatives, null);
   assert.equal(legacy.proposal.stats.instructionsLeftAlone, null, "no instruction rows means nothing to count");
-  assert.equal(legacy.proposal.stats.candidatesLeftAlone, null);
   assert.equal(legacy.proposal.stats.instructionsSuppressed, null);
-  assert.equal(legacy.proposal.stats.candidatesCombined, null);
 });
 
 test("the funnel's left-alone count names the candidates no accepted edit touched", () => {
@@ -735,38 +733,6 @@ test("the funnel's left-alone count names the candidates no accepted edit touche
   assert.deepEqual(claimed.violations, []);
   assert.equal(claimed.proposal.stats.instructionsLeftAlone, 1);
   assert.equal(claimed.proposal.stats.leftAloneMaxSessions, 6);
-});
-
-test("the funnel accounts for candidates combined into one edit", () => {
-  const edit = memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", ""));
-  const gated = gate({
-    edit,
-    annotation: {
-      edits: [
-        claim(["H1"], {
-          kind: "remove",
-          title: "drop the stale Node pin",
-          instructions: ["AG-001", "AG-002"],
-        }),
-      ],
-    },
-    context: {
-      summary: {
-        analyzedSessions: 4,
-        totals: { positive: 0, negative: 8, gapClusters: 0 },
-        instructions: [
-          { instruction: "AG-001", negative: 4, harmSessions: 4, sessions: 4 },
-          { instruction: "AG-002", negative: 4, harmSessions: 4, sessions: 4 },
-          { instruction: "AG-003", negative: 0, harmSessions: 4, sessions: 4 },
-        ],
-      },
-    },
-  });
-
-  assert.deepEqual(gated.violations, []);
-  assert.equal(gated.proposal.stats.candidatesLeftAlone, 0);
-  assert.equal(gated.proposal.stats.candidatesCombined, 1);
-  assert.equal(gated.proposal.edits.length, 1);
 });
 
 test("the funnel's display counters never change which edits are proposed or refused", () => {
@@ -2055,10 +2021,8 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       droppedGapSingletons: 32,
       instructionsWithNegatives: 7,
       instructionsLeftAlone: 2,
-      candidatesLeftAlone: 2,
       leftAloneMaxSessions: 1,
       instructionsSuppressed: 1,
-      candidatesCombined: 1,
       skillExtractions: 0,
     },
     config: { maxEditsPerRun: 5, minGapEvidence: 2 },
@@ -2085,10 +2049,9 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       "sent to synthesis 8",
       "2 dropped - the model chose not to edit: ignored in only 1 session each",
       "1 dropped - a previous review rejected the same edit",
-      "1 dropped - combined with another candidate in the same edit",
       "edits proposed 4 of 5",
     ],
-    "one funnel: 133 - 70 - 22 = 41, 41 - 32 - 1 = 8, 8 - 2 - 1 - 1 = 4",
+    "the final step reports measured edits rather than inferring candidate attribution",
   );
   assert.ok(
     !lines.some((l) => (l.drop || "").includes("too few projects")),
@@ -2127,6 +2090,25 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
         "32 dropped - seen in fewer than 3 sessions: 3 sessions have to confirm them (kept for later runs)",
     ),
   );
+
+  const offScaleCap = renderTemplateScript({
+    ...proposal,
+    stats: {
+      ...proposal.stats,
+      positive: 0,
+      negative: 1,
+      gapSightings: 0,
+      gapClusters: 0,
+      reportOnlyGapClusters: 0,
+      reportOnlyByReason: { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 0 },
+      droppedGapSingletons: 0,
+      instructionsWithNegatives: 1,
+      instructionsLeftAlone: 0,
+      instructionsSuppressed: 0,
+    },
+    edits: [rewrite("e1")],
+  });
+  assert.equal(funnelLines(offScaleCap).at(-1).cap, undefined, "an off-scale cap tick is hidden");
 });
 
 test("a proposal saved before the funnel counts existed falls back to the classic stat row", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1309,9 +1309,7 @@ test("a previously rejected edit is suppressed until new evidence arrives", () =
   const first = gate({
     edit,
     annotation: {
-      edits: [
-        claim(["H1"], { kind: "remove", title: "drop the stale Node pin", instructions: ["AG-001"] }),
-      ],
+      edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin", instructions: ["AG-001"] })],
     },
   });
   const rejections = recordRejection(first.proposal.edits[0], { version: 1, entries: {} });
@@ -1319,9 +1317,7 @@ test("a previously rejected edit is suppressed until new evidence arrives", () =
   const suppressed = gate({
     edit,
     annotation: {
-      edits: [
-        claim(["H1"], { kind: "remove", title: "drop the stale Node pin", instructions: ["AG-001"] }),
-      ],
+      edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin", instructions: ["AG-001"] })],
     },
     context: {
       rejections,
@@ -2088,12 +2084,7 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
     },
     config: { maxEditsPerRun: 5, minGapEvidence: 2 },
     budget: { current: 4049, projected: 4117, capTokens: 5000, descriptionTokens: 0, mode: "cap" },
-    edits: [
-      rewrite("e1"),
-      rewrite("e2"),
-      rewrite("e3"),
-      rewrite("e4", 0),
-    ],
+    edits: [rewrite("e1"), rewrite("e2"), rewrite("e3"), rewrite("e4", 0)],
   };
   const rendered = renderTemplateScript(proposal);
 
@@ -2178,8 +2169,7 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
   );
   assert.ok(
     funnelLines(projectFloor(3)).some(
-      (line) =>
-        line.drop === "1 dropped - seen in too few projects: the same mistake has to show up in 3 projects",
+      (line) => line.drop === "1 dropped - seen in too few projects: the same mistake has to show up in 3 projects",
     ),
   );
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -671,14 +671,30 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   assert.equal(funneled.proposal.stats.instructionsWithNegatives, 3);
 
   // A summary from before the counts existed yields null, never an invented zero.
-  const legacy = gate({ edit, annotation, context: { summary: { analyzedSessions: 4, totals: {} } } });
+  const legacy = gate({
+    edit,
+    annotation,
+    context: {
+      summary: {
+        analyzedSessions: 4,
+        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        instructions: Array.from({ length: 20 }, (_, i) => ({
+          instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+          negative: 4,
+          harmSessions: 4,
+          sessions: 4,
+        })),
+      },
+    },
+  });
   assert.equal(legacy.proposal.stats.gapSightings, null);
   assert.equal(legacy.proposal.stats.orchestrationGapSightings, null);
   assert.equal(legacy.proposal.stats.reportOnlyGapClusters, null);
   assert.equal(legacy.proposal.stats.reportOnlyByReason, null);
   assert.equal(legacy.proposal.stats.droppedGapSingletons, null);
   assert.equal(legacy.proposal.stats.instructionsWithNegatives, null);
-  assert.equal(legacy.proposal.stats.instructionsLeftAlone, null, "no instruction rows means nothing to count");
+  assert.equal(legacy.proposal.stats.instructionsLeftAlone, null, "legacy instruction rows do not invent counts");
+  assert.equal(legacy.proposal.stats.leftAloneMaxSessions, null);
   assert.equal(legacy.proposal.stats.instructionsSuppressed, null);
 });
 
@@ -727,7 +743,7 @@ test("the funnel's left-alone count names the candidates no accepted edit touche
   assert.equal(gated.proposal.stats.leftAloneMaxSessions, 1, "the maximum does not imply every count is one");
   assert.ok(
     funnelLines(renderTemplateScript(gated.proposal)).some(
-      (line) => line.drop === "2 dropped - the model chose not to edit",
+      (line) => line.drop === "2 dropped - no accepted edit named these candidates",
     ),
   );
 
@@ -739,7 +755,16 @@ test("the funnel's left-alone count names the candidates no accepted edit touche
     context: {
       summary: {
         analyzedSessions: 4,
-        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        totals: {
+          positive: 3,
+          negative: 2,
+          gapClusters: 1,
+          gapSightings: 1,
+          reportOnlyGapClusters: 0,
+          reportOnlyByReason: { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 0 },
+          droppedGapSingletons: 0,
+          instructionsWithNegatives: 2,
+        },
         instructions: [row("AG-001", 3, 1), row("AG-002", 1, 6), { ...row("AG-003", 0, 0), positive: 5 }],
       },
     },
@@ -1298,7 +1323,29 @@ test("a previously rejected edit is suppressed until new evidence arrives", () =
         claim(["H1"], { kind: "remove", title: "drop the stale Node pin", instructions: ["AG-001"] }),
       ],
     },
-    context: { rejections, isSuppressed: isSuppressedByRejection },
+    context: {
+      rejections,
+      isSuppressed: isSuppressedByRejection,
+      summary: {
+        analyzedSessions: 4,
+        totals: {
+          positive: 3,
+          negative: 80,
+          gapClusters: 1,
+          gapSightings: 1,
+          reportOnlyGapClusters: 0,
+          reportOnlyByReason: { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 0 },
+          droppedGapSingletons: 0,
+          instructionsWithNegatives: 20,
+        },
+        instructions: Array.from({ length: 20 }, (_, i) => ({
+          instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+          negative: 4,
+          harmSessions: 4,
+          sessions: 4,
+        })),
+      },
+    },
   });
   assert.equal(suppressed.proposal.edits.length, 0, "same evidence weight stays rejected");
   assert.deepEqual(suppressed.violations, [], "a suppressed edit is dropped, not a violation");
@@ -2061,7 +2108,7 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       "32 dropped - seen only once: a second session has to confirm them (kept for later runs)",
       "1 dropped - not this project's fault: the tooling that ran the session caused it",
       "sent to synthesis 8",
-      "2 dropped - the model chose not to edit",
+      "2 dropped - no accepted edit named these candidates",
       "1 dropped - a previous review rejected the same edit",
       "edits proposed 4 of 5",
     ],

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1990,6 +1990,7 @@ function funnelLines({ nodes, textOf }) {
       label: textOf(label),
       value: textOf(value),
       lanes: track.children.filter((c) => c.className === "a" || c.className === "b").map((c) => c.style.width),
+      overScale: track.children.find((c) => c.className === "overscale")?.attrs["data-l"],
       cap: track.children.find((c) => c.className === "capline")?.style.left,
     };
   });
@@ -2172,6 +2173,30 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       (line) => line.drop === "1 dropped - seen in too few projects: the same mistake has to show up in 3 projects",
     ),
   );
+
+  const overScale = renderTemplateScript({
+    ...proposal,
+    stats: {
+      ...proposal.stats,
+      positive: 0,
+      negative: 1,
+      gapSightings: 0,
+      gapClusters: 0,
+      reportOnlyGapClusters: 0,
+      reportOnlyByReason: { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 0 },
+      droppedGapSingletons: 0,
+      instructionsWithNegatives: 1,
+      instructionsLeftAlone: 0,
+      instructionsSuppressed: 0,
+    },
+    edits: [rewrite("e1"), rewrite("e2", 0)],
+  });
+  const overScaleLines = funnelLines(overScale);
+  const findingsLine = overScaleLines.find((line) => line.label === "findings");
+  const proposedLine = overScaleLines.find((line) => line.label === "edits proposed");
+  assert.deepEqual(proposedLine.lanes, ["50%", "50%"], "the clamped bar preserves its lane split");
+  assert.equal(proposedLine.overScale, "1 over scale", "the clamped bar is visibly marked");
+  assert.equal(findingsLine.overScale, undefined, "an ordinary 100% bar has no over-scale marker");
 
   const offScaleCap = renderTemplateScript({
     ...proposal,

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -702,10 +702,19 @@ test("the funnel's left-alone count names the candidates no accepted edit touche
     context: {
       summary: {
         analyzedSessions: 4,
-        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        totals: {
+          positive: 0,
+          negative: 4,
+          gapClusters: 0,
+          gapSightings: 0,
+          reportOnlyGapClusters: 0,
+          reportOnlyByReason: { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 0 },
+          droppedGapSingletons: 0,
+          instructionsWithNegatives: 2,
+        },
         instructions: [
           // The accepted edit claims no instruction, so every candidate is left alone.
-          row("AG-001", 3, 1),
+          row("AG-001", 3, 0),
           row("AG-002", 1, 1),
           // Only positives: never a candidate, so never "left alone" either.
           { ...row("AG-003", 0, 0), positive: 5 },
@@ -715,7 +724,12 @@ test("the funnel's left-alone count names the candidates no accepted edit touche
   });
   assert.deepEqual(gated.violations, []);
   assert.equal(gated.proposal.stats.instructionsLeftAlone, 2);
-  assert.equal(gated.proposal.stats.leftAloneMaxSessions, 1, "both were ignored in a single session");
+  assert.equal(gated.proposal.stats.leftAloneMaxSessions, 1, "the maximum does not imply every count is one");
+  assert.ok(
+    funnelLines(renderTemplateScript(gated.proposal)).some(
+      (line) => line.drop === "2 dropped - the model chose not to edit",
+    ),
+  );
 
   // An edit that names one of them removes it from the count, and the surviving
   // candidate's session count is reported as it stands.
@@ -2047,7 +2061,7 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       "32 dropped - seen only once: a second session has to confirm them (kept for later runs)",
       "1 dropped - not this project's fault: the tooling that ran the session caused it",
       "sent to synthesis 8",
-      "2 dropped - the model chose not to edit: ignored in only 1 session each",
+      "2 dropped - the model chose not to edit",
       "1 dropped - a previous review rejected the same edit",
       "edits proposed 4 of 5",
     ],
@@ -2078,6 +2092,15 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
   );
   assert.equal(rendered.nodes.get("ctx").hidden, false, "the band frame is revealed");
   assert.ok(!rendered.nodes.has("statrow"), "the band replaces the classic stat row rather than joining it");
+
+  const projectCovered = renderTemplateScript({ ...proposal, scope: "user" });
+  assert.ok(
+    funnelLines(projectCovered).some(
+      (line) =>
+        line.drop ===
+        "32 dropped - fewer than 2 sessions count toward corroboration: 2 qualifying sessions are required (kept for later runs)",
+    ),
+  );
 
   const higherFloor = renderTemplateScript({
     ...proposal,

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1984,7 +1984,8 @@ function renderTemplateScript(proposal) {
 // The funnel band, read back the way it renders: one entry per bar or drop line.
 function funnelLines({ nodes, textOf }) {
   return nodes.get("funnel-bars").children.map((row) => {
-    if (!row.className.startsWith("frow")) return { drop: textOf(row) };
+    if (row.className === "fdrop") return { drop: textOf(row) };
+    if (row.className === "fconvert") return { conversion: textOf(row) };
     const [label, track, value] = row.children;
     return {
       label: textOf(label),
@@ -2091,7 +2092,7 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
 
   const lines = funnelLines(rendered);
   assert.deepEqual(
-    lines.map((l) => l.drop ?? `${l.label} ${l.value}`),
+    lines.map((l) => l.drop ?? l.conversion ?? `${l.label} ${l.value}`),
     [
       "findings 133",
       "70 dropped - the instruction was followed: nothing to fix",
@@ -2102,9 +2103,10 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       "sent to synthesis 8",
       "2 dropped - no accepted edit named these candidates",
       "1 dropped - a previous review rejected the same edit",
+      "counting changes here: 5 candidates · 4 proposed edits",
       "edits proposed 4 of 5",
     ],
-    "the final step reports measured edits rather than inferring candidate attribution",
+    "the many-to-many synthesis boundary names the unit conversion instead of implying candidates equal edits",
   );
   assert.ok(
     !lines.some((l) => (l.drop || "").includes("too few projects")),
@@ -2197,6 +2199,10 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
   assert.deepEqual(proposedLine.lanes, ["50%", "50%"], "the clamped bar preserves its lane split");
   assert.equal(proposedLine.overScale, "1 over scale", "the clamped bar is visibly marked");
   assert.equal(findingsLine.overScale, undefined, "an ordinary 100% bar has no over-scale marker");
+  assert.ok(
+    overScaleLines.some((line) => line.conversion === "counting changes here: 1 candidate · 2 proposed edits"),
+    "several edits from one candidate are an explicit unit conversion, not an unexplained gain",
+  );
 
   const offScaleCap = renderTemplateScript({
     ...proposal,
@@ -2215,7 +2221,36 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
     },
     edits: [rewrite("e1")],
   });
-  assert.equal(funnelLines(offScaleCap).at(-1).cap, undefined, "an off-scale cap tick is hidden");
+  const offScaleLines = funnelLines(offScaleCap);
+  assert.equal(offScaleLines.at(-1).cap, undefined, "an off-scale cap tick is hidden");
+  assert.ok(
+    offScaleLines.some((line) => line.conversion === "counting changes here: 1 candidate · 1 proposed edit"),
+    "equal numbers still name the change from candidate units to edit units",
+  );
+
+  const noCandidate = renderTemplateScript({
+    ...proposal,
+    stats: {
+      ...proposal.stats,
+      positive: 0,
+      negative: 0,
+      gapSightings: 0,
+      gapClusters: 0,
+      reportOnlyGapClusters: 0,
+      reportOnlyByReason: { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 0 },
+      droppedGapSingletons: 0,
+      instructionsWithNegatives: 0,
+      instructionsLeftAlone: 0,
+      instructionsSuppressed: 0,
+    },
+    edits: [rewrite("e1")],
+  });
+  assert.ok(
+    funnelLines(noCandidate).some(
+      (line) => line.conversion === "counting changes here: 0 candidates · 1 proposed edit",
+    ),
+    "an edit with no candidate attribution is visible instead of appearing as an unexplained gain",
+  );
 });
 
 test("a proposal saved before the funnel counts existed falls back to the classic stat row", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -646,8 +646,10 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
           gapSightings: 9,
           gapClusters: 0,
           reportOnlyGapClusters: 2,
+          reportOnlyByReason: { majorityOrchestration: 1, belowFloorMixed: 1, tooFewProjects: 0 },
           droppedGapSingletons: 3,
           orchestrationGapSightings: 6,
+          instructionsWithNegatives: 3,
         },
         instructions: Array.from({ length: 20 }, (_, i) => ({
           instruction: `AG-${String(i + 1).padStart(3, "0")}`,
@@ -659,15 +661,118 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   assert.equal(funneled.proposal.stats.gapSightings, 9);
   assert.equal(funneled.proposal.stats.orchestrationGapSightings, 6);
   assert.equal(funneled.proposal.stats.reportOnlyGapClusters, 2);
+  assert.deepEqual(funneled.proposal.stats.reportOnlyByReason, {
+    majorityOrchestration: 1,
+    belowFloorMixed: 1,
+    tooFewProjects: 0,
+  });
   assert.equal(funneled.proposal.stats.droppedGapSingletons, 3);
   assert.equal(funneled.proposal.stats.gapClusters, 0);
+  assert.equal(funneled.proposal.stats.instructionsWithNegatives, 3);
 
   // A summary from before the counts existed yields null, never an invented zero.
-  const legacy = gate({ edit, annotation });
+  const legacy = gate({ edit, annotation, context: { summary: { analyzedSessions: 4, totals: {} } } });
   assert.equal(legacy.proposal.stats.gapSightings, null);
   assert.equal(legacy.proposal.stats.orchestrationGapSightings, null);
   assert.equal(legacy.proposal.stats.reportOnlyGapClusters, null);
+  assert.equal(legacy.proposal.stats.reportOnlyByReason, null);
   assert.equal(legacy.proposal.stats.droppedGapSingletons, null);
+  assert.equal(legacy.proposal.stats.instructionsWithNegatives, null);
+  assert.equal(legacy.proposal.stats.instructionsLeftAlone, null, "no instruction rows means nothing to count");
+});
+
+test("the funnel's left-alone count names the candidates no accepted edit touched", () => {
+  const edit = memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", ""));
+  const annotation = { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] };
+  const row = (instruction, negative, nonComplianceSessions) => ({
+    instruction,
+    positive: 0,
+    negative,
+    nonComplianceSessions,
+    harmSessions: 4,
+    sessions: 4,
+    relevance: 1,
+    quotes: [],
+  });
+
+  const gated = gate({
+    edit,
+    annotation,
+    context: {
+      summary: {
+        analyzedSessions: 4,
+        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        instructions: [
+          // The accepted edit claims no instruction, so every candidate is left alone.
+          row("AG-001", 3, 1),
+          row("AG-002", 1, 1),
+          // Only positives: never a candidate, so never "left alone" either.
+          { ...row("AG-003", 0, 0), positive: 5 },
+        ],
+      },
+    },
+  });
+  assert.deepEqual(gated.violations, []);
+  assert.equal(gated.proposal.stats.instructionsLeftAlone, 2);
+  assert.equal(gated.proposal.stats.leftAloneMaxSessions, 1, "both were ignored in a single session");
+
+  // An edit that names one of them removes it from the count, and the surviving
+  // candidate's session count is reported as it stands.
+  const claimed = gate({
+    edit,
+    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop it", instructions: ["AG-001"] })] },
+    context: {
+      summary: {
+        analyzedSessions: 4,
+        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        instructions: [row("AG-001", 3, 1), row("AG-002", 1, 6), { ...row("AG-003", 0, 0), positive: 5 }],
+      },
+    },
+  });
+  assert.deepEqual(claimed.violations, []);
+  assert.equal(claimed.proposal.stats.instructionsLeftAlone, 1);
+  assert.equal(claimed.proposal.stats.leftAloneMaxSessions, 6);
+});
+
+test("the funnel's display counters never change which edits are proposed or refused", () => {
+  const edit = memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", ""));
+  const annotation = { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] };
+  const instructions = Array.from({ length: 20 }, (_, i) => ({
+    instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+    positive: 0,
+    negative: 4,
+    nonComplianceSessions: 4,
+    harmSessions: 4,
+    sessions: 4,
+    relevance: 1,
+    quotes: [],
+  }));
+  const totals = { positive: 3, negative: 2, gapClusters: 1, gapSightings: 9, droppedGapSingletons: 3 };
+
+  const withCounters = gate({
+    edit,
+    annotation,
+    context: {
+      summary: {
+        analyzedSessions: 4,
+        totals: {
+          ...totals,
+          instructionsWithNegatives: 20,
+          reportOnlyGapClusters: 2,
+          reportOnlyByReason: { majorityOrchestration: 2, belowFloorMixed: 0, tooFewProjects: 0 },
+        },
+        instructions,
+      },
+    },
+  });
+  const without = gate({
+    edit,
+    annotation,
+    context: { summary: { analyzedSessions: 4, totals, instructions } },
+  });
+
+  assert.deepEqual(withCounters.violations, without.violations);
+  assert.deepEqual(withCounters.proposal.edits, without.proposal.edits);
 });
 
 test("a proposal that would exceed the budget fails the gate", () => {
@@ -1765,18 +1870,25 @@ test("renderApplySurface writes one valid document through the real template", (
   assert.deepEqual(extractInjectedPayload(html), { ...payload, toolVersion: "0.1.0" });
 });
 
-test("the apply surface separates memory, description, and on-trigger deltas", () => {
+// Runs the real template's own script against a DOM stub small enough to keep the
+// assertions textual: the surface is exercised as the browser would build it, not mocked.
+function renderTemplateScript(proposal) {
   class Node {
     constructor(text = "") {
       this.textContent = text;
+      this.className = "";
       this.children = [];
       this.style = {};
+      this.attrs = {};
+      this.hidden = false;
     }
     appendChild(child) {
       this.children.push(child);
       return child;
     }
-    setAttribute() {}
+    setAttribute(name, value) {
+      this.attrs[name] = value;
+    }
     addEventListener() {}
   }
   const nodes = new Map();
@@ -1788,7 +1900,33 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
       return nodes.get(id);
     },
   };
+  const repo = makeRepo();
+  const target = renderApplySurface(proposal, new State(repo.root), "0.1.0");
+  const html = fs.readFileSync(target, "utf8");
+  const window = {};
+  window.window = window;
+  for (const match of html.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
+    vm.runInNewContext(match[1], { window, document });
+  }
   const textOf = (node) => node.textContent + node.children.map(textOf).join("");
+  return { nodes, textOf };
+}
+
+// The funnel band, read back the way it renders: one entry per bar or drop line.
+function funnelLines({ nodes, textOf }) {
+  return nodes.get("funnel-bars").children.map((row) => {
+    if (!row.className.startsWith("frow")) return { drop: textOf(row) };
+    const [label, track, value] = row.children;
+    return {
+      label: textOf(label),
+      value: textOf(value),
+      lanes: track.children.filter((c) => c.className === "a" || c.className === "b").map((c) => c.style.width),
+      cap: track.children.find((c) => c.className === "capline")?.style.left,
+    };
+  });
+}
+
+test("the apply surface separates memory, description, and on-trigger deltas", () => {
   const proposal = {
     generatedAt: "2026-08-01T00:00:00.000Z",
     repo: { name: "demo" },
@@ -1828,14 +1966,7 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
       },
     ],
   };
-  const repo = makeRepo();
-  const target = renderApplySurface(proposal, new State(repo.root), "0.1.0");
-  const html = fs.readFileSync(target, "utf8");
-  const window = {};
-  window.window = window;
-  for (const match of html.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
-    vm.runInNewContext(match[1], { window, document });
-  }
+  const { nodes, textOf } = renderTemplateScript(proposal);
 
   const cards = nodes.get("edits").children;
   assert.match(textOf(cards[0]), /Δ memory -20 tok/);
@@ -1851,6 +1982,107 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
   assert.match(textOf(cards[1]), /Δ description \(always-loaded\) -2 tok/);
   assert.match(textOf(cards[1]), /file: \.agents\/skills\/db\/SKILL\.md/);
   assert.equal(nodes.get("gauge-title").textContent, "Always-loaded budget · AGENTS.md + skill descriptions");
+});
+
+test("the apply surface draws one funnel from findings to the edits it proposed", () => {
+  const rewrite = (id) => ({
+    id,
+    kind: "rewrite",
+    file: "AGENTS.md",
+    targetsMemoryFile: true,
+    hunks: [],
+    evidence: [],
+  });
+  const rendered = renderTemplateScript({
+    generatedAt: "2026-09-02T00:00:00.000Z",
+    repo: { name: "user" },
+    memoryFile: { path: ".claude/CLAUDE.md" },
+    stats: {
+      harnessCounts: {},
+      transcripts: 82,
+      positive: 70,
+      negative: 25,
+      gapSightings: 36,
+      gapClusters: 1,
+      reportOnlyGapClusters: 1,
+      reportOnlyByReason: { majorityOrchestration: 1, belowFloorMixed: 0, tooFewProjects: 0 },
+      droppedGapSingletons: 32,
+      instructionsWithNegatives: 5,
+      instructionsLeftAlone: 2,
+      leftAloneMaxSessions: 1,
+      skillExtractions: 0,
+    },
+    config: { maxEditsPerRun: 5, minGapEvidence: 2 },
+    budget: { current: 4049, projected: 4117, capTokens: 5000, descriptionTokens: 0, mode: "cap" },
+    edits: [
+      rewrite("e1"),
+      rewrite("e2"),
+      rewrite("e3"),
+      { id: "e4", kind: "add", file: "SKILL.md", targetsMemoryFile: false, hunks: [], evidence: [] },
+    ],
+  });
+
+  const lines = funnelLines(rendered);
+  assert.deepEqual(
+    lines.map((l) => l.drop ?? `${l.label} ${l.value}`),
+    [
+      "findings 131",
+      "70 dropped - the instruction was followed: nothing to fix",
+      "22 dropped - duplicates: the same instruction or the same mistake, reported more than once",
+      "candidates 39",
+      "32 dropped - seen only once: a second session has to confirm them (kept for later runs)",
+      "1 dropped - not this project's fault: the tooling that ran the session caused it",
+      "sent to synthesis 6",
+      "2 dropped - the model chose not to edit: ignored in only 1 session each",
+      "edits proposed 4 of 5",
+    ],
+    "one funnel: 131 - 70 - 22 = 39, 39 - 32 - 1 = 6, 6 - 2 = 4",
+  );
+  assert.ok(
+    !lines.some((l) => (l.drop || "").includes("too few projects")),
+    "a drop line that dropped nothing is never drawn",
+  );
+
+  // Every bar shares one scale (findings = 100%) so a lane can be followed down the
+  // band, and each bar splits into existing-instruction then missing-instruction.
+  const share = (n) => `${(n / 131) * 100}%`;
+  assert.deepEqual(
+    lines.filter((l) => l.label).map((l) => l.lanes),
+    [
+      [share(95), share(36)],
+      [share(5), share(34)],
+      [share(5), share(1)],
+      [share(3), share(1)],
+    ],
+  );
+  assert.equal(lines.at(-1).cap, share(5), "the cap tick sits on the same scale as the bar it crosses");
+
+  assert.equal(
+    rendered.textOf(rendered.nodes.get("funnel-facts")),
+    "82 transcripts · corroboration floor · 2 sessions · cap · 5 edits",
+  );
+  assert.equal(rendered.nodes.get("ctx").hidden, false, "the band frame is revealed");
+  assert.ok(!rendered.nodes.has("statrow"), "the band replaces the classic stat row rather than joining it");
+});
+
+test("a proposal saved before the funnel counts existed falls back to the classic stat row", () => {
+  const legacy = {
+    generatedAt: "2026-08-01T00:00:00.000Z",
+    repo: { name: "demo" },
+    memoryFile: { path: "AGENTS.md" },
+    // Recorded when only the gap funnel existed: no lane counts, so no band.
+    stats: { harnessCounts: {}, transcripts: 9, positive: 4, negative: 2, gapClusters: 1, skillExtractions: 0 },
+    config: { maxEditsPerRun: 5, minGapEvidence: 2 },
+    budget: { current: 10, projected: 12, capTokens: 100, descriptionTokens: 0, mode: "cap" },
+    edits: [],
+  };
+  const rendered = renderTemplateScript(legacy);
+
+  assert.ok(!rendered.nodes.has("funnel-bars"), "no band is drawn without the counts it needs");
+  assert.ok(!rendered.nodes.has("ctx"), "the band frame stays hidden as the markup shipped it");
+  assert.equal(rendered.nodes.get("statrow").hidden, false);
+  assert.equal(rendered.nodes.get("statrow").children.length, 5);
+  assert.match(rendered.textOf(rendered.nodes.get("statrow")), /positive evidence/);
 });
 
 test("terminal review labels every file in a multi-file extraction", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -2091,6 +2091,28 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
     ),
   );
 
+  const projectFloor = (minGapProjects) =>
+    renderTemplateScript({
+      ...proposal,
+      config: { ...proposal.config, minGapProjects },
+      stats: {
+        ...proposal.stats,
+        reportOnlyByReason: { majorityOrchestration: 0, belowFloorMixed: 0, tooFewProjects: 1 },
+      },
+    });
+  assert.ok(
+    funnelLines(projectFloor(2)).some(
+      (line) =>
+        line.drop === "1 dropped - seen in too few projects: the same mistake has to show up in another project",
+    ),
+  );
+  assert.ok(
+    funnelLines(projectFloor(3)).some(
+      (line) =>
+        line.drop === "1 dropped - seen in too few projects: the same mistake has to show up in 3 projects",
+    ),
+  );
+
   const offScaleCap = renderTemplateScript({
     ...proposal,
     stats: {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -679,6 +679,9 @@ test("the proposal carries the fold's gap-funnel counts for the apply surface", 
   assert.equal(legacy.proposal.stats.droppedGapSingletons, null);
   assert.equal(legacy.proposal.stats.instructionsWithNegatives, null);
   assert.equal(legacy.proposal.stats.instructionsLeftAlone, null, "no instruction rows means nothing to count");
+  assert.equal(legacy.proposal.stats.candidatesLeftAlone, null);
+  assert.equal(legacy.proposal.stats.instructionsSuppressed, null);
+  assert.equal(legacy.proposal.stats.candidatesCombined, null);
 });
 
 test("the funnel's left-alone count names the candidates no accepted edit touched", () => {
@@ -732,6 +735,38 @@ test("the funnel's left-alone count names the candidates no accepted edit touche
   assert.deepEqual(claimed.violations, []);
   assert.equal(claimed.proposal.stats.instructionsLeftAlone, 1);
   assert.equal(claimed.proposal.stats.leftAloneMaxSessions, 6);
+});
+
+test("the funnel accounts for candidates combined into one edit", () => {
+  const edit = memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", ""));
+  const gated = gate({
+    edit,
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "remove",
+          title: "drop the stale Node pin",
+          instructions: ["AG-001", "AG-002"],
+        }),
+      ],
+    },
+    context: {
+      summary: {
+        analyzedSessions: 4,
+        totals: { positive: 0, negative: 8, gapClusters: 0 },
+        instructions: [
+          { instruction: "AG-001", negative: 4, harmSessions: 4, sessions: 4 },
+          { instruction: "AG-002", negative: 4, harmSessions: 4, sessions: 4 },
+          { instruction: "AG-003", negative: 0, harmSessions: 4, sessions: 4 },
+        ],
+      },
+    },
+  });
+
+  assert.deepEqual(gated.violations, []);
+  assert.equal(gated.proposal.stats.candidatesLeftAlone, 0);
+  assert.equal(gated.proposal.stats.candidatesCombined, 1);
+  assert.equal(gated.proposal.edits.length, 1);
 });
 
 test("the funnel's display counters never change which edits are proposed or refused", () => {
@@ -1268,17 +1303,27 @@ test("a previously rejected edit is suppressed until new evidence arrives", () =
   const edit = memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", ""));
   const first = gate({
     edit,
-    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] },
+    annotation: {
+      edits: [
+        claim(["H1"], { kind: "remove", title: "drop the stale Node pin", instructions: ["AG-001"] }),
+      ],
+    },
   });
   const rejections = recordRejection(first.proposal.edits[0], { version: 1, entries: {} });
 
   const suppressed = gate({
     edit,
-    annotation: { edits: [claim(["H1"], { kind: "remove", title: "drop the stale Node pin" })] },
+    annotation: {
+      edits: [
+        claim(["H1"], { kind: "remove", title: "drop the stale Node pin", instructions: ["AG-001"] }),
+      ],
+    },
     context: { rejections, isSuppressed: isSuppressedByRejection },
   });
   assert.equal(suppressed.proposal.edits.length, 0, "same evidence weight stays rejected");
   assert.deepEqual(suppressed.violations, [], "a suppressed edit is dropped, not a violation");
+  assert.equal(suppressed.proposal.stats.instructionsLeftAlone, 19);
+  assert.equal(suppressed.proposal.stats.instructionsSuppressed, 1);
 
   const revived = gate({
     edit,
@@ -1291,6 +1336,7 @@ test("a previously rejected edit is suppressed until new evidence arrives", () =
             ...QUOTE,
             { polarity: "negative", text: "a third session hit the same pin", source: "pi · ghi · turn 2" },
           ],
+          instructions: ["AG-001"],
         }),
       ],
     },
@@ -1985,15 +2031,15 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
 });
 
 test("the apply surface draws one funnel from findings to the edits it proposed", () => {
-  const rewrite = (id) => ({
+  const rewrite = (id, removed = 1) => ({
     id,
     kind: "rewrite",
     file: "AGENTS.md",
     targetsMemoryFile: true,
-    hunks: [],
+    hunks: [{ removed, added: 1 }],
     evidence: [],
   });
-  const rendered = renderTemplateScript({
+  const proposal = {
     generatedAt: "2026-09-02T00:00:00.000Z",
     repo: { name: "user" },
     memoryFile: { path: ".claude/CLAUDE.md" },
@@ -2001,15 +2047,18 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       harnessCounts: {},
       transcripts: 82,
       positive: 70,
-      negative: 25,
+      negative: 27,
       gapSightings: 36,
       gapClusters: 1,
       reportOnlyGapClusters: 1,
       reportOnlyByReason: { majorityOrchestration: 1, belowFloorMixed: 0, tooFewProjects: 0 },
       droppedGapSingletons: 32,
-      instructionsWithNegatives: 5,
+      instructionsWithNegatives: 7,
       instructionsLeftAlone: 2,
+      candidatesLeftAlone: 2,
       leftAloneMaxSessions: 1,
+      instructionsSuppressed: 1,
+      candidatesCombined: 1,
       skillExtractions: 0,
     },
     config: { maxEditsPerRun: 5, minGapEvidence: 2 },
@@ -2018,25 +2067,28 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
       rewrite("e1"),
       rewrite("e2"),
       rewrite("e3"),
-      { id: "e4", kind: "add", file: "SKILL.md", targetsMemoryFile: false, hunks: [], evidence: [] },
+      rewrite("e4", 0),
     ],
-  });
+  };
+  const rendered = renderTemplateScript(proposal);
 
   const lines = funnelLines(rendered);
   assert.deepEqual(
     lines.map((l) => l.drop ?? `${l.label} ${l.value}`),
     [
-      "findings 131",
+      "findings 133",
       "70 dropped - the instruction was followed: nothing to fix",
       "22 dropped - duplicates: the same instruction or the same mistake, reported more than once",
-      "candidates 39",
+      "candidates 41",
       "32 dropped - seen only once: a second session has to confirm them (kept for later runs)",
       "1 dropped - not this project's fault: the tooling that ran the session caused it",
-      "sent to synthesis 6",
+      "sent to synthesis 8",
       "2 dropped - the model chose not to edit: ignored in only 1 session each",
+      "1 dropped - a previous review rejected the same edit",
+      "1 dropped - combined with another candidate in the same edit",
       "edits proposed 4 of 5",
     ],
-    "one funnel: 131 - 70 - 22 = 39, 39 - 32 - 1 = 6, 6 - 2 = 4",
+    "one funnel: 133 - 70 - 22 = 41, 41 - 32 - 1 = 8, 8 - 2 - 1 - 1 = 4",
   );
   assert.ok(
     !lines.some((l) => (l.drop || "").includes("too few projects")),
@@ -2045,13 +2097,13 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
 
   // Every bar shares one scale (findings = 100%) so a lane can be followed down the
   // band, and each bar splits into existing-instruction then missing-instruction.
-  const share = (n) => `${(n / 131) * 100}%`;
+  const share = (n) => `${(n / 133) * 100}%`;
   assert.deepEqual(
     lines.filter((l) => l.label).map((l) => l.lanes),
     [
-      [share(95), share(36)],
-      [share(5), share(34)],
-      [share(5), share(1)],
+      [share(97), share(36)],
+      [share(7), share(34)],
+      [share(7), share(1)],
       [share(3), share(1)],
     ],
   );
@@ -2063,6 +2115,18 @@ test("the apply surface draws one funnel from findings to the edits it proposed"
   );
   assert.equal(rendered.nodes.get("ctx").hidden, false, "the band frame is revealed");
   assert.ok(!rendered.nodes.has("statrow"), "the band replaces the classic stat row rather than joining it");
+
+  const higherFloor = renderTemplateScript({
+    ...proposal,
+    config: { ...proposal.config, minGapEvidence: 3 },
+  });
+  assert.ok(
+    funnelLines(higherFloor).some(
+      (line) =>
+        line.drop ===
+        "32 dropped - seen in fewer than 3 sessions: 3 sessions have to confirm them (kept for later runs)",
+    ),
+  );
 });
 
 test("a proposal saved before the funnel counts existed falls back to the classic stat row", () => {


### PR DESCRIPTION
## Intent

Ship the revision-5 one-funnel band for the backpass apply surface, as specified in data/backpass-unified-funnel-s1/report.md section 6 and its approved mock apply-mock.html (revision 5, after four rounds of captain feedback).

The captain's decision, verbatim, is the governing constraint: "ok this is good let's ship it. make sure this is a presentation only change - shouldn't affect any actual proposed edits at all."

Goal: today's apply surface showed only the gap story (sightings -> distinct gaps -> eligible to propose) beside a stat pane, with the rewrite edits nowhere in it, so anything below the eligible-gap bar read as leftovers of that bar. Replace it with ONE band on ONE scale (findings = 100%) read top to bottom: findings -> candidates -> sent to synthesis -> edits proposed. Every finding enters at the top and is sorted into two lanes that stay side by side down to the last bar (blue = a finding about an instruction that already exists, amber = a finding about a missing instruction), so both lanes sit above every gate. Between two bars sit drop lines in everyday words; a drop line whose count is zero is never drawn (an explicit captain rule from revision 3). The drop phrasings, the lane colours, the 'N dropped - reason' grey styling and the omission of lane dots/legend boxes on drop lines are all exactly what the captain approved in revisions 3 to 5 - they are deliberate, reviewed copy, not placeholders.

HARD EXCLUSION, the captain's constraint: nothing in this change may alter which edits are proposed, which are refused, or any number that gates them. Specifically untouched: onlyAdds, the session floor, the project floor, the harm floor, edit.transcripts, clustering, and the domain/orchestration vote. The append-sentence floor question (s1 R4) is deliberately a separate ship and is NOT decided here. Report section 6's S3 (measured card evidence line) and S4 (CLI/TUI copy) are deliberately OUT of this ship: the task's allowed surface is narrower than section 6, and S4 is marked optional there. Do not add them.

Allowed surface, and what I did within it:
- templates/apply.html: the run-context band markup, CSS and script replaced with the revision-5 band; the second ctx-stats pane removed; a cap tick on the final bar; a hairline minimum width so a tiny lane is never invisible next to one that dwarfs it.
- src/fold.js: two DISPLAY-ONLY counters added to totals - reportOnlyByReason (majorityOrchestration / belowFloorMixed / tooFewProjects, attributed in the same priority order the existing report-only filter already uses) and instructionsWithNegatives. No gate reads either.
- src/proposal.js: those copied into proposal.stats, plus instructionsLeftAlone and leftAloneMaxSessions, which are computed in buildProposal rather than the fold because they depend on the accepted edit list. All of them are null (never an invented 0) for a summary saved before they existed, matching the existing convention for gap counts. A proposal lacking them falls back to the classic stat row, exactly as the template already did for pre-funnel proposals.
- Tests: fold coverage for all three report-only reasons plus the candidate count; proposal coverage for the new stats and their null fallback, for left-alone counting, for the band rendered through the REAL template (rows, exact drop-line phrasings, zero-count lines absent, lane widths on one scale, cap tick position) and for the legacy stat-row fallback. Plus a test asserting the same annotation yields identical edits[] and violations with and without the new counters - the captain's constraint encoded as a test. I extracted a shared renderTemplateScript helper so the existing real-template render test and the new ones share one DOM stub.

Two small judgement calls beyond the band itself, both because the change made them stale or wrong: README stage 8's sentence describing the old gap funnel was rewritten to describe the one funnel, and one AGENTS.md sharp-edge bullet was added recording that these counters are display-only and must never gate. I also raised the narrow-width (<=760px) row label from 92px to 124px because the new longer label 'sent to synthesis' was being ellipsized at 420px.

Verification already done locally: pnpm run check green (520 tests); the real dry-run payload rendered in headless Chrome at 1280px (band 279px, matching the approved mock pixel for pixel, no horizontal overflow, clean console) and at 420px (no overflow, no truncated labels).

## What Changed

- Replace the gap funnel and stat pane with a single-scale, two-lane funnel from findings through proposed edits, including named nonzero drops and an edit-cap marker.
- Add display-only fold and proposal counters for funnel outcomes, with a legacy stat-row fallback when counters are unavailable.
- Update documentation and behavioral coverage for funnel rendering, counter attribution, responsive layout, and unchanged proposal decisions.

## Risk Assessment

✅ Low: The change is presentation-only, well-bounded, preserves gating behavior, and the latest over-scale fix visibly clamps bars while retaining lane proportions.

## Testing

The author-reported full `pnpm run check` baseline was green; this phase ran focused fold/proposal tests and rendered the real apply template in Chrome at 1280px and 420px. Screenshots confirm the unified two-lane funnel, drop copy, cap tick, responsive layout, and clamped over-scale marker, with no overflow or console errors.

- Evidence: [Unified apply funnel at 1280px](https://github.com/kunchenguid/backpass/blob/4595b83778ca8321736e9da02b2d71b9e224bc16/.no-mistakes/evidence/fm/backpass-apply-funnel-viz-redesign-r1/apply-funnel-1280.png)
- Evidence: [Unified apply funnel at 420px](https://github.com/kunchenguid/backpass/blob/4595b83778ca8321736e9da02b2d71b9e224bc16/.no-mistakes/evidence/fm/backpass-apply-funnel-viz-redesign-r1/apply-funnel-420.png)
- Evidence: [Over-scale marker and preserved lane split at 1280px](https://github.com/kunchenguid/backpass/blob/4595b83778ca8321736e9da02b2d71b9e224bc16/.no-mistakes/evidence/fm/backpass-apply-funnel-viz-redesign-r1/apply-funnel-over-scale-1280.png)
- Evidence: [Over-scale marker and preserved lane split at 420px](https://github.com/kunchenguid/backpass/blob/4595b83778ca8321736e9da02b2d71b9e224bc16/.no-mistakes/evidence/fm/backpass-apply-funnel-viz-redesign-r1/apply-funnel-over-scale-420.png)

<details>
<summary>Evidence: Rendered apply funnel HTML</summary>

Source: [Rendered apply funnel HTML](https://github.com/kunchenguid/backpass/blob/4595b83778ca8321736e9da02b2d71b9e224bc16/.no-mistakes/evidence/fm/backpass-apply-funnel-viz-redesign-r1/apply-funnel.html)

```text
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>backpass apply</title>
    <style>
      :root {
        --bg: #0b0e14;
        --panel: #10141d;
        --panel-2: #0e1219;
        --line: #1c2431;
        --line-soft: #161d28;
        --text: #d9dfea;
        --dim: #8a93a5;
        --faint: #5a6375;
        --accent: #4fe3c1;
        --accent-dim: rgba(79, 227, 193, 0.12);
        --reject: #ff5d73;
        --reject-dim: rgba(255, 93, 115, 0.1);
        --defer: #ffc857;
        --defer-dim: rgba(255, 200, 87, 0.1);
        --blue: #6ea8ff;
        /* The funnel's two lanes: a finding about an existing instruction, and one
           about a missing instruction. Used by the legend swatches and the bars. */
        --lane-a: rgba(110, 168, 255, 0.4);
        --lane-b: rgba(255, 200, 87, 0.38);
        --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
      }
      * {
        box-sizing: border-box;
      }
      html {
        background: var(--bg);
      }
      body {
        margin: 0;
        background: var(--bg);
        color: var(--text);
        font-family: var(--sans);
        font-size: 15px;
        line-height: 1.55;
        -webkit-font-smoothing: antialiased;
        background-image:
          linear-gradient(rgba(110, 168, 255, 0.025) 1px, transparent 1px),
          linear-gradient(90deg, rgba(110, 168, 255, 0.025) 1px, transparent 1px);
        background-size: 48px 48px;
      }
      .wrap {
        max-width: 1080px;
        margin: 0 auto;
        padding: 48px 28px 140px;
      }
      .microlabel {
        font-family: var(--mono);
        font-size: 10.5px;
        letter-spacing: 0.14em;
        text-transform: uppercase;
        color: var(--faint);
      }
      .num {
        font-variant-numeric: tabular-nums;
      }

      /* ---------- header ---------- */
      .brand {
        display: flex;
        align-items: baseline;
        gap: 14px;
        margin-bottom: 6px;
        flex-wrap: wrap;
      }
      .brand h1 {
        font-family: var(--mono);
        font-weight: 500;
        font-size: 22px;
        margin: 0;
        letter-spacing: 0.01em;
      }
      .brand h1 .cmd {
        color: var(--accent);
      }
      .brand .ver {
        font-family: var(--mono);
        font-size: 11.5px;
        color: var(--faint);
      }
      .runline {
        font-family: var(--mono);
        font-size: 12px;
        color: var(--dim);
        margin-bottom: 34px;
        word-break: break-word;
      }
      .runline b {
        color: var(--text);
        font-weight: 500;
      }

      .statrow {
        display: grid;
        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
        gap: 1px;
        background: var(--line);
        border: 1px solid var(--line);
        margin-bottom: 36px;
      }
      .stat {
        background: var(--panel);
        padding: 14px 16px;
        min-width: 0;
      }
      .stat .v {
        font-family: var(--mono);
        font-size: 21px;
        font-weight: 500;
        color: var(--text);
      }
      .stat .v em {
        font-style: normal;
        color: var(--accent);
      }
      .stat .k {
        font-family: var(--mono);
        font-size: 10.5px;
        letter-spacing: 0.12em;
        text-transform: uppercase;
        color: var(--faint);
        margin-top: 3px;
      }

      /* ---------- run funnel ---------- */
      /* The template's own display rules (.statrow's grid) would beat the UA
         stylesheet's [hidden]; this keeps the hidden attribute authoritative. */
      [hidden] {
        display: none !important;
      }
      .run-context {
        border: 1px solid var(--line);
        background: var(--line);
        display: grid;
        grid-template-columns: minmax(0, 1fr);
        gap: 1px;
        margin-bottom: 36px;
      }
      .ctx-funnel {
        background: var(--panel);
        padding: 13px 18px 12px;
        min-width: 0;
      }
      .funnel-head {
        display: flex;
        justify-content: space-between;
        align-items: baseline;
        flex-wrap: wrap;
        gap: 8px;
        margin-bottom: 10px;
      }
      .funnel-head .t {
        font-size: 13px;
        color: var(--dim);
      }
      .funnel-head .facts {
        font-family: var(--mono);
        font-size: 11px;
        color: var(--faint);
      }
      .funnel-head .facts b {
        color: var(--text);
        font-weight: 500;
      }
      /* Lane key. Blue is a finding about an instruction that already exists, amber a
         finding about one that is missing; the same two colours run left to right on
         every bar, so a lane can be followed from the findings row to the last bar. */
      .funnel-head .legend {
        font-family: var(--mono);
        font-size: 10.5px;
        color: var(--faint);
      }
      .funnel-head .legend i {
        display: inline-block;
        width: 8px;
        height: 8px;
        margin: 0 5px 0 10px;
        vertical-align: 0;
      }
      .lane-a {
        background: var(--lane-a);
        border: 1px solid var(--blue);
      }
      .lane-b {
        background: var(--lane-b);
        border: 1px solid var(--defer);
      }
      .frow {
        display: flex;
        align-items: center;
        gap: 12px;
        margin: 4px 0;
      }
      .frow .fl {
        width: 160px;
        flex: none;
        font-family: var(--mono);
        font-size: 10px;
        letter-spacing: 0.11em;
        text-transform: uppercase;
        color: var(--faint);
        white-space: nowrap;
        overflow: hidden;
        text-overflow: ellipsis;
      }
      .frow .fb {
        position: relative;
        flex: 1;
        min-width: 0;
        display: flex;
        align-items: center;
        height: 16px;
        background: var(--panel-2);
        border: 1px solid var(--line-soft);
      }
      .frow .fb i {
        display: block;
        flex-shrink: 0;
        height: 100%;
      }
      .frow .fb i.a {
        background: var(--lane-a);
        border-right: 1px solid var(--blue);
      }
      .frow .fb i.b {
        background: var(--lane-b);
        border-right: 1px solid var(--defer);
      }
      .frow.lit .fb i.a {
        background: rgba(110, 168, 255, 0.62);
      }
      .frow.lit .fb i.b {
        background: rgba(255, 200, 87, 0.62);
      }
      .frow.zero .fb i {
        border-right: none;
      }
      .frow .fb .overscale {
        position: absolute;
        inset: -1px 0 -1px auto;
        width: 9px;
        border-right: 2px solid var(--reject);
        background: repeating-linear-gradient(135deg, transparent 0 2px, var(--reject) 2px 3px);
      }
      /* The learning-rate cap, on the same scale as the bar it sits over. */
      .frow .fb .capline {
        position: absolute;
        top: -3px;
        bottom: -3px;
        width: 2px;
        background: var(--reject);
      }
      .frow .fb .capline::after {
        content: attr(data-l);
        position: absolute;
        left: 5px;
        top: 0;
        font-family: var(--mono);
        font-size: 9.5px;
        letter-spacing: 0.08em;
        color: var(--reject);
        white-space: nowrap;
      }
      .frow .fv {
        flex: none;
        width: 58px;
        text-align: right;
        white-space: nowrap;
        font-family: var(--mono);
        font-size: 12.5px;
        color: var(--text);
      }
      .frow .fv small {
        color: var(--faint);
        font-size: 10.5px;
      }
      .frow.zero .fv {
        color: var(--faint);
      }
      .frow.lit .fv {
        color: var(--accent);
      }
      .fdrop {
        margin: 1px 0 7px 172px;
        font-size: 12px;
        color: var(--dim);
      }
      .fdrop b {
        font-family: var(--mono);
        font-weight: 500;
        color: var(--faint);
      }
      .funnel-note {
        margin-top: 10px;
        padding-top: 9px;
        border-top: 1px dashed var(--line-soft);
        fon

... [31755 bytes truncated] ...

div", "diff");
          diffLines(edit).forEach(function (line) {
            diff.appendChild(el("span", line.type, line.text));
          });
          body.appendChild(diff);

          if ((edit.evidence || []).length) {
            var det = el("details", "evidence");
            var counts = { positive: 0, negative: 0 };
            edit.evidence.forEach(function (q) {
              counts[q.polarity === "positive" ? "positive" : "negative"] += 1;
            });
            det.appendChild(
              el(
                "summary",
                null,
                "evidence · " +
                  (edit.transcripts || 0) +
                  " transcripts (" +
                  counts.negative +
                  "-, " +
                  counts.positive +
                  "+)",
              ),
            );
            edit.evidence.forEach(function (q) {
              var quote = el(
                "div",
                "quote " + (q.polarity === "positive" ? "positive" : "negative"),
                "“" + q.text + "”",
              );
              quote.appendChild(el("span", "src", q.source));
              det.appendChild(quote);
            });
            body.appendChild(det);
          }

          var decide = el("div", "decide");
          ["accept", "reject"].forEach(function (choice) {
            var btn = el("button", choice === "accept" ? "on-accept" : "", choice.toUpperCase());
            btn.type = "button";
            btn.addEventListener("click", function () {
              decisions[edit.id] = choice === "accept" ? "accepted" : "rejected";
              card.setAttribute("data-state", decisions[edit.id]);
              Array.prototype.forEach.call(decide.children, function (b) {
                b.className = "";
              });
              btn.className = "on-" + choice;
              recompute();
            });
            decide.appendChild(btn);
          });
          body.appendChild(decide);
          card.appendChild(body);
          host.appendChild(card);
        });

        function nonEmpty(line) {
          return line.length > 0;
        }

        function editFiles(edit) {
          if (!Array.isArray(edit.hunks)) return edit.file ? [edit.file] : [];
          var files = edit.hunks.reduce(function (files, hunk) {
            var file = hunk.file || edit.file;
            if (file && files.indexOf(file) === -1) files.push(file);
            return files;
          }, []);
          return files.length ? files : edit.file ? [edit.file] : [];
        }

        // The skills one extract creates. A proposal saved before an extract could carry
        // several (merged removals) has a single `skill`; both shapes read the same way.
        function editSkills(edit) {
          if (Array.isArray(edit.skills)) {
            return edit.skills.filter(function (skill) {
              return skill;
            });
          }
          return edit.skill ? [edit.skill] : [];
        }

        // Measured edits carry display lines per hunk (ctx/del/ins); a legacy
        // find/replace edit is shown as removed then added lines.
        function diffLines(edit) {
          if (Array.isArray(edit.hunks)) {
            var out = [];
            edit.hunks.forEach(function (hunk, i) {
              if (i > 0) out.push({ type: "gap", text: "\u2026" });
              out.push({ type: "file", text: "--- " + (hunk.file || edit.file) + " ---" });
              (hunk.lines || []).forEach(function (line) {
                out.push(line);
              });
            });
            return out;
          }
          return (edit.find || "")
            .split("\n")
            .filter(nonEmpty)
            .map(function (text) {
              return { type: "del", text: text };
            })
            .concat(
              (edit.replace || "")
                .split("\n")
                .filter(nonEmpty)
                .map(function (text) {
                  return { type: "ins", text: text };
                }),
            );
        }

        // ---- notes ----
        if ((P.notes || []).length) {
          document.getElementById("notes").hidden = false;
          var list = document.getElementById("noteslist");
          P.notes.forEach(function (n) {
            list.appendChild(el("li", null, n));
          });
        }

        // ---- live tally + projection ----
        function recompute() {
          var accepted = 0,
            rejected = 0,
            tok = budget.current,
            descriptionTok = budget.descriptionTokens || 0;
          edits.forEach(function (e) {
            if (decisions[e.id] === "accepted") {
              accepted += 1;
              // The always-loaded projection: memory-file deltas plus each edit's
              // measured description-line delta (a tuned skill trigger, or the
              // description a created skill adds). Skill bodies never move this bar.
              if (e.targetsMemoryFile) tok += e.deltaTokens || 0;
              tok += e.descriptionDelta || 0;
              descriptionTok += e.descriptionDelta || 0;
            } else if (decisions[e.id] === "rejected") {
              rejected += 1;
            }
          });
          var over = tok > budget.capTokens;

          document.getElementById("gauge-title").textContent =
            "Always-loaded budget · " + (P.memoryFile.path || "") + (descriptionTok > 0 ? " + skill descriptions" : "");
          document.getElementById("n-accept").textContent = accepted;
          document.getElementById("n-reject").textContent = rejected;

          var readout = document.getElementById("gauge-readout");
          readout.textContent = "";
          readout.appendChild(document.createTextNode("now " + fmt(budget.current) + " tok -> if accepted "));
          // In shrink mode the file started over budget: progress is the goal, not arrival.
          readout.appendChild(
            el("b", (budget.mode === "shrink" ? tok >= budget.current : over) ? "over" : null, fmt(tok) + " tok"),
          );
          readout.appendChild(
            document.createTextNode(
              " / " +
                fmt(budget.capTokens) +
                " cap" +
                (budget.mode === "shrink"
                  ? " · shrink plan: " + fmt(Math.max(0, tok - budget.capTokens)) + " tok still over"
                  : ""),
            ),
          );

          var after = document.getElementById("gauge-after");
          after.style.width = pct(tok, budget.capTokens) + "%";
          after.className = "fill-after" + (over ? " over" : "");

          var proj = document.getElementById("projline");
          proj.textContent = "";
          proj.appendChild(document.createTextNode("projected: "));
          proj.appendChild(el("b", over ? "over" : null, fmt(tok)));
          proj.appendChild(document.createTextNode(" / " + fmt(budget.capTokens) + " tok"));

          var btn = document.getElementById("btn-apply");
          btn.textContent =
            accepted > 0 ? "APPLY " + accepted + " EDIT" + (accepted === 1 ? "" : "S") + " ->" : "NOTHING TO APPLY";
          btn.disabled = accepted === 0 && rejected === 0;
        }

        // ---- the single structured decision vector back to the CLI ----
        document.getElementById("btn-apply").addEventListener("click", function () {
          var vector = edits
            .map(function (e) {
              return e.id + "=" + decisions[e.id];
            })
            .join(" ");
          var message = "BACKPASS_DECISIONS " + vector;
          if (window.lavish && typeof window.lavish.queuePrompt === "function") {
            window.lavish.queuePrompt(message, {
              tag: "choice",
              text: vector,
              data: { question: "backpass-apply-decisions", decisions: decisions },
              queueKey: "backpass-apply-decisions",
            });
            this.textContent = "QUEUED - SEND FROM THE PANEL";
          } else {
            this.textContent = "QUEUED (offline preview)";
          }
          this.disabled = true;
        });

        recompute();
      })();
    </script>
  </body>
</html>
```
</details>

- Evidence: [Rendered over-scale apply funnel HTML](https://github.com/kunchenguid/backpass/blob/4595b83778ca8321736e9da02b2d71b9e224bc16/.no-mistakes/evidence/fm/backpass-apply-funnel-viz-redesign-r1/apply-funnel-over-scale.html)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"80d73d13c689c9238f1bc120274083b9c78771b4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (6) ✅</summary>

- 🚨 `templates/apply.html:903` - The required lane meaning is violated by classifying proposed edits with `e.kind === &#34;add&#34;`. `buildProposal` explicitly determines new instructions from measured `onlyAdds`, regardless of the model-declared kind. A pure insertion annotated as `rewrite` passes the new-instruction gates but renders blue as an existing-instruction edit. This contradicts the criterion that blue means an existing instruction and amber means a missing instruction. The display should use measured edit shape, but changing the approved presentation semantics requires user confirmation.
- 🚨 `src/proposal.js:779` - The final transition does not conserve funnel counts because `instructionsLeftAlone` counts instruction IDs while the final bar counts edits. For example, two negative candidates touched by one accepted rewrite produce `sent to synthesis: 2`, no left-alone drop, and `edits proposed: 1`. Multi-instruction edits are supported by the annotation contract, so this is reachable. The required one-band progression therefore has an unexplained loss. Resolving whether to count edits, instructions, or show a consolidation drop is a product decision requiring authorization.
- 🚨 `templates/apply.html:976` - The drop text always says `seen only once` and that a second session confirms the candidate, but `droppedGapSingletons` actually includes every non-mixed cluster with sessions below the configured floor. With `minGapEvidence: 3`, a two-session cluster is displayed as seen once and implied eligible after two sessions even though it needs three. Because the intent says the approved phrasing is deliberate, correcting its behavior for configurable floors requires user review.
- ⚠️ `src/proposal.js:780` - Previously rejected edits suppressed by `isSuppressed` are absent from `accepted`, so an instruction the model did edit is counted as left alone and rendered as `the model chose not to edit`. This is reachable in a successful proposal when synthesis repeats a suppressed edit. Fixing the counter or changing the approved drop wording affects deliberate presentation semantics and needs user confirmation.

🔧 Fix: Fix apply funnel classification and count reconciliation
2 issues (1 error, 1 warning) still open:

- 🚨 `src/proposal.js:808` - The new reconciliation formula assumes every accepted edit consumes exactly one sent candidate unless extra instruction IDs prove consolidation. That invariant is not enforced. For example, one negative candidate plus a valid rewrite whose optional `instructions` array is empty produces sent=1, leftAlone=1, combined=0, and edits proposed=1, so 1 - 1 != 1. Two accepted rewrites naming the same candidate similarly produce sent=1 and proposed=2. Positive-only extraction and overlap-driven edits can even produce edits when sent=0 because `instructionsWithNegatives` excludes their source. The required one-band progression therefore remains incorrect for reachable proposals. Correcting this requires an authorized attribution/unit policy rather than further inference; revert the fix-round reconciliation machinery to the minimal approach and ask the user whether the final band should count edits or candidate outcomes.
- ⚠️ `templates/apply.html:951` - When the edit cap exceeds the findings scale, the cap tick is clamped to 100%, falsely placing it at the findings total. For example, one finding with a cap of 5 renders the tick at the same position as 1/1 while labeling the row `of 5`. The approved cap indicator needs an explicit presentation rule for an off-scale cap, such as hiding it or representing it outside the track; that product choice needs user authorization.

🔧 Fix: Clarify funnel units and hide off-scale cap
1 warning still open:

- ⚠️ `templates/apply.html:997` - The drop reason always says the mistake must appear in &#34;another project,&#34; but `minGapProjects` is configurable above 2. For example, a gap seen in one project with `minGapProjects: 3` remains ineligible after appearing in one additional project, so the funnel understates the actual gate. Preserve the approved wording for a floor of 2, but report the configured total requirement for other floors.

🔧 Fix: Correct project-floor funnel wording
2 warnings still open:

- ⚠️ `templates/apply.html:981` - In user scope, `checkProjectCoverage` excludes locally covered sightings from `cluster.sessions`, but those sightings remain in `gapSightings` and their cluster is included in `droppedGapSingletons`. A gap reported by two sessions, one locally covered and one uncovered, therefore renders as &#34;seen only once: a second session has to confirm them&#34; even though it was seen twice; a fully covered cluster can render the same message with zero qualifying sessions. Correctly explaining this needs a distinct display reason or authorized wording, so the presentation change requires user approval.
- ⚠️ `src/proposal.js:793` - `leftAloneMaxSessions` cannot establish that every untouched candidate was ignored in exactly one session. For example, candidates with `nonComplianceSessions` values 0 and 1 reduce to 1, causing the template to say both were &#34;ignored in only 1 session each&#34; even though one has no non-compliance session at all. The proposal needs an explicit all-candidates condition, or an authorized reinterpretation of this serialized display field; adding that display fact requires user approval.

🔧 Fix: Clarify corroboration and left-alone funnel copy
2 warnings still open:

- ⚠️ `src/proposal.js:784` - The funnel treats `edit.instructions` as authoritative, but annotation does not require or validate those IDs. A rewrite of negatively cited AG-001 with `instructions: []` is accepted, then AG-001 is counted as untouched and rendered as &#34;the model chose not to edit&#34;. The same sequence for a suppressed rewrite also violates the settled requirement that suppressed edits not receive that label. Because adding an attribution gate would violate the presentation-only constraint, authorize weaker copy such as &#34;no accepted edit named these candidates&#34; or another presentation-only remedy.
- ⚠️ `src/proposal.js:758` - The intent requires all new counters to be null for summaries saved before they existed, but `funnelInstructionOutcome` returns numeric left-alone and suppression values whenever an old summary has its normal `instructions` array, even when `instructionsWithNegatives` and `reportOnlyByReason` are absent. Thus a legacy summary can serialize invented new stats rather than null. Gate this derivation on the new summary counters being present; the current legacy test misses the reachable case by omitting `instructions` entirely.

🔧 Fix: Correct legacy counters and attribution wording
✅ Re-checked - no issues remain.

- ⚠️ `templates/apply.html:947` - The required &#34;ONE scale (findings = 100%)&#34; breaks when a later row exceeds the finding count. This is reachable because multiple move/extract edits may reuse one finding while remaining exempt from the session floor. For example, 1 finding and 2 proposed moves assigns the final lane `width: 200%`, but the fill&#39;s default `flex-shrink: 1` compresses it to the track&#39;s 100% width, making 200% visually indistinguishable from 100%. The real-template test observes only the inline percentage and misses the computed layout. Please authorize how above-scale rows should render, since preserving the scale without overflow or distortion is a presentation decision.

🔧 Fix: Mark and clamp over-scale funnel bars
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-name-pattern='the fold counts the funnel|proposal carries the fold|funnel.s left-alone|funnel.s display counters|apply surface draws one funnel|proposal saved before the funnel' test/fold.test.js test/proposal.test.js`
- <code>Generated a realistic apply proposal through `injectPayload` and the real `templates/apply.html`, then rendered it in Chrome.</code>
- `Captured the apply surface at 1280x900 and an emulated 420x900 mobile viewport.`
- `Checked browser layout dimensions: no horizontal overflow at either viewport, and all funnel row labels remained untruncated at 420px.`

✅ No issues found.
- `node --test --test-name-pattern='fold counts the funnel|proposal carries the fold|funnel.s left-alone|display counters never change|apply surface draws one funnel|proposal saved before the funnel' test/fold.test.js test/proposal.test.js`
- <code>Generated rendered apply surfaces with the exported `injectPayload` function and the real `templates/apply.html`.</code>
- <code>Used `chrome-devtools-axi` at 1280px and 420px to inspect and capture the normal funnel and the 1-finding/2-edit over-scale case.</code>
- `Verified computed lane widths, visible over-scale markers, no horizontal overflow, readable narrow labels, and an empty browser console.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
