### PR TITLE
feat: support targeted memory and skill runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,11 @@ evidence-backed edits to `AGENTS.md` / `CLAUDE.md` under a token budget.
   repo live in `src/scope.js`; user state never enters `<repo>/.backpass/`.
   `minGapProjects` defaults to 1 (the gate exists; cross-project corroboration is not
   required). A project-scoped run never writes a user-level file.
+- **`--target` is a write-surface, not a second scope.** `src/target.js` resolves one
+  memory file or one skill. Default and `--scope user` still train the whole surface.
+  A targeted run must not copy or propose the rest of the surface; existing skills stay
+  read-only on a memory-file target except for **new** extracts. Tests live in
+  `test/target.test.js`.
 - **Sibling clones are a live-path tier, not a recorded-remote one.** `git worktree
 list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches the
   parent of each worktree (and `discovery.cloneRoots`) for other checkouts that share a

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ backpass --scope user
 backpass apply --scope user
 ```
 
+### One file instead of the whole surface
+
+The default run, and `backpass --scope user`, still train the whole named surface: the primary memory file plus every skill. `--target` names one memory file or one skill for this run and does not silently expand to the rest.
+
+```sh
+backpass --target AGENTS.md
+backpass --target db                          # skill name, or a SKILL.md path
+backpass --scope user --target db
+```
+
+A memory-file target may still extract a **new** skill (that is how the file shrinks). Existing skills are not writable on that run. A skill target writes only that SKILL.md. `--target` cannot be combined with `--memory-file`.
+
 ## How It Works
 
 ### 1. Collect samples - which sessions belong to this repo

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ backpass apply --scope user
 
 ### One file instead of the whole surface
 
-The default run, and `backpass --scope user`, still train the whole named surface: the primary memory file plus every skill. `--target` names one memory file or one skill for this run and does not silently expand to the rest.
+The default run, and `backpass --scope user`, still train the whole named surface: the
+primary memory file plus every skill. `--target` names one memory file or one skill for
+this run and does not silently expand to the rest. Empty, unknown, or ambiguous targets
+fail instead of falling back to the whole surface.
 
 ```sh
 backpass --target AGENTS.md
@@ -124,7 +127,11 @@ backpass --target db                          # skill name, or a SKILL.md path
 backpass --scope user --target db
 ```
 
-A memory-file target may still extract a **new** skill (that is how the file shrinks). Existing skills are not writable on that run. A skill target writes only that SKILL.md. `--target` cannot be combined with `--memory-file`.
+A memory-file target may still extract a **new** skill (that is how the file shrinks).
+Existing skills are not writable on that run. A skill target writes only that SKILL.md.
+`--target` cannot be combined with `--memory-file`, and `init` does not accept it. A plain
+`backpass apply` applies the saved proposal's target; if `--target` is repeated on apply,
+it must resolve to that same target.
 
 ## How It Works
 
@@ -226,8 +233,9 @@ weights still evolve as transcripts age, so the selected set can change over tim
 `--max-transcripts all` to analyze every transcript, or `--seed <n>` to draw a different,
 equally reproducible sample.
 
-Each distilled trace goes to a cheap model with the memory file, the project skill index,
-and a rubric. It returns strict JSON: which instructions helped, which were violated, and
+Each distilled trace goes to a cheap model with the file under audit, the applicable
+skill index, and a rubric. A skill target excludes every other skill from that index. The
+model returns strict JSON: which instructions helped, which were violated, and
 what mistakes no current instruction covers. Every negative carries a class - `harm` (following the instruction
 caused damage), `non-compliance` (the agent ignored it), or `irrelevant` - because those
 argue for opposite fates: harm argues against an instruction, non-compliance argues for
@@ -251,11 +259,13 @@ draw repeated non-compliance, synthesis is steered to restructure the paragraph 
 items instead of adding a cosmetic label.
 
 Results are cached per transcript, keyed to the transcript's content, the effective
-memory-surface hash, and the analysis-index version. The surface hash covers the memory-file
-set plus every project skill's name and description. Edit a memory file or skill description
-and the evidence correctly re-computes; edit only a skill body and the cache remains valid
-because bodies are inspected only for failed-trigger confirmation. A repo without skills
-keeps the prior memory-set hash. A surface edit therefore reanalyzes without `--force` - that
+memory-surface hash, and the analysis-index version. On a whole-surface or memory-file run,
+the surface hash covers the memory-file set plus every project skill's name and description.
+Edit a memory file or skill description and the evidence correctly re-computes; edit only a
+skill body and the cache remains valid because bodies are inspected only for failed-trigger
+confirmation. A skill target instead hashes the complete targeted SKILL.md because that is
+the file under audit. A repo without skills keeps the prior memory-set hash. A surface edit
+therefore reanalyzes without `--force` - that
 is not a cache miss, it is the cache doing its job - and the run says so on stderr, naming the
 old and new hash, so a "0 reused" line reads as "the surface changed" rather than "reuse is
 broken." Evidence files that are not refreshed remain on disk but are excluded while their
@@ -313,8 +323,8 @@ of the proposal entirely.
 A high-reasoning synthesis run turns the aggregated gradients into concrete edits: ADD,
 REMOVE, REWRITE, EXTRACT→SKILL, or MOVE. The agent does not describe edits for backpass to
 splice in - it makes them, with its harness's own file tools, in a **staging copy** of the
-memory file and project skills under `.backpass/synthesis/` (the repo itself is read-only
-to it, for grounding). backpass then diffs the copy against the original and shows the agent the
+run's writable surface under `.backpass/synthesis/` (the repo itself is read-only to it,
+for grounding). backpass then diffs the copy against the original and shows the agent the
 measured changes by id; the agent annotates each one with a title, rationale, and the
 verbatim evidence behind it. Nothing textual is ever taken from the model: every hunk's
 text is copied out of your file by construction, so an edit can never "not appear" in it.
@@ -391,11 +401,12 @@ pass optimizes under.
 **Default: 5,000 estimated tokens (~20KB)** for the always-loaded surface, configurable.
 The estimator is bytes/4 - harness-neutral, ±15%.
 
-The gated number is the **memory file plus every skill's `description:` line** - that is
-what an agent actually pays on every session. Skill bodies stay free until triggered and
-never compete for this budget. (A repo that already carries many skills may find itself
-over budget with no file having changed when upgrading to this accounting - that is the
-one-time re-tune of `budgetTokens`, not a regression.)
+For a whole-surface or memory-file run, the gated number is the **memory file plus every
+skill's `description:` line** - that is what an agent actually pays on every session. For
+a skill target, it is that skill's `description:` line only. Skill bodies stay free until
+triggered and never compete for this budget. (A repo that already carries many skills may
+find itself over budget with no file having changed when upgrading to this accounting -
+that is the one-time re-tune of `budgetTokens`, not a regression.)
 
 ```
 AGENTS.md      [###############.................] 2,412 / 5,000 tok · 63 instructions
@@ -486,9 +497,10 @@ backpass apply --dry-run   # show what would be written
 
 ### 9. Which file is the weights
 
-`memoryFiles` is an ordered list (default `["AGENTS.md", "CLAUDE.md"]`); the first one
-that exists is the file a run optimizes, so **AGENTS.md is canonical**. Resolution is
-pointer-aware:
+On a whole-surface run, `memoryFiles` is an ordered list (default
+`["AGENTS.md", "CLAUDE.md"]`); the first one that exists is the file the run optimizes, so
+**AGENTS.md is canonical**. `--target` overrides that selection for its narrowed run.
+Resolution is pointer-aware:
 
 - `CLAUDE.md` containing only `@AGENTS.md` (the standard import) is a pointer: optimizing
   AGENTS.md covers both harness families and the pointer stays valid. Nothing to report.
@@ -654,7 +666,7 @@ exclude (`.git/info/exclude`, written by `backpass init`) rather than the tracke
   evidence/<identity>.json per-transcript loss
   evidence-summary.json  aggregated gradients
   proposal.json          the latest parseable gradient-descent step (absent if none was produced)
-  synthesis/             the staging copy the gradient-descent agent edited (memory file + skills)
+  synthesis/             the staging copy of the run's writable surface
   prompts/               the exact prompts of the last run
   agent-probe-cache.json which harnesses were available and logged in, and when
   rejections.json        edits you turned down, and the evidence behind them

--- a/VISION.md
+++ b/VISION.md
@@ -4,6 +4,7 @@
 It serves the developer who owns that surface, whether it is a project's `AGENTS.md`, the `CLAUDE.md` Claude Code reads in its place, or user-level memory, and it turns transcripts already sitting on their disk into a small set of reviewable edits.
 By default the project file is the one it trains, because learned knowledge belongs with the repo it was learned in, and a write into a person's user-level file from a project run would pollute every project at once.
 A person's user-level surface (`~/.claude/CLAUDE.md`, user-level skills) is a target only when they name it as the scope of a run: that is still the human choosing which weights to train, and it is the only way a person who keeps their instructions at user level has a file to improve.
+A run may name one memory file or one skill instead of the whole project or user surface; that choice is still the human naming the weights, and the run must not silently widen to the rest of the surface.
 Project-scoped and user-scoped evidence stay isolated, so one run cannot launder the other's corroboration.
 It owns exactly one thing: the backward pass from session transcripts to a proposed change in the named memory surface - the memory file and the skills loaded with it.
 

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -312,14 +312,17 @@ export async function analyzeTranscripts({
   // the skill index, so a mistake an existing skill's content covers is reported as a
   // failed trigger (`coveredBySkill`) instead of a brand-new gap.
   const openGapIndex = renderOpenGapIndex(state.readGapLedger(), memoryFile.path);
-  const skillIndex = renderSkillIndexForAnalysis(
-    modelCwd && path.resolve(modelCwd) !== path.resolve(repo.root)
-      ? skills.map((skill) => ({
-          ...skill,
-          path: path.isAbsolute(skill.path) ? skill.path : path.join(repo.root, skill.path),
-        }))
-      : skills,
-  );
+  const skillIndex =
+    config.runTarget?.kind === "skill"
+      ? "(this run targets this skill only; other project skills are out of scope)"
+      : renderSkillIndexForAnalysis(
+          modelCwd && path.resolve(modelCwd) !== path.resolve(repo.root)
+            ? skills.map((skill) => ({
+                ...skill,
+                path: path.isAbsolute(skill.path) ? skill.path : path.join(repo.root, skill.path),
+              }))
+            : skills,
+        );
 
   let done = 0;
   const evidenceTotals = { positive: 0, negative: 0, gaps: 0 };

--- a/src/apply/terminal.js
+++ b/src/apply/terminal.js
@@ -43,7 +43,7 @@ function renderDiff(edit) {
   return lines.join("\n");
 }
 
-export function renderEdit(edit, index, total) {
+export function renderEdit(edit, index, total, target = null) {
   const out = [];
   const kind = edit.kind === "extract" ? "EXTRACT -> SKILL" : edit.kind.toUpperCase();
   const delta = edit.deltaTokens || 0;
@@ -51,11 +51,14 @@ export function renderEdit(edit, index, total) {
   // A skill-file edit is on-trigger text except for its description line, which is
   // always loaded and billed; say which part of the delta is which.
   const signed = (n) => `${n > 0 ? "+" : ""}${formatTokens(n)}`;
-  const deltaText = edit.targetsMemoryFile
-    ? `${signed(delta)} tok${descriptionDelta ? ` (+${formatTokens(descriptionDelta)} tok skill description)` : ""}`
-    : descriptionDelta
+  const deltaText =
+    target?.kind === "skill"
       ? `${signed(descriptionDelta)} tok always-loaded (description), ${signed(delta - descriptionDelta)} tok on trigger`
-      : `${signed(delta)} tok (not always-loaded)`;
+      : edit.targetsMemoryFile
+        ? `${signed(delta)} tok${descriptionDelta ? ` (+${formatTokens(descriptionDelta)} tok skill description)` : ""}`
+        : descriptionDelta
+          ? `${signed(descriptionDelta)} tok always-loaded (description), ${signed(delta - descriptionDelta)} tok on trigger`
+          : `${signed(delta)} tok (not always-loaded)`;
 
   out.push("");
   out.push(`${color.bold(`[${index + 1}/${total}] ${kind}`)}  ${color.dim(deltaText)}`);
@@ -119,7 +122,7 @@ export async function reviewInTerminal(proposal) {
     );
 
     for (const [index, edit] of proposal.edits.entries()) {
-      console.error(renderEdit(edit, index, proposal.edits.length));
+      console.error(renderEdit(edit, index, proposal.edits.length, proposal.target));
       let answer = "";
       while (!["a", "r", "q"].includes(answer)) {
         const reply = await rl.question(`\n  ${color.cyan("[a]ccept / [r]eject / [q]uit")} > `).catch(() => null);

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -66,7 +66,7 @@ function descriptionTokensIn(text) {
   return estimateTokens(parseFrontmatter(text).description || "");
 }
 
-function acceptedSubsetBudgetFailure({
+function applyBudget({
   proposal,
   capTokens,
   memoryText,
@@ -75,13 +75,31 @@ function acceptedSubsetBudgetFailure({
   descriptionTokensProjected,
 }) {
   const relative = proposal.memoryFile.path;
-  if (memoryText === null) return null;
+  if (proposal.target?.kind === "skill") {
+    return {
+      budget: budgetStatus(
+        parseFrontmatter(memoryText).description || "",
+        parseFrontmatter(projectedMemoryText).description || "",
+        capTokens,
+      ),
+      label: `${relative} description`,
+    };
+  }
+  return {
+    budget: budgetStatus(memoryText, projectedMemoryText, capTokens, {
+      current: descriptionTokensNow,
+      projected: descriptionTokensProjected,
+    }),
+    label: surfaceLabel(relative, Math.max(descriptionTokensNow, descriptionTokensProjected)),
+  };
+}
 
-  const budget = budgetStatus(memoryText, projectedMemoryText, capTokens, {
-    current: descriptionTokensNow,
-    projected: descriptionTokensProjected,
-  });
-  const label = surfaceLabel(relative, Math.max(descriptionTokensNow, descriptionTokensProjected));
+function acceptedSubsetBudgetFailure(args) {
+  if (args.memoryText === null) return null;
+
+  const { budget, label } = applyBudget(args);
+  const { capTokens } = args;
+  const relative = args.proposal.memoryFile.path;
   const gate = budgetGateKind(budget);
   if (gate === "cap") {
     return {
@@ -543,12 +561,17 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   };
   const landedDescriptionDelta = descriptionTokensProjected - descriptionTokensNow;
   const budgetTarget = memoryPlan || orderedPlanned[0];
-  const surfaceBudget = budgetTarget
-    ? budgetStatus(memoryText, memoryPlan?.text ?? memoryText, config.budgetTokens, {
-        current: descriptionTokensNow,
-        projected: descriptionTokensNow + landedDescriptionDelta,
+  const budgetResult = budgetTarget
+    ? applyBudget({
+        proposal,
+        capTokens: config.budgetTokens,
+        memoryText,
+        projectedMemoryText: memoryPlan?.text ?? memoryText,
+        descriptionTokensNow,
+        descriptionTokensProjected: descriptionTokensNow + landedDescriptionDelta,
       })
     : null;
+  const surfaceBudget = budgetResult?.budget ?? null;
   for (const item of orderedPlanned) {
     const { relative, resolved, text, applied } = item;
     const budget = item === budgetTarget ? surfaceBudget : null;
@@ -571,15 +594,7 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   }
 
   if (surfaceBudget && !surfaceBudget.withinBudget) {
-    results.warnings.push(
-      overBudgetWarning(
-        surfaceLabel(
-          proposal.memoryFile.path,
-          Math.max(descriptionTokensNow, descriptionTokensNow + landedDescriptionDelta),
-        ),
-        surfaceBudget,
-      ),
-    );
+    results.warnings.push(overBudgetWarning(budgetResult.label, surfaceBudget));
   }
 
   if (!dryRun && canonical) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ import { UserError, fail, setQuiet } from "./logger.js";
 import { loadConfig, parseMaxTranscripts, parseScopeKind } from "./config.js";
 import { resolveRepo } from "./repo.js";
 import { printScopeNote, resolveScope } from "./scope.js";
+import { parseTargetFlag, printTargetNote, resolveRunTarget } from "./target.js";
 import { State } from "./state.js";
 import { AgentResolver } from "./agents.js";
 
@@ -46,6 +47,7 @@ const OPTIONS = {
   scope: { type: "string" },
   project: { type: "string", multiple: true },
   "memory-file": { type: "string", multiple: true },
+  target: { type: "string" },
   "skills-dir": { type: "string" },
 
   "analysis-agent": { type: "string" },
@@ -118,6 +120,8 @@ BUDGET AND SHAPE
   --scope <project|user>   which surface a run reads and writes          [project]
   --project <glob>         user-scope: only sessions whose project/cwd matches (repeatable)
   --memory-file <path>     memory file to optimize (repeatable)
+  --target <path>          one memory file or one skill (name or SKILL.md);
+                           does not expand to the rest of the surface
   --skills-dir <path>      where skill extractions are written          [.agents/skills]
 
 APPLY
@@ -142,6 +146,8 @@ EXAMPLES
   backpass                                  a full run, ending with a proposal
   backpass scan --since 7d --strict         what would be collected, deterministic only
   backpass --scope user                     train the user-level memory file and skills
+  backpass --target AGENTS.md              train only this memory file
+  backpass --target db                      train only this skill (name or SKILL.md path)
   backpass --synthesis-agent claude --synthesis-model claude-opus-5
   backpass apply --no-ui                    review and write from the terminal
 `;
