### PR TITLE
fix: allow acpx adapters to finish cold starts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,17 +281,12 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   Grok overlays ride acpx `--agent`; that hatch has no `-s` of its own (acpx 0.13.x:
   `unknown option '-s'`), so `openSession`'s `prompt()` sends the `prompt` subcommand
   before `-s` when `acpxAgentCommand` is set. Built-in agents keep the implicit form.
-- **A stalled adapter spawn is a timeout, never missing session support.** acpx launches most
-  built-in ACP adapters through an npm package-exec bridge (`acpx --verbose` names it), so
-  `sessions new` can carry a cold install - the codex adapter alone pulls a ~270MB binary -
-  plus a registry security-advisory round-trip, before the adapter process exists; an agent
-  acpx runs as a local binary (grok) pays neither and answers in under a second. backpass
-  kills that call at `SESSION_CREATE_TIMEOUT_MS` and acpx exits 130 on SIGTERM, so what
-  `openSession` sees is an unclassifiable non-zero exit that generic handling read as
-  `unsupported` - the same degradation the Windows shim refusal warns about, one boundary
-  over. `result.timedOut` is the only signal separating a killed call from a real refusal, so
-  it is read first (`test/acpx-session-create-timeout.test.js`). `--jobs N` multiplies that
-  bridge cost N-fold, because each parallel effortful call opens its own session.
+- **Only acpx session creation gets the adapter cold-start budget.** Built-in adapters may
+  launch through a package-exec bridge, so `sessions new` uses
+  `SESSION_CREATE_TIMEOUT_MS`; probe status/close retain `PROBE_TIMEOUT_MS` (including its
+  per-agent override), and open sessions keep their shorter post-create limits. Handle
+  `result.timedOut` before generic non-zero exits so a stalled create is never reported as
+  missing session support. `test/acpx-session-create-timeout.test.js` covers both contracts.
 - **Model and effort overrides are invocation-scoped.** Never ACP `set model` / Pi
   `set thought_level` (those rewrite `~/.pi/agent/settings.json`) and never edit-then-restore
   harness defaults. `src/harness-invoke.js` owns the harness overlay mechanisms and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,17 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   Grok overlays ride acpx `--agent`; that hatch has no `-s` of its own (acpx 0.13.x:
   `unknown option '-s'`), so `openSession`'s `prompt()` sends the `prompt` subcommand
   before `-s` when `acpxAgentCommand` is set. Built-in agents keep the implicit form.
+- **A stalled adapter spawn is a timeout, never missing session support.** acpx launches most
+  built-in ACP adapters through an npm package-exec bridge (`acpx --verbose` names it), so
+  `sessions new` can carry a cold install - the codex adapter alone pulls a ~270MB binary -
+  plus a registry security-advisory round-trip, before the adapter process exists; an agent
+  acpx runs as a local binary (grok) pays neither and answers in under a second. backpass
+  kills that call at `SESSION_CREATE_TIMEOUT_MS` and acpx exits 130 on SIGTERM, so what
+  `openSession` sees is an unclassifiable non-zero exit that generic handling read as
+  `unsupported` - the same degradation the Windows shim refusal warns about, one boundary
+  over. `result.timedOut` is the only signal separating a killed call from a real refusal, so
+  it is read first (`test/acpx-session-create-timeout.test.js`). `--jobs N` multiplies that
+  bridge cost N-fold, because each parallel effortful call opens its own session.
 - **Model and effort overrides are invocation-scoped.** Never ACP `set model` / Pi
   `set thought_level` (those rewrite `~/.pi/agent/settings.json`) and never edit-then-restore
   harness defaults. `src/harness-invoke.js` owns the harness overlay mechanisms and

--- a/README.md
+++ b/README.md
@@ -557,9 +557,11 @@ wins:
 | analysis  | medium | `gpt-5.6-luna` via pi, opencode, codex | `claude-sonnet-5` via claude | `grok-4.6` via pi, opencode, grok |
 | synthesis | high   | `gpt-5.6-sol` via pi, opencode, codex  | `claude-opus-5` via claude   | `grok-4.6` via pi, opencode, grok |
 
