### PR TITLE
fix: preserve stable evidence session identities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,15 +151,19 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   not `extract` or `move` must quote `minGapEvidence` distinct sessions - add, rewrite and
   remove alike. `buildProposal` discards empty quote text, then counts canonical non-empty
   source labels from the edit's own `evidence` that also appear in `summary.sources`
-  (the labels this run's fold issued; `src/fold.js`). The model's `transcripts` field is
-  not read. A misspelled or date-shifted label is not a second session. Sourceless quotes
+  (the labels this run's fold issued; `gapSource` / `disambiguateSourceLabels` in
+  `src/gap-ledger.js`, folded in `src/fold.js`). Labels carry the untruncated native
+  session id, not an 8-character prefix: Codex ULIDs are time-prefixed, so same-minute
+  sessions collide at 8 characters and would over-refuse a valid two-session rewrite.
+  The model's `transcripts` field is not read. A misspelled or date-shifted label is not a second session. Sourceless quotes
   remain visible as `unknown source` but do not count. There is no shape predicate
   separating an additive rewrite from a tightening, so a one-session tightening is
   refused too. Never reintroduce a lexical-overlap, token-growth, or other text classifier
   here. In user scope the same edits also clear `minGapProjects` (unchanged default),
   counted by `countedEvidenceProjects` from cited gap clusters and from
   `summary.sourceProjects`, the fold's source -> project map that lets instruction-row
-  evidence answer for a rewrite. `sourceProjects` is empty without a project;
+  evidence answer for a rewrite. That map is keyed by the same unique labels, never
+  last-write-wins on a colliding truncated id. `sourceProjects` is empty without a project;
   `summary.sources` is the allowlist for both scopes.
 - **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,18 +152,17 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   remove alike. `buildProposal` discards empty quote text, then counts canonical non-empty
   source labels from the edit's own `evidence` that also appear in `summary.sources`
   (the labels this run's fold issued; `gapSource` / `disambiguateSourceLabels` in
-  `src/gap-ledger.js`, folded in `src/fold.js`). Labels carry the untruncated native
-  session id, not an 8-character prefix: Codex ULIDs are time-prefixed, so same-minute
-  sessions collide at 8 characters and would over-refuse a valid two-session rewrite.
-  The model's `transcripts` field is not read. A misspelled or date-shifted label is not a second session. Sourceless quotes
+  `src/gap-ledger.js`, folded in `src/fold.js`). Labels must remain one-to-one with
+  canonical sessions; `test/proposal.test.js` covers the evidence-floor contract. The
+  model's `transcripts` field is not read. A misspelled or date-shifted label is not a second session. Sourceless quotes
   remain visible as `unknown source` but do not count. There is no shape predicate
   separating an additive rewrite from a tightening, so a one-session tightening is
   refused too. Never reintroduce a lexical-overlap, token-growth, or other text classifier
   here. In user scope the same edits also clear `minGapProjects` (unchanged default),
   counted by `countedEvidenceProjects` from cited gap clusters and from
   `summary.sourceProjects`, the fold's source -> project map that lets instruction-row
-  evidence answer for a rewrite. That map is keyed by the same unique labels, never
-  last-write-wins on a colliding truncated id. `sourceProjects` is empty without a project;
+  evidence answer for a rewrite. Keep that map keyed by the same unique labels.
+  `sourceProjects` is empty without a project;
   `summary.sources` is the allowlist for both scopes.
 - **Negative evidence has a sign the pipeline must not lose.** Analysis classifies every
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other

--- a/src/fold.js
+++ b/src/fold.js
@@ -3,7 +3,13 @@ import fs from "node:fs";
 import { loadConfig } from "./config.js";
 import { classifyInteraction, INTERACTIVE, NON_INTERACTIVE } from "./interaction.js";
 import { findInstructionUnit, instructionUnits, resolveMemoryFiles, similarity } from "./memory.js";