@@ -258,7 +264,17 @@ export async function main(argv) {
     }
     const scope = resolveScope(process.cwd(), { ...values, scope: kind, strict: Boolean(values.strict) }, config, repo);
     printScopeNote(scope);
-    config.memoryFiles = scope.memoryFiles;
+    if (values.target && Array.isArray(values["memory-file"]) && values["memory-file"].length) {
+      throw new UserError("--target cannot be combined with --memory-file", "name the one file with --target");
+    }
+    const runTarget =
+      commandName === "init"
+        ? { kind: "surface" }
+        : resolveRunTarget(parseTargetFlag(values), { repo: scope.repo, config, scope });
+    printTargetNote(runTarget);
+    config.runTarget = runTarget;
+    if (runTarget.kind === "memory") config.memoryFiles = [runTarget.path];
+    else config.memoryFiles = scope.memoryFiles;
     config.skillsDir = scope.overflowDir;
     if (scope.skillDirs.length) config.skillsDirs = scope.skillDirs;
     config.state = new State(scope.root, {

--- a/src/cli.js
+++ b/src/cli.js
@@ -264,9 +264,13 @@ export async function main(argv) {
     }
     const scope = resolveScope(process.cwd(), { ...values, scope: kind, strict: Boolean(values.strict) }, config, repo);
     printScopeNote(scope);
-    if (values.target && Array.isArray(values["memory-file"]) && values["memory-file"].length) {
+    const hasTarget = values.target !== undefined;
+    if (hasTarget && Array.isArray(values["memory-file"]) && values["memory-file"].length) {
       throw new UserError("--target cannot be combined with --memory-file", "name the one file with --target");
     }
+    config.memoryFiles = scope.memoryFiles;
+    config.skillsDir = scope.overflowDir;
+    config.skillsDirs = scope.skillDirs;
     const runTarget =
       commandName === "init"
         ? { kind: "surface" }
@@ -274,9 +278,6 @@ export async function main(argv) {
     printTargetNote(runTarget);
     config.runTarget = runTarget;
     if (runTarget.kind === "memory") config.memoryFiles = [runTarget.path];
-    else config.memoryFiles = scope.memoryFiles;
-    config.skillsDir = scope.overflowDir;
-    if (scope.skillDirs.length) config.skillsDirs = scope.skillDirs;
     config.state = new State(scope.root, {
       stateDir: scope.stateDir,
       mode: kind === "user" ? 0o700 : undefined,

--- a/src/cli.js
+++ b/src/cli.js
@@ -265,6 +265,9 @@ export async function main(argv) {
     const scope = resolveScope(process.cwd(), { ...values, scope: kind, strict: Boolean(values.strict) }, config, repo);
     printScopeNote(scope);
     const hasTarget = values.target !== undefined;
+    if (commandName === "init" && hasTarget) {
+      throw new UserError("--target cannot be used with init", "initialize the scope first, then run with --target");
+    }
     if (hasTarget && Array.isArray(values["memory-file"]) && values["memory-file"].length) {
       throw new UserError("--target cannot be combined with --memory-file", "name the one file with --target");
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -119,7 +119,7 @@ BUDGET AND SHAPE
   --min-gap-projects <n>    user-scope: distinct projects needed for a gap [1]
   --scope <project|user>   which surface a run reads and writes          [project]
   --project <glob>         user-scope: only sessions whose project/cwd matches (repeatable)
-  --memory-file <path>     memory file to optimize (repeatable)
+  --memory-file <path>     primary memory file for a whole-surface run (repeatable)
   --target <path>          one memory file or one skill (name or SKILL.md);
                            does not expand to the rest of the surface
   --skills-dir <path>      where skill extractions are written          [.agents/skills]

--- a/src/commands/analyze.js
+++ b/src/commands/analyze.js
@@ -1,10 +1,10 @@
 import path from "node:path";
 
 import { analyzeTranscripts } from "../analyze.js";
-import { userClaudeSkillsDir } from "../config.js";
 import { UserError, color, info, json, out, warn } from "../logger.js";
 import { memorySurfaceHash, resolveMemoryFiles } from "../memory.js";
-import { loadProjectSkills, resolveOverflowTarget, skillDescriptionTokens } from "../skills.js";
+import { skillDescriptionTokens } from "../skills.js";
+import { loadScopeSkills } from "../target.js";
 import { emitProgress } from "../progress.js";
 import { discoverForRun } from "./scan.js";
 import { printUsage } from "./usage.js";
@@ -25,8 +25,28 @@ import { capTranscripts } from "../sample.js";
  *
  * When no configured file exists, `backpass` (the default run) bootstraps one; every
  * other command fails with a pointer to that.
+ *
+ * `--target` narrows the write surface. A skill target makes that SKILL.md the file
+ * under audit; a memory-file target still sees every skill as read-only analysis
+ * context so failed triggers stay visible, but those skills are not writable.
  */
 export function primaryMemoryFile(repo, config, scope = null) {
+  const runTarget = config.runTarget || { kind: "surface" };
+  const { skills: allSkills } = loadScopeSkills(repo, config, scope);
+  if (runTarget.kind === "skill") {
+    const file = runTarget.file;
+    file.alwaysLoadedTokens = skillDescriptionTokens([runTarget.skill]);
+    return {
+      file,
+      all: [file],
+      hash: file.hash,
+      resolved: { primary: file, all: [file], pointers: [], separate: [], hash: file.hash },
+      skills: [],
+      allSkills,
+      runTarget,
+    };
+  }
+
   const resolved = resolveMemoryFiles(repo.root, config.memoryFiles, { allowExternal: scope?.kind === "user" });
   if (!resolved.primary) {
     if (scope?.kind === "user") {
@@ -40,30 +60,29 @@ export function primaryMemoryFile(repo, config, scope = null) {
       "run `backpass` to bootstrap an AGENTS.md, or set memoryFiles in .backpassrc.json",
     );
   }
-  for (const other of resolved.separate) {
-    const relativeImport = path
-      .relative(path.dirname(other.absolute), resolved.primary.absolute)
-      .split(path.sep)
-      .join("/");
-    const pointerImport = relativeImport;
-    warn(
-      `${other.path} is a separate memory file and will NOT be updated - only ${resolved.primary.path} is optimized. ` +
-        `To cover both, consolidate: move its content into ${resolved.primary.path} and make ${other.path} a pointer ` +
-        `(a single line: @${pointerImport}).`,
-    );
+  if (runTarget.kind !== "memory") {
+    for (const other of resolved.separate) {
+      const relativeImport = path
+        .relative(path.dirname(other.absolute), resolved.primary.absolute)
+        .split(path.sep)
+        .join("/");
+      const pointerImport = relativeImport;
+      warn(
+        `${other.path} is a separate memory file and will NOT be updated - only ${resolved.primary.path} is optimized. ` +
+          `To cover both, consolidate: move its content into ${resolved.primary.path} and make ${other.path} a pointer ` +
+          `(a single line: @${pointerImport}).`,
+      );
+    }
   }
   // Overflow-layout warnings are the synthesis stage's to print; this resolution is read-only.
-  const userScope = scope?.kind === "user";
-  const overflow = resolveOverflowTarget(repo.root, config.skillsDir, {
-    claudeSkillsDir: userScope ? userClaudeSkillsDir() : undefined,
-  });
-  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
   return {
     file: resolved.primary,
     all: resolved.all,
-    hash: memorySurfaceHash(resolved.hash, skills),
+    hash: memorySurfaceHash(resolved.hash, allSkills),
     resolved,
-    skills,
+    skills: allSkills,
+    allSkills,
+    runTarget,
   };
 }
 
@@ -72,10 +91,11 @@ export async function runAnalysis(ctx) {
   const { file, hash, skills } = primaryMemoryFile(repo, config, scope);
   // Deterministic by design: tokens and units come from parsing the file, no model.
   const descriptionTokens = skillDescriptionTokens(skills);
+  const alwaysLoaded = file.alwaysLoadedTokens ?? file.tokens + descriptionTokens;
   emitProgress("memory", {
     path: file.path,
     label: skills.length ? `${file.path} + skill descriptions` : file.path,
-    tokens: file.tokens + descriptionTokens,
+    tokens: alwaysLoaded,
     budget: config.budgetTokens,
     units: file.units.length,
   });

--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -26,6 +26,17 @@ export async function cmdApply(ctx) {
   if (proposalScope !== runScope) {
     throw new UserError(`this proposal is ${proposalScope} scope; run \`backpass apply --scope ${proposalScope}\``);
   }
+  if (ctx.flags.target !== undefined) {
+    const requested = config.runTarget || { kind: "surface" };
+    const saved = proposal.target || { kind: "surface" };
+    if (requested.kind !== saved.kind || (requested.kind !== "surface" && requested.path !== saved.path)) {
+      const savedLabel = saved.kind === "surface" ? "the whole surface" : saved.path;
+      throw new UserError(
+        `this proposal targets ${savedLabel}, not ${requested.path || "the whole surface"}`,
+        "apply the proposal with its original --target, or run backpass again for the requested target",
+      );
+    }
+  }
   if (proposal.violations?.length) {
     throw new UserError(
       "the saved proposal failed its mechanical gates and was never approved for apply",

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -70,8 +70,8 @@ export async function cmdRun(ctx) {
       return 0;
     }
 
-    // The banner shows what the gate measures: the always-loaded surface, which is the
-    // memory file plus every skill description line.
+    // The banner shows what the gate measures: the always-loaded write target, either
+    // the file plus skill descriptions or a targeted skill's description alone.
     const descriptionTokens = skillDescriptionTokens(analysis.skills || []);
     const alwaysLoaded =
       analysis.file.alwaysLoadedTokens != null

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -34,7 +34,10 @@ export async function cmdRun(ctx) {
 
     config.state.clearProposal();
 
-    if (!resolveMemoryFiles(repo.root, config.memoryFiles, { allowExternal: scope?.kind === "user" }).primary) {
+    if (
+      config.runTarget?.kind !== "skill" &&
+      !resolveMemoryFiles(repo.root, config.memoryFiles, { allowExternal: scope?.kind === "user" }).primary
+    ) {
       if (scope?.kind === "user") {
         throw new UserError(
           `no user memory file found (looked for ${config.memoryFiles.join(", ")})`,
@@ -70,7 +73,10 @@ export async function cmdRun(ctx) {
     // The banner shows what the gate measures: the always-loaded surface, which is the
     // memory file plus every skill description line.
     const descriptionTokens = skillDescriptionTokens(analysis.skills || []);
-    const alwaysLoaded = analysis.file.tokens + descriptionTokens;
+    const alwaysLoaded =
+      analysis.file.alwaysLoadedTokens != null
+        ? analysis.file.alwaysLoadedTokens
+        : analysis.file.tokens + descriptionTokens;
     const budget = budgetBar({
       utilization: alwaysLoaded / config.budgetTokens,
       withinBudget: alwaysLoaded <= config.budgetTokens,

--- a/src/prompts/analysis.md
+++ b/src/prompts/analysis.md
@@ -4,7 +4,7 @@ Your job is NOT to review the code. It is to measure how well the memory file's
 instructions actually steered this session, and to spot mistakes an instruction could
 have prevented. This is the loss signal for a backward pass over the memory file.
 
-## The memory file under audit: {{MEMORY_PATH}}
+## The file under audit: {{MEMORY_PATH}}
 
 Each instruction has a stable id in [brackets]. Refer to instructions ONLY by these ids.
 

--- a/src/prompts/synthesis.md
+++ b/src/prompts/synthesis.md
@@ -70,6 +70,7 @@ signal.
 
 ## Hard rules - a violation fails the whole proposal
 
+{{TARGET_RULE}}
 1. **At most {{MAX_EDITS}} edits.** This is the learning rate. An edit is one change a
    human can decide on; pick the highest-signal ones. A small correct step beats a large
    speculative one.

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import { renderHunkLines } from "./diff.js";
 import { normalizeSourceLabel } from "./gap-ledger.js";
 import { mixFromCounts } from "./interaction.js";
@@ -70,7 +73,8 @@ export const SHRINK_EDIT_TOKENS = 40;
 
 export function effectiveMaxEdits(memoryFile, config, alwaysLoadedExtraTokens = 0) {
   if (Number.isInteger(config.maxEditsPerRun) && config.maxEditsPerRun > 0) return config.maxEditsPerRun;
-  const overage = memoryFile.tokens + alwaysLoadedExtraTokens - config.budgetTokens;
+  const tokens = memoryFile.alwaysLoadedTokens ?? memoryFile.tokens;
+  const overage = tokens + alwaysLoadedExtraTokens - config.budgetTokens;
   if (overage <= 0) return DEFAULT_MAX_EDITS;
   return Math.min(SHRINK_MAX_EDITS, Math.max(DEFAULT_MAX_EDITS, Math.ceil(overage / SHRINK_EDIT_TOKENS)));
 }
@@ -332,6 +336,7 @@ export function buildProposal(rawResult, context) {
     isSuppressed = () => false,
     skillFiles = [],
     scope = null,
+    runTarget = config.runTarget || { kind: "surface" },
   } = context;
 
   const violations = [];
@@ -403,8 +408,41 @@ export function buildProposal(rawResult, context) {
     const memoryHunks = hunks.filter((hunk) => hunk.file === memoryFile.path);
     const otherHunks = hunks.filter((hunk) => hunk.file !== memoryFile.path);
     const destFiles = [...new Set(otherHunks.map((hunk) => hunk.file))];
+    const written = [...new Set([...files, ...created.map((c) => c.file)])];
+    if (runTarget?.kind === "skill") {
+      const extra = written.find((file) => file !== memoryFile.path);
+      if (extra) {
+        violations.push(`edit ${edit.id}: this run targets ${memoryFile.path} only; ${extra} is out of scope`);
+        continue;
+      }
+    }
+    if (runTarget?.kind === "memory") {
+      const existingSkill = created.find((c) => {
+        const abs = path.isAbsolute(c.file) ? c.file : path.join(repo.root, c.file);
+        return fs.existsSync(abs);
+      });
+      if (existingSkill) {
+        violations.push(
+          `edit ${edit.id}: ${existingSkill.file} already exists; this run targets ${memoryFile.path} and does not rewrite existing skills`,
+        );
+        continue;
+      }
+      const extraMemory = written.find(
+        (file) => file !== memoryFile.path && !isSkillFilePath(file, config.skillDirs || config.skillsDir),
+      );
+      if (extraMemory) {
+        violations.push(`edit ${edit.id}: this run targets ${memoryFile.path} only; ${extraMemory} is out of scope`);
+        continue;
+      }
+    }
 
     if (edit.kind === "extract") {
+      if (runTarget?.kind === "skill") {
+        violations.push(
+          `edit ${edit.id}: this run targets ${runTarget.path} only; extraction would write another file`,
+        );
+        continue;
+      }
       if (!memoryHunks.length || (!created.length && !destFiles.length)) {
         violations.push(
           `edit ${edit.id}: kind "extract" must group SKILL.md file(s) (created or extended) with change(s) to ${memoryFile.path}`,
@@ -664,8 +702,10 @@ export function buildProposal(rawResult, context) {
         const next = applyEdit(before, slice);
         running.set(target, next);
         const delta = estimateTokens(next) - estimateTokens(before);
-        if (target === memoryFile.path) memoryDelta += delta;
-        else {
+        if (target === memoryFile.path) {
+          memoryDelta += runTarget?.kind === "skill" ? descriptionLineDelta(before, next) : delta;
+          if (runTarget?.kind === "skill") descriptionDelta += descriptionLineDelta(before, next);
+        } else {
           otherDelta += delta;
           if (isSkillFilePath(target, config.skillDirs || config.skillsDir)) {
             descriptionDelta += descriptionLineDelta(before, next);
@@ -687,10 +727,17 @@ export function buildProposal(rawResult, context) {
   const projectedText = running.get(memoryFile.path) ?? memoryFile.text;
   const descriptionTokensProjected =
     descriptionTokensNow + accepted.reduce((sum, edit) => sum + (edit.descriptionDelta || 0), 0);
-  const budget = budgetStatus(memoryFile.text, projectedText, config.budgetTokens, {
-    current: descriptionTokensNow,
-    projected: descriptionTokensProjected,
-  });
+  const skillTarget = runTarget?.kind === "skill";
+  const budget = skillTarget
+    ? budgetStatus(
+        parseFrontmatter(memoryFile.text).description || "",
+        parseFrontmatter(projectedText).description || "",
+        config.budgetTokens,
+      )
+    : budgetStatus(memoryFile.text, projectedText, config.budgetTokens, {
+        current: descriptionTokensNow,
+        projected: descriptionTokensProjected,
+      });
 
   /**
    * The budget gate has two modes (design section 6).
@@ -700,11 +747,14 @@ export function buildProposal(rawResult, context) {
    * would fail every run on exactly the repos that need backpass most. There, the run is a shrink
    * plan and the gate is progress: the edit set must be strictly net-negative.
    */
-  budget.mode = memoryFile.tokens + descriptionTokensNow > config.budgetTokens ? "shrink" : "cap";
+  const currentAlwaysLoaded = skillTarget
+    ? budget.current
+    : (memoryFile.alwaysLoadedTokens ?? memoryFile.tokens) + descriptionTokensNow;
+  budget.mode = currentAlwaysLoaded > config.budgetTokens ? "shrink" : "cap";
   budget.startedOverBudget = budget.mode === "shrink";
   // For displays: how much of `current` is the skill layer, so a surface number is
   // never presented as if it measured the file alone.
-  budget.descriptionTokens = descriptionTokensNow;
+  budget.descriptionTokens = skillTarget ? budget.current : descriptionTokensNow;
 
   // With skills present the gated number is the surface, not the file alone; name what
   // the number actually measures.
@@ -750,6 +800,12 @@ export function buildProposal(rawResult, context) {
     generatedAt: new Date().toISOString(),
     repo: { name: repo.name, root: repo.root },
     scope: scope?.kind || "project",
+    target:
+      runTarget?.kind === "skill"
+        ? { kind: "skill", path: runTarget.path, name: runTarget.name }
+        : runTarget?.kind === "memory"
+          ? { kind: "memory", path: runTarget.path }
+          : { kind: "surface" },
     memoryFile: { path: memoryFile.path, hash: memoryFile.hash, tokens: memoryFile.tokens },
     targetFiles,
     budget,

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -597,6 +597,21 @@ export function buildProposal(rawResult, context) {
       continue;
     }
 
+    if (!preservesAlwaysLoaded(edit.kind) && runTarget?.kind === "skill") {
+      const deleted = hunks
+        .filter((hunk) => hunk.removed && !hunk.added)
+        .flatMap((hunk) => (hunk.lines || []).filter((line) => line.type === "del").map((line) => line.text))
+        .filter((text) => text.trim());
+      if (deleted.length) {
+        violations.push(
+          `edit ${edit.id} ("${edit.title}") deletes "${deleted[0].trim().slice(0, 80)}" from ${files[0]}; ` +
+            `no evidence can attribute to skill files, so no deletion there clears the ` +
+            `${config.minGapEvidence}-session harm floor - revert the deletion`,
+        );
+        continue;
+      }
+    }
+
     // A removal is measured the same way: a hunk that only deletes text, outside an
     // extraction or move, deletes instructions - whatever the edit's kind says. Deleting
     // an instruction needs the same corroboration adding one does, and only negatives the

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -14,7 +14,7 @@ import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./w
  * gates it must clear before a human ever sees it (design sections 3, 6, 7). The
  * budget gate (`budgetGateKind`) runs again on the accepted subset at apply.
  *
- * The synthesis agent edits a staging copy of the memory file and project skills natively
+ * The synthesis agent edits a staging copy of the run's writable surface natively
  * (`src/workspace.js`); backpass measures the result as anchored hunks (`src/diff.js`)
  * and the agent annotates them - kind, title, rationale, evidence - by id. An edit is
  * therefore a group of measured changes, normally against one file (an extract also

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -703,7 +703,7 @@ export function buildProposal(rawResult, context) {
         running.set(target, next);
         const delta = estimateTokens(next) - estimateTokens(before);
         if (target === memoryFile.path) {
-          memoryDelta += runTarget?.kind === "skill" ? descriptionLineDelta(before, next) : delta;
+          memoryDelta += delta;
           if (runTarget?.kind === "skill") descriptionDelta += descriptionLineDelta(before, next);
         } else {
           otherDelta += delta;
@@ -900,7 +900,14 @@ export function slug(text) {
  * (the descriptions on disk at apply time); each accepted edit's measured
  * `descriptionDelta` moves it, so the budget describes the whole surface.
  */
-export function projectWithDecisions(memoryText, edits, acceptedIds, capTokens, descriptionTokensCurrent = 0) {
+export function projectWithDecisions(
+  memoryText,
+  edits,
+  acceptedIds,
+  capTokens,
+  descriptionTokensCurrent = 0,
+  runTarget = null,
+) {
   const chosen = edits.filter((e) => acceptedIds.includes(e.id) && e.targetsMemoryFile && e.applicable !== false);
   let text = memoryText;
   for (const edit of chosen) {
@@ -916,9 +923,16 @@ export function projectWithDecisions(memoryText, edits, acceptedIds, capTokens, 
     .reduce((sum, e) => sum + (e.descriptionDelta || 0), 0);
   return {
     text,
-    budget: budgetStatus(memoryText, text, capTokens, {
-      current: descriptionTokensCurrent,
-      projected: descriptionTokensCurrent + descriptionDelta,
-    }),
+    budget:
+      runTarget?.kind === "skill"
+        ? budgetStatus(
+            parseFrontmatter(memoryText).description || "",
+            parseFrontmatter(text).description || "",
+            capTokens,
+          )
+        : budgetStatus(memoryText, text, capTokens, {
+            current: descriptionTokensCurrent,
+            projected: descriptionTokensCurrent + descriptionDelta,
+          }),
   };
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -58,7 +58,8 @@ export function readSkill(repoRoot, file, fallbackName = null) {
   const frontmatter = parseFrontmatter(text);
   const relative = path.relative(repoRoot, file);
   const skillPath = relative.startsWith("..") || path.isAbsolute(relative) ? file : relative;
-  const inferredName = path.basename(file) === "SKILL.md" ? path.basename(path.dirname(file)) : path.basename(file, ".md");
+  const inferredName =
+    path.basename(file) === "SKILL.md" ? path.basename(path.dirname(file)) : path.basename(file, ".md");
   return {
     name: frontmatter.name || fallbackName || inferredName,
     description: frontmatter.description || "",

--- a/src/skills.js
+++ b/src/skills.js
@@ -41,27 +41,32 @@ export function loadSkills(repoRoot, skillsDir) {
         ? path.join(root, entry.name)
         : null;
     if (!file || !fs.existsSync(file)) continue;
-    let text;
-    try {
-      text = fs.readFileSync(file, "utf8");
-    } catch {
-      continue;
-    }
-    const frontmatter = parseFrontmatter(text);
-    skills.push({
-      name: frontmatter.name || entry.name.replace(/\.md$/, ""),
-      description: frontmatter.description || "",
-      path: (() => {
-        const relative = path.relative(repoRoot, file);
-        return relative.startsWith("..") || path.isAbsolute(relative) ? file : relative;
-      })(),
-      body: skillBody(text),
-      bodyTokens: estimateTokens(text),
-      descriptionTokens: estimateTokens(frontmatter.description || ""),
-    });
+    const skill = readSkill(repoRoot, file, entry.name.replace(/\.md$/, ""));
+    if (skill) skills.push(skill);
   }
 
   return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function readSkill(repoRoot, file, fallbackName = null) {
+  let text;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  const frontmatter = parseFrontmatter(text);
+  const relative = path.relative(repoRoot, file);
+  const skillPath = relative.startsWith("..") || path.isAbsolute(relative) ? file : relative;
+  const inferredName = path.basename(file) === "SKILL.md" ? path.basename(path.dirname(file)) : path.basename(file, ".md");
+  return {
+    name: frontmatter.name || fallbackName || inferredName,
+    description: frontmatter.description || "",
+    path: skillPath,
+    body: skillBody(text),
+    bodyTokens: estimateTokens(text),
+    descriptionTokens: estimateTokens(frontmatter.description || ""),
+  };
 }
 
 /**

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -14,6 +14,7 @@ import {
   resolveProjectSkillDirs,
   skillDescriptionTokens,
 } from "./skills.js";
+import { copyExistingSkills, workspaceSkillDirs } from "./target.js";
 import { isSuppressedByRejection } from "./state.js";
 import { emitProgress } from "./progress.js";
 import { measureWorkspace, prepareWorkspace, repoFingerprint, workspacePathFor } from "./workspace.js";
@@ -70,6 +71,11 @@ const EMPTY_TURN_VIOLATION =
 const UNPARSEABLE_VIOLATION = "synthesis answered with text, but not with a JSON object";
 const KEPT_EDITING_VIOLATION = "synthesis kept editing the staging copy instead of annotating the measured changes";
 
+function alwaysLoadedTokensOf(memoryFile, descriptionTokens = 0) {
+  if (memoryFile.alwaysLoadedTokens != null) return memoryFile.alwaysLoadedTokens;
+  return memoryFile.tokens + descriptionTokens;
+}
+
 /**
  * The budget the prompts frame is the always-loaded surface: the memory file plus
  * every skill description line, the same sum the mechanical gate measures
@@ -77,7 +83,8 @@ const KEPT_EDITING_VIOLATION = "synthesis kept editing the staging copy instead 
  * fail a gate it was never told about.
  */
 function budgetRule(memoryFile, config, maxEdits, descriptionTokens = 0) {
-  const remaining = config.budgetTokens - memoryFile.tokens - descriptionTokens;
+  const current = alwaysLoadedTokensOf(memoryFile, descriptionTokens);
+  const remaining = config.budgetTokens - current;
   const counted = descriptionTokens
     ? ` The budget counts this file plus every skill description line (${descriptionTokens} tok of descriptions today); skill bodies stay free until triggered.`
     : "";
@@ -111,7 +118,7 @@ function budgetRule(memoryFile, config, maxEdits, descriptionTokens = 0) {
 }
 
 function budgetState(memoryFile, config, descriptionTokens = 0) {
-  const ratio = (memoryFile.tokens + descriptionTokens) / config.budgetTokens;
+  const ratio = alwaysLoadedTokensOf(memoryFile, descriptionTokens) / config.budgetTokens;
   if (ratio > 1) return "OVER BUDGET";
   if (ratio > 0.85) return "near budget";
   return "within budget";
@@ -146,6 +153,23 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
   );
 }
 
+function targetRule(runTarget, memoryPath, skillsDir) {
+  if (runTarget?.kind === "skill") {
+    return (
+      `This run targets the skill at \`./${memoryPath}\` only. Do not edit any other file, ` +
+      `including the project memory file. Do not create a new skill. Extraction does not apply.\n\n`
+    );
+  }
+  if (runTarget?.kind === "memory") {
+    return (
+      `This run targets \`./${memoryPath}\` only. Existing skills listed below are read-only: ` +
+      `do not edit them. You may create a NEW skill under \`./${skillsDir}/\` as an extraction ` +
+      `from this file. Do not rewrite other memory files.\n\n`
+    );
+  }
+  return "";
+}
+
 /**
  * Everything the edit and annotation turns need: prompt values, the `buildProposal`
  * context, and the overflow target.
@@ -159,20 +183,27 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
   });
   for (const w of overflow.warnings) warn(w);
   const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
-  const skillFiles = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
-  const descriptionTokens = skillDescriptionTokens(skillFiles);
-  const maxEdits = effectiveMaxEdits(memoryFile, config, descriptionTokens);
+  const allSkills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
+  const runTarget = config.runTarget || { kind: "surface" };
+  const skillFiles = runTarget.kind === "skill" ? [] : allSkills;
+  const descriptionTokens =
+    runTarget.kind === "skill"
+      ? (memoryFile.alwaysLoadedTokens ?? skillDescriptionTokens(runTarget.skill ? [runTarget.skill] : []))
+      : skillDescriptionTokens(skillFiles);
+  const maxEdits = effectiveMaxEdits(memoryFile, config, runTarget.kind === "skill" ? 0 : descriptionTokens);
+  const stagedSkillDirs = workspaceSkillDirs(runTarget, skillDirs);
 
   const common = {
     MEMORY_PATH: workspacePathFor(memoryFile.path),
     BUDGET_RULE: budgetRule(memoryFile, config, maxEdits, descriptionTokens),
     MAX_EDITS: String(maxEdits),
     MIN_GAP_EVIDENCE: String(config.minGapEvidence),
+    TARGET_RULE: targetRule(runTarget, workspacePathFor(memoryFile.path), workspacePathFor(overflow.dir)),
   };
 
   const context = {
     memoryFile,
-    config: { ...config, skillsDir: overflow.dir, skillDirs },
+    config: { ...config, skillsDir: overflow.dir, skillDirs: stagedSkillDirs },
     repo,
     scope,
     summary,
@@ -180,6 +211,7 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
     rejections,
     isSuppressed: isSuppressedByRejection,
     skillFiles,
+    runTarget,
   };
 
   const promptDir = path.join(state.root, "prompts");
@@ -189,13 +221,17 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
     state,
     rejections,
     overflow,
-    skillDirs,
+    skillDirs: stagedSkillDirs,
+    allSkillDirs: skillDirs,
     skillFiles,
+    allSkills,
+    copyExistingSkills: copyExistingSkills(runTarget),
     descriptionTokens,
     maxEdits,
     common,
     context,
     promptDir,
+    runTarget,
   };
 }
 
@@ -409,11 +445,14 @@ export async function synthesizeProposal({
     overflow,
     skillDirs,
     skillFiles,
+    allSkills,
+    copyExistingSkills: copySkills,
     descriptionTokens,
     maxEdits,
     common,
     context,
     promptDir,
+    runTarget,
   } = synthesisSetup({
     memoryFile,
     summary,
@@ -423,14 +462,34 @@ export async function synthesizeProposal({
     scope,
   });
 
-  let workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, skillDirs });
+  const workspaceOpts = {
+    state,
+    repo,
+    memoryFile,
+    skillsDir: overflow.dir,
+    skillDirs,
+    copyExistingSkills: copySkills,
+  };
+  let workspace = prepareWorkspace(workspaceOpts);
   const stagedSkillsDir =
     workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged ||
     workspacePathFor(overflow.dir);
-  const stagedSkillFiles = skillFiles.map((skill) => ({
-    ...skill,
-    path: workspace.stagedPaths.get(skill.path) || workspacePathFor(skill.path),
-  }));
+  const skillIndexSkills =
+    runTarget?.kind === "memory"
+      ? allSkills
+      : skillFiles.map((skill) => ({
+          ...skill,
+          path: workspace.stagedPaths.get(skill.path) || workspacePathFor(skill.path),
+        }));
+  const skillIndex =
+    runTarget?.kind === "skill"
+      ? "(this run targets this skill only; other skills are out of scope)"
+      : renderSkillIndex(skillIndexSkills);
+
+  const alwaysLoadedNow =
+    runTarget?.kind === "skill"
+      ? (memoryFile.alwaysLoadedTokens ?? descriptionTokens)
+      : memoryFile.tokens + descriptionTokens;
 
   const editValues = {
     ...common,
@@ -442,12 +501,12 @@ export async function synthesizeProposal({
       Object.entries(harnessCounts)
         .map(([h, n]) => `${h} ${n}`)
         .join(" · ") || "none",
-    CURRENT_TOKENS: String(memoryFile.tokens + descriptionTokens),
+    CURRENT_TOKENS: String(alwaysLoadedNow),
     BUDGET_TOKENS: String(config.budgetTokens),
-    BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
+    BUDGET_STATE: budgetState(memoryFile, config, runTarget?.kind === "skill" ? 0 : descriptionTokens),
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
     SKILLS_DIR: stagedSkillsDir,
-    SKILL_INDEX: renderSkillIndex(stagedSkillFiles),
+    SKILL_INDEX: skillIndex,
     EVIDENCE: renderEvidenceForPrompt(summary),
     REJECTIONS: renderRejections(rejections),
   };
@@ -455,7 +514,7 @@ export async function synthesizeProposal({
   const editPromptFile = path.join(promptDir, "synthesis-edit.md");
   fs.writeFileSync(editPromptFile, renderPrompt("synthesis", editValues));
 
-  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
+  const fingerprint = repoFingerprint(repo, [...new Set([memoryFile.path, ...allSkills.map((s) => s.path)])]);
   const sessionName = `backpass-synth-${process.pid}`;
   const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
   const usage = [];
@@ -507,7 +566,7 @@ export async function synthesizeProposal({
     holder.ranWith = current.agent;
     chosen = current;
     if (current !== pick) notes.push(`synthesis fell through to ${current.agent} (${current.model})`);
-    workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: overflow.dir, skillDirs });
+    workspace = prepareWorkspace(workspaceOpts);
     progress("edit", { attempt: 1 });
     holder.session = await openSession({
       agent: current.agent,

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -71,8 +71,9 @@ const EMPTY_TURN_VIOLATION =
 const UNPARSEABLE_VIOLATION = "synthesis answered with text, but not with a JSON object";
 const KEPT_EDITING_VIOLATION = "synthesis kept editing the staging copy instead of annotating the measured changes";
 
-function alwaysLoadedTokensOf(memoryFile, descriptionTokens = 0) {
+function alwaysLoadedTokensOf(memoryFile, descriptionTokens = 0, runTarget = null) {
   if (memoryFile.alwaysLoadedTokens != null) return memoryFile.alwaysLoadedTokens;
+  if (runTarget?.kind === "skill") return descriptionTokens;
   return memoryFile.tokens + descriptionTokens;
 }
 
@@ -82,13 +83,25 @@ function alwaysLoadedTokensOf(memoryFile, descriptionTokens = 0) {
  * (`buildProposal`). Framing one number and gating another would set the model up to
  * fail a gate it was never told about.
  */
-function budgetRule(memoryFile, config, maxEdits, descriptionTokens = 0) {
-  const current = alwaysLoadedTokensOf(memoryFile, descriptionTokens);
+function budgetRule(memoryFile, config, maxEdits, descriptionTokens = 0, runTarget = null) {
+  const skillTarget = runTarget?.kind === "skill";
+  const current = alwaysLoadedTokensOf(memoryFile, descriptionTokens, runTarget);
   const remaining = config.budgetTokens - current;
-  const counted = descriptionTokens
-    ? ` The budget counts this file plus every skill description line (${descriptionTokens} tok of descriptions today); skill bodies stay free until triggered.`
-    : "";
+  const counted = skillTarget
+    ? ` The budget counts only this skill's description (${current} tok today); its body stays free until triggered.`
+    : descriptionTokens
+      ? ` The budget counts this file plus every skill description line (${descriptionTokens} tok of descriptions today); skill bodies stay free until triggered.`
+      : "";
   if (remaining <= 0) {
+    if (skillTarget) {
+      return (
+        `The targeted skill description is ALREADY ${Math.abs(remaining)} tokens OVER budget, so this run is a ` +
+        `SHRINK PLAN. You are NOT expected to reach ${config.budgetTokens} tokens in one run. What is required is ` +
+        `real progress: the description MUST be net-negative. Tighten its trigger without losing when the skill ` +
+        `should load. Extraction does not apply, and any description addition must be offset by a larger description ` +
+        `removal.${counted}`
+      );
+    }
     return (
       `The always-loaded surface is ALREADY ${Math.abs(remaining)} tokens OVER budget, so this run is a SHRINK ` +
       `PLAN. You are NOT expected to reach ${config.budgetTokens} tokens in one run - the ` +
@@ -104,21 +117,23 @@ function budgetRule(memoryFile, config, maxEdits, descriptionTokens = 0) {
     );
   }
   if (remaining < config.budgetTokens * 0.15) {
-    return (
-      `Only ${remaining} tokens of headroom remain. Treat this as zero-sum: every addition must ` +
-      `name its offsetting removal or skill extraction. The post-edit always-loaded surface must stay at or below ` +
-      `${config.budgetTokens} tokens.` +
-      counted
-    );
+    return skillTarget
+      ? `Only ${remaining} tokens of description headroom remain. Treat this as zero-sum: every description addition ` +
+          `must name its offsetting description removal. The post-edit description must stay at or below ` +
+          `${config.budgetTokens} tokens.${counted}`
+      : `Only ${remaining} tokens of headroom remain. Treat this as zero-sum: every addition must ` +
+          `name its offsetting removal or skill extraction. The post-edit always-loaded surface must stay at or below ` +
+          `${config.budgetTokens} tokens.${counted}`;
   }
-  return (
-    `The post-edit always-loaded surface must stay at or below ${config.budgetTokens} tokens ` +
-    `(${remaining} tokens of headroom today).${counted}`
-  );
+  return skillTarget
+    ? `The targeted skill description must stay at or below ${config.budgetTokens} tokens ` +
+        `(${remaining} tokens of headroom today).${counted}`
+    : `The post-edit always-loaded surface must stay at or below ${config.budgetTokens} tokens ` +
+        `(${remaining} tokens of headroom today).${counted}`;
 }
 
-function budgetState(memoryFile, config, descriptionTokens = 0) {
-  const ratio = alwaysLoadedTokensOf(memoryFile, descriptionTokens) / config.budgetTokens;
+function budgetState(memoryFile, config, descriptionTokens = 0, runTarget = null) {
+  const ratio = alwaysLoadedTokensOf(memoryFile, descriptionTokens, runTarget) / config.budgetTokens;
   if (ratio > 1) return "OVER BUDGET";
   if (ratio > 0.85) return "near budget";
   return "within budget";
@@ -195,7 +210,7 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
 
   const common = {
     MEMORY_PATH: workspacePathFor(memoryFile.path),
-    BUDGET_RULE: budgetRule(memoryFile, config, maxEdits, descriptionTokens),
+    BUDGET_RULE: budgetRule(memoryFile, config, maxEdits, descriptionTokens, runTarget),
     MAX_EDITS: String(maxEdits),
     MIN_GAP_EVIDENCE: String(config.minGapEvidence),
     TARGET_RULE: targetRule(runTarget, workspacePathFor(memoryFile.path), workspacePathFor(overflow.dir)),
@@ -241,14 +256,14 @@ function synthesisSetup({ memoryFile, summary, config, repo, harnessCounts, scop
  * fresh session used after an empty reply would otherwise be asked to quote evidence it
  * has never been shown.
  */
-function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0 }) {
+function prefaceFor({ memoryFile, summary, config, repo, workspaceRoot, descriptionTokens = 0, runTarget = null }) {
   return render(loadPrompt("annotate-preface"), {
     MEMORY_PATH: workspacePathFor(memoryFile.path),
     REPO_NAME: repo.name,
     REPO_ROOT: repo.root,
     WORKSPACE_ROOT: workspaceRoot,
-    CURRENT_TOKENS: String(memoryFile.tokens + descriptionTokens),
-    BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens),
+    CURRENT_TOKENS: String(alwaysLoadedTokensOf(memoryFile, descriptionTokens, runTarget)),
+    BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens, runTarget),
     TRANSCRIPT_COUNT: String(summary.analyzedSessions),
     EVIDENCE: renderEvidenceForPrompt(summary),
   });
@@ -486,10 +501,7 @@ export async function synthesizeProposal({
       ? "(this run targets this skill only; other skills are out of scope)"
       : renderSkillIndex(skillIndexSkills);
 
-  const alwaysLoadedNow =
-    runTarget?.kind === "skill"
-      ? (memoryFile.alwaysLoadedTokens ?? descriptionTokens)
-      : memoryFile.tokens + descriptionTokens;
+  const alwaysLoadedNow = alwaysLoadedTokensOf(memoryFile, descriptionTokens, runTarget);
 
   const editValues = {
     ...common,
@@ -503,7 +515,7 @@ export async function synthesizeProposal({
         .join(" · ") || "none",
     CURRENT_TOKENS: String(alwaysLoadedNow),
     BUDGET_TOKENS: String(config.budgetTokens),
-    BUDGET_STATE: budgetState(memoryFile, config, runTarget?.kind === "skill" ? 0 : descriptionTokens),
+    BUDGET_STATE: budgetState(memoryFile, config, descriptionTokens, runTarget),
     INSTRUCTION_INDEX: renderInstructionIndex(memoryFile),
     SKILLS_DIR: stagedSkillsDir,
     SKILL_INDEX: skillIndex,
@@ -621,7 +633,15 @@ export async function synthesizeProposal({
       overflow,
       progress,
       renderPreface: () =>
-        prefaceFor({ memoryFile, summary, config, repo, workspaceRoot: workspace.root, descriptionTokens }),
+        prefaceFor({
+          memoryFile,
+          summary,
+          config,
+          repo,
+          workspaceRoot: workspace.root,
+          descriptionTokens,
+          runTarget,
+        }),
     });
   } finally {
     await holder.session.close();

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -25,10 +25,10 @@ import { UserError, color, info, warn } from "./logger.js";
  * evidence into concrete edits.
  *
  * The agent never describes an edit for backpass to locate - it makes the edit, with its
- * harness's own file tools, in a staging copy of the memory file and project skills
+ * harness's own file tools, in a staging copy of the run's writable surface
  * (`src/workspace.js`). A run starts in one session with two kinds of turn:
  *
- *   edit      the synthesis prompt; the agent edits `./AGENTS.md` in the staging copy
+ *   edit      the synthesis prompt; the agent edits the file under audit in the staging copy
  *   annotate  backpass measures the copy against the original (`src/diff.js`) and shows
  *             the changes by id; the agent attaches kind, title, rationale, and evidence
  *
@@ -78,10 +78,11 @@ function alwaysLoadedTokensOf(memoryFile, descriptionTokens = 0, runTarget = nul
 }
 
 /**
- * The budget the prompts frame is the always-loaded surface: the memory file plus
- * every skill description line, the same sum the mechanical gate measures
- * (`buildProposal`). Framing one number and gating another would set the model up to
- * fail a gate it was never told about.
+ * The budget the prompts frame is the always-loaded write target: the memory file plus
+ * every skill description line for a surface or memory target, or the targeted skill's
+ * description alone. It is the same sum the mechanical gate measures (`buildProposal`).
+ * Framing one number and gating another would set the model up to fail a gate it was
+ * never told about.
  */
 function budgetRule(memoryFile, config, maxEdits, descriptionTokens = 0, runTarget = null) {
   const skillTarget = runTarget?.kind === "skill";

--- a/src/target.js
+++ b/src/target.js
@@ -5,7 +5,7 @@ import { userClaudeSkillsDir } from "./config.js";
 import { UserError, info } from "./logger.js";
 import { readMemoryFile, resolveMemoryPath } from "./memory.js";
 import { expandUserPath } from "./scope.js";
-import { loadProjectSkills, resolveOverflowTarget, resolveProjectSkillDirs } from "./skills.js";
+import { loadProjectSkills, readSkill, resolveOverflowTarget, resolveProjectSkillDirs } from "./skills.js";
 
 /**
  * A run's write surface. Default is the whole project or user surface (the primary
@@ -83,7 +83,7 @@ function matchSkill(spec, skills, { root }) {
   if (!file) return null;
   const logical = posixRel(root, file);
   if (path.basename(file) === "SKILL.md" || /(?:^|\/)skills\/.+\.md$/.test(logical.replaceAll("\\", "/"))) {
-    return skills.find((skill) => skill.path === logical) || { name: path.basename(path.dirname(file)), path: logical };
+    return skills.find((skill) => skill.path === logical) || readSkill(root, file);
   }
   return null;
 }

--- a/src/target.js
+++ b/src/target.js
@@ -25,13 +25,15 @@ export const SURFACE_TARGET = { kind: "surface" };
  */
 export function loadScopeSkills(repo, config, scope = null) {
   const userScope = scope?.kind === "user";
-  const overflow = resolveOverflowTarget(repo.root, config.skillsDir, {
+  const configuredSkillsDir = scope?.overflowDir ?? config.skillsDir;
+  const configuredSkillDirs = scope?.skillDirs ?? config.skillsDirs ?? [];
+  const overflow = resolveOverflowTarget(repo.root, configuredSkillsDir, {
     claudeSkillsDir: userScope ? userClaudeSkillsDir() : undefined,
   });
-  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || [], {
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, configuredSkillDirs, {
     exact: userScope,
   });
-  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
+  const skills = loadProjectSkills(repo.root, overflow.dir, configuredSkillDirs, { exact: userScope });
   return { overflow, skillDirs, skills };
 }
 
@@ -96,38 +98,48 @@ function looksLikeMemoryFile(spec, root, allowExternal, memoryFiles = []) {
     if (!(err instanceof UserError)) throw err;
   }
   const base = spec.split(/[/\\]/).pop();
+  const matches = [];
   for (const candidate of memoryFiles) {
     try {
       const absolute = resolveMemoryPath(root, candidate, { allowExternal });
       if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) continue;
       const logical = posixRel(root, absolute);
       if (candidate === spec || logical === spec || path.basename(absolute) === base) {
-        return { absolute, path: logical };
+        matches.push({ absolute, path: logical });
       }
     } catch (err) {
       if (!(err instanceof UserError)) throw err;
     }
   }
-  return null;
+  const unique = [...new Map(matches.map((match) => [match.absolute, match])).values()];
+  if (unique.length > 1) {
+    throw new UserError(
+      `--target "${spec}" matches ${unique.length} memory files (${unique.map((match) => match.path).join(", ")})`,
+      "pass the exact memory file path to disambiguate",
+    );
+  }
+  return unique[0] || null;
 }
 
 /**
  * Resolve `--target` against this scope's memory files and skills.
- * Missing or empty spec is the whole surface.
+ * A missing spec is the whole surface; an explicitly empty spec is invalid.
  *
  * @param {string | null | undefined} spec
  * @param {{ repo: { root: string }, config: object, scope?: object | null, skills?: object[], skillDirs?: string[] }} context
  */
 export function resolveRunTarget(spec, { repo, config, scope = null, skills = null, skillDirs = null }) {
-  if (spec == null || spec === "") return { ...SURFACE_TARGET };
+  if (spec == null) return { ...SURFACE_TARGET };
 
   const trimmed = String(spec).trim();
-  if (!trimmed) return { ...SURFACE_TARGET };
+  if (!trimmed) {
+    throw new UserError("--target cannot be empty", "name one memory file or skill, or omit --target");
+  }
 
   const loaded = skills && skillDirs ? { skills, skillDirs } : loadScopeSkills(repo, config, scope);
   const allowExternal = scope?.kind === "user";
   const skill = matchSkill(trimmed, loaded.skills, { root: repo.root });
-  const memory = looksLikeMemoryFile(trimmed, repo.root, allowExternal, config.memoryFiles || []);
+  const memory = looksLikeMemoryFile(trimmed, repo.root, allowExternal, scope?.memoryFiles ?? config.memoryFiles ?? []);
 
   if (skill && memory && skill.path !== memory.path) {
     throw new UserError(
@@ -176,7 +188,7 @@ function skillHint(skillPath) {
 
 export function parseTargetFlag(values) {
   const spec = values?.target;
-  if (spec == null || spec === "") return null;
+  if (spec == null) return null;
   if (Array.isArray(spec)) {
     if (spec.length > 1) {
       throw new UserError("--target names one memory file or one skill, not several", "run once per file");

--- a/src/target.js
+++ b/src/target.js
@@ -1,0 +1,207 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { userClaudeSkillsDir } from "./config.js";
+import { UserError, info } from "./logger.js";
+import { readMemoryFile, resolveMemoryPath } from "./memory.js";
+import { expandUserPath } from "./scope.js";
+import { loadProjectSkills, resolveOverflowTarget, resolveProjectSkillDirs } from "./skills.js";
+
+/**
+ * A run's write surface. Default is the whole project or user surface (the primary
+ * memory file plus every skill). `--target` names one memory file or one skill, and
+ * that choice must not silently widen to the rest of the surface.
+ *
+ *   surface  today's default: primary memory file + all skills
+ *   memory   that memory file; new skill extracts allowed; existing skills are not writable
+ *   skill    that skill file only; the memory file and every other skill stay out
+ */
+
+export const SURFACE_TARGET = { kind: "surface" };
+
+/**
+ * Skills and overflow layout for this scope. Synthesis prints overflow-layout
+ * warnings; this resolution is read-only.
+ */
+export function loadScopeSkills(repo, config, scope = null) {
+  const userScope = scope?.kind === "user";
+  const overflow = resolveOverflowTarget(repo.root, config.skillsDir, {
+    claudeSkillsDir: userScope ? userClaudeSkillsDir() : undefined,
+  });
+  const skillDirs = resolveProjectSkillDirs(repo.root, overflow.dir, config.skillsDirs || [], {
+    exact: userScope,
+  });
+  const skills = loadProjectSkills(repo.root, overflow.dir, config.skillsDirs || [], { exact: userScope });
+  return { overflow, skillDirs, skills };
+}
+
+function posixRel(root, absolute) {
+  const rel = path.relative(root, absolute);
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return absolute;
+  return rel.split(path.sep).join("/");
+}
+
+function specPath(spec, root) {
+  const expanded = expandUserPath(spec);
+  const absolute = path.isAbsolute(expanded) ? path.resolve(expanded) : path.resolve(root, expanded);
+  return { absolute, relative: posixRel(root, absolute) };
+}
+
+function skillFileAt(absolute) {
+  if (!fs.existsSync(absolute)) return null;
+  const stat = fs.statSync(absolute);
+  if (stat.isFile() && path.basename(absolute) === "SKILL.md") return absolute;
+  if (stat.isDirectory()) {
+    const nested = path.join(absolute, "SKILL.md");
+    if (fs.existsSync(nested) && fs.statSync(nested).isFile()) return nested;
+  }
+  if (stat.isFile() && absolute.endsWith(".md")) return absolute;
+  return null;
+}
+
+function matchSkill(spec, skills, { root }) {
+  const { absolute, relative } = specPath(spec, root);
+  const byName = skills.filter((skill) => skill.name === spec);
+  const byPath = skills.filter((skill) => {
+    if (skill.path === spec || skill.path === relative || skill.path === absolute) return true;
+    const skillAbs = path.isAbsolute(skill.path) ? skill.path : path.resolve(root, skill.path);
+    return path.resolve(skillAbs) === absolute;
+  });
+
+  const unique = [...new Map([...byName, ...byPath].map((skill) => [skill.path, skill])).values()];
+  if (unique.length === 1) return unique[0];
+  if (unique.length > 1) {
+    throw new UserError(
+      `--target "${spec}" matches ${unique.length} skills (${unique.map((s) => s.path).join(", ")})`,
+      "pass the SKILL.md path to disambiguate",
+    );
+  }
+
+  const file = skillFileAt(absolute);
+  if (!file) return null;
+  const logical = posixRel(root, file);
+  if (path.basename(file) === "SKILL.md" || /(?:^|\/)skills\/.+\.md$/.test(logical.replaceAll("\\", "/"))) {
+    return skills.find((skill) => skill.path === logical) || { name: path.basename(path.dirname(file)), path: logical };
+  }
+  return null;
+}
+
+function looksLikeMemoryFile(spec, root, allowExternal, memoryFiles = []) {
+  try {
+    const absolute = resolveMemoryPath(root, spec, { allowExternal });
+    if (fs.existsSync(absolute) && fs.statSync(absolute).isFile()) {
+      return { absolute, path: posixRel(root, absolute) };
+    }
+  } catch (err) {
+    if (!(err instanceof UserError)) throw err;
+  }
+  const base = spec.split(/[/\\]/).pop();
+  for (const candidate of memoryFiles) {
+    try {
+      const absolute = resolveMemoryPath(root, candidate, { allowExternal });
+      if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) continue;
+      const logical = posixRel(root, absolute);
+      if (candidate === spec || logical === spec || path.basename(absolute) === base) {
+        return { absolute, path: logical };
+      }
+    } catch (err) {
+      if (!(err instanceof UserError)) throw err;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve `--target` against this scope's memory files and skills.
+ * Missing or empty spec is the whole surface.
+ *
+ * @param {string | null | undefined} spec
+ * @param {{ repo: { root: string }, config: object, scope?: object | null, skills?: object[], skillDirs?: string[] }} context
+ */
+export function resolveRunTarget(spec, { repo, config, scope = null, skills = null, skillDirs = null }) {
+  if (spec == null || spec === "") return { ...SURFACE_TARGET };
+
+  const trimmed = String(spec).trim();
+  if (!trimmed) return { ...SURFACE_TARGET };
+
+  const loaded = skills && skillDirs ? { skills, skillDirs } : loadScopeSkills(repo, config, scope);
+  const allowExternal = scope?.kind === "user";
+  const skill = matchSkill(trimmed, loaded.skills, { root: repo.root });
+  const memory = looksLikeMemoryFile(trimmed, repo.root, allowExternal, config.memoryFiles || []);
+
+  if (skill && memory && skill.path !== memory.path) {
+    throw new UserError(
+      `--target "${trimmed}" names both skill ${skill.path} and memory file ${memory.path}`,
+      "pass the SKILL.md path, or the memory file path, not a name that matches both",
+    );
+  }
+  if (skill) {
+    const file = readMemoryFile(repo.root, skill.path, { allowExternal });
+    if (!file) {
+      throw new UserError(`skill ${skill.path} is unreadable`, "check the SKILL.md path and retry");
+    }
+    return {
+      kind: "skill",
+      spec: trimmed,
+      path: file.path,
+      name: skill.name,
+      skill: { ...skill, path: file.path },
+      file,
+    };
+  }
+  if (memory) {
+    if (path.basename(memory.path) === "SKILL.md") {
+      throw new UserError(
+        `${memory.path} is a skill file; a memory-file target cannot write it`,
+        `pass --target ${skillHint(memory.path)} to train that skill`,
+      );
+    }
+    return { kind: "memory", spec: trimmed, path: memory.path };
+  }
+
+  const listed = loaded.skills.length
+    ? `known skills: ${loaded.skills.map((s) => s.name).join(", ")}`
+    : "this scope has no skills yet";
+  throw new UserError(
+    `--target "${trimmed}" is not a memory file or skill in this ${scope?.kind === "user" ? "user scope" : "repo"}`,
+    listed,
+  );
+}
+
+function skillHint(skillPath) {
+  const parts = String(skillPath).split("/");
+  const named = parts.length >= 2 && parts[parts.length - 1] === "SKILL.md" ? parts[parts.length - 2] : skillPath;
+  return named;
+}
+
+export function parseTargetFlag(values) {
+  const spec = values?.target;
+  if (spec == null || spec === "") return null;
+  if (Array.isArray(spec)) {
+    if (spec.length > 1) {
+      throw new UserError("--target names one memory file or one skill, not several", "run once per file");
+    }
+    return spec[0];
+  }
+  return spec;
+}
+
+/** Existing skills are writable only on a whole-surface run. */
+export function copyExistingSkills(runTarget) {
+  return !runTarget || runTarget.kind === "surface";
+}
+
+/** Skill-dir mappings that measure created SKILL.md files. Empty for a skill-only run. */
+export function workspaceSkillDirs(runTarget, skillDirs) {
+  if (runTarget?.kind === "skill") return [];
+  return skillDirs;
+}
+
+export function printTargetNote(runTarget) {
+  if (!runTarget || runTarget.kind === "surface") return;
+  if (runTarget.kind === "skill") {
+    info(`targeting skill ${runTarget.name} (${runTarget.path}); the memory file and other skills are out of this run`);
+    return;
+  }
+  info(`targeting ${runTarget.path}; existing skills are not writable this run`);
+}

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -34,7 +34,14 @@ export function workspacePathFor(file) {
  * Build a fresh staging copy. `originals` records every file placed there, so the
  * measurement can tell a modified file from a created or deleted one.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs = [skillsDir] }) {
+export function prepareWorkspace({
+  state,
+  repo,
+  memoryFile,
+  skillsDir,
+  skillDirs = [skillsDir],
+  copyExistingSkills = true,
+}) {
   const root = workspaceRoot(state);
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
@@ -51,21 +58,22 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs
   const skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) }));
   for (const { logical: sourceDir, staged: stagedDir } of skillMappings) {
     const skillsSource = path.isAbsolute(sourceDir) ? sourceDir : path.join(repo.root, sourceDir);
-    if (!fs.existsSync(skillsSource) || !fs.statSync(skillsSource).isDirectory()) continue;
-    for (const relative of walkFiles(skillsSource)) {
-      const from = path.join(skillsSource, relative);
-      const logical = path.isAbsolute(sourceDir)
-        ? path.join(sourceDir, relative)
-        : path.posix.join(sourceDir, relative);
-      const staged = path.posix.join(stagedDir, relative);
-      const to = path.join(root, staged);
-      fs.mkdirSync(path.dirname(to), { recursive: true });
-      fs.copyFileSync(from, to);
-      originals.set(logical, fs.readFileSync(from, "utf8"));
-      stagedPaths.set(logical, staged);
+    if (copyExistingSkills && fs.existsSync(skillsSource) && fs.statSync(skillsSource).isDirectory()) {
+      for (const relative of walkFiles(skillsSource)) {
+        const from = path.join(skillsSource, relative);
+        const logical = path.isAbsolute(sourceDir)
+          ? path.join(sourceDir, relative)
+          : path.posix.join(sourceDir, relative);
+        const staged = path.posix.join(stagedDir, relative);
+        const to = path.join(root, staged);
+        fs.mkdirSync(path.dirname(to), { recursive: true });
+        fs.copyFileSync(from, to);
+        originals.set(logical, fs.readFileSync(from, "utf8"));
+        stagedPaths.set(logical, staged);
+      }
     }
   }
-  fs.mkdirSync(path.join(root, workspacePathFor(skillsDir)), { recursive: true });
+  if (skillsDir) fs.mkdirSync(path.join(root, workspacePathFor(skillsDir)), { recursive: true });
 
   return {
     root,

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -1164,9 +1164,13 @@
               "Δ " + label + " " + (value > 0 ? "+" : "") + fmt(value) + " tok",
             );
           }
-          head.appendChild(
-            edit.targetsMemoryFile ? deltaNode("memory", delta) : deltaNode("on trigger", delta - descriptionDelta),
-          );
+          if (P.target && P.target.kind === "skill") {
+            head.appendChild(deltaNode("on trigger", delta - descriptionDelta));
+          } else {
+            head.appendChild(
+              edit.targetsMemoryFile ? deltaNode("memory", delta) : deltaNode("on trigger", delta - descriptionDelta),
+            );
+          }
           if (descriptionDelta) head.appendChild(deltaNode("description (always-loaded)", descriptionDelta));
           card.appendChild(head);
 
@@ -1325,8 +1329,12 @@
               // The always-loaded projection: memory-file deltas plus each edit's
               // measured description-line delta (a tuned skill trigger, or the
               // description a created skill adds). Skill bodies never move this bar.
-              if (e.targetsMemoryFile) tok += e.deltaTokens || 0;
-              tok += e.descriptionDelta || 0;
+              if (P.target && P.target.kind === "skill") {
+                tok += e.descriptionDelta || 0;
+              } else {
+                if (e.targetsMemoryFile) tok += e.deltaTokens || 0;
+                tok += e.descriptionDelta || 0;
+              }
               descriptionTok += e.descriptionDelta || 0;
             } else if (decisions[e.id] === "rejected") {
               rejected += 1;
@@ -1335,7 +1343,13 @@
           var over = tok > budget.capTokens;
 
           document.getElementById("gauge-title").textContent =
-            "Always-loaded budget · " + (P.memoryFile.path || "") + (descriptionTok > 0 ? " + skill descriptions" : "");
+            "Always-loaded budget · " +
+            (P.memoryFile.path || "") +
+            (P.target && P.target.kind === "skill"
+              ? " description"
+              : descriptionTok > 0
+                ? " + skill descriptions"
+                : "");
           document.getElementById("n-accept").textContent = accepted;
           document.getElementById("n-reject").textContent = rejected;
 

--- a/test/helpers/staging.js
+++ b/test/helpers/staging.js
@@ -32,12 +32,26 @@ export function writeIn(root, relative, textOrFn) {
 }
 
 /**
- * @param {{ repo: any, memoryPath?: string, skillsDir?: string, edit: (workspaceRoot: string) => void }} options
+ * @param {{ repo: any, memoryPath?: string, skillsDir?: string, skillDirs?: string[], copyExistingSkills?: boolean, edit: (workspaceRoot: string) => void }} options
  */
-export function stageAndMeasure({ repo, memoryPath = "AGENTS.md", skillsDir = ".agents/skills", edit }) {
+export function stageAndMeasure({
+  repo,
+  memoryPath = "AGENTS.md",
+  skillsDir = ".agents/skills",
+  skillDirs,
+  copyExistingSkills = true,
+  edit,
+}) {
   const memoryFile = readMemoryFile(repo.root, memoryPath);
   const state = new State(repo.root).ensure();
-  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir });
+  const workspace = prepareWorkspace({
+    state,
+    repo,
+    memoryFile,
+    skillsDir,
+    skillDirs: skillDirs || [skillsDir],
+    copyExistingSkills,
+  });
   edit(workspace.root);
   return { memoryFile, state, workspace, measured: measureWorkspace(workspace) };
 }

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -2289,6 +2289,39 @@ test("the apply surface separates memory, description, and on-trigger deltas", (
   assert.equal(nodes.get("gauge-title").textContent, "Always-loaded budget · AGENTS.md + skill descriptions");
 });
 
+test("the apply surface counts a targeted skill description once", () => {
+  const proposal = {
+    generatedAt: "2026-08-01T00:00:00.000Z",
+    repo: { name: "demo" },
+    target: { kind: "skill", name: "db", path: ".agents/skills/db/SKILL.md" },
+    memoryFile: { path: ".agents/skills/db/SKILL.md" },
+    stats: { harnessCounts: {}, transcripts: 2, positive: 0, negative: 0, gapClusters: 0, skillExtractions: 0 },
+    config: { maxEditsPerRun: 5, minGapEvidence: 2 },
+    budget: { current: 10, projected: 15, capTokens: 100, descriptionTokens: 10, mode: "cap" },
+    edits: [
+      {
+        id: "e1",
+        kind: "rewrite",
+        title: "improve database guidance",
+        file: ".agents/skills/db/SKILL.md",
+        targetsMemoryFile: true,
+        deltaTokens: 25,
+        descriptionDelta: 5,
+        hunks: [],
+        evidence: [],
+      },
+    ],
+  };
+  const { nodes, textOf } = renderTemplateScript(proposal);
+
+  const card = nodes.get("edits").children[0];
+  assert.match(textOf(card), /Δ on trigger \+20 tok/);
+  assert.match(textOf(card), /Δ description \(always-loaded\) \+5 tok/);
+  assert.doesNotMatch(textOf(card), /Δ memory/);
+  assert.equal(nodes.get("gauge-title").textContent, "Always-loaded budget · .agents/skills/db/SKILL.md description");
+  assert.match(textOf(nodes.get("gauge-readout")), /if accepted 15 tok/);
+});
+
 test("the apply surface draws one funnel from findings to the edits it proposed", () => {
   const rewrite = (id, removed = 1) => ({
     id,

--- a/test/subprocess.test.js
+++ b/test/subprocess.test.js
@@ -39,7 +39,7 @@ setInterval(() => {}, 1000);
 
     let harnessPid;
     try {
-      const result = await runCapture(process.execPath, [acpxPath], { timeoutMs: 250 });
+      const result = await runCapture(process.execPath, [acpxPath], { timeoutMs: 1000 });
       assert.equal(result.timedOut, true);
       assert.ok(fs.existsSync(pidPath));
       assert.equal(fs.readFileSync(signalPath, "utf8"), "SIGTERM");

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -577,17 +577,21 @@ test("a skill target stages only that skill, so a write to AGENTS.md cannot ente
     {
       edit: {
         [workspacePathFor(".agents/skills/db/SKILL.md")]: {
-          replace: [["Keep transactions short.", "Keep every transaction short."]],
+          replace: [
+            ["Load for database work.", "Database work."],
+            ["Keep transactions short.", "Keep every transaction short."],
+          ],
         },
         "AGENTS.md": "# hijack\n",
       },
-      annotations: [{ reply: { edits: [tighten(["H1"])], verdicts: [], notes: [] } }],
+      annotations: [{ reply: "" }, { reply: { edits: [tighten(["H1", "H2"])], verdicts: [], notes: [] } }],
     },
     { text: AGENTS },
   );
   fs.mkdirSync(path.join(repo.root, ".agents/skills/db"), { recursive: true });
   fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skillText);
   const memoryFile = readMemoryFile(repo.root, ".agents/skills/db/SKILL.md");
+  config.budgetTokens = 1;
   config.runTarget = {
     kind: "skill",
     path: memoryFile.path,
@@ -610,4 +614,15 @@ test("a skill target stages only that skill, so a write to AGENTS.md cannot ente
     false,
   );
   assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), AGENTS);
+
+  const descriptionTokens = (await import("../src/tokens.js")).estimateTokens("Load for database work.");
+  const editPrompt = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-edit.md"), "utf8");
+  assert.match(editPrompt, new RegExp(`Budget: ${descriptionTokens} / 1 estimated always-loaded tokens`));
+  assert.match(editPrompt, /targeted skill description is ALREADY/);
+  assert.doesNotMatch(editPrompt, /lead with skill extractions/);
+  const freshPrompt = fs.readFileSync(
+    path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-2.md"),
+    "utf8",
+  );
+  assert.match(freshPrompt, new RegExp(`SKILL\\.md.* - ${descriptionTokens} tokens, OVER BUDGET`));
 });

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -620,9 +620,6 @@ test("a skill target stages only that skill, so a write to AGENTS.md cannot ente
   assert.match(editPrompt, new RegExp(`Budget: ${descriptionTokens} / 1 estimated always-loaded tokens`));
   assert.match(editPrompt, /targeted skill description is ALREADY/);
   assert.doesNotMatch(editPrompt, /lead with skill extractions/);
-  const freshPrompt = fs.readFileSync(
-    path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-2.md"),
-    "utf8",
-  );
+  const freshPrompt = fs.readFileSync(path.join(repo.root, ".backpass", "prompts", "synthesis-annotate-2.md"), "utf8");
   assert.match(freshPrompt, new RegExp(`SKILL\\.md.* - ${descriptionTokens} tokens, OVER BUDGET`));
 });

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -543,3 +543,71 @@ test("an oversized non-compliance blob synthesizes as a list-item restructure, n
   assert.match(editPrompt, /Preferred reinforcement is a restructure-in-place/);
   assert.match(editPrompt, /bold label on the blob is not a strengthen/);
 });
+
+test("a memory-file target does not stage existing skills, and the proposal cannot name them", async () => {
+  const { repo, config, run } = setup({
+    edit: {
+      "AGENTS.md": { replace: [["- Keep this file short.\n", "- Keep this file short; point at files.\n"]] },
+    },
+    annotations: [{ reply: { edits: [tighten(["H1"])], verdicts: [], notes: [] } }],
+  });
+  fs.mkdirSync(path.join(repo.root, ".agents/skills/db"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repo.root, ".agents/skills/db/SKILL.md"),
+    "---\nname: db\ndescription: Load for database work.\n---\n\n- Keep transactions short.\n",
+  );
+  config.runTarget = { kind: "memory", path: "AGENTS.md" };
+  const { proposal, violations } = await run();
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.target.kind, "memory");
+  assert.equal(proposal.memoryFile.path, "AGENTS.md");
+  assert.equal(proposal.edits.length, 1);
+  assert.equal(proposal.edits[0].file, "AGENTS.md");
+  assert.equal(fs.existsSync(path.join(repo.root, ".backpass", "synthesis", ".agents/skills/db/SKILL.md")), false);
+  assert.equal(
+    proposal.edits.some((e) => (e.hunks || []).some((h) => String(h.file).includes("SKILL.md"))),
+    false,
+  );
+  assert.match(fs.readFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), "utf8"), /Load for database work/);
+});
+
+test("a skill target stages only that skill, so a write to AGENTS.md cannot enter the proposal", async () => {
+  const skillText = "---\nname: db\ndescription: Load for database work.\n---\n\n- Keep transactions short.\n";
+  const { repo, config } = setup(
+    {
+      edit: {
+        [workspacePathFor(".agents/skills/db/SKILL.md")]: {
+          replace: [["Keep transactions short.", "Keep every transaction short."]],
+        },
+        "AGENTS.md": "# hijack\n",
+      },
+      annotations: [{ reply: { edits: [tighten(["H1"])], verdicts: [], notes: [] } }],
+    },
+    { text: AGENTS },
+  );
+  fs.mkdirSync(path.join(repo.root, ".agents/skills/db"), { recursive: true });
+  fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), skillText);
+  const memoryFile = readMemoryFile(repo.root, ".agents/skills/db/SKILL.md");
+  config.runTarget = {
+    kind: "skill",
+    path: memoryFile.path,
+    name: "db",
+    skill: { name: "db", path: memoryFile.path, description: "Load for database work." },
+    file: memoryFile,
+  };
+  const { proposal, violations } = await synthesizeProposal({
+    memoryFile,
+    summary: summaryFor(),
+    config,
+    repo,
+    transcripts: [{ harness: "claude" }],
+  });
+  assert.ok(violations.length === 0 || proposal.edits.every((e) => e.file === memoryFile.path));
+  assert.equal(proposal.target.kind, "skill");
+  assert.equal(proposal.memoryFile.path, ".agents/skills/db/SKILL.md");
+  assert.equal(
+    proposal.edits.some((e) => e.file === "AGENTS.md" || (e.hunks || []).some((h) => h.file === "AGENTS.md")),
+    false,
+  );
+  assert.equal(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), AGENTS);
+});

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -246,6 +246,45 @@ test("buildProposal on a memory-file target refuses to recreate an existing skil
   assert.equal(proposal.target.kind, "memory");
 });
 
+test("a skill target refuses pure deletion even with harm evidence", () => {
+  const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
+  const memoryFile = readMemoryFile(repo.root, ".agents/skills/db/SKILL.md");
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile,
+    skillsDir: ".agents/skills",
+    skillDirs: [],
+    copyExistingSkills: false,
+  });
+  writeIn(workspace.root, workspacePathFor(memoryFile.path), (text) =>
+    text.replace("- Wrap migrations in a transaction.\n", ""),
+  );
+  const measured = measureWorkspace(workspace);
+  const { proposal, violations } = buildProposal(
+    {
+      edits: [
+        {
+          changes: measured.changes.map((change) => change.id),
+          kind: "remove",
+          title: "drop transaction guidance",
+          evidence: QUOTE,
+        },
+      ],
+    },
+    {
+      memoryFile,
+      config: { budgetTokens: 5000, maxEditsPerRun: 5, minGapEvidence: 2, skillsDir: ".agents/skills" },
+      repo,
+      summary: summary(),
+      measured,
+      runTarget: { kind: "skill", path: memoryFile.path, name: "db" },
+    },
+  );
+  assert.equal(proposal.edits.length, 0);
+  assert.ok(violations.some((violation) => /no evidence can attribute to skill files/.test(violation)));
+});
+
 test("a skill target ignores other writes and applies against its description-only budget", () => {
   const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
   const memoryFile = readMemoryFile(repo.root, ".agents/skills/db/SKILL.md");

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -7,12 +7,14 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { applyDecisions } from "../src/apply/writer.js";
+import { cmdApply } from "../src/commands/apply.js";
 import { primaryMemoryFile } from "../src/commands/analyze.js";
 import { loadConfig } from "../src/config.js";
 import { UserError } from "../src/logger.js";
 import { readMemoryFile } from "../src/memory.js";
 import { buildProposal, projectWithDecisions } from "../src/proposal.js";
 import { State } from "../src/state.js";
+import { resolveScope } from "../src/scope.js";
 import { resolveRunTarget } from "../src/target.js";
 import { estimateTokens } from "../src/tokens.js";
 import { prepareWorkspace, measureWorkspace, workspacePathFor } from "../src/workspace.js";
@@ -90,11 +92,36 @@ test("resolveRunTarget accepts a skill by name or SKILL.md path", () => {
   assert.equal(byDir.path, ".agents/skills/db/SKILL.md");
 });
 
-test("resolveRunTarget refuses an unknown name instead of falling back to the whole surface", () => {
+test("resolveRunTarget refuses empty and unknown names instead of widening", () => {
   const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
   const config = cfg(repo);
+  assert.throws(() => resolveRunTarget("   ", { repo, config }), /--target cannot be empty/);
   assert.throws(() => resolveRunTarget("nope", { repo, config }), UserError);
   assert.throws(() => resolveRunTarget("nope", { repo, config }), /not a memory file or skill/);
+});
+
+test("resolveRunTarget refuses an ambiguous memory basename", () => {
+  const repo = makeRepo({
+    "docs/AGENTS.md": AGENTS,
+    "packages/a/AGENTS.md": AGENTS,
+  });
+  const config = { memoryFiles: ["docs/AGENTS.md", "packages/a/AGENTS.md"], skillsDir: ".agents/skills" };
+  assert.throws(() => resolveRunTarget("AGENTS.md", { repo, config }), /matches 2 memory files/);
+  assert.equal(resolveRunTarget("docs/AGENTS.md", { repo, config }).path, "docs/AGENTS.md");
+});
+
+test("resolveRunTarget uses scope-normalized user skill directories", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-user-"));
+  writeIn(home, "memory-skills/db/SKILL.md", DB_SKILL);
+  const config = {
+    memoryFiles: ["~/.agents/AGENTS.md"],
+    skillsDir: "~/memory-skills",
+    skillsDirs: ["~/memory-skills"],
+  };
+  const scope = resolveScope(home, { scope: "user" }, config, null, { home });
+  const target = resolveRunTarget("db", { repo: scope.repo, config, scope });
+  assert.equal(target.kind, "skill");
+  assert.equal(target.path, "memory-skills/db/SKILL.md");
 });
 
 test("resolveRunTarget refuses a name that matches two skills", () => {
@@ -296,6 +323,27 @@ test("a skill target ignores other writes and applies against its description-on
   assert.match(fs.readFileSync(path.join(repo.root, memoryFile.path), "utf8"), /Wrap every migration/);
 });
 
+test("apply refuses a requested target that differs from the saved proposal", async () => {
+  const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
+  const state = new State(repo.root).ensure();
+  state.writeProposal({
+    scope: "project",
+    target: { kind: "surface" },
+    memoryFile: { path: "AGENTS.md" },
+    edits: [{ id: "e1" }],
+  });
+  await assert.rejects(
+    () =>
+      cmdApply({
+        repo,
+        scope: { kind: "project" },
+        config: { state, runTarget: { kind: "skill", path: ".agents/skills/db/SKILL.md", name: "db" } },
+        flags: { target: "db" },
+      }),
+    /proposal targets the whole surface/,
+  );
+});
+
 function initGitRepo(files) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-cli-"));
   for (const [name, text] of Object.entries(files)) {
@@ -324,6 +372,22 @@ test("the CLI refuses --target combined with --memory-file, and an unknown targe
   });
   assert.notEqual(combined.status, 0);
   assert.match(`${combined.stdout}${combined.stderr}`, /cannot be combined with --memory-file/);
+
+  const empty = spawnSync(process.execPath, [CLI, "status", "--target", ""], {
+    cwd: dir,
+    encoding: "utf8",
+    env,
+  });
+  assert.notEqual(empty.status, 0);
+  assert.match(`${empty.stdout}${empty.stderr}`, /--target cannot be empty/);
+
+  const emptyCombined = spawnSync(
+    process.execPath,
+    [CLI, "status", "--target", "", "--memory-file", "AGENTS.md"],
+    { cwd: dir, encoding: "utf8", env },
+  );
+  assert.notEqual(emptyCombined.status, 0);
+  assert.match(`${emptyCombined.stdout}${emptyCombined.stderr}`, /cannot be combined with --memory-file/);
 
   const missing = spawnSync(process.execPath, [CLI, "status", "--target", "no-such-skill"], {
     cwd: dir,

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -1,0 +1,319 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { primaryMemoryFile } from "../src/commands/analyze.js";
+import { loadConfig } from "../src/config.js";
+import { UserError } from "../src/logger.js";
+import { readMemoryFile } from "../src/memory.js";
+import { buildProposal } from "../src/proposal.js";
+import { State } from "../src/state.js";
+import { resolveRunTarget } from "../src/target.js";
+import { prepareWorkspace, measureWorkspace, workspacePathFor } from "../src/workspace.js";
+import { makeRepo, writeIn } from "./helpers/staging.js";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CLI = path.join(ROOT, "bin", "backpass.js");
+
+const AGENTS = "# Memory\n\n- Run tests before pushing.\n- Keep the README current.\n";
+const DB_SKILL =
+  "---\nname: db\ndescription: Load before touching the database.\n---\n\n- Wrap migrations in a transaction.\n";
+const REVIEW_SKILL =
+  "---\nname: review\ndescription: Load before reviewing a pull request.\n---\n\n- Request tests for behavior changes.\n";
+
+const QUOTE = [
+  { polarity: "negative", text: "it skipped the migration wrapper the first time", source: "claude · abc · turn 3" },
+  { polarity: "negative", text: "and skipped the wrapper on a second session too", source: "codex · def · turn 8" },
+];
+
+function git(args, cwd) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+function repoWith(files) {
+  const repo = makeRepo({ "AGENTS.md": AGENTS, ...files });
+  return repo;
+}
+
+function cfg(repo, extra = {}) {
+  return loadConfig(repo.root, extra);
+}
+
+function summary() {
+  return {
+    analyzedSessions: 4,
+    totals: { positive: 0, negative: 2, gapClusters: 0 },
+    sources: ["claude · abc · turn 3", "codex · def · turn 8"],
+    instructions: Array.from({ length: 10 }, (_, i) => ({
+      instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+      positive: 0,
+      negative: 4,
+      harmSessions: 4,
+      sessions: 4,
+      relevance: 1,
+      quotes: [],
+    })),
+  };
+}
+
+test("resolveRunTarget names one memory file without picking up skills", () => {
+  const repo = repoWith({
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+    ".agents/skills/review/SKILL.md": REVIEW_SKILL,
+  });
+  const config = cfg(repo);
+  const target = resolveRunTarget("AGENTS.md", { repo, config });
+  assert.equal(target.kind, "memory");
+  assert.equal(target.path, "AGENTS.md");
+});
+
+test("resolveRunTarget accepts a skill by name or SKILL.md path", () => {
+  const repo = repoWith({
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+    ".agents/skills/review/SKILL.md": REVIEW_SKILL,
+  });
+  const config = cfg(repo);
+  const byName = resolveRunTarget("db", { repo, config });
+  assert.equal(byName.kind, "skill");
+  assert.equal(byName.name, "db");
+  assert.equal(byName.path, ".agents/skills/db/SKILL.md");
+  const byPath = resolveRunTarget(".agents/skills/review/SKILL.md", { repo, config });
+  assert.equal(byPath.kind, "skill");
+  assert.equal(byPath.name, "review");
+  const byDir = resolveRunTarget(".agents/skills/db", { repo, config });
+  assert.equal(byDir.path, ".agents/skills/db/SKILL.md");
+});
+
+test("resolveRunTarget refuses an unknown name instead of falling back to the whole surface", () => {
+  const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
+  const config = cfg(repo);
+  assert.throws(() => resolveRunTarget("nope", { repo, config }), UserError);
+  assert.throws(() => resolveRunTarget("nope", { repo, config }), /not a memory file or skill/);
+});
+
+test("resolveRunTarget refuses a name that matches two skills", () => {
+  const repo = repoWith({
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+    ".claude/skills/db/SKILL.md": DB_SKILL.replace("Wrap migrations", "- Also wrap reads"),
+  });
+  const config = cfg(repo);
+  assert.throws(() => resolveRunTarget("db", { repo, config }), /matches 2 skills/);
+});
+
+test("a memory-file target stages the memory file and an empty skills dir, not existing skills", () => {
+  const repo = repoWith({
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+    ".agents/skills/review/SKILL.md": REVIEW_SKILL,
+  });
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile,
+    skillsDir: ".agents/skills",
+    copyExistingSkills: false,
+  });
+  assert.equal(fs.readFileSync(path.join(workspace.root, "AGENTS.md"), "utf8"), AGENTS);
+  assert.ok(fs.existsSync(path.join(workspace.root, ".agents/skills")));
+  assert.equal(fs.existsSync(path.join(workspace.root, ".agents/skills/db/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(workspace.root, ".agents/skills/review/SKILL.md")), false);
+  assert.deepEqual([...workspace.originals.keys()], ["AGENTS.md"]);
+});
+
+test("a skill target stages that skill as the file under audit and does not copy the memory file or other skills", () => {
+  const repo = repoWith({
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+    ".agents/skills/review/SKILL.md": REVIEW_SKILL,
+  });
+  const memoryFile = readMemoryFile(repo.root, ".agents/skills/db/SKILL.md");
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile,
+    skillsDir: ".agents/skills",
+    skillDirs: [],
+    copyExistingSkills: false,
+  });
+  assert.ok(fs.existsSync(path.join(workspace.root, workspacePathFor(memoryFile.path))));
+  assert.equal(fs.existsSync(path.join(workspace.root, "AGENTS.md")), false);
+  assert.equal(fs.existsSync(path.join(workspace.root, ".agents/skills/review/SKILL.md")), false);
+  assert.deepEqual([...workspace.originals.keys()], [".agents/skills/db/SKILL.md"]);
+});
+
+test("a whole-surface workspace still copies every skill", () => {
+  const repo = repoWith({
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+    ".agents/skills/review/SKILL.md": REVIEW_SKILL,
+  });
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile: readMemoryFile(repo.root, "AGENTS.md"),
+    skillsDir: ".agents/skills",
+  });
+  assert.deepEqual(
+    [...workspace.originals.keys()].sort(),
+    ["AGENTS.md", ".agents/skills/db/SKILL.md", ".agents/skills/review/SKILL.md"].sort(),
+  );
+});
+
+test("primaryMemoryFile on a skill target audits that skill and does not hand synthesis the rest of the surface", () => {
+  const repo = repoWith({
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+    ".agents/skills/review/SKILL.md": REVIEW_SKILL,
+  });
+  const config = cfg(repo);
+  config.runTarget = resolveRunTarget("db", { repo, config });
+  const resolved = primaryMemoryFile(repo, config);
+  assert.equal(resolved.file.path, ".agents/skills/db/SKILL.md");
+  assert.deepEqual(resolved.skills, []);
+  assert.equal(resolved.allSkills.length, 2);
+  assert.equal(resolved.runTarget.kind, "skill");
+  assert.notEqual(resolved.hash, primaryMemoryFile(repo, cfg(repo)).hash);
+});
+
+test("buildProposal on a memory-file target refuses to recreate an existing skill", () => {
+  const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const state = new State(repo.root).ensure();
+  const workspace = prepareWorkspace({
+    state,
+    repo,
+    memoryFile,
+    skillsDir: ".agents/skills",
+    copyExistingSkills: false,
+  });
+  writeIn(workspace.root, "AGENTS.md", (text) => text.replace("- Keep the README current.\n", ""));
+  writeIn(workspace.root, ".agents/skills/db/SKILL.md", DB_SKILL);
+  const measured = measureWorkspace(workspace);
+  const created = measured.changes.find((c) => c.kind === "created");
+  assert.equal(created?.file, ".agents/skills/db/SKILL.md");
+  const { proposal, violations } = buildProposal(
+    {
+      edits: [
+        {
+          changes: measured.changes.map((c) => c.id),
+          kind: "extract",
+          title: "extract the readme rule",
+          evidence: QUOTE,
+        },
+      ],
+    },
+    {
+      memoryFile,
+      config: { budgetTokens: 5000, maxEditsPerRun: 5, minGapEvidence: 2, skillsDir: ".agents/skills" },
+      repo,
+      summary: summary(),
+      measured,
+      runTarget: { kind: "memory", path: "AGENTS.md" },
+    },
+  );
+  assert.equal(proposal.edits.length, 0);
+  assert.ok(violations.some((v) => /already exists/.test(v)));
+  assert.equal(proposal.target.kind, "memory");
+});
+
+test("buildProposal on a skill target ignores a write to the project memory file", () => {
+  const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
+  const memoryFile = readMemoryFile(repo.root, ".agents/skills/db/SKILL.md");
+  const state = new State(repo.root).ensure();
+  const workspace = prepareWorkspace({
+    state,
+    repo,
+    memoryFile,
+    skillsDir: ".agents/skills",
+    skillDirs: [],
+    copyExistingSkills: false,
+  });
+  writeIn(workspace.root, workspacePathFor(memoryFile.path), (text) =>
+    text.replace("Wrap migrations in a transaction.", "Wrap every migration in a transaction."),
+  );
+  writeIn(workspace.root, "AGENTS.md", "# hijack\n");
+  const measured = measureWorkspace(workspace);
+  assert.ok(measured.stray.includes("AGENTS.md"), "a write to AGENTS.md is stray, not a proposed edit");
+  assert.equal(
+    measured.changes.some((c) => c.file === "AGENTS.md"),
+    false,
+  );
+  const skillHunk = measured.changes.find((c) => c.kind === "hunk" && c.file === memoryFile.path);
+  assert.ok(skillHunk);
+  const { proposal, violations } = buildProposal(
+    {
+      edits: [
+        {
+          changes: [skillHunk.id],
+          kind: "rewrite",
+          title: "sharpen the transaction rule",
+          evidence: QUOTE,
+        },
+      ],
+    },
+    {
+      memoryFile,
+      config: { budgetTokens: 5000, maxEditsPerRun: 5, minGapEvidence: 2, skillsDir: ".agents/skills" },
+      repo,
+      summary: summary(),
+      measured,
+      runTarget: { kind: "skill", path: memoryFile.path, name: "db" },
+    },
+  );
+  assert.deepEqual(violations, []);
+  assert.equal(proposal.edits.length, 1);
+  assert.equal(proposal.edits[0].file, ".agents/skills/db/SKILL.md");
+  assert.equal(proposal.target.kind, "skill");
+  assert.equal(proposal.memoryFile.path, ".agents/skills/db/SKILL.md");
+  assert.equal(
+    proposal.edits.some((e) => e.file === "AGENTS.md" || (e.hunks || []).some((h) => h.file === "AGENTS.md")),
+    false,
+  );
+});
+
+function initGitRepo(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-cli-"));
+  for (const [name, text] of Object.entries(files)) {
+    const absolute = path.join(dir, name);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, text);
+  }
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.com"], dir);
+  git(["config", "user.name", "test"], dir);
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "-m", "init"], dir);
+  return fs.realpathSync(dir);
+}
+
+test("the CLI refuses --target combined with --memory-file, and an unknown target", () => {
+  const dir = initGitRepo({
+    "AGENTS.md": AGENTS,
+    ".agents/skills/db/SKILL.md": DB_SKILL,
+  });
+  const env = { ...process.env, NO_COLOR: "1", CI: "1" };
+  const combined = spawnSync(process.execPath, [CLI, "status", "--target", "AGENTS.md", "--memory-file", "AGENTS.md"], {
+    cwd: dir,
+    encoding: "utf8",
+    env,
+  });
+  assert.notEqual(combined.status, 0);
+  assert.match(`${combined.stdout}${combined.stderr}`, /cannot be combined with --memory-file/);
+
+  const missing = spawnSync(process.execPath, [CLI, "status", "--target", "no-such-skill"], {
+    cwd: dir,
+    encoding: "utf8",
+    env,
+  });
+  assert.notEqual(missing.status, 0);
+  assert.match(`${missing.stdout}${missing.stderr}`, /not a memory file or skill/);
+
+  const ok = spawnSync(process.execPath, [CLI, "status", "--target", "db"], {
+    cwd: dir,
+    encoding: "utf8",
+    env,
+  });
+  assert.equal(ok.status, 0, ok.stderr);
+  assert.match(ok.stderr, /targeting skill db/);
+});

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -92,6 +92,20 @@ test("resolveRunTarget accepts a skill by name or SKILL.md path", () => {
   assert.equal(byDir.path, ".agents/skills/db/SKILL.md");
 });
 
+test("a direct SKILL.md target retains parsed trigger metadata", () => {
+  const directSkill = DB_SKILL.replace("name: db", "name: database-ops");
+  const repo = repoWith({ "custom/db/SKILL.md": directSkill });
+  const config = cfg(repo);
+  const target = resolveRunTarget("custom/db/SKILL.md", { repo, config });
+  assert.equal(target.kind, "skill");
+  assert.equal(target.name, "database-ops");
+  assert.equal(target.skill.description, "Load before touching the database.");
+  assert.equal(target.skill.descriptionTokens, estimateTokens("Load before touching the database."));
+  config.runTarget = target;
+  const resolved = primaryMemoryFile(repo, config);
+  assert.equal(resolved.file.alwaysLoadedTokens, target.skill.descriptionTokens);
+});
+
 test("resolveRunTarget refuses empty and unknown names instead of widening", () => {
   const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
   const config = cfg(repo);

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -359,12 +359,22 @@ function initGitRepo(files) {
   return fs.realpathSync(dir);
 }
 
-test("the CLI refuses --target combined with --memory-file, and an unknown target", () => {
+test("the CLI rejects invalid target usage without widening", () => {
   const dir = initGitRepo({
     "AGENTS.md": AGENTS,
     ".agents/skills/db/SKILL.md": DB_SKILL,
   });
   const env = { ...process.env, NO_COLOR: "1", CI: "1" };
+  const initTarget = spawnSync(process.execPath, [CLI, "init", "--target", "no-such-skill"], {
+    cwd: dir,
+    encoding: "utf8",
+    env,
+  });
+  assert.notEqual(initTarget.status, 0);
+  assert.match(`${initTarget.stdout}${initTarget.stderr}`, /--target cannot be used with init/);
+  assert.equal(fs.existsSync(path.join(dir, ".backpassrc.json")), false);
+  assert.equal(fs.existsSync(path.join(dir, ".backpass")), false);
+
   const combined = spawnSync(process.execPath, [CLI, "status", "--target", "AGENTS.md", "--memory-file", "AGENTS.md"], {
     cwd: dir,
     encoding: "utf8",

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -11,9 +11,10 @@ import { primaryMemoryFile } from "../src/commands/analyze.js";
 import { loadConfig } from "../src/config.js";
 import { UserError } from "../src/logger.js";
 import { readMemoryFile } from "../src/memory.js";
-import { buildProposal } from "../src/proposal.js";
+import { buildProposal, projectWithDecisions } from "../src/proposal.js";
 import { State } from "../src/state.js";
 import { resolveRunTarget } from "../src/target.js";
+import { estimateTokens } from "../src/tokens.js";
 import { prepareWorkspace, measureWorkspace, workspacePathFor } from "../src/workspace.js";
 import { makeRepo, writeIn } from "./helpers/staging.js";
 
@@ -231,7 +232,9 @@ test("a skill target ignores other writes and applies against its description-on
     copyExistingSkills: false,
   });
   writeIn(workspace.root, workspacePathFor(memoryFile.path), (text) =>
-    text.replace("Wrap migrations in a transaction.", "Wrap every migration in a transaction."),
+    text
+      .replace("Load before touching the database.", "Load before planning or changing database storage.")
+      .replace("Wrap migrations in a transaction.", "Wrap every migration in a transaction and verify rollback."),
   );
   writeIn(workspace.root, "AGENTS.md", "# hijack\n");
   const measured = measureWorkspace(workspace);
@@ -240,13 +243,13 @@ test("a skill target ignores other writes and applies against its description-on
     measured.changes.some((c) => c.file === "AGENTS.md"),
     false,
   );
-  const skillHunk = measured.changes.find((c) => c.kind === "hunk" && c.file === memoryFile.path);
-  assert.ok(skillHunk);
+  const skillHunks = measured.changes.filter((c) => c.kind === "hunk" && c.file === memoryFile.path);
+  assert.equal(skillHunks.length, 2);
   const { proposal, violations } = buildProposal(
     {
       edits: [
         {
-          changes: [skillHunk.id],
+          changes: skillHunks.map((hunk) => hunk.id),
           kind: "rewrite",
           title: "sharpen the transaction rule",
           evidence: QUOTE,
@@ -267,6 +270,15 @@ test("a skill target ignores other writes and applies against its description-on
   assert.equal(proposal.edits[0].file, ".agents/skills/db/SKILL.md");
   assert.equal(proposal.target.kind, "skill");
   assert.equal(proposal.memoryFile.path, ".agents/skills/db/SKILL.md");
+  const projectedSkill = fs.readFileSync(path.join(workspace.root, workspacePathFor(memoryFile.path)), "utf8");
+  const descriptionDelta =
+    estimateTokens("Load before planning or changing database storage.") -
+    estimateTokens("Load before touching the database.");
+  assert.equal(proposal.edits[0].deltaTokens, estimateTokens(projectedSkill) - memoryFile.tokens);
+  assert.equal(proposal.edits[0].descriptionDelta, descriptionDelta);
+  assert.equal(proposal.budget.delta, descriptionDelta);
+  const projected = projectWithDecisions(memoryFile.text, proposal.edits, ["e1"], 5000, 0, proposal.target);
+  assert.equal(projected.budget.projected, proposal.budget.projected);
   assert.equal(
     proposal.edits.some((e) => e.file === "AGENTS.md" || (e.hunks || []).some((h) => h.file === "AGENTS.md")),
     false,
@@ -277,7 +289,7 @@ test("a skill target ignores other writes and applies against its description-on
     decisions: { e1: "accepted" },
     repo,
     state,
-    config: { budgetTokens: proposal.budget.current, skillsDir: ".agents/skills" },
+    config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
   });
   assert.deepEqual(results.failed, []);
   assert.equal(results.written[0].budget.current, proposal.budget.current);

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -444,11 +444,11 @@ test("the CLI rejects invalid target usage without widening", () => {
   assert.notEqual(empty.status, 0);
   assert.match(`${empty.stdout}${empty.stderr}`, /--target cannot be empty/);
 
-  const emptyCombined = spawnSync(
-    process.execPath,
-    [CLI, "status", "--target", "", "--memory-file", "AGENTS.md"],
-    { cwd: dir, encoding: "utf8", env },
-  );
+  const emptyCombined = spawnSync(process.execPath, [CLI, "status", "--target", "", "--memory-file", "AGENTS.md"], {
+    cwd: dir,
+    encoding: "utf8",
+    env,
+  });
   assert.notEqual(emptyCombined.status, 0);
   assert.match(`${emptyCombined.stdout}${emptyCombined.stderr}`, /cannot be combined with --memory-file/);
 

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -6,6 +6,7 @@ import path from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { applyDecisions } from "../src/apply/writer.js";
 import { primaryMemoryFile } from "../src/commands/analyze.js";
 import { loadConfig } from "../src/config.js";
 import { UserError } from "../src/logger.js";
@@ -217,7 +218,7 @@ test("buildProposal on a memory-file target refuses to recreate an existing skil
   assert.equal(proposal.target.kind, "memory");
 });
 
-test("buildProposal on a skill target ignores a write to the project memory file", () => {
+test("a skill target ignores other writes and applies against its description-only budget", () => {
   const repo = repoWith({ ".agents/skills/db/SKILL.md": DB_SKILL });
   const memoryFile = readMemoryFile(repo.root, ".agents/skills/db/SKILL.md");
   const state = new State(repo.root).ensure();
@@ -270,6 +271,17 @@ test("buildProposal on a skill target ignores a write to the project memory file
     proposal.edits.some((e) => e.file === "AGENTS.md" || (e.hunks || []).some((h) => h.file === "AGENTS.md")),
     false,
   );
+
+  const results = applyDecisions({
+    proposal,
+    decisions: { e1: "accepted" },
+    repo,
+    state,
+    config: { budgetTokens: proposal.budget.current, skillsDir: ".agents/skills" },
+  });
+  assert.deepEqual(results.failed, []);
+  assert.equal(results.written[0].budget.current, proposal.budget.current);
+  assert.match(fs.readFileSync(path.join(repo.root, memoryFile.path), "utf8"), /Wrap every migration/);
 });
 
 function initGitRepo(files) {


### PR DESCRIPTION
## Intent

Support a backpass run that aims to improve a specific memory file, or a specific skill, not everything in the project or user scope.

Acceptance:
- An operator can target one memory file or one skill for a run.
- A targeted run does not silently expand to the whole project or whole user scope.
- Existing whole-project / user-scope runs stay available and unchanged unless a small compatibility rename is required.
- Tests cover the targeted path and prove it does not widen to the full scope.

Decisions already made for this work:
- The narrowing flag is --target (a path or skill name). Do not change --memory-file into targeting; that flag still means which memory file is primary on a whole-surface run.
- --target cannot be combined with --memory-file.
- An unknown or ambiguous target must error loudly, never silently fall back to the whole surface.
- A memory-file target may still create a new skill (extraction) so the file can shrink; existing skills are not writable.
- A skill target trains only that SKILL.md: no extract, no memory-file edits, no other skills.
- --target is a write-surface, not a second scope; it combines with --scope user.

## What Changed

- Add `--target` to narrow project or user-scope runs to one memory file or skill, with loud errors for invalid, ambiguous, or conflicting targets.
- Restrict staging, synthesis, proposal validation, budgeting, and apply behavior to the selected write surface while preserving whole-surface runs.
- Document targeted-run behavior and add coverage proving targets cannot widen to other memory files or skills.

## Risk Assessment

✅ Low: The targeted write surface is consistently enforced during resolution, synthesis, proposal validation, and apply, with no material source-verifiable defects found.

## Testing

Focused tests exercised target resolution, scope narrowing, proposal generation, write isolation, apply matching, direct-skill metadata, and deletion safeguards. Manual CLI evidence confirmed clear targeting notices and loud invalid-target failures. All checks passed and the worktree remained clean.

<details>
<summary>Evidence: Targeted CLI behavior transcript</summary>

Source: [Targeted CLI behavior transcript](https://github.com/kunchenguid/backpass/blob/5271441e4191a1d46c88723709074e4fe271c38f/.no-mistakes/evidence/fm/backpass-single-target-run-r1/target-cli-transcript.txt)

```text
$ backpass status --target db
targeting skill db (.agents/skills/db/SKILL.md); the memory file and other skills are out of this run
backpass-target-e2e.o8LReC /private/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/backpass-target-e2e.o8LReC

BUDGET (always-loaded)
  AGENTS.md + skill descriptions [................................] 22 / 5,000 tok · 1 instructions
  overflow: 1 skill(s) in .agents/skills · 27 tok on trigger, 10 tok always loaded

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  none yet - run `backpass`

MODELS
  analysis        auto - 7 candidates, none probed yet
  synthesis       auto - 7 candidates, none probed yet

$ backpass status --target AGENTS.md
targeting AGENTS.md; existing skills are not writable this run
backpass-target-e2e.o8LReC /private/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/backpass-target-e2e.o8LReC

BUDGET (always-loaded)
  AGENTS.md + skill descriptions [................................] 22 / 5,000 tok · 1 instructions
  overflow: 1 skill(s) in .agents/skills · 27 tok on trigger, 10 tok always loaded

CACHE
  scan cache      0 file(s) fingerprinted
  evidence        0 ok · 0 skipped · 0 failed
  rejections      0 remembered

PROPOSAL
  none yet - run `backpass`

MODELS
  analysis        auto - 7 candidates, none probed yet
  synthesis       auto - 7 candidates, none probed yet

$ backpass status --target no-such-skill
error --target "no-such-skill" is not a memory file or skill in this repo
  known skills: db
[exit 1]

$ backpass status --target db --memory-file AGENTS.md
error --target cannot be combined with --memory-file
  name the one file with --target
[exit 1]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"90fed70659c2e20a596c7b44cea9c3a8023d4cf1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (7) ✅</summary>

- 🚨 `src/cli.js:270` - `--target` is resolved and announced for `apply`, but `cmdApply` never consumes `config.runTarget` or compares it with the saved proposal. For example, `backpass apply --target db` can accept and write an older whole-surface proposal after claiming it is targeting only `db`. This contradicts the requirement that a targeted run must not silently expand. Either reject `--target` for apply or require it to match the proposal target.
- 🚨 `src/target.js:122` - An explicitly supplied empty target, such as `backpass --target &#34;&#34;`, is treated as a whole-surface run. This silently widens an unknown target and also bypasses the `--target` plus `--memory-file` conflict check, contradicting the requirement that unknown targets error loudly. Only an absent flag should select the surface.
- 🚨 `src/target.js:104` - Memory basename matching returns the first configured match instead of detecting ambiguity. With configured files `docs/AGENTS.md` and `packages/a/AGENTS.md`, no root `AGENTS.md`, and `--target AGENTS.md`, the first file is silently selected. This contradicts the explicit requirement that an ambiguous target error loudly; collect all matches and require an exact path when more than one remains.
- 🚨 `src/proposal.js:731` - Skill-target proposal validation budgets only the target skill&#39;s description, but apply still recalculates the accepted subset using the complete SKILL.md text plus every project skill description. A proposal that passes here can therefore fail at apply solely because of the target body or unrelated skills, especially with a low custom budget. Make the apply-time budget calculation honor `proposal.target.kind === &#34;skill&#34;` and use the same description-only inputs as proposal construction.

🔧 Fix: Align skill-target apply budgets with proposal validation
4 issues (3 errors, 1 warning) still open:

- 🚨 `src/cli.js:270` - The criterion says a targeted run must not silently expand, but `--target` is resolved and announced for `apply` while `cmdApply` only compares scope. For example, `backpass apply --target db` can apply a saved whole-surface or different-skill proposal. Reject `--target` for apply or require it to match `proposal.target`.
- 🚨 `src/target.js:122` - The criterion says an unknown target must error loudly, but an explicitly supplied empty or whitespace-only `--target` returns the whole surface. This silently widens the run and an empty value also bypasses the `--target` plus `--memory-file` conflict check. Only an absent flag should select the surface.
- 🚨 `src/target.js:104` - The criterion says an ambiguous target must error loudly, but basename matching returns the first configured memory file. With `docs/AGENTS.md` and `packages/a/AGENTS.md`, no root `AGENTS.md`, and `--target AGENTS.md`, the first candidate is silently selected. Collect all matches and require an exact path when multiple remain.
- ⚠️ `src/proposal.js:706` - For a skill target, a description change is stored in both `deltaTokens` and `descriptionDelta`. The apply surface then adds both to its live budget projection and renders two deltas, so a 5-token description increase is shown as 10 tokens even though proposal validation and the writer count 5. Preserve the full skill-file delta separately and make target-aware review projections count the description delta exactly once.

🔧 Fix: Prevent double-counting targeted skill description deltas
5 issues (4 errors, 1 warning) still open:

- 🚨 `src/cli.js:270` - The requirement says a targeted run must not silently expand, but `--target` is resolved and announced for `apply` while `cmdApply` compares only scope. `backpass apply --target db` can therefore apply a saved whole-surface or different-skill proposal. Reject `--target` for apply or require it to match `proposal.target`.
- 🚨 `src/target.js:122` - The requirement says an unknown target must error loudly, but an explicitly supplied empty or whitespace-only `--target` returns the whole surface. It also bypasses the `--target` plus `--memory-file` conflict check. Only an absent flag should select the surface.
- 🚨 `src/target.js:104` - The requirement says an ambiguous target must error loudly, but basename matching returns the first configured memory file. With `docs/AGENTS.md` and `packages/a/AGENTS.md`, no root `AGENTS.md`, and `--target AGENTS.md`, the first candidate is silently selected. Collect all matches and require an exact path when multiple remain.
- 🚨 `src/target.js:28` - The requirement says `--target` combines with `--scope user`, but skill lookup uses the pre-normalized config instead of `scope.overflowDir` and `scope.skillDirs`. For example, a user skill configured under `~/memory-skills` is searched as `$HOME/~/memory-skills`, so `--scope user --target db` reports the existing skill as unknown. Resolve skills from the scope-normalized paths.
- ⚠️ `src/synthesize.js:96` - An over-budget skill target receives whole-surface guidance to lead with skill extractions even though `TARGET_RULE` forbids extraction, which can steer synthesis into mechanically rejected edits. After an empty annotation turn, line 250 also reports full skill tokens plus description tokens while the gate budgets only the description. Make budget guidance and fresh-session token reporting target-aware.

🔧 Fix: Make skill-target synthesis budget guidance consistent
4 errors still open:

- 🚨 `src/cli.js:273` - The requirement says a targeted run must not silently expand, but `--target` is resolved and announced for `apply` while `cmdApply` compares only scope. `backpass apply --target db` can therefore apply a saved whole-surface or different-skill proposal. Reject `--target` for apply or require it to match `proposal.target`.
- 🚨 `src/target.js:122` - The requirement says an unknown target must error loudly, but an explicitly supplied empty or whitespace-only `--target` returns the whole surface. An empty value also bypasses the `--target` plus `--memory-file` conflict check. Only an absent flag should select the surface.
- 🚨 `src/target.js:104` - The requirement says an ambiguous target must error loudly, but basename matching returns the first configured memory file. With `docs/AGENTS.md` and `packages/a/AGENTS.md`, no root `AGENTS.md`, and `--target AGENTS.md`, the first candidate is silently selected. Collect all matches and require an exact path when multiple remain.
- 🚨 `src/target.js:28` - The requirement says `--target` combines with `--scope user`, but target resolution loads skills from the raw config before `src/cli.js` installs the scope-normalized `overflowDir` and `skillDirs`. For example, a user skill configured under `~/memory-skills` is searched as `$HOME/~/memory-skills`, so `--scope user --target db` reports the existing skill as unknown. Resolve targets from the scope-normalized paths.

🔧 Fix: Enforce exact target resolution and apply isolation
1 error still open:

- 🚨 `src/cli.js:274` - The requirement says an unknown target must error loudly and a targeted run must not silently widen, but `commandName === &#34;init&#34;` replaces every supplied `--target` with `{ kind: &#34;surface&#34; }` without parsing or rejecting it. For example, `backpass init --target no-such-skill` proceeds as a whole-surface bootstrap. Reject `--target` for `init`, since bootstrap has no targetable training surface.

🔧 Fix: Reject target flags during initialization
1 error still open:

- 🚨 `src/proposal.js:606` - A skill target makes its SKILL.md the `memoryFile`, so this branch permits a pure deletion whenever cited skill-unit rows have enough harm evidence. That bypasses the existing invariant and prompt rule that skill-file text may be rewritten but never dropped. Concretely, two harm-class observations for a targeted skill unit let a `remove` edit pass all gates and delete it. Detect `runTarget.kind === &#34;skill&#34;` before the memory-file removal path and reject pure deletions as skill-file deletions.

🔧 Fix: Refuse pure deletions from targeted skills
2 issues (1 error, 1 warning) still open:

- 🚨 `src/target.js:93` - The requirement says an unknown target must error loudly, but any existing regular file is classified as a memory target. For example, `--target README.md` or `--target package.json` proceeds to analyze and potentially rewrite that file. It can also make a valid skill name ambiguous when a same-named ordinary file exists. Restrict memory matching to the configured memory-file set, or ask the user to explicitly authorize targeting arbitrary repository files.
- ⚠️ `src/target.js:86` - A SKILL.md outside the loaded skill directories is synthesized with only `name` and `path`. `primaryMemoryFile` then computes its always-loaded description cost as zero, so prompts, progress, and adaptive edit limits use the wrong budget state even when the file has a non-empty description. Parse the directly targeted skill&#39;s frontmatter and populate the same metadata as `loadSkills`.

🔧 Fix: Preserve metadata for directly targeted skills
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test test/target.test.js`
- `node --test --test-name-pattern='target|skill target|memory-file target' test/proposal.test.js test/synthesize.test.js`
- <code>Manual CLI verification in a temporary Git repository: `backpass status --target db`, `backpass status --target AGENTS.md`, unknown target rejection, and `--target` plus `--memory-file` conflict rejection</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
