### PR TITLE
fix: count only fold-issued sources toward session floors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,13 +150,17 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
 - **One session floor covers the whole always-loaded surface.** Every edit whose kind is
   not `extract` or `move` must quote `minGapEvidence` distinct sessions - add, rewrite and
   remove alike. `buildProposal` discards empty quote text, then counts canonical non-empty
-  source labels from the edit's own `evidence`; the model's `transcripts` field is not read.
-  Sourceless quotes remain visible as `unknown source` but do not count. There is no shape
-  predicate separating an additive rewrite from a tightening, so a one-session tightening
-  is refused too. Never reintroduce a lexical-overlap, token-growth, or other text classifier
-  here. In user scope the same edits also clear `minGapProjects`, counted by
-  `countedEvidenceProjects` from cited gap clusters and from `summary.sourceProjects`, the
-  fold's source -> project map that lets instruction-row evidence answer for a rewrite.
+  source labels from the edit's own `evidence` that also appear in `summary.sources`
+  (the labels this run's fold issued; `src/fold.js`). The model's `transcripts` field is
+  not read. A misspelled or date-shifted label is not a second session. Sourceless quotes
+  remain visible as `unknown source` but do not count. There is no shape predicate
+  separating an additive rewrite from a tightening, so a one-session tightening is
+  refused too. Never reintroduce a lexical-overlap, token-growth, or other text classifier
+  here. In user scope the same edits also clear `minGapProjects` (unchanged default),
+  counted by `countedEvidenceProjects` from cited gap clusters and from
+  `summary.sourceProjects`, the fold's source -> project map that lets instruction-row
+  evidence answer for a rewrite. `sourceProjects` is empty without a project;
+  `summary.sources` is the allowlist for both scopes.
 - **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other
   values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each

--- a/README.md
+++ b/README.md
@@ -317,7 +317,9 @@ Then mechanical gates run, and they are not negotiable:
   is a violation, so is an edit that names no change
 - every edit that changes the always-loaded surface - adding, rewriting or removing text -
   needs quotes from `minGapEvidence` distinct sessions. The count is measured from the
-  edit's own quote sources; a session count the model reports is ignored. Rewrites are not
+  edit's own quote sources, and only source labels issued by this run's fold count. A
+  mistyped or invented label does not create another session, and a session count the model
+  reports is ignored. Rewrites are not
   classified by shape: a one-session tightening is refused along with a one-session
   append, because deciding which is which is a question about meaning that a line diff
   cannot answer. `extract` and `move` are exempt - they keep every always-loaded line.

--- a/src/fold.js
+++ b/src/fold.js
@@ -152,6 +152,10 @@ export function foldEvidence(
   // when a majority of its sightings vote orchestration. Mixed clusters stay visible
   // so one inconsistent classifier call cannot drop a real recurrence below the floor.
   const allObservations = gapObservations ?? recordObservations;
+  for (const observation of allObservations) {
+    const source = normalizeSourceLabel(observation?.source);
+    if (source) sources.add(source);
+  }
   const orchestrationGapSightings = allObservations.filter((obs) => obs?.domain === "orchestration").length;
 
   const gapClusters = clusterGapObservations(allObservations, { checkProjectCoverage });

--- a/src/fold.js
+++ b/src/fold.js
@@ -87,11 +87,14 @@ export function foldEvidence(
   const recordObservations = [];
   // Which project each quote's source label came from. Instruction-row quotes carry no
   // project of their own, so this is what lets the user-scope project floor count a
-  // rewrite's evidence instead of only a gap cluster's.
+  // rewrite's evidence instead of only a gap cluster's. `sources` is the same labels
+  // without the project requirement, so a project-scoped run still has an allowlist.
+  const sources = new Set();
   const sourceProjects = {};
   for (const record of usable) {
     if (record.usedRawTranscript) usedRawCount += 1;
     const source = normalizeSourceLabel(gapSource(record.transcript));
+    sources.add(source);
     if (record.transcript.project) sourceProjects[source] = record.transcript.project;
 
     for (const polarity of ["positive", "negative"]) {
@@ -268,6 +271,7 @@ export function foldEvidence(
       crossSurfaceDuplicates: duplicates.length,
     },
     instructions: instructionRows,
+    sources: [...sources],
     sourceProjects,
     parentHarmSessions,
     gaps,

--- a/src/prompts/annotate.md
+++ b/src/prompts/annotate.md
@@ -37,9 +37,9 @@ Hard rules - a violation fails the whole proposal:
 2. **At most {{MAX_EDITS}} edits** - the learning rate. Regroup or revert if you are over.
 3. **Every edit carries at least one verbatim quote in `evidence`**, with its source.
 4. **Every `add`, `rewrite` and `remove` - of {{MEMORY_PATH}} or of a skill file - carries
-   quotes from at least {{MIN_GAP_EVIDENCE}} distinct sessions.** Backpass counts the
-   distinct `source` values in your `evidence`; do not report a count of your own, it is
-   not read. This covers
+   quotes from at least {{MIN_GAP_EVIDENCE}} distinct sessions.** Backpass counts distinct
+   `source` values in your `evidence` only when they match source labels issued by this
+   run's fold; do not report a count of your own, it is not read. This covers
    rewrites of every shape, a tightening included - one session is not enough to change
    text that loads on every future run. `extract` and `move` are exempt, because they keep
    every line. If you have only one session for a change, revert it in the file, or cite a

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -102,7 +102,7 @@ export class ProposalViolation extends Error {
   }
 }
 
-function normalizeEdit(raw, index) {
+function normalizeEdit(raw, index, knownSources = null) {
   const kind = String(raw?.kind || "").toLowerCase();
   const refs = Array.isArray(raw?.changes) ? raw.changes : Array.isArray(raw?.hunks) ? raw.hunks : [];
   const normalizedEvidence = normalizeEvidence(raw?.evidence);
@@ -119,8 +119,9 @@ function normalizeEdit(raw, index) {
     instructions: Array.isArray(raw?.instructions) ? raw.instructions.map(String) : [],
     evidence,
     // Corroboration is measured from the edit's normalized quotes, never from a
-    // model-reported count.
-    transcripts: countSources(normalizedEvidence),
+    // model-reported count. When the fold handed over this run's source labels,
+    // only those labels count - a typed-but-never-issued source is not a session.
+    transcripts: countSources(normalizedEvidence, knownSources),
   };
 }
 
@@ -135,9 +136,11 @@ function normalizeEvidence(evidence) {
     }));
 }
 
-function countSources(evidence) {
+function countSources(evidence, known = null) {
   if (!Array.isArray(evidence)) return 0;
-  return new Set(evidence.map((e) => normalizeSourceLabel(e?.source)).filter(Boolean)).size;
+  const labels = new Set(evidence.map((e) => normalizeSourceLabel(e?.source)).filter(Boolean));
+  if (!known) return labels.size;
+  return [...labels].filter((label) => known.has(label)).length;
 }
 
 /** The del-line texts of a hunk that are not carried by `lineCounts` (blank lines ignored). */
@@ -334,7 +337,10 @@ export function buildProposal(rawResult, context) {
   const violations = [];
   const notes = Array.isArray(rawResult?.notes) ? rawResult.notes.map(String) : [];
   const rawEdits = Array.isArray(rawResult?.edits) ? rawResult.edits : [];
-  const edits = rawEdits.map((raw, i) => normalizeEdit(raw, i));
+  const knownSources = Array.isArray(summary?.sources)
+    ? new Set(summary.sources.map(normalizeSourceLabel).filter(Boolean))
+    : null;
+  const edits = rawEdits.map((raw, i) => normalizeEdit(raw, i, knownSources));
   const changesById = new Map(measured.changes.map((c) => [c.id, c]));
 
   // Skill description lines are always loaded, so they sit under the same cap as the

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -108,10 +108,11 @@ function fakeSynthesize(captured) {
             changes: ["H1"],
             kind: "rewrite",
             title: "record the migration trap",
-            evidence: [
-              { polarity: "negative", text: "applied the migration to prod-db", source: "claude · s1" },
-              { polarity: "negative", text: "applied the migration to prod-db", source: "claude · s2" },
-            ],
+            evidence: summary.gaps[0].quotes.map((quote) => ({
+              polarity: "negative",
+              text: quote.text,
+              source: quote.source,
+            })),
             transcripts: 2,
           },
         ],

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -41,6 +41,35 @@ test("evidence is grouped per instruction with session-level relevance", () => {
   assert.equal(row.relevance, 0.5);
 });
 
+test("fold lists every analyzed session source even when the record has no project", () => {
+  const quoted = record("alpha1", { positive: [{ instruction: "AG-001", quote: "q1" }] });
+  const silent = record("beta2", {});
+  const otherProject = record("gamma3", {
+    transcript: {
+      id: "gamma3",
+      harness: "codex",
+      project: "wheelhouse",
+      startedAt: Date.parse("2026-08-02T00:00:00Z"),
+    },
+    negative: [{ instruction: "AG-001", quote: "q2", class: "non-compliance" }],
+  });
+  const summary = foldEvidence([quoted, silent, otherProject], { memoryFile });
+
+  assert.equal(summary.sources.length, 3, "every usable record issues a source, including one with no quotes");
+  assert.equal(summary.sourceProjects[summary.sources.find((label) => label.startsWith("codex"))], "wheelhouse");
+  assert.equal(
+    Object.keys(summary.sourceProjects).length,
+    1,
+    "project-less records must not be dropped from sources just because sourceProjects is empty for them",
+  );
+  const instructionQuoteSources = summary.instructions
+    .flatMap((row) => row.quotes.map((quote) => quote.source))
+    .filter(Boolean);
+  for (const source of instructionQuoteSources) {
+    assert.ok(summary.sources.includes(source), `fold-issued quote source missing from sources: ${source}`);
+  }
+});
+
 test("instructions with no evidence still appear - they are the removal candidates", () => {
   const summary = foldEvidence([record("s1", { positive: [{ instruction: "AG-001", quote: "q" }] })], { memoryFile });
 

--- a/test/gap-ledger.test.js
+++ b/test/gap-ledger.test.js
@@ -96,6 +96,23 @@ test("a gap seen once now and once on a later run accumulates to two sessions an
   assert.deepEqual(second.gaps[0].quotes.map((q) => q.text).sort(), ["quote from claude-s1", "quote from claude-s2"]);
 });
 
+test("persisted selected gap sources remain fold-issued without fresh evidence", async () => {
+  const h = harness();
+  const old = record("claude-s1", [GAP]);
+  await run(h, [old]);
+
+  const fresh = record("claude-s2", [GAP_REPHRASED], { memoryHash: "h2" });
+  h.state.writeEvidence(fresh.transcript.id, fresh);
+  const summary = await foldForRun(h.ctx, memoryFile(), "h2", [], [old.transcript, fresh.transcript]);
+
+  assert.equal(summary.analyzedSessions, 1, "the stale evidence record stays excluded");
+  assert.equal(summary.gaps.length, 1, "its selected ledger observation still corroborates the gap");
+  assert.equal(summary.gaps[0].sessions, 2);
+  for (const quote of summary.gaps[0].quotes) {
+    assert.ok(summary.sources.includes(quote.source), `fold-issued gap source missing from allowlist: ${quote.source}`);
+  }
+});
+
 test("the same session is never double-counted across runs", async () => {
   const h = harness();
   await run(h, [record("claude-s1", [GAP])]);

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -502,6 +502,176 @@ test("the dry run's three appends still pass on their real quote-source counts",
   }
 });
 
+test("a quote counts as a session only when the fold issued its source label", () => {
+  const foldRecord = (id, day, quote) => ({
+    status: "ok",
+    transcript: { id, harness: "claude", startedAt: Date.parse(`2026-08-${day}T00:00:00Z`) },
+    positive: [],
+    negative: [{ instruction: "AG-001", quote, effect: "the rule was skipped", class: "non-compliance" }],
+    gaps: [],
+  });
+  const summary = foldEvidence(
+    [foldRecord("b859b8f3deadbeef", "18", "real quote"), foldRecord("c0ffee00deadbeef", "19", "other quote")],
+    { memoryFile: { units: parseMemoryUnits(MEMORY_TEXT) }, minGapEvidence: 2 },
+  );
+  const issued = summary.sources.find((label) => label.includes("b859b8f3"));
+  assert.ok(issued, "the fold must issue a source for the cited session");
+  const mistypedDate = issued.replace("2026-08-18", "2026-08-17");
+  assert.notEqual(mistypedDate, issued);
+  assert.equal(summary.sources.includes(mistypedDate), false);
+
+  const rewrite = memoryEdit(REWRITE_SHAPES["append a sentence"]);
+  const typo = gate({
+    edit: rewrite,
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "rewrite",
+          title: "one session under two labels",
+          evidence: [
+            { polarity: "negative", text: "real quote", source: issued },
+            { polarity: "negative", text: "same session, wrong date", source: mistypedDate },
+          ],
+        }),
+      ],
+    },
+    context: { summary },
+  });
+  assert.equal(typo.proposal.edits.length, 0);
+  assert.ok(
+    typo.violations.some((v) => /backed by 1 session\(s\); 2 are required/.test(v)),
+    typo.violations.join("\n"),
+  );
+
+  const twoIssued = gate({
+    edit: rewrite,
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "rewrite",
+          title: "two fold-issued sessions",
+          evidence: summary.sources.map((source, i) => ({
+            polarity: "negative",
+            text: `quote ${i}`,
+            source,
+          })),
+        }),
+      ],
+    },
+    context: { summary },
+  });
+  assert.deepEqual(twoIssued.violations, [], twoIssued.violations.join("\n"));
+  assert.equal(twoIssued.proposal.edits[0].transcripts, 2);
+
+  const unissued = gate({
+    edit: rewrite,
+    annotation: {
+      edits: [claim(["H1"], { kind: "rewrite", title: "label the fold never issued", evidence: ONE_SESSION })],
+    },
+    context: { summary },
+  });
+  assert.equal(unissued.proposal.edits.length, 0);
+  assert.ok(
+    unissued.violations.some((v) => /backed by 0 session\(s\); 2 are required/.test(v)),
+    unissued.violations.join("\n"),
+  );
+});
+
+test("on the r1 dry-run corpus, only the edit whose second source was never issued is refused", () => {
+  const foldRecord = (id, day, quote) => ({
+    status: "ok",
+    transcript: { id, harness: "claude", startedAt: Date.parse(`2026-08-${day}T00:00:00Z`) },
+    positive: [],
+    negative: [{ instruction: "AG-001", quote, effect: "the rule was skipped", class: "non-compliance" }],
+    gaps: [],
+  });
+  const summary = foldEvidence(
+    [
+      foldRecord("sess0001", "01", "e1a"),
+      foldRecord("sess0002", "02", "e1b"),
+      foldRecord("sess0003", "03", "e1c"),
+      foldRecord("sess0004", "04", "e4b"),
+    ],
+    { memoryFile: { units: parseMemoryUnits(MEMORY_TEXT) }, minGapEvidence: 2 },
+  );
+  const [s1, s2, s3, s4] = summary.sources;
+  const phantom = s1.replace(/2026-08-01/, "2026-08-17");
+  assert.equal(summary.sources.includes(phantom), false);
+
+  const cases = [
+    {
+      name: "e1 em dash",
+      expect: "pass",
+      kind: "rewrite",
+      sources: [s1, s2, s3],
+      edit: (t) =>
+        t.replace(
+          "include its URL.",
+          "include its URL. Before sending prose, check for and replace every bare reference.",
+        ),
+    },
+    {
+      name: "e2 repro before fix",
+      expect: "pass",
+      kind: "rewrite",
+      sources: [s1, s2],
+      edit: (t) =>
+        t.replace(
+          "- Prefer small commits.",
+          "- Prefer small commits. Reproduce before implementing the fix, then repeat the same check after.",
+        ),
+    },
+    {
+      name: "e3 lint warnings",
+      expect: "refuse",
+      kind: "rewrite",
+      sources: [s1, phantom],
+      edit: (t) =>
+        t.replace(
+          "before running any script.",
+          "before running any script. Treat warnings as issues rather than dismissing them.",
+        ),
+    },
+    {
+      name: "e4 current_head skill",
+      expect: "pass",
+      kind: "add",
+      sources: [s2, s4],
+      edit: (t) =>
+        t.replace(
+          "- Prefer small commits.",
+          "- Prefer small commits.\n- Prefer the current branch head when naming git state.",
+        ),
+    },
+  ];
+
+  for (const item of cases) {
+    const evidence = item.sources.map((source, i) => ({
+      polarity: "negative",
+      text: `${item.name} quote ${i}`,
+      source,
+    }));
+    const { proposal, violations } = gate({
+      edit: memoryEdit(item.edit),
+      annotation: {
+        edits: [claim(["H1"], { kind: item.kind, title: item.name, evidence, transcripts: 20 })],
+      },
+      context: { summary },
+    });
+    if (item.expect === "pass") {
+      assert.deepEqual(violations, [], `${item.name}: ${violations.join("\n")}`);
+      assert.equal(proposal.edits.length, 1, item.name);
+      assert.equal(proposal.edits[0].transcripts, item.sources.length, item.name);
+    } else {
+      assert.equal(proposal.edits.length, 0, `${item.name} was accepted`);
+      assert.ok(
+        violations.some((v) => /backed by 1 session\(s\); 2 are required/.test(v)),
+        `${item.name}: ${violations.join("\n")}`,
+      );
+    }
+  }
+});
+
 test("extract and move stay exempt from the session floor: they keep every always-loaded line", () => {
   const extracted = "- Use Node 18 via nvm before running any script.";
   const extract = gate({
@@ -575,12 +745,26 @@ test("the user-scope project floor counts instruction evidence, not only gap quo
   assert.deepEqual(twoProjects.violations, [], twoProjects.violations.join("\n"));
   assert.equal(twoProjects.proposal.edits[0].projects, 2);
 
-  // Same evidence in a project-scoped run: no project gate at all.
+  // Same evidence in a project-scoped run: no project gate at all. Quote the fold's
+  // own labels; a project-scoped fold still issues `sources` even when sourceProjects is empty.
+  const projectSummary = foldFor(["repo-a", "repo-a"]);
   const projectScope = gate({
     edit: rewrite,
-    annotation: { edits: [claim(["H1"], { kind: "rewrite", title: "spell out the URL" })] },
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "rewrite",
+          title: "spell out the URL",
+          evidence: projectSummary.instructions[0].quotes.map((quote) => ({
+            polarity: "negative",
+            text: quote.text,
+            source: quote.source,
+          })),
+        }),
+      ],
+    },
     config: config({ minGapProjects: 2 }),
-    context: { summary: foldFor(["repo-a", "repo-a"]), scope: { kind: "project" } },
+    context: { summary: projectSummary, scope: { kind: "project" } },
   });
   assert.deepEqual(projectScope.violations, [], projectScope.violations.join("\n"));
 });
