### PR TITLE
fix(acpx): surface opencode stderr on exec and session-prompt failures

### DIFF
--- a/src/acpx.js
+++ b/src/acpx.js
@@ -334,7 +334,7 @@ export async function execOneShot({
       throw new AcpxError(`acpx ${agent} exec timed out after ${timeoutSeconds}s`, result);
     }
     if (result.code !== 0) {
-      throw new AcpxError(`acpx ${agent} exec failed (exit ${result.code})`, result);
+      throw new AcpxError(`acpx ${agent} exec failed (exit ${result.code}): ${firstLine(result.stderr)}`, result);
     }
 
     const combined = `${result.stdout}\n${result.stderr}`;
@@ -478,7 +478,12 @@ export async function openSession({ agent, model = null, effort = null, sessionN
     ];
     const result = await run(args, { timeoutMs: (timeoutSeconds + 30) * 1000, cwd, env: invocation.env });
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
-    if (result.code !== 0) throw new AcpxError(`acpx ${agent} session prompt failed (exit ${result.code})`, result);
+    if (result.code !== 0) {
+      throw new AcpxError(
+        `acpx ${agent} session prompt failed (exit ${result.code}): ${firstLine(result.stderr)}`,
+        result,
+      );
+    }
 
     const combined = `${result.stdout}\n${result.stderr}`;
     /** @type {Record<string, number> | null} */

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -334,7 +334,10 @@ export async function execOneShot({
       throw new AcpxError(`acpx ${agent} exec timed out after ${timeoutSeconds}s`, result);
     }
     if (result.code !== 0) {
-      throw new AcpxError(`acpx ${agent} exec failed (exit ${result.code}): ${firstLine(result.stderr)}`, result);
+      throw new AcpxError(
+        `acpx ${agent} exec failed (exit ${result.code}): ${firstLine(result.stderr) || `exit ${result.code}`}`,
+        result,
+      );
     }
 
     const combined = `${result.stdout}\n${result.stderr}`;
@@ -480,7 +483,7 @@ export async function openSession({ agent, model = null, effort = null, sessionN
     if (result.timedOut) throw new AcpxError(`acpx ${agent} session prompt timed out after ${timeoutSeconds}s`, result);
     if (result.code !== 0) {
       throw new AcpxError(
-        `acpx ${agent} session prompt failed (exit ${result.code}): ${firstLine(result.stderr)}`,
+        `acpx ${agent} session prompt failed (exit ${result.code}): ${firstLine(result.stderr) || `exit ${result.code}`}`,
         result,
       );
     }

--- a/test/acpx-empty-stderr.test.js
+++ b/test/acpx-empty-stderr.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Regression for a real backpass run: opencode's acpx adapter exited 1 with no
+ * stderr detail on both `exec` and a named-session prompt. `AcpxError` built its
+ * message from stderr with no fallback, so the failure surfaced as a message with
+ * a dangling trailing colon instead of naming the exit code.
+ */
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-acpx-empty-stderr-"));
+const fakeAcpx = path.join(fixtureDir, "acpx");
+const promptFile = path.join(fixtureDir, "prompt.md");
+fs.writeFileSync(promptFile, "analyze this\n");
+
+fs.writeFileSync(
+  fakeAcpx,
+  `#!${process.execPath}
+const argv = process.argv.slice(2);
+if (argv.includes("sessions") && argv.includes("new")) process.exit(0);
+if (argv.includes("sessions") && argv.includes("close")) process.exit(0);
+process.exit(1);
+`,
+);
+fs.chmodSync(fakeAcpx, 0o755);
+
+process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+const { AcpxError, execOneShot, openSession } = await import("../src/acpx.js");
+
+test.after(() => {
+  fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+test("exec one-shot names the exit code when opencode exits with no stderr", async () => {
+  await assert.rejects(
+    () => execOneShot({ agent: "opencode", promptFile, cwd: fixtureDir, timeoutSeconds: 5 }),
+    (err) => {
+      assert.ok(err instanceof AcpxError, String(err));
+      assert.equal(err.message, "acpx opencode exec failed (exit 1): exit 1");
+      assert.doesNotMatch(err.message, /: $/);
+      return true;
+    },
+  );
+});
+
+test("session prompt names the exit code when opencode exits with no stderr", async () => {
+  const session = await openSession({ agent: "opencode", sessionName: "backpass-empty-stderr", cwd: fixtureDir });
+  try {
+    await assert.rejects(
+      () => session.prompt({ promptFile, timeoutSeconds: 5 }),
+      (err) => {
+        assert.ok(err instanceof AcpxError, String(err));
+        assert.equal(err.message, "acpx opencode session prompt failed (exit 1): exit 1");
+        assert.doesNotMatch(err.message, /: $/);
+        return true;
+      },
+    );
+  } finally {
+    await session.close();
+  }
+});


### PR DESCRIPTION
## Intent

The developer hit a backpass run failure where opencode exec/session-prompt calls exited 1 with no diagnostic detail, and asked the assistant to investigate. The assistant traced it to src/acpx.js's execOneShot and openSession().prompt building AcpxError from just the exit code while discarding result.stderr, unlike sibling call sites (session-create, set-model) that already include firstLine(stderr); it fixed both to match that pattern so future failures show the actual opencode stderr. The developer then asked for a commit prepared per CONTRIBUTING.md, explicitly requiring that no references to their repo appear in the commit or PR text. The assistant rebased the fix onto a fresh branch off origin/main (since local main was 50 commits behind), verified all tests passed, and committed with generic wording. Finally the developer asked to push, which must go through `git push no-mistakes` per CONTRIBUTING.md since PRs cannot be opened manually and require the no-mistakes pipeline's head-SHA-bound attestation.

## What Changed
- `execOneShot` and `openSession().prompt` in `src/acpx.js` now build `AcpxError` with the first line of `result.stderr` appended to the exit-code message, matching the pattern already used by session-create and set-model call sites.
- Added an exit-code fallback (`` `exit ${result.code}` ``) for both call sites when `stderr` is empty, so the error message never goes blank.
- Added `test/acpx-empty-stderr.test.js` covering the empty-stderr fallback behavior for these failure paths.

## Risk Assessment

✅ Low: The fix-round change is a 2-line, mechanical fallback addition matching an existing sibling pattern verbatim, touches only error-message formatting with no effect on control flow, classification (classifyAcpxFailure reads the separate .stderr field, not .message), or other call sites.

## Testing

Added test/acpx-empty-stderr.test.js, which drives the public execOneShot and openSession().prompt entry points against a fake acpx binary that exits 1 with no stderr — the exact opencode failure mode from the user's report — and asserts the thrown AcpxError message ends in the exit-code fallback rather than a dangling ': '. The test passes on the target commit and was verified to fail on the pre-fix code, giving true regression coverage for both call sites named in the accepted review findings.

<details>
<summary>Evidence: acpx-empty-stderr.test.js run against target commit (pass)</summary>

```text
✔ exec one-shot names the exit code when opencode exits with no stderr
✔ session prompt names the exit code when opencode exits with no stderr
Message: 'acpx opencode exec failed (exit 1): exit 1' / 'acpx opencode session prompt failed (exit 1): exit 1'
```
</details>
<details>
<summary>Evidence: same test run against pre-fix src/acpx.js (fails, proving regression coverage)</summary>

```text
AssertionError: expected 'acpx opencode exec failed (exit 1): exit 1' but got 'acpx opencode exec failed (exit 1)' (dangling trailing colon)
AssertionError: expected 'acpx opencode session prompt failed (exit 1): exit 1' but got 'acpx opencode session prompt failed (exit 1)'
```
</details>
- Outcome: ⚠️ 1 info across 1 run (1m32s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"270dfd9a5e26a78f4d4f41a2aec3a8c5e947017a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/acpx.js:337` - When result.stderr is empty (whitespace-only or undefined), firstLine(result.stderr) returns &#34;&#34;, so the thrown message becomes `acpx ${agent} exec failed (exit ${result.code}): ` with a trailing empty segment. Sibling call sites this fix explicitly modeled itself on (e.g. lines 402, 433, 449 — `firstLine(x.stderr) || \`exit ${x.code}\``) guard against exactly this by falling back when stderr is empty. This is precisely the scenario the fix targets (opencode exiting 1 with no stderr detail): after the fix such a failure still surfaces as a message with a dangling &#39;: &#39; instead of useful content. Apply the same `|| ...` fallback used elsewhere for consistency and to avoid the malformed trailing colon.
- ⚠️ `src/acpx.js:483` - Same issue as line 337: `firstLine(result.stderr)` with no `|| fallback` leaves the session-prompt failure message with a dangling trailing colon when stderr is empty, unlike the sibling call sites this change says it now matches.

🔧 Fix: Add exit-code fallback when stderr is empty in acpx error messages
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `test/acpx-empty-stderr.test.js` - new test file written by agent: test/acpx-empty-stderr.test.js
- `node --test test/acpx-empty-stderr.test.js (new focused test, target commit b7c0f60): both cases pass`
- `same test re-run with src/acpx.js reverted to base commit 5392421 to confirm it fails without the fix (dangling trailing colon), then restored`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