-Each candidate is checked with a ~1.5s zero-token acpx probe (claude via `claude auth status`,
-because its adapter accepts sessions while logged out). A potentially transient busy-harness
-miss retries once and is not cached; durable verdicts are cached in
+Each candidate is checked with a zero-token acpx probe (claude also uses `claude auth status`,
+because its adapter accepts sessions while logged out). Session creation may wait up to three
+minutes for a cold-starting adapter; the remaining probe operations retain their shorter
+10-20 second limits. A potentially transient busy-harness miss retries once and is not cached;
+durable verdicts are cached in
 `.backpass/agent-probe-cache.json` for 12h (30min for negatives). Pi and OpenCode entries
 are re-probed when their credential or auth-file state changes; `--force` re-probes every
 entry. The probe is a filter, not a promise: if the chosen harness answers `AUTH_REQUIRED`

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -116,7 +116,7 @@ function sessionCreateTimeoutError({ agent, acpxAgentArgs, timeoutMs }) {
   const seconds = Math.round(timeoutMs / 1000);
   return new UserError(
     `acpx ${agent} did not create a session within ${seconds}s`,
-    `its ACP adapter never started; acpx spawns built-in adapters through npm, so a cold or stalled package fetch blocks session create - check with: acpx --verbose ${acpxAgentArgs.join(" ")} sessions new --name backpass-probe`,
+    `its ACP adapter did not finish starting; adapter initialization or a cold or stalled npm package fetch can block session creation - check with: acpx --verbose ${acpxAgentArgs.join(" ")} sessions new --name backpass-probe`,
   );
 }
 

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -283,14 +283,23 @@ export async function acpxVersion({ timeoutMs = 10_000 } = {}) {
  * @returns {Promise<{ verdict: "ok" | "unauthenticated" | "model-unavailable" | "unreachable" | "timeout",
  *   detail: string, availableModels: string[], transient?: boolean }>}
  */
-export async function probeSession({ agent, sessionName, cwd = undefined, timeoutMs = 20_000 }) {
+export async function probeSession({
+  agent,
+  sessionName,
+  cwd = undefined,
+  timeoutMs = 20_000,
+  createTimeoutMs = timeoutMs,
+}) {
   const acpxAgent = acpxAgentName(agent);
-  const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], { timeoutMs, cwd });
+  const created = await run([acpxAgent, "sessions", "new", "--name", sessionName], {
+    timeoutMs: createTimeoutMs,
+    cwd,
+  });
   if (created.spawnError?.code === "ENOENT") throw notFoundError(created);
   if (created.timedOut) {
     return {
       verdict: "timeout",
-      detail: `probe timed out after ${Math.round(timeoutMs / 1000)}s`,
+      detail: `probe timed out after ${Math.round(createTimeoutMs / 1000)}s`,
       availableModels: [],
     };
   }

--- a/src/acpx.js
+++ b/src/acpx.js
@@ -90,6 +90,37 @@ function notFoundError(result) {
 }
 
 /**
+ * How long `acpx <agent> sessions new` may take before backpass kills it.
+ *
+ * acpx spawns most built-in ACP adapters through an npm package-exec bridge
+ * (`acpx --verbose` prints it: `npm exec --yes --package=@agentclientprotocol/codex-acp@...`,
+ * `npx pi-acp@...`), so session create can include a cold package install before the
+ * adapter process exists at all. The codex adapter alone pulls a ~270MB platform binary,
+ * which no 60s budget can cover on a first run; npm also performs a registry
+ * security-advisory round-trip per spawn, which stalls session create when that endpoint
+ * is slow. An agent acpx launches as a local binary (grok) never pays either cost.
+ */
+export const SESSION_CREATE_TIMEOUT_MS = 180_000;
+
+/**
+ * A session-create timeout must be raised by name, before any generic handling.
+ *
+ * backpass kills the call itself, and acpx exits 130 on SIGTERM, so the result reaching
+ * `openSession` is an ordinary non-zero exit with empty stderr. Read generically it lands
+ * in the `unsupported` branch and the run stops with "its acpx adapter does not support
+ * sessions - upgrade acpx or omit the effort override": three claims that are all false
+ * for a harness whose adapter simply had not started yet, and advice that cannot help.
+ * `result.timedOut` is the only signal that separates the two, so it is checked first.
+ */
+function sessionCreateTimeoutError({ agent, acpxAgentArgs, timeoutMs }) {
+  const seconds = Math.round(timeoutMs / 1000);
+  return new UserError(
+    `acpx ${agent} did not create a session within ${seconds}s`,
+    `its ACP adapter never started; acpx spawns built-in adapters through npm, so a cold or stalled package fetch blocks session create - check with: acpx --verbose ${acpxAgentArgs.join(" ")} sessions new --name backpass-probe`,
+  );
+}
+
+/**
  * Availability verdicts for a failed acpx call. Only a *classifiable* failure is a
  * reason to drop a candidate and fall through to the next one; anything else (a
  * timeout on a long prompt, garbage output) stays a plain error so a run never
@@ -360,6 +391,8 @@ export async function execOneShot({
  *
  * Resolves to the handle, or throws an `AcpxError` (`unsupported: true` when the adapter
  * has no session support; `sessionPrompt` only falls back when it can preserve the requested overlays).
+ * A `sessions new` that backpass itself killed on timeout is raised by name first
+ * (`SESSION_CREATE_TIMEOUT_MS`), never as missing session support.
  *
  * @returns {Promise<{ notes: string[],
  *   prompt: (options: { promptFile: string, timeoutSeconds?: number, promptRetries?: number,
@@ -367,10 +400,20 @@ export async function execOneShot({
  *     Promise<{ text: string, usage: Record<string, number> | null, raw: string, notes: string[] }>,
  *   close: () => Promise<void> }>}
  */
-export async function openSession({ agent, model = null, effort = null, sessionName, cwd, writeAccess = false }) {
+export async function openSession({
+  agent,
+  model = null,
+  effort = null,
+  sessionName,
+  cwd,
+  writeAccess = false,
+  createTimeoutMs = SESSION_CREATE_TIMEOUT_MS,
+}) {
   const invocation = prepareHarnessInvocation({ agent, model, effort, writeAccess });
   const notes = [...invocation.notes];
   const acpxAgentArgs = invocationAgentArgs(invocation, agent);
+  // The adapter is already up once the session exists, so the later `set` calls do not
+  // need the cold-start budget `sessions new` gets.
   const runOpts = { timeoutMs: 60_000, cwd, env: invocation.env };
   /** @type {Awaited<ReturnType<typeof run>>} */
   let created;
@@ -385,7 +428,7 @@ export async function openSession({ agent, model = null, effort = null, sessionN
         "--name",
         sessionName,
       ],
-      runOpts,
+      { ...runOpts, timeoutMs: createTimeoutMs },
     );
   } catch (err) {
     invocation.dispose();
@@ -394,6 +437,10 @@ export async function openSession({ agent, model = null, effort = null, sessionN
   if (created.spawnError && created.spawnError.code === "ENOENT") {
     invocation.dispose();
     throw notFoundError(created);
+  }
+  if (created.timedOut) {
+    invocation.dispose();
+    throw sessionCreateTimeoutError({ agent, acpxAgentArgs, timeoutMs: createTimeoutMs });
   }
   if (created.code !== 0) {
     invocation.dispose();
@@ -433,7 +480,9 @@ export async function openSession({ agent, model = null, effort = null, sessionN
     if (invocation.sessionMode) {
       const setMode = await run([...acpxAgentArgs, "-s", sessionName, "set-mode", invocation.sessionMode], runOpts);
       if (setMode.code !== 0) {
-        const detail = firstLine(setMode.stderr) || `exit ${setMode.code}`;
+        // Same degradation as session create: backpass kills the call, acpx exits 130 with
+        // no stderr, and `exit 130` would read as the harness rejecting the mode.
+        const detail = setMode.timedOut ? "timed out" : firstLine(setMode.stderr) || `exit ${setMode.code}`;
         if (invocation.sessionModeRequired) {
           throw new AcpxError(
             `acpx ${agent} could not enable write session mode=${invocation.sessionMode}: ${detail}`,
@@ -448,10 +497,10 @@ export async function openSession({ agent, model = null, effort = null, sessionN
     if (effort && invocation.setEffortKey) {
       const set = await run([...acpxAgentArgs, "-s", sessionName, "set", invocation.setEffortKey, effort], runOpts);
       if (set.code !== 0) {
-        throw new AcpxError(
-          `acpx ${agent} could not apply invocation-scoped effort=${effort}: ${firstLine(set.stderr) || `exit ${set.code}`}`,
-          set,
-        );
+        // Same degradation as session create: a killed call exits 130 with no stderr, and
+        // `exit 130` would read as the adapter refusing the effort key.
+        const detail = set.timedOut ? "timed out" : firstLine(set.stderr) || `exit ${set.code}`;
+        throw new AcpxError(`acpx ${agent} could not apply invocation-scoped effort=${effort}: ${detail}`, set);
       }
     }
   } catch (err) {
@@ -534,10 +583,11 @@ export async function sessionPrompt({
   promptRetries = 1,
   approveReads = true,
   suppressReads = true,
+  createTimeoutMs = SESSION_CREATE_TIMEOUT_MS,
 }) {
   let session;
   try {
-    session = await openSession({ agent, model, effort, sessionName, cwd });
+    session = await openSession({ agent, model, effort, sessionName, cwd, createTimeoutMs });
   } catch (err) {
     if (!(err instanceof AcpxError) || !err.unsupported) throw err;
     if (effort && effortOptionKey(agent)) {

--- a/src/agents.js
+++ b/src/agents.js
@@ -39,6 +39,8 @@ import { runCapture } from "./subprocess.js";
 const OK_TTL_MS = 12 * 60 * 60 * 1000;
 const NEGATIVE_TTL_MS = 30 * 60 * 1000;
 const NATIVE_TIMEOUT_MS = 5_000;
+const PROBE_TIMEOUT_MS = 20_000;
+const PROBE_TIMEOUT_BY_AGENT = { opencode: 10_000 };
 const PROBE_RETRY_BACKOFF_MS = 1_000;
 
 /** Adapters whose model list is open-ended: any id is forwarded, none can be verified. */
@@ -175,7 +177,8 @@ export function candidateKey({ agent, model }) {
  *
  * @param {{ agent: string, model: string }} candidate
  * @param {{ cwd?: string, sessionName?: string,
- *   probeSession?: (args: { agent: string, sessionName: string, cwd?: string, timeoutMs?: number }) =>
+ *   probeSession?: (args: { agent: string, sessionName: string, cwd?: string,
+ *     timeoutMs?: number, createTimeoutMs?: number }) =>
  *     Promise<{ verdict: string, detail: string, availableModels?: string[], transient?: boolean }>,
  *   runCapture?: typeof runCapture,
  *   providerAuthTypes?: Record<string, "subscription" | "api_key">,
@@ -196,7 +199,8 @@ export async function probeCandidate(candidate, options = {}) {
     agent,
     sessionName,
     cwd,
-    timeoutMs: SESSION_CREATE_TIMEOUT_MS,
+    timeoutMs: PROBE_TIMEOUT_BY_AGENT[agent] || PROBE_TIMEOUT_MS,
+    createTimeoutMs: SESSION_CREATE_TIMEOUT_MS,
   });
   if (result.verdict !== "ok") {
     return {

--- a/src/agents.js
+++ b/src/agents.js
@@ -1,6 +1,6 @@
 import { UserError, color, info, warn } from "./logger.js";
 import { DEFAULT_EFFORT, LEGACY_DEFAULT_AGENTS } from "./config.js";
-import { AcpxError, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
+import { AcpxError, SESSION_CREATE_TIMEOUT_MS, acpxVersion, classifyAcpxFailure, probeSession } from "./acpx.js";
 import { ambiguousModelDetail, providerAuthState, rankCollidingIds, readProviderAuthTypes } from "./provider-auth.js";
 import { runCapture } from "./subprocess.js";
 
@@ -9,8 +9,8 @@ import { runCapture } from "./subprocess.js";
  *
  * Each role (analysis, synthesis) has a ladder of candidates - a model id served by a
  * few harnesses, in preference order. This module walks the ladder and picks the first
- * candidate that is installed, authenticated, and serves the model, using a ~1.5s
- * zero-token probe per candidate. The probe is a *filter*, not a guarantee: the first
+ * candidate that is installed, authenticated, and serves the model, using a zero-token
+ * probe per candidate. The probe is a *filter*, not a guarantee: the first
  * real call is the decider, and a classifiable failure there (AUTH_REQUIRED, model
  * rejected, adapter missing) demotes the candidate and falls through to the next one.
  *
@@ -23,8 +23,8 @@ import { runCapture } from "./subprocess.js";
  * All model invocation still goes through `src/acpx.js`. The one documented exception
  * is `NATIVE_PROBES` below: the claude adapter creates sessions happily while logged
  * out and only fails at prompt time, so its login state has to come from the harness's
- * own `claude auth status`. opencode's ACP session has been seen to wedge for minutes
- * on a large profile, so `opencode models` answers first and the ACP probe is capped.
+ * own `claude auth status`. `opencode models` answers first because its ACP session has
+ * been seen to wedge on a large profile.
  *
  * Verdicts are cached in `.backpass/agent-probe-cache.json` (12h for ok, 30min for
  * negatives) and memoized for the run. An acpx version change invalidates every entry;
@@ -39,8 +39,6 @@ import { runCapture } from "./subprocess.js";
 const OK_TTL_MS = 12 * 60 * 60 * 1000;
 const NEGATIVE_TTL_MS = 30 * 60 * 1000;
 const NATIVE_TIMEOUT_MS = 5_000;
-const PROBE_TIMEOUT_MS = 20_000;
-const PROBE_TIMEOUT_BY_AGENT = { opencode: 10_000 };
 const PROBE_RETRY_BACKOFF_MS = 1_000;
 
 /** Adapters whose model list is open-ended: any id is forwarded, none can be verified. */
@@ -198,7 +196,7 @@ export async function probeCandidate(candidate, options = {}) {
     agent,
     sessionName,
     cwd,
-    timeoutMs: PROBE_TIMEOUT_BY_AGENT[agent] || PROBE_TIMEOUT_MS,
+    timeoutMs: SESSION_CREATE_TIMEOUT_MS,
   });
   if (result.verdict !== "ok") {
     return {

--- a/src/cli.js
+++ b/src/cli.js
@@ -99,7 +99,7 @@ COLLECT SAMPLES
 
 MODELS (two-tier: cheap analysis, smart synthesis - all through acpx)
   By default each pass auto-picks the first harness in its ladder that is installed,
-  logged in, and serves the model (a ~1.5s zero-token probe per candidate, cached):
+  logged in, and serves the model (a cached zero-token probe; cold starts may take 3m):
     analysis   gpt-5.6-luna via pi, opencode, codex  >  claude-sonnet-5 via claude  >  grok-4.6 via pi, opencode, grok
     synthesis  gpt-5.6-sol  via pi, opencode, codex  >  claude-opus-5  via claude  >  grok-4.6 via pi, opencode, grok
   Setting an agent pins that pass and skips its ladder.

--- a/test/acpx-session-create-timeout.test.js
+++ b/test/acpx-session-create-timeout.test.js
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Regression for a real backpass run against acpx 0.13.0.
+ *
+ * acpx spawns most built-in ACP adapters through an npm package-exec bridge, so
+ * `sessions new` can sit for minutes before the adapter process exists. backpass kills
+ * the call on its own timeout, and acpx exits 130 on SIGTERM with nothing on stderr -
+ * a plain non-zero exit. Read generically that landed in the `unsupported` branch, and
+ * every stalled harness (claude, codex, pi) failed the run with "its acpx adapter does
+ * not support sessions - upgrade acpx or omit the effort override". All three claims
+ * were false and the advice could not help. `timedOut` is the only signal that
+ * separates the two, so it has to be read before the exit code.
+ */
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-acpx-create-timeout-"));
+const promptFile = path.join(fixtureDir, "prompt.md");
+fs.writeFileSync(promptFile, "analyze this\n");
+
+/**
+ * One fake acpx, two behaviours picked at spawn time by `FAKE_ACPX_MODE`:
+ *   hang        `sessions new` never answers, then exits 130 on SIGTERM as acpx does
+ *   no-sessions `sessions new` is rejected outright, the genuine unsupported case
+ * `ACPX_BIN` is bound when `src/acpx.js` is imported, so the mode cannot be a second path.
+ */
+const fakeAcpx = path.join(fixtureDir, "acpx");
+fs.writeFileSync(
+  fakeAcpx,
+  `#!${process.execPath}
+const argv = process.argv.slice(2);
+// An effort overlay verifies the adapter config before creating the session.
+if (argv.includes("config") && argv.includes("show")) {
+  process.stdout.write(JSON.stringify({ agents: {} }));
+  process.exit(0);
+}
+const creating = argv.includes("sessions") && argv.includes("new");
+if (creating && process.env.FAKE_ACPX_MODE === "no-sessions") {
+  process.stderr.write("error: unknown command 'sessions'\\n");
+  process.exit(2);
+}
+if (creating) {
+  process.on("SIGTERM", () => process.exit(130));
+  setInterval(() => {}, 1000);
+} else {
+  process.exit(0);
+}
+`,
+);
+fs.chmodSync(fakeAcpx, 0o755);
+
+process.env.BACKPASS_ACPX_BIN = fakeAcpx;
+process.env.FAKE_ACPX_MODE = "hang";
+const { AcpxError, SESSION_CREATE_TIMEOUT_MS, openSession, sessionPrompt } = await import("../src/acpx.js");
+const { UserError } = await import("../src/logger.js");
+
+test.after(() => {
+  fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+test("a session-create timeout is named as a timeout, not as missing session support", async () => {
+  await assert.rejects(
+    () =>
+      openSession({ agent: "codex", sessionName: "backpass-create-timeout", cwd: fixtureDir, createTimeoutMs: 1500 }),
+    (err) => {
+      assert.ok(err instanceof UserError, String(err));
+      assert.equal(err.message, "acpx codex did not create a session within 2s");
+      assert.doesNotMatch(err.message, /support/i);
+      assert.doesNotMatch(String(err.hint), /upgrade acpx/i);
+      assert.match(String(err.hint), /adapter never started/);
+      return true;
+    },
+  );
+});
+
+test("a stalled harness no longer claims the effort override is unsupported", async () => {
+  await assert.rejects(
+    () =>
+      sessionPrompt({
+        agent: "codex",
+        effort: "medium",
+        sessionName: "backpass-create-timeout-effort",
+        promptFile,
+        cwd: fixtureDir,
+        createTimeoutMs: 1500,
+      }),
+    (err) => {
+      assert.ok(err instanceof UserError, String(err));
+      assert.doesNotMatch(err.message, /does not support sessions/);
+      assert.match(err.message, /did not create a session within/);
+      return true;
+    },
+  );
+});
+
+test("an adapter that really rejects sessions still reports missing session support", async () => {
+  process.env.FAKE_ACPX_MODE = "no-sessions";
+  try {
+    await assert.rejects(
+      () =>
+        openSession({ agent: "codex", sessionName: "backpass-no-sessions", cwd: fixtureDir, createTimeoutMs: 1500 }),
+      (err) => {
+        assert.ok(err instanceof AcpxError, String(err));
+        assert.equal(err.unsupported, true);
+        assert.match(err.message, /has no session support/);
+        return true;
+      },
+    );
+  } finally {
+    process.env.FAKE_ACPX_MODE = "hang";
+  }
+});
+
+test("the shipped session-create budget covers a cold npm-bridged adapter spawn", () => {
+  // 60s was under the floor: the codex adapter's first spawn installs a ~270MB binary.
+  assert.ok(SESSION_CREATE_TIMEOUT_MS >= 120_000, `too tight for a cold spawn: ${SESSION_CREATE_TIMEOUT_MS}`);
+});

--- a/test/acpx-session-create-timeout.test.js
+++ b/test/acpx-session-create-timeout.test.js
@@ -37,11 +37,18 @@ if (argv.includes("config") && argv.includes("show")) {
   process.exit(0);
 }
 const creating = argv.includes("sessions") && argv.includes("new");
+const status = argv.includes("status");
+const closing = argv.includes("sessions") && argv.includes("close");
 if (creating && process.env.FAKE_ACPX_MODE === "no-sessions") {
   process.stderr.write("error: unknown command 'sessions'\\n");
   process.exit(2);
 }
-if (creating) {
+if (creating && process.env.FAKE_ACPX_MODE === "scoped-timeouts") {
+  setTimeout(() => process.exit(0), 300);
+} else if ((status || closing) && process.env.FAKE_ACPX_MODE === "scoped-timeouts") {
+  process.on("SIGTERM", () => process.exit(130));
+  setInterval(() => {}, 1000);
+} else if (creating) {
   process.on("SIGTERM", () => process.exit(130));
   setInterval(() => {}, 1000);
 } else {
@@ -53,8 +60,7 @@ fs.chmodSync(fakeAcpx, 0o755);
 
 process.env.BACKPASS_ACPX_BIN = fakeAcpx;
 process.env.FAKE_ACPX_MODE = "hang";
-const { AcpxError, openSession, sessionPrompt } = await import("../src/acpx.js");
-const { probeCandidate } = await import("../src/agents.js");
+const { AcpxError, openSession, probeSession, sessionPrompt } = await import("../src/acpx.js");
 const { UserError } = await import("../src/logger.js");
 
 test.after(() => {
@@ -115,19 +121,21 @@ test("an adapter that really rejects sessions still reports missing session supp
   }
 });
 
-test("the availability probe gives session creation the cold-start budget", async () => {
-  let receivedTimeoutMs;
-  const result = await probeCandidate(
-    { agent: "codex", model: "gpt-5.6-luna" },
-    {
-      sessionName: "backpass-cold-start-probe",
-      probeSession: async ({ timeoutMs }) => {
-        receivedTimeoutMs = timeoutMs;
-        return { verdict: "ok", detail: "", availableModels: ["gpt-5.6-luna"] };
-      },
-    },
-  );
+test("the availability probe scopes the cold-start budget to session creation", async () => {
+  process.env.FAKE_ACPX_MODE = "scoped-timeouts";
+  const startedAt = Date.now();
+  try {
+    const result = await probeSession({
+      agent: "codex",
+      sessionName: "backpass-scoped-timeouts",
+      cwd: fixtureDir,
+      timeoutMs: 100,
+      createTimeoutMs: 1_000,
+    });
 
-  assert.equal(result.verdict, "ok");
-  assert.equal(receivedTimeoutMs, 180_000);
+    assert.equal(result.verdict, "ok");
+    assert.ok(Date.now() - startedAt < 1_500, "status and close exceeded the short operation budget");
+  } finally {
+    process.env.FAKE_ACPX_MODE = "hang";
+  }
 });

--- a/test/acpx-session-create-timeout.test.js
+++ b/test/acpx-session-create-timeout.test.js
@@ -53,7 +53,8 @@ fs.chmodSync(fakeAcpx, 0o755);
 
 process.env.BACKPASS_ACPX_BIN = fakeAcpx;
 process.env.FAKE_ACPX_MODE = "hang";
-const { AcpxError, SESSION_CREATE_TIMEOUT_MS, openSession, sessionPrompt } = await import("../src/acpx.js");
+const { AcpxError, openSession, sessionPrompt } = await import("../src/acpx.js");
+const { probeCandidate } = await import("../src/agents.js");
 const { UserError } = await import("../src/logger.js");
 
 test.after(() => {
@@ -69,7 +70,8 @@ test("a session-create timeout is named as a timeout, not as missing session sup
       assert.equal(err.message, "acpx codex did not create a session within 2s");
       assert.doesNotMatch(err.message, /support/i);
       assert.doesNotMatch(String(err.hint), /upgrade acpx/i);
-      assert.match(String(err.hint), /adapter never started/);
+      assert.match(String(err.hint), /adapter did not finish starting/);
+      assert.match(String(err.hint), /adapter initialization or a cold or stalled npm package fetch/);
       return true;
     },
   );
@@ -113,7 +115,19 @@ test("an adapter that really rejects sessions still reports missing session supp
   }
 });
 
-test("the shipped session-create budget covers a cold npm-bridged adapter spawn", () => {
-  // 60s was under the floor: the codex adapter's first spawn installs a ~270MB binary.
-  assert.ok(SESSION_CREATE_TIMEOUT_MS >= 120_000, `too tight for a cold spawn: ${SESSION_CREATE_TIMEOUT_MS}`);
+test("the availability probe gives session creation the cold-start budget", async () => {
+  let receivedTimeoutMs;
+  const result = await probeCandidate(
+    { agent: "codex", model: "gpt-5.6-luna" },
+    {
+      sessionName: "backpass-cold-start-probe",
+      probeSession: async ({ timeoutMs }) => {
+        receivedTimeoutMs = timeoutMs;
+        return { verdict: "ok", detail: "", availableModels: ["gpt-5.6-luna"] };
+      },
+    },
+  );
+
+  assert.equal(result.verdict, "ok");
+  assert.equal(receivedTimeoutMs, 180_000);
 });


### PR DESCRIPTION
## Intent

Retry the unfinished backpass target/scope matrix on this machine. This is not a load problem. Pick skills that are heavily used. Also get to the bottom why acpx could not invoke those harnesses properly and fix them in backpass if possible, because other users running those harnesses would be blocked.

Prior dry-run: that matrix exercised backpass --target and --scope across six cells - project scope and user scope, each run with no target, with a memory-file target, and with a skill target. 2 of 6 cells finished and showed --target/--scope working. Four cells reached real model calls then failed: claude hang at ACP initialize, codex acpx adapter no session support for effort, opencode ndjson vs terminal-title escape, grok PERMISSION_DENIED, pi sessions new SIGINT.

## What Changed

- Allow acpx session creation up to three minutes while retaining shorter timeouts for status, configuration, and close operations.
- Report stalled session creation as an adapter startup timeout instead of incorrectly claiming that sessions or effort overrides are unsupported.
- Add regression coverage for cold-start timeout scoping and genuine unsupported-session errors.

## Risk Assessment

✅ Low: The change is narrowly scoped, correctly separates session-create timeout budgets from status and close operations, and adds behavioral regression coverage.

## Testing

Inspected the base-to-target change, ran the focused acpx timeout and agent-resolution tests, and manually reproduced a stalled adapter through the executable session interface. The result names session creation as timed out instead of falsely claiming missing session support, while status and close retain their short timeout; the CLI-only surface is captured as a text artifact, so no visual screenshot applies.

<details>
<summary>Evidence: Session-create diagnostic and probe timeout-scoping demonstration</summary>

Source: [Session-create diagnostic and probe timeout-scoping demonstration](https://github.com/kunchenguid/backpass/blob/ee5f414a92503150bf1e8292d1e5cc1927379e60/.no-mistakes/evidence/fm/backpass-retry-acpx-r1/acpx-session-timeout-demo.txt)

```text
End-user diagnostic:
error: acpx codex did not create a session within 2s
  its ACP adapter did not finish starting; adapter initialization or a cold or stalled npm package fetch can block session creation - check with: acpx --verbose codex sessions new --name backpass-probe
warn could not close acpx probe session scope-demo

Probe timeout scoping:
{
  "createDelayMs": 300,
  "operationBudgetMs": 100,
  "verdict": "ok",
  "elapsedMs": 569
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6f6b78179542c3c0c11ea404b31965ee15801833","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `src/acpx.js:431` - The 180s cold-start budget applies only to the real session. On a fresh auto-agent run, `probeCandidate` first invokes the same `sessions new` operation through `probeSession` with a 20s timeout (10s for OpenCode), retries once, then skips the harness. An adapter needing more than 60s for the documented cold package fetch therefore never reaches this fixed path, leaving new users blocked. Apply an appropriate cold-start session budget at the probe boundary too.
- ⚠️ `src/acpx.js:119` - `timedOut` proves only that session creation did not finish. An adapter can start and then hang during ACP initialization, including the Claude failure named in the intent, but this message states that the adapter &#34;never started&#34; and attributes the failure to package fetching. Keep the timeout diagnosis while presenting adapter startup or package fetching as possible causes rather than established facts.
- ⚠️ `test/acpx-session-create-timeout.test.js:118` - This test only imports an implementation constant and asserts its numeric value. It does not exercise the default timeout or demonstrate that a cold adapter spawn completes, so it is a newly added source-content-only assertion prohibited by the test-quality rule. Remove it or replace it with an executable behavioral check of the default timeout contract.

🔧 Fix: Extend probe cold-start timeout and clarify diagnostics
1 warning still open:

- ⚠️ `src/agents.js:202` - The fixer passes the 180s cold-start budget as `probeSession.timeoutMs`, but that value also controls `status` and `sessions close` in `src/acpx.js`. A successful create followed by a wedged status or close can now block for three minutes per command, and transient probes are retried. The prior fix only required extending session creation. Keep the shorter probe-operation timeout and apply 180s specifically to `sessions new`.

🔧 Fix: Scope probe cold-start timeout to session creation
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat d9610eaae2bfb23fca92804ea468b2d1cf579a81..bfaee635f9373ec5d52c3f6a5e8e63c07cb42433` and focused source/test diff inspection</code>
- `node --test test/acpx-session-create-timeout.test.js test/acpx-empty-stderr.test.js`
- `node --test test/agents.test.js`
- <code>Manual fake-acpx exercise of `openSession` and `probeSession`, capturing the user-facing timeout diagnostic and independently bounded create/status/close timing</code>
- <code>`git status --short` to confirm testing left the worktree clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