@@ -2516,7 +2700,19 @@ test("sentence-level harm clears removal of its oversized parent paragraph", () 
   const result = gate({
     text,
     edit: memoryEdit((current) => current.replace(`${blob}\n\n`, "")),
-    annotation: { edits: [claim(["H1"], { kind: "remove", title: "remove the harmful paragraph" })] },
+    annotation: {
+      edits: [
+        claim(["H1"], {
+          kind: "remove",
+          title: "remove the harmful paragraph",
+          evidence: summary.sources.map((source, i) => ({
+            polarity: "negative",
+            text: `harm quote ${i}`,
+            source,
+          })),
+        }),
+      ],
+    },
     context: { summary },
   });
   assert.deepEqual(result.violations, []);

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -497,12 +497,12 @@ test("an oversized non-compliance blob synthesizes as a list-item restructure, n
                   {
                     polarity: "negative",
                     text: "skipped the second sentence of the blob entirely here",
-                    source: "claude · s1 · turn 4",
+                    source: summary.sources[0],
                   },
                   {
                     polarity: "negative",
                     text: "the same blob's second sentence was skipped again",
-                    source: "codex · s2 · turn 9",
+                    source: summary.sources[1],
                   },
                 ],
                 instructions: ["AG-001.2"],


### PR DESCRIPTION
## Intent

Captain chose A: a quote counts as a session only when its source label is one the fold actually issued this run.

Ship that identity check. Do not read quote text and do not add a classifier.

The fold should expose summary.sources so project-scope runs are covered too, not only sourceProjects which is empty without a project. countSources counts only labels in that set.

Acceptance:
- Every current valid session-floor refusal stays a refusal.
- The label-typo bypass is refused: one real session quoted under two labels, one with a wrong date, counts as 1 session.
- On the r1 corpus, e3 is refused because its second source was not a fold-issued label; e1, e2, and e4 still pass.
- Tests pin the identity check through the public proposal path, not by matching source text.
- No change to minGapProjects. That default stays 1 until the captain rules separately.

Implementation is an identity check against this run's fold-issued labels (not a lexical or quote-text classifier). A missing summary.sources keeps the previous count (legacy summaries). Pass known sources into normalizeEdit rather than a module-level mutable.

## What Changed

- Expose normalized source labels from analyzed sessions and selected gap-ledger observations in fold summaries.
- Count only fold-issued labels toward proposal session floors, preventing mistyped or invented labels from inflating corroboration.
- Preserve legacy behavior when summaries do not include a source allowlist.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves legacy-summary behavior, and correctly includes both fresh evidence and selected persisted gap sources in the per-run source allowlist.

## Testing

Inspected the target diff, ran focused fold, ledger, and public proposal-path tests, then generated reviewer-visible JSON from an end-to-end r1 corpus scenario. Existing refusal cases remained refused, e1/e2/e4 passed, and e3 was refused because its mistyped second label was not fold-issued; the worktree remained clean.

<details>
<summary>Evidence: End-to-end fold source allowlist and r1 proposal decisions</summary>

Source: [End-to-end fold source allowlist and r1 proposal decisions](https://github.com/kunchenguid/backpass/blob/b5dcd17579be1dfcc39938233011719c89ec516c/.no-mistakes/evidence/fm/backpass-source-allowlist-r1/source-allowlist-e2e.json)

```text
{
  "foldIssuedSourceCount": 4,
  "minGapProjects": 1,
  "outcomes": [
    {
      "edit": "e1",
      "decision": "accepted",
      "countedSessions": 3,
      "sourcesIssuedByFold": [
        true,
        true,
        true
      ],
      "violation": null
    },
    {
      "edit": "e2",
      "decision": "accepted",
      "countedSessions": 2,
      "sourcesIssuedByFold": [
        true,
        true
      ],
      "violation": null
    },
    {
      "edit": "e3",
      "decision": "refused",
      "countedSessions": 1,
      "sourcesIssuedByFold": [
        true,
        false
      ],
      "violation": "edit e1 (\"e3\") changes AGENTS.md backed by 1 session(s); 2 are required"
    },
    {
      "edit": "e4",
      "decision": "accepted",
      "countedSessions": 2,
      "sourcesIssuedByFold": [
        true,
        true
      ],
      "violation": null
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"95f47f6d6bf364a213744fa6bf9bd44db7dc83bf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/fold.js:97` - Intent requires that a quote count when its label was &#34;fold actually issued this run,&#34; but `sources` includes only current `usable` evidence records and omits persisted `gapObservations`. Reachable sequence: T1 and T2 previously corroborate a ledger gap; on a later selected run T1 lacks fresh evidence while T2 remains fresh; `foldForRun` still supplies both selected ledger observations, so synthesis displays a two-session eligible gap and both source labels, but `summary.sources` contains only T2. An edit citing both displayed quotes is incorrectly measured as one session and refused. Populate the allowlist at the fold boundary from source labels in the effective observations as well as usable records.

🔧 Fix: Include persisted gap sources in fold allowlist
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff aa714d1d5debe9b1ea39818245411a2563eac3de..54acae4600daae0e006abdff0fc92b454daa19d9 -- src/fold.js src/proposal.js test`
- `node --test --test-name-pattern='quote counts as a session only|r1 dry-run corpus|user-scope project floor|every current valid|lists every analyzed session source|persisted selected gap sources' test/proposal.test.js test/fold.test.js test/gap-ledger.test.js`
- `node --test --test-name-pattern='too few sessions|single-session rewrite|empty evidence|sourceless evidence|source-label whitespace|spread over two hunks|two quoted sessions|dry run.s three appends|quote counts as a session|r1 dry-run corpus|extract and move stay exempt|user-scope project floor' test/proposal.test.js`
- <code>Executed a focused end-to-end Node scenario through `foldEvidence` and `buildProposal`, recording decisions for r1 edits e1-e4 and the unchanged `minGapProjects: 1` setting.</code>
- <code>`git status --short` confirmed testing left the worktree clean.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