-import { GAP_COVERED_THRESHOLD, GAP_SIMILARITY_THRESHOLD, gapSource, normalizeSourceLabel } from "./gap-ledger.js";
+import {
+  GAP_COVERED_THRESHOLD,
+  GAP_SIMILARITY_THRESHOLD,
+  disambiguateSourceLabels,
+  gapSource,
+  normalizeSourceLabel,
+} from "./gap-ledger.js";
 import { crossSurfaceDuplicates } from "./overlap.js";
 
 /**
@@ -91,9 +97,15 @@ export function foldEvidence(
   // without the project requirement, so a project-scoped run still has an allowlist.
   const sources = new Set();
   const sourceProjects = {};
-  for (const record of usable) {
+  const recordSources = disambiguateSourceLabels(
+    usable.map((record) => ({
+      source: gapSource(record.transcript),
+      identity: record.transcript.identity || record.transcript.id,
+    })),
+  );
+  for (const [index, record] of usable.entries()) {
     if (record.usedRawTranscript) usedRawCount += 1;
-    const source = normalizeSourceLabel(gapSource(record.transcript));
+    const source = recordSources[index];
     sources.add(source);
     if (record.transcript.project) sourceProjects[source] = record.transcript.project;
 
@@ -152,13 +164,14 @@ export function foldEvidence(
   // when a majority of its sightings vote orchestration. Mixed clusters stay visible
   // so one inconsistent classifier call cannot drop a real recurrence below the floor.
   const allObservations = gapObservations ?? recordObservations;
-  for (const observation of allObservations) {
+  const labeledObservations = labelObservationSources(allObservations);
+  for (const observation of labeledObservations) {
     const source = normalizeSourceLabel(observation?.source);
     if (source) sources.add(source);
   }
-  const orchestrationGapSightings = allObservations.filter((obs) => obs?.domain === "orchestration").length;
+  const orchestrationGapSightings = labeledObservations.filter((obs) => obs?.domain === "orchestration").length;
 
-  const gapClusters = clusterGapObservations(allObservations, { checkProjectCoverage });
+  const gapClusters = clusterGapObservations(labeledObservations, { checkProjectCoverage });
 
   // Instructions that exist in the file but drew no evidence at all are the strongest
   // removal / extraction candidates, so they must appear in the summary too.
@@ -317,6 +330,19 @@ function oversizedRestructureTargets(memoryFile, nonComplianceSessions, minGapEv
     });
   }
   return targets;
+}
+
+function labelObservationSources(observations) {
+  const labels = disambiguateSourceLabels(
+    observations.map((observation) => ({
+      source: observation?.source,
+      identity: observation?.sessionId,
+    })),
+  );
+  return observations.map((observation, index) => ({
+    ...observation,
+    source: labels[index] || observation?.source,
+  }));
 }
 
 /**

--- a/src/fold.js
+++ b/src/fold.js
@@ -97,12 +97,19 @@ export function foldEvidence(
   // without the project requirement, so a project-scoped run still has an allowlist.
   const sources = new Set();
   const sourceProjects = {};
-  const recordSources = disambiguateSourceLabels(
-    usable.map((record) => ({
+  const persistedObservations = gapObservations ?? [];
+  const issuedSources = disambiguateSourceLabels([
+    ...usable.map((record) => ({
       source: gapSource(record.transcript),
       identity: record.transcript.identity || record.transcript.id,
     })),
-  );
+    ...persistedObservations.map((observation) => ({
+      source: observation?.source,
+      identity: observation?.sessionId,
+    })),
+  ]);
+  const recordSources = issuedSources.slice(0, usable.length);
+  const observationSources = issuedSources.slice(usable.length);
   for (const [index, record] of usable.entries()) {
     if (record.usedRawTranscript) usedRawCount += 1;
     const source = recordSources[index];
@@ -163,11 +170,18 @@ export function foldEvidence(
   // with project sightings of the same gap; a cluster is withheld from proposals only
   // when a majority of its sightings vote orchestration. Mixed clusters stay visible
   // so one inconsistent classifier call cannot drop a real recurrence below the floor.
-  const allObservations = gapObservations ?? recordObservations;
-  const labeledObservations = labelObservationSources(allObservations);
+  const labeledObservations = gapObservations
+    ? persistedObservations.map((observation, index) => ({
+        ...observation,
+        source: observationSources[index] || observation?.source,
+      }))
+    : recordObservations;
+  const allObservations = labeledObservations;
   for (const observation of labeledObservations) {
     const source = normalizeSourceLabel(observation?.source);
-    if (source) sources.add(source);
+    if (!source) continue;
+    sources.add(source);
+    if (observation.project && !sourceProjects[source]) sourceProjects[source] = observation.project;
   }
   const orchestrationGapSightings = labeledObservations.filter((obs) => obs?.domain === "orchestration").length;
 
@@ -330,19 +344,6 @@ function oversizedRestructureTargets(memoryFile, nonComplianceSessions, minGapEv
     });
   }
   return targets;
-}
-
-function labelObservationSources(observations) {
-  const labels = disambiguateSourceLabels(
-    observations.map((observation) => ({
-      source: observation?.source,
-      identity: observation?.sessionId,
-    })),
-  );
-  return observations.map((observation, index) => ({
-    ...observation,
-    source: labels[index] || observation?.source,
-  }));
 }
 
 /**

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -95,17 +95,27 @@ export function normalizeSourceLabel(source) {
  * @returns {string[]}
  */
 export function disambiguateSourceLabels(entries) {
-  const identitiesBySource = new Map();
   const normalized = (Array.isArray(entries) ? entries : []).map((entry) => ({
     source: normalizeSourceLabel(entry?.source),
     identity: String(entry?.identity || "").trim(),
   }));
+  const sourceByIdentity = new Map();
   for (const entry of normalized) {
+    if (entry.identity && entry.source && !sourceByIdentity.has(entry.identity)) {
+      sourceByIdentity.set(entry.identity, entry.source);
+    }
+  }
+  const canonical = normalized.map((entry) => ({
+    ...entry,
+    source: sourceByIdentity.get(entry.identity) || entry.source,
+  }));
+  const identitiesBySource = new Map();
+  for (const entry of canonical) {
     if (!entry.source) continue;
     if (!identitiesBySource.has(entry.source)) identitiesBySource.set(entry.source, new Set());
     identitiesBySource.get(entry.source).add(entry.identity || entry.source);
   }
-  return normalized.map((entry) => {
+  return canonical.map((entry) => {
     const identities = identitiesBySource.get(entry.source);
     if (identities?.size > 1 && entry.identity && !entry.source.includes(entry.identity)) {
       return `${entry.source} · ${entry.identity}`;

--- a/src/gap-ledger.js
+++ b/src/gap-ledger.js
@@ -60,17 +60,58 @@ export function emptyGapLedger() {
   return { version: 1, entries: {} };
 }
 
+/**
+ * Fold-issued source label for one session. Evidence floors, `summary.sources`, and
+ * `sourceProjects` all key off this string, so it must not collapse two sessions.
+ * Time-prefixed Codex ULIDs share an 8-character prefix when they start in the same
+ * minute; keep the native id whole.
+ */
 export function gapSource(transcript = {}) {
   const date = transcript.startedAt ? new Date(transcript.startedAt).toISOString().slice(0, 10) : "unknown date";
-  return `${transcript.harness} · ${String(transcript.id || "")
-    .replace(/^[a-z-]+-/, "")
-    .slice(0, 8)} · ${date}`;
+  return `${transcript.harness} · ${sessionSourceId(transcript)} · ${date}`;
+}
+
+export function sessionSourceId(transcript = {}) {
+  const native = String(transcript.nativeId ?? "").trim();
+  if (native) return native;
+  const raw = String(transcript.id || "").trim();
+  const harness = String(transcript.harness || "");
+  if (harness && raw.startsWith(`${harness}-`)) return raw.slice(harness.length + 1);
+  return raw.replace(/^[a-z-]+-/, "") || String(transcript.identity || "").trim();
 }
 
 export function normalizeSourceLabel(source) {
   return String(source || "")
     .trim()
     .replace(/\s+/g, " ");
+}
+
+/**
+ * When two sessions share a base source label, suffix the canonical session identity
+ * so `summary.sources` and `sourceProjects` stay 1:1 with sessions instead of
+ * last-write-wins on the colliding key.
+ *
+ * @param {{ source?: string, identity?: string }[]} entries
+ * @returns {string[]}
+ */
+export function disambiguateSourceLabels(entries) {
+  const identitiesBySource = new Map();
+  const normalized = (Array.isArray(entries) ? entries : []).map((entry) => ({
+    source: normalizeSourceLabel(entry?.source),
+    identity: String(entry?.identity || "").trim(),
+  }));
+  for (const entry of normalized) {
+    if (!entry.source) continue;
+    if (!identitiesBySource.has(entry.source)) identitiesBySource.set(entry.source, new Set());
+    identitiesBySource.get(entry.source).add(entry.identity || entry.source);
+  }
+  return normalized.map((entry) => {
+    const identities = identitiesBySource.get(entry.source);
+    if (identities?.size > 1 && entry.identity && !entry.source.includes(entry.identity)) {
+      return `${entry.source} · ${entry.identity}`;
+    }
+    return entry.source;
+  });
 }
 
 function normalize(text) {

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -132,7 +132,7 @@ function normalizeEvidence(evidence) {
     .map((e) => ({
       polarity: e.polarity === "positive" ? "positive" : e.polarity === "neutral" ? "neutral" : "negative",
       text: String(e.text).trim().slice(0, 600),
-      source: String(e.source || "").slice(0, 120),
+      source: String(e.source || "").slice(0, 256),
     }));
 }
 

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -99,10 +99,23 @@ test("same-day Codex ULIDs that share an 8-character prefix stay distinct source
   assert.equal(Object.keys(summary.sourceProjects).length, 2);
 });
 
-test("legacy truncated gap sources with distinct session ids are not last-write-wins", () => {
+test("current records and legacy gap observations share one label per session", () => {
   const truncated = "codex · 01K4M0ND · 2026-09-03";
+  const nativeId = "01K4M0NDEKTSV4RRFFQ69G5FAV";
   const phrasing = "Always vendor the lockfile.";
-  const summary = foldEvidence([], {
+  const current = record(`codex-${nativeId}`, {
+    transcript: {
+      id: `codex-${nativeId}`,
+      nativeId,
+      identity: "identity-a",
+      harness: "codex",
+      project: "repo-a",
+      startedAt: Date.parse("2026-09-03T00:01:00Z"),
+    },
+    negative: [{ instruction: "AG-001", quote: "current q-a", class: "non-compliance" }],
+  });
+  const summary = foldEvidence([current], {
+    memoryFile,
     minGapEvidence: 2,
     gapObservations: [
       {
@@ -126,7 +139,10 @@ test("legacy truncated gap sources with distinct session ids are not last-write-
   assert.equal(summary.gaps.length, 1);
   assert.equal(summary.gaps[0].sessions, 2);
   assert.equal(new Set(summary.gaps[0].quotes.map((quote) => quote.source)).size, 2);
+  assert.equal(summary.sources.length, 2);
+  assert.equal(summary.instructions[0].quotes[0].source, summary.gaps[0].quotes[0].source);
   assert.ok(summary.gaps[0].quotes.every((quote) => summary.sources.includes(quote.source)));
+  assert.deepEqual(new Set(Object.values(summary.sourceProjects)), new Set(["repo-a", "repo-b"]));
 });
 
 test("instructions with no evidence still appear - they are the removal candidates", () => {

--- a/test/fold.test.js
+++ b/test/fold.test.js
@@ -70,6 +70,65 @@ test("fold lists every analyzed session source even when the record has no proje
   }
 });
 
+test("same-day Codex ULIDs that share an 8-character prefix stay distinct source keys", () => {
+  // Codex session ids are time-prefixed ULIDs. Truncating to 8 characters after the
+  // harness prefix collapses two sessions that started in the same minute, and
+  // sourceProjects last-write-wins would keep only one project.
+  const startedAt = Date.parse("2026-09-03T00:01:00Z");
+  const a = "01K4M0NDEKTSV4RRFFQ69G5FAV";
+  const b = "01K4M0NDZZABCDEFGHJKMNPQRS";
+  const session = (nativeId, project) =>
+    record(`codex-${nativeId}`, {
+      transcript: {
+        id: `codex-${nativeId}`,
+        nativeId,
+        identity: `identity-${nativeId}`,
+        harness: "codex",
+        project,
+        startedAt,
+      },
+      negative: [{ instruction: "AG-001", quote: `quote ${nativeId}`, class: "non-compliance" }],
+    });
+  const summary = foldEvidence([session(a, "repo-a"), session(b, "repo-b")], { memoryFile });
+
+  assert.equal(new Set(summary.sources).size, 2);
+  assert.ok(summary.sources.some((label) => label.includes(a)));
+  assert.ok(summary.sources.some((label) => label.includes(b)));
+  assert.equal(summary.sources.filter((label) => label === `codex · ${a.slice(0, 8)} · 2026-09-03`).length, 0);
+  assert.deepEqual(new Set(Object.values(summary.sourceProjects)), new Set(["repo-a", "repo-b"]));
+  assert.equal(Object.keys(summary.sourceProjects).length, 2);
+});
+
+test("legacy truncated gap sources with distinct session ids are not last-write-wins", () => {
+  const truncated = "codex · 01K4M0ND · 2026-09-03";
+  const phrasing = "Always vendor the lockfile.";
+  const summary = foldEvidence([], {
+    minGapEvidence: 2,
+    gapObservations: [
+      {
+        proposedInstruction: phrasing,
+        quote: "q-a",
+        mistake: "skipped it",
+        source: truncated,
+        sessionId: "identity-a",
+        project: "repo-a",
+      },
+      {
+        proposedInstruction: phrasing,
+        quote: "q-b",
+        mistake: "skipped it again",
+        source: truncated,
+        sessionId: "identity-b",
+        project: "repo-b",
+      },
+    ],
+  });
+  assert.equal(summary.gaps.length, 1);
+  assert.equal(summary.gaps[0].sessions, 2);
+  assert.equal(new Set(summary.gaps[0].quotes.map((quote) => quote.source)).size, 2);
+  assert.ok(summary.gaps[0].quotes.every((quote) => summary.sources.includes(quote.source)));
+});
+
 test("instructions with no evidence still appear - they are the removal candidates", () => {
   const summary = foldEvidence([record("s1", { positive: [{ instruction: "AG-001", quote: "q" }] })], { memoryFile });
 

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -769,6 +769,56 @@ test("the user-scope project floor counts instruction evidence, not only gap quo
   assert.deepEqual(projectScope.violations, [], projectScope.violations.join("\n"));
 });
 
+test("same-day Codex ULID prefix collisions still clear the two-session rewrite floor", () => {
+  const startedAt = Date.parse("2026-09-03T00:01:00Z");
+  const a = "01K4M0NDEKTSV4RRFFQ69G5FAV";
+  const b = "01K4M0NDZZABCDEFGHJKMNPQRS";
+  const record = (nativeId, project) => ({
+    status: "ok",
+    transcript: {
+      id: `codex-${nativeId}`,
+      nativeId,
+      identity: `identity-${nativeId}`,
+      harness: "codex",
+      project,
+      startedAt,
+    },
+    positive: [],
+    negative: [
+      {
+        instruction: "AG-001",
+        quote: `quote from ${nativeId}`,
+        effect: "the URL was omitted",
+        class: "non-compliance",
+      },
+    ],
+    gaps: [],
+  });
+  const summary = foldEvidence([record(a, "repo-a"), record(b, "repo-b")], {
+    memoryFile: { units: parseMemoryUnits(MEMORY_TEXT) },
+    minGapEvidence: 2,
+  });
+  const truncated = `codex · ${a.slice(0, 8)} · 2026-09-03`;
+  assert.equal(summary.sources.includes(truncated), false);
+  assert.equal(Object.keys(summary.sourceProjects).length, 2);
+  assert.deepEqual(new Set(Object.values(summary.sourceProjects)), new Set(["repo-a", "repo-b"]));
+
+  const evidence = summary.instructions[0].quotes.map((quote) => ({
+    polarity: "negative",
+    text: quote.text,
+    source: quote.source,
+  }));
+  const { proposal, violations } = gate({
+    edit: memoryEdit((t) => t.replace("include its URL.", "include its full https:// URL.")),
+    annotation: { edits: [claim(["H1"], { kind: "rewrite", title: "spell out the URL", evidence })] },
+    config: config({ minGapProjects: 2 }),
+    context: { summary, scope: { kind: "user" } },
+  });
+  assert.deepEqual(violations, [], violations.join("\n"));
+  assert.equal(proposal.edits[0].transcripts, 2);
+  assert.equal(proposal.edits[0].projects, 2);
+});
+
 test("an edit with no verbatim quote is rejected", () => {
   const { proposal, violations } = gate({
     edit: memoryEdit((t) => t.replace("- Use Node 18 via nvm before running any script.\n", "")),


### PR DESCRIPTION
## Intent

Stop truncating session identity to an 8-character gapSource in evidence floors. Those labels collide for two same-day sessions and over-refuse a valid two-session rewrite. Thread a stable session identity through fold -> prompt -> annotation -> proposal floors.

Measured 2026-09-03 on the captain's real 1,078-transcript user-scope corpus: 34 gapSource labels are shared by more than one session, covering 75 transcripts (7.0%); 17 of those collisions span two different projects. Codex ULIDs are time-prefixed, so sessions started in the same minute collide. summary.sourceProjects is keyed by the same label and is last-write-wins, so the user-scope project floor can read the wrong project.

Do not mix this into other presentation or floor PRs.

Acceptance:
- Evidence floors use a stable session identity that does not collide across same-day sessions.
- The collision class above is covered by a regression test.
- sourceProjects / project-floor labeling no longer last-write-wins on a colliding truncated label.

## What Changed

- Preserve full native session IDs in evidence source labels and disambiguate legacy ledger observations by canonical session identity.
- Keep `summary.sources` and `sourceProjects` one-to-one with sessions so colliding same-day labels satisfy session and project evidence floors correctly.
- Expand accepted source-label length and add regression coverage for same-prefix Codex ULIDs.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves one label per canonical session across evidence paths, and covers the reported same-prefix Codex collision through the proposal and project floors.

## Testing

Targeted regression tests and a product-level fold-to-proposal scenario confirmed both sessions retain distinct full labels, map to separate projects, and satisfy the two-session and two-project rewrite floors. No visual artifact was applicable because this is a non-UI evidence-gating change.

<details>
<summary>Evidence: Stable session identity and accepted proposal evidence</summary>

Source: [Stable session identity and accepted proposal evidence](https://github.com/kunchenguid/backpass/blob/4e655a260b94482fa3d186cca16b6d70c49bb278/.no-mistakes/evidence/fm/backpass-stable-session-identity-r1/stable-session-identity.json)

```text
{
  "scenario": "Two same-day Codex ULIDs sharing the formerly truncated 8-character prefix",
  "formerlyCollidingPrefix": "01K4M0ND",
  "issuedSources": [
    "codex · 01K4M0NDEKTSV4RRFFQ69G5FAV · 2026-09-03",
    "codex · 01K4M0NDZZABCDEFGHJKMNPQRS · 2026-09-03"
  ],
  "sourceProjects": {
    "codex · 01K4M0NDEKTSV4RRFFQ69G5FAV · 2026-09-03": "repo-a",
    "codex · 01K4M0NDZZABCDEFGHJKMNPQRS · 2026-09-03": "repo-b"
  },
  "proposalOutcome": "accepted",
  "violations": [],
  "countedSessions": 2,
  "countedProjects": 2
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"221b2d5564c7238a9e1603524b8e2e2ccbd545c9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/fold.js:167` - Record and ledger-observation labels are disambiguated independently, so one session can still receive two fold-issued labels. After upgrading, a current instruction quote may use the new full-id label while the same session&#39;s persisted ledger quote retains its legacy truncated label. If that gap clusters with another session, both labels reach the synthesis prompt; citing the two quotes makes `countSources` report two sessions although both quotes came from one, bypassing the evidence floor. Assign labels once across records and observations by canonical session identity, then reuse that mapping for quotes, `sources`, and `sourceProjects`.

🔧 Fix: Unify source labels across records and ledger observations
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff against `093921bf2f72b9383af34feef2836caf6285ac37`.</code>
- `node --test --test-name-pattern='same-day Codex|current records and legacy gap observations|user-scope project floor' test/fold.test.js test/proposal.test.js`
- <code>Executed `foldEvidence` and `buildProposal` end-to-end with two same-day Codex ULIDs sharing `01K4M0ND`, then recorded the resulting labels, project mapping, and proposal decision.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
