### PR TITLE
fix(skills): see and stage skills that are symlinked into the loaded directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,11 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   file, widened until unique, so a hunk can only go stale by the file itself changing after
   the proposal, which apply refuses rather than part-applies. Never pass
   `approveAll` with the repo as `cwd`; the repo is fingerprinted and a harness that
-  writes there fails the run loudly.
+  writes there fails the run loudly. Staging withholds a loaded skill it could never write -
+  one resolving outside the repository, or into a location nothing may write - naming the
+  reason in the skill index, and the fingerprint follows staging: a withheld file is one
+  backpass has guaranteed it will never write, so a third party's edit to it must not abort
+  the run. Staging and the fingerprint must stay in step.
 - **Annotate-loop outcomes stay distinct** (`annotateLoop` in `src/synthesize.js`): a
   moved staging tree is re-measured without spending an `ANNOTATE_TURNS` attempt (bounded
   by `REMEASURE_TURNS`); no adapter text is retried once in a new session; and only a
@@ -176,7 +180,11 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each
   quote. Records from before the class existed carry none, and none never counts as harm.
 - **Skill target/load-layout rules live in `src/skills.js`.** Preserve an existing configured
-  harness-loaded directory; a bare `skills/` directory is never auto-detected.
+  harness-loaded directory; a bare `skills/` directory is never auto-detected. A harness loads
+  what a path resolves to, so a symlinked directory under the loaded dir is a skill: entry types
+  are stat'd (`isDirectoryEntry`), fail-soft, and a broken or cyclic link reads as absent. One
+  library reached through k links is k loaded entries, billed k times - `loadedCopies` multiplies
+  a description-line delta by that count in both `buildProposal` and the writer's projection.
 - **Memory resolution is pointer-aware** (`resolveMemoryFiles` in `src/memory.js`): the
   first configured file is canonical, a `@AGENTS.md`-only CLAUDE.md is a pointer, and a
   second full file is warned about, never silently ignored or double-written.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,12 @@ Harness load paths, verified for v1:
 - **Codex** loads `AGENTS.md` from `CODEX_HOME` (default `~/.codex`). It follows the
   AGENTS.md convention; `@` import is not assumed.
 
-A target that is a symlink into a read-only store (dotfiles, nix) is refused with
-`<path> is a symlink to <real>, which is not writable; edit the source that generates it`.
+A target that resolves into a read-only store (nix, home-manager) is refused by name
+rather than written. The whole path is resolved, so the link may be the file itself
+(`<path> is a symlink to <real>, which is not writable; edit the source that generates
+it`) or a directory on the way to it (`<path> resolves to <real>, which is not
+writable; ...`). The test is whether the directory holding the resolved location can be
+written; both messages name that resolved location, so you know which source to edit.
 
 ```sh
 backpass init --scope user
@@ -123,7 +127,10 @@ directory, a path to a SKILL.md, or an existing file the config does not name - 
 unknown name fails, listing the valid ones, instead of falling back to the whole surface. A
 configured file that contains only an `@` import is rejected rather than rewritten or silently
 mapped to its import; the error names the imported memory file, which must itself be configured
-to be targeted.
+to be targeted. A correctly named skill whose file backpass cannot write - one resolving into a
+location nothing may write, or in project scope one resolving outside the repository - is refused
+by name too: backpass loads and bills that skill, but a targeted run against it could only end in
+a refused write.
 
 ```sh
 backpass --target AGENTS.md          # this memory file; existing skills are read-only
@@ -407,8 +414,11 @@ The estimator is bytes/4 - harness-neutral, ±15%.
 
 The gated number is the **memory file plus every skill's `description:` line** - that is
 what an agent actually pays on every session. Skill bodies stay free until triggered and
-never compete for this budget. (A repo that already carries many skills may find itself
-over budget with no file having changed when upgrading to this accounting - that is the
+never compete for this budget. Every entry the harness loads counts, including one that is
+a symlink into a shared library: a harness loads what the path resolves to, so one library
+reached through several links is loaded - and billed - once per link, and an edit to its
+description line costs that many times its delta. (A repo that already carries many skills
+may find itself over budget with no file having changed when upgrading to this accounting - that is the
 one-time re-tune of `budgetTokens`, not a regression.)
 
 ```

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -30,25 +30,24 @@ function resolveTarget(root, relative) {
   return path.isAbsolute(relative) ? relative : path.join(root, relative);
 }
 
-/** Named refusal when a user-level target is a symlink into a read-only store. */
+/** Named refusal when a target is a symlink into a read-only store. */
 export function readOnlySymlinkMessage(absolute, realPath) {
   return `${absolute} is a symlink to ${realPath}, which is not writable; edit the source that generates it`;
 }
 
+/**
+ * The link is as often a directory on the way to the file (`~/.claude/skills/foo` pointing
+ * into a nix store) as the file itself, so the whole path is resolved rather than the leaf
+ * lstat'd: an lstat of the leaf sees a plain file and hands the user a raw EROFS instead.
+ */
 function refuseReadOnlySymlink(absolute) {
-  let lstat;
-  try {
-    lstat = fs.lstatSync(absolute);
-  } catch {
-    return null;
-  }
-  if (!lstat.isSymbolicLink()) return null;
   let real;
   try {
     real = fs.realpathSync(absolute);
   } catch {
     return null;
   }
+  if (real === path.resolve(absolute)) return null;
   try {
     fs.accessSync(real, fs.constants.W_OK);
     fs.accessSync(path.dirname(real), fs.constants.W_OK | fs.constants.X_OK);

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -35,6 +35,11 @@ export function readOnlySymlinkMessage(absolute, realPath) {
   return `${absolute} is a symlink to ${realPath}, which is not writable; edit the source that generates it`;
 }
 
+/** The same refusal when a directory on the way to the target is the link, not the target. */
+export function readOnlyTargetMessage(absolute, realPath) {
+  return `${absolute} resolves to ${realPath}, which is not writable; edit the source that generates it`;
+}
+
 /**
  * The link is as often a directory on the way to the file (`~/.claude/skills/foo` pointing
  * into a nix store) as the file itself, so the whole path is resolved rather than the leaf
@@ -53,7 +58,15 @@ function refuseReadOnlySymlink(absolute) {
     fs.accessSync(path.dirname(real), fs.constants.W_OK | fs.constants.X_OK);
     return null;
   } catch {
-    return readOnlySymlinkMessage(absolute, real);
+    return isSymbolicLink(absolute) ? readOnlySymlinkMessage(absolute, real) : readOnlyTargetMessage(absolute, real);
+  }
+}
+
+function isSymbolicLink(absolute) {
+  try {
+    return fs.lstatSync(absolute).isSymbolicLink();
+  } catch {
+    return false;
   }
 }
 

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 
 import { applyEdit, filesOfEdit, sliceEditForFile } from "../proposal.js";
-import { memoryTextHash, resolveMemoryPath } from "../memory.js";
+import { memoryTextHash, readOnlyResolvedPath, resolveMemoryPath } from "../memory.js";
 import { userClaudeSkillsDir } from "../config.js";
 import { budgetGateKind, budgetStatus, estimateTokens, formatTokens } from "../tokens.js";
 import { recordRejection } from "../state.js";
@@ -47,20 +47,9 @@ export function readOnlyTargetMessage(absolute, realPath) {
  * lstat'd: an lstat of the leaf sees a plain file and hands the user a raw EROFS instead.
  */
 function refuseReadOnlySymlink(absolute) {
-  let real;
-  try {
-    real = fs.realpathSync(absolute);
-  } catch {
-    return null;
-  }
-  if (real === path.resolve(absolute)) return null;
-  try {
-    fs.accessSync(real, fs.constants.W_OK);
-    fs.accessSync(path.dirname(real), fs.constants.W_OK | fs.constants.X_OK);
-    return null;
-  } catch {
-    return isSymbolicLink(absolute) ? readOnlySymlinkMessage(absolute, real) : readOnlyTargetMessage(absolute, real);
-  }
+  const real = readOnlyResolvedPath(absolute);
+  if (!real) return null;
+  return isSymbolicLink(absolute) ? readOnlySymlinkMessage(absolute, real) : readOnlyTargetMessage(absolute, real);
 }
 
 function isSymbolicLink(absolute) {

--- a/src/apply/writer.js
+++ b/src/apply/writer.js
@@ -13,6 +13,7 @@ import {
   editSkills,
   ensureSkillsLayout,
   loadProjectSkills,
+  loadedCopies,
   parseFrontmatter,
   removeOwnedSkillPaths,
   resolveOverflowTarget,
@@ -451,7 +452,9 @@ export function applyDecisions({ proposal, decisions, repo, state, config, dryRu
   let descriptionTokensProjected = descriptionTokensNow;
   for (const item of resolvedPlanned) {
     if (!existingSkillPaths.has(item.relative)) continue;
-    descriptionTokensProjected += descriptionTokensIn(item.text) - descriptionTokensIn(item.before);
+    descriptionTokensProjected +=
+      (descriptionTokensIn(item.text) - descriptionTokensIn(item.before)) *
+      loadedCopies(repo.root, skillsNow, item.relative);
   }
   descriptionTokensProjected += plannedSkills.reduce(
     (sum, { skill }) => sum + estimateTokens(skill.description || ""),

--- a/src/memory.js
+++ b/src/memory.js
@@ -325,9 +325,13 @@ export function resolveMemoryPath(repoRoot, configuredPath, { allowExternal = fa
 
 /**
  * Where a write to `absolute` would really land when that is somewhere else and cannot be
- * written - a skill linked into a nix or home-manager store, typically. The probe is what
- * `atomicReplace` needs and nothing more: the directory that receives the rename. The
- * resolved file's own mode never decides, because no write path opens it for writing.
+ * written - a skill linked into a nix or home-manager store, typically. The probe refuses
+ * when the directory the resolved location sits in is unwritable, whether the link is a
+ * directory on the way to the file or the file itself. For a leaf link that is stricter
+ * than `atomicReplace` strictly needs - it renames into the link's own parent, which may
+ * be writable - and deliberately so: that rename would swap the link for a private copy
+ * and leave the store source behind, silently unlinking the file from what generates it.
+ * The resolved file's own mode never decides, because no write path opens it for writing.
  *
  * `null` means the write can land, and deliberately covers the undecidable cases too - an
  * unresolvable path, a broken link, a racing rename. A probe that cannot establish that a

--- a/src/memory.js
+++ b/src/memory.js
@@ -326,7 +326,8 @@ export function resolveMemoryPath(repoRoot, configuredPath, { allowExternal = fa
 /**
  * Where a write to `absolute` would really land when that is somewhere else and cannot be
  * written - a skill linked into a nix or home-manager store, typically. The probe is what
- * `atomicReplace` needs: the resolved file, and the directory that receives the rename.
+ * `atomicReplace` needs and nothing more: the directory that receives the rename. The
+ * resolved file's own mode never decides, because no write path opens it for writing.
  *
  * `null` means the write can land, and deliberately covers the undecidable cases too - an
  * unresolvable path, a broken link, a racing rename. A probe that cannot establish that a
@@ -341,7 +342,6 @@ export function readOnlyResolvedPath(absolute) {
   }
   if (real === path.resolve(absolute)) return null;
   try {
-    fs.accessSync(real, fs.constants.W_OK);
     fs.accessSync(path.dirname(real), fs.constants.W_OK | fs.constants.X_OK);
     return null;
   } catch {

--- a/src/memory.js
+++ b/src/memory.js
@@ -323,6 +323,32 @@ export function resolveMemoryPath(repoRoot, configuredPath, { allowExternal = fa
   return absolute;
 }
 
+/**
+ * Where a write to `absolute` would really land when that is somewhere else and cannot be
+ * written - a skill linked into a nix or home-manager store, typically. The probe is what
+ * `atomicReplace` needs: the resolved file, and the directory that receives the rename.
+ *
+ * `null` means the write can land, and deliberately covers the undecidable cases too - an
+ * unresolvable path, a broken link, a racing rename. A probe that cannot establish that a
+ * file is unwritable never decides against it; the apply gate remains the backstop.
+ */
+export function readOnlyResolvedPath(absolute) {
+  let real;
+  try {
+    real = fs.realpathSync(absolute);
+  } catch {
+    return null;
+  }
+  if (real === path.resolve(absolute)) return null;
+  try {
+    fs.accessSync(real, fs.constants.W_OK);
+    fs.accessSync(path.dirname(real), fs.constants.W_OK | fs.constants.X_OK);
+    return null;
+  } catch {
+    return real;
+  }
+}
+
 export function readMemoryFile(repoRoot, relativePath, options = {}) {
   const absolute = resolveMemoryPath(repoRoot, relativePath, options);
   if (!fs.existsSync(absolute)) return null;

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -747,8 +747,7 @@ export function buildProposal(rawResult, context) {
     );
   }
 
-  for (const file of measured.stray || [])
-    notes.push(`ignored ${file}: synthesis wrote it outside the memory file and skills`);
+  for (const { file, reason } of measured.stray || []) notes.push(`ignored ${file}: ${reason}`);
 
   // Every non-memory file an accepted edit targets, with the fingerprint of the exact
   // image its hunks were cut from. The writer re-checks these before composing, the

--- a/src/proposal.js
+++ b/src/proposal.js
@@ -2,7 +2,7 @@ import { renderHunkLines } from "./diff.js";
 import { normalizeSourceLabel } from "./gap-ledger.js";
 import { mixFromCounts } from "./interaction.js";
 import { memoryTextHash } from "./memory.js";
-import { editSkills, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
+import { editSkills, loadedCopies, parseFrontmatter, skillDescriptionTokens } from "./skills.js";
 import { budgetGateKind, budgetStatus, estimateTokens } from "./tokens.js";
 import { isSkillFilePath, normalizeRecoveryLine, recoveredLineCounts } from "./workspace.js";
 
@@ -689,7 +689,7 @@ export function buildProposal(rawResult, context) {
         else {
           otherDelta += delta;
           if (isSkillFilePath(target, config.skillDirs || config.skillsDir)) {
-            descriptionDelta += descriptionLineDelta(before, next);
+            descriptionDelta += descriptionLineDelta(before, next) * loadedCopies(repo.root, skillFiles, target);
           }
         }
       }

--- a/src/skills.js
+++ b/src/skills.js
@@ -221,7 +221,9 @@ export function renderSkillIndex(skills) {
   return skills
     .map(
       (s) =>
-        `- ${s.name} (${s.path}; ${s.bodyTokens} tok body, ${s.descriptionTokens} tok description) :: ${s.description || "(no description)"}`,
+        `- ${s.name} (${s.path}; ${s.bodyTokens} tok body, ${s.descriptionTokens} tok description` +
+        `${s.readOnly ? "; read-only, resolves outside the repository" : ""})` +
+        ` :: ${s.description || "(no description)"}`,
     )
     .join("\n");
 }

--- a/src/skills.js
+++ b/src/skills.js
@@ -222,7 +222,7 @@ export function renderSkillIndex(skills) {
     .map(
       (s) =>
         `- ${s.name} (${s.path}; ${s.bodyTokens} tok body, ${s.descriptionTokens} tok description` +
-        `${s.readOnly ? "; read-only, resolves outside the repository" : ""})` +
+        `${s.readOnly ? `; read-only, ${s.readOnly}` : ""})` +
         ` :: ${s.description || "(no description)"}`,
     )
     .join("\n");

--- a/src/skills.js
+++ b/src/skills.js
@@ -91,7 +91,7 @@ export function loadSkills(repoRoot, skillsDir) {
     });
   }
 
-  return skills.sort((a, b) => a.name.localeCompare(b.name));
+  return skills.sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
 }
 
 /**

--- a/src/skills.js
+++ b/src/skills.js
@@ -152,6 +152,24 @@ export function skillDescriptionTokens(skills) {
   return (skills || []).reduce((sum, s) => sum + (s.descriptionTokens ?? estimateTokens(s.description || "")), 0);
 }
 
+/**
+ * How many loaded entries are the same file as `file`. One library reached through k links
+ * is loaded k times and billed k times (`skillDescriptionTokens` sums every entry), so a
+ * change to its description line costs k times that delta on the always-loaded surface.
+ */
+export function loadedCopies(repoRoot, skills, file) {
+  const identity = (p) => {
+    try {
+      return fs.realpathSync(path.isAbsolute(p) ? p : path.join(repoRoot, p));
+    } catch {
+      return null;
+    }
+  };
+  const target = identity(file);
+  if (!target) return 1;
+  return Math.max(1, (skills || []).filter((skill) => identity(skill.path) === target).length);
+}
+
 /** Minimal YAML frontmatter reader for plain values and `>` / `|` multi-line values. */
 export function parseFrontmatter(text) {
   const match = /^---\n([\s\S]*?)\n---/.exec(text);

--- a/src/skills.js
+++ b/src/skills.js
@@ -30,6 +30,23 @@ function logicalSkillDir(repoRoot, skillsDir) {
   return relative.split(path.sep).join("/");
 }
 
+/**
+ * True when a directory entry is a directory once symlinks are followed. A broken or
+ * cyclic link is not, and never throws.
+ *
+ * @param {string} root
+ * @param {import("node:fs").Dirent} entry
+ */
+export function isDirectoryEntry(root, entry) {
+  if (entry.isDirectory()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return fs.statSync(path.join(root, entry.name)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 /** Read the existing skills so synthesis can tune a description instead of duplicating it. */
 export function loadSkills(repoRoot, skillsDir) {
   const root = path.isAbsolute(skillsDir) ? skillsDir : path.join(repoRoot, skillsDir);
@@ -44,7 +61,11 @@ export function loadSkills(repoRoot, skillsDir) {
   }
 
   for (const entry of entries) {
-    const file = entry.isDirectory()
+    // A harness loads what the path resolves to, so a symlinked skill directory is a skill.
+    // `readdir` reports the link itself, never its target, so the type has to be stat'd -
+    // otherwise a library-plus-symlinks layout (the common way to share skills across
+    // harnesses) is invisible here and its always-loaded descriptions go unbilled.
+    const file = isDirectoryEntry(root, entry)
       ? path.join(root, entry.name, "SKILL.md")
       : entry.name.endsWith(".md")
         ? path.join(root, entry.name)

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -138,12 +138,16 @@ function harnessCountsOf(transcripts) {
 /**
  * The repo must be exactly as fingerprinted; the staging copy is the only place to write.
  *
- * Only skills staging withheld are left out. Such a file is one backpass has guaranteed it
- * will never write, so aborting a run over a third party's edit to it would discard
- * measured work for nothing; an ordinary repository skill stays fingerprinted whether or
- * not this run narrows to it. A fingerprinted path can still resolve outside the
- * repository - that is the ordinary user-scope layout - so a change there is reported for
- * what it is rather than as a direct repository edit.
+ * Skills staging withheld are left out: such a file is one backpass has guaranteed it will
+ * never write, so aborting a run over a third party's edit to it would discard measured
+ * work for nothing. That holds on every run for the two reasons staging settles before it
+ * narrows - the path resolves outside the repository, or into a location nothing may
+ * write. It does not hold for the one reason it settles after: a skill withheld only as a
+ * duplicate of a name already staged is still fingerprinted on a narrowed run, which never
+ * reaches that decision. An ordinary repository skill stays fingerprinted either way. A
+ * fingerprinted path can still resolve outside the repository - that is the ordinary
+ * user-scope layout - so a change there is reported for what it is rather than as a direct
+ * repository edit.
  */
 function assertRepoUntouched(repo, before, workspaceRoot) {
   const after = repoFingerprint(repo, Object.keys(before));

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -147,7 +147,7 @@ function assertRepoUntouched(repo, before, workspaceRoot) {
   );
 }
 
-function targetRule(target, memoryPath, skillsDir, stagedTargetPath = null) {
+function targetRule(target, memoryPath, skillsDir, stagedTargetPath = null, unstageable = []) {
   if (target.kind === "skill") {
     return (
       `0. **This run targets \`./${stagedTargetPath || workspacePathFor(target.path)}\` only.** It is the one staged file. ` +
@@ -158,6 +158,14 @@ function targetRule(target, memoryPath, skillsDir, stagedTargetPath = null) {
     return (
       `0. **This run targets \`./${memoryPath}\` only.** The skills listed above live in the repository and are ` +
       `read-only: do not edit them. You may still extract a NEW skill under \`./${skillsDir}/\`.\n`
+    );
+  }
+  if (unstageable.length) {
+    return (
+      `0. **The skills marked \`read-only\` above resolve outside this repository**, so they are not in ` +
+      `your staging copy and backpass cannot write them. Read them for grounding and treat what they ` +
+      `already cover as covered - do not edit them, re-create them, or copy their content into ` +
+      `\`./${memoryPath}\`.\n`
     );
   }
   return "";
@@ -464,10 +472,14 @@ export async function synthesizeProposal({
     workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged ||
     workspacePathFor(overflow.dir);
   // Unstaged skills keep their repository paths in the index: the model may read them
-  // there for grounding, and the target rule says they are not writable.
+  // there for grounding, and the target rule says they are not writable. The ones staging
+  // confined out are also marked, so a run that narrows nothing still says so.
+  const isUnstageable = (file) =>
+    workspace.unstageable.some((prefix) => file === prefix || file.startsWith(`${prefix}/`));
   const stagedSkillFiles = skillFiles.map((skill) => ({
     ...skill,
     path: workspace.stagedPaths.get(skill.path) || skill.path,
+    readOnly: isUnstageable(skill.path),
   }));
 
   const editValues = {
@@ -477,6 +489,7 @@ export async function synthesizeProposal({
       workspace.memoryWorkspacePath,
       stagedSkillsDir,
       target.kind === "skill" ? workspace.stagedPaths.get(target.path) || workspacePathFor(target.path) : null,
+      stagedSkillFiles.filter((skill) => skill.readOnly),
     ),
     REPO_NAME: repo.name,
     REPO_ROOT: repo.root,

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -450,7 +450,15 @@ export async function synthesizeProposal({
   // Staging holds only the write surface: every skill on a surface run, none of them on
   // a memory-file target (new extracts are still measured), just the one on a skill target.
   const stagedSkills = target.kind === "surface" ? null : target.kind === "skill" ? [target.path] : [];
-  const workspaceOptions = { state, repo, memoryFile, skillsDir: overflow.dir, skillDirs, stagedSkills };
+  const workspaceOptions = {
+    state,
+    repo,
+    memoryFile,
+    skillsDir: overflow.dir,
+    skillDirs,
+    stagedSkills,
+    allowExternal: scope?.kind === "user",
+  };
   let workspace = prepareWorkspace(workspaceOptions);
   const stagedSkillsDir =
     workspace.skillMappings.find((mapping) => mapping.logical === overflow.dir)?.staged ||

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -138,9 +138,10 @@ function harnessCountsOf(transcripts) {
 /**
  * The repo must be exactly as fingerprinted; the staging copy is the only place to write.
  *
- * A skill symlinked out of the repository is fingerprinted too - the synthesis agent
- * writing through that link is the betrayal this guard exists to catch. But such a path
- * is not in the repository and the writer may have been another process, so it is
+ * Only the files staging actually staged are fingerprinted. A skill backpass withheld is
+ * one it has guaranteed it will never write, and aborting a run over a third party's edit
+ * to such a file would discard measured work for nothing. A staged path can still resolve
+ * outside the repository - that is the ordinary user-scope layout - so a change there is
  * reported for what it is rather than as a direct repository edit.
  */
 function assertRepoUntouched(repo, before, workspaceRoot) {
@@ -542,7 +543,10 @@ export async function synthesizeProposal({
   const editPromptFile = path.join(promptDir, "synthesis-edit.md");
   fs.writeFileSync(editPromptFile, renderPrompt("synthesis", editValues));
 
-  const fingerprint = repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) => s.path)]);
+  const fingerprint = repoFingerprint(repo, [
+    memoryFile.path,
+    ...skillFiles.filter((skill) => workspace.stagedPaths.has(skill.path)).map((skill) => skill.path),
+  ]);
   const sessionName = `backpass-synth-${process.pid}`;
   const timeoutSeconds = Math.max(config.timeoutSeconds, 900);
   const usage = [];

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -162,8 +162,8 @@ function targetRule(target, memoryPath, skillsDir, stagedTargetPath = null, unst
   }
   if (unstageable.length) {
     return (
-      `0. **The skills marked \`read-only\` above resolve outside this repository**, so they are not in ` +
-      `your staging copy and backpass cannot write them. Read them for grounding and treat what they ` +
+      `0. **The skills marked \`read-only\` above are not in your staging copy**, for the reason each row ` +
+      `gives, and backpass cannot write them at that path. Read them for grounding and treat what they ` +
       `already cover as covered - do not edit them, re-create them, or copy their content into ` +
       `\`./${memoryPath}\`.\n`
     );
@@ -474,12 +474,12 @@ export async function synthesizeProposal({
   // Unstaged skills keep their repository paths in the index: the model may read them
   // there for grounding, and the target rule says they are not writable. The ones staging
   // confined out are also marked, so a run that narrows nothing still says so.
-  const isUnstageable = (file) =>
-    workspace.unstageable.some((prefix) => file === prefix || file.startsWith(`${prefix}/`));
+  const readOnlyReason = (file) =>
+    workspace.unstageable.find((entry) => file === entry.path || file.startsWith(`${entry.path}/`))?.reason || null;
   const stagedSkillFiles = skillFiles.map((skill) => ({
     ...skill,
     path: workspace.stagedPaths.get(skill.path) || skill.path,
-    readOnly: isUnstageable(skill.path),
+    readOnly: readOnlyReason(skill.path),
   }));
 
   const editValues = {

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -138,11 +138,12 @@ function harnessCountsOf(transcripts) {
 /**
  * The repo must be exactly as fingerprinted; the staging copy is the only place to write.
  *
- * Only the files staging actually staged are fingerprinted. A skill backpass withheld is
- * one it has guaranteed it will never write, and aborting a run over a third party's edit
- * to such a file would discard measured work for nothing. A staged path can still resolve
- * outside the repository - that is the ordinary user-scope layout - so a change there is
- * reported for what it is rather than as a direct repository edit.
+ * Only skills staging withheld are left out. Such a file is one backpass has guaranteed it
+ * will never write, so aborting a run over a third party's edit to it would discard
+ * measured work for nothing; an ordinary repository skill stays fingerprinted whether or
+ * not this run narrows to it. A fingerprinted path can still resolve outside the
+ * repository - that is the ordinary user-scope layout - so a change there is reported for
+ * what it is rather than as a direct repository edit.
  */
 function assertRepoUntouched(repo, before, workspaceRoot) {
   const after = repoFingerprint(repo, Object.keys(before));
@@ -545,7 +546,7 @@ export async function synthesizeProposal({
 
   const fingerprint = repoFingerprint(repo, [
     memoryFile.path,
-    ...skillFiles.filter((skill) => workspace.stagedPaths.has(skill.path)).map((skill) => skill.path),
+    ...skillFiles.filter((skill) => !readOnlyReason(skill.path)).map((skill) => skill.path),
   ]);
   const sessionName = `backpass-synth-${process.pid}`;
   const timeoutSeconds = Math.max(config.timeoutSeconds, 900);

--- a/src/synthesize.js
+++ b/src/synthesize.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { extractJson, openSession, usageRecord } from "./acpx.js";
 import { userClaudeSkillsDir } from "./config.js";
 import { renderEvidenceForPrompt } from "./fold.js";
-import { renderInstructionIndex } from "./memory.js";
+import { renderInstructionIndex, resolveMemoryPath } from "./memory.js";
 import { renderPrompt, render, loadPrompt } from "./prompts.js";
 import { buildProposal, effectiveMaxEdits, ProposalViolation, renderChangesForPrompt } from "./proposal.js";
 import {
@@ -135,15 +135,45 @@ function harnessCountsOf(transcripts) {
   return counts;
 }
 
-/** The repo must be exactly as fingerprinted; the staging copy is the only place to write. */
+/**
+ * The repo must be exactly as fingerprinted; the staging copy is the only place to write.
+ *
+ * A skill symlinked out of the repository is fingerprinted too - the synthesis agent
+ * writing through that link is the betrayal this guard exists to catch. But such a path
+ * is not in the repository and the writer may have been another process, so it is
+ * reported for what it is rather than as a direct repository edit.
+ */
 function assertRepoUntouched(repo, before, workspaceRoot) {
   const after = repoFingerprint(repo, Object.keys(before));
   const moved = Object.keys(before).filter((file) => before[file] !== after[file]);
   if (!moved.length) return;
+  const insideRepo = (file) => {
+    try {
+      resolveMemoryPath(repo.root, file);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const inside = moved.filter(insideRepo);
+  const outside = moved.filter((file) => !inside.includes(file));
+  const claims = [];
+  if (inside.length) {
+    claims.push(
+      `synthesis changed ${inside.join(", ")} in the repository directly instead of the staging copy (${workspaceRoot})`,
+    );
+  }
+  if (outside.length) {
+    claims.push(
+      `${outside.join(", ")} changed during synthesis; ` +
+        `${outside.length > 1 ? "those paths resolve" : "that path resolves"} outside the repository`,
+    );
+  }
   throw new UserError(
-    `synthesis changed ${moved.join(", ")} in the repository directly instead of the staging copy ` +
-      `(${workspaceRoot}); nothing was proposed`,
-    `inspect the change with \`git diff\`, restore the file, and re-run - a harness that edits outside its cwd cannot be trusted with the synthesis role`,
+    `${claims.join("; also ")}; nothing was proposed`,
+    inside.length
+      ? `inspect the change with \`git diff\`, restore the file, and re-run - a harness that edits outside its cwd cannot be trusted with the synthesis role`
+      : `inspect the file and re-run - either the synthesis harness wrote through the link to a skill it was told is read-only, or another process changed the shared library mid-run`,
   );
 }
 

--- a/src/target.js
+++ b/src/target.js
@@ -84,10 +84,10 @@ export function resolveTarget(spec, scope) {
         "project scope can read and bill that skill but never write it; edit it where it really lives, or run `--scope user`",
       );
     }
-    const aliases = aliased ? skillMatches.slice(1).map((other) => other.path) : [];
-    return aliases.length
-      ? { kind: "skill", path: skill.path, name: skill.name, aliases }
-      : { kind: "skill", path: skill.path, name: skill.name };
+    if (aliased) {
+      info(`${spec} is one file under ${skillMatches.length} links; targeting it as ${skill.path}`);
+    }
+    return { kind: "skill", path: skill.path, name: skill.name };
   }
   const memoryList = scope.memoryFiles.length ? scope.memoryFiles.join(", ") : "(none configured)";
   const skillList = skills.length ? skills.map((skill) => skill.name).join(", ") : "(none)";
@@ -119,7 +119,4 @@ export function printTargetNote(target) {
   if (!target || target.kind === "surface") return;
   const rest = target.kind === "skill" ? "the memory file and other skills" : "existing skills";
   info(`targeting ${describeTarget(target)}; ${rest} are read-only this run`);
-  if (target.aliases?.length) {
-    info(`${target.name} is one file under ${target.aliases.length + 1} links; editing it as ${target.path}`);
-  }
 }

--- a/src/target.js
+++ b/src/target.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { userClaudeSkillsDir } from "./config.js";
 import { UserError, info } from "./logger.js";
-import { pointerImportPath, readOnlyResolvedPath, resolveMemoryFiles, resolveMemoryPath } from "./memory.js";
+import { pointerImportPath, resolveMemoryFiles } from "./memory.js";
 import { pathInRoot, resolveInRoot } from "./scope.js";
 import { loadProjectSkills, resolveOverflowTarget } from "./skills.js";
 
@@ -41,18 +41,13 @@ export function resolveTarget(spec, scope) {
   const normalized = pathInRoot(spec, root);
   const memoryMatches = scope.memoryFiles.filter((entry) => pathInRoot(entry, root) === normalized);
   const skillMatches = skills.filter((skill) => skill.name === spec);
-  // Several links to one library are several names for one file, and staging already
-  // resolves that layout by giving the first name the write. Only distinct files sharing
-  // a name are genuinely ambiguous - there, renaming really is the fix.
-  const aliased = skillMatches.length > 1 && sameFile(root, skillMatches);
-  const selected = aliased ? [skillMatches[0]] : skillMatches;
 
-  const found = memoryMatches.length + selected.length;
+  const found = memoryMatches.length + skillMatches.length;
   if (found > 1) {
     const names = [...memoryMatches, ...skillMatches.map((skill) => skill.path)];
     throw new UserError(
       `--target "${spec}" is ambiguous: it names ${names.join(" and ")}`,
-      "rename the skill so one name means one file",
+      "those may be one file under several links, or genuinely different files; --target needs a name that identifies exactly one file",
     );
   }
   if (memoryMatches.length) {
@@ -71,31 +66,8 @@ export function resolveTarget(spec, scope) {
     }
     return { kind: "memory", path: entry };
   }
-  if (selected.length) {
-    const skill = selected[0];
-    // The same path gate apply applies: a skill reached through a symlink out of the repo
-    // is loaded and billed, but project scope can never write it - say so here rather than
-    // staging nothing and failing the synthesis turn with an unrelated hint.
-    try {
-      resolveMemoryPath(root, skill.path, { allowExternal: user });
-    } catch {
-      throw new UserError(
-        `--target ${spec} is at ${skill.path}, which resolves outside the repository`,
-        "project scope can read and bill that skill but never write it; edit it where it really lives, or run `--scope user`",
-      );
-    }
-    // The same probe staging and apply use: a skill that resolves into a store nothing may
-    // write is loaded and billed, but a run targeting it could only end in a refusal.
-    const unwritable = readOnlyResolvedPath(resolveInRoot(root, skill.path));
-    if (unwritable) {
-      throw new UserError(
-        `--target ${spec} is at ${skill.path}, which resolves to ${unwritable} and cannot be written`,
-        "edit the source that generates it, or point the link at a writable copy",
-      );
-    }
-    if (aliased) {
-      info(`${spec} is one file under ${skillMatches.length} links; targeting it as ${skill.path}`);
-    }
+  if (skillMatches.length) {
+    const skill = skillMatches[0];
     return { kind: "skill", path: skill.path, name: skill.name };
   }
   const memoryList = scope.memoryFiles.length ? scope.memoryFiles.join(", ") : "(none configured)";
@@ -104,19 +76,6 @@ export function resolveTarget(spec, scope) {
     `--target "${spec}" is not a configured memory file or a loaded skill in this ${user ? "user scope" : "repo"}`,
     `memory files: ${memoryList} · skills: ${skillList}`,
   );
-}
-
-/** True when every match is the same file on disk, reached under different names. */
-function sameFile(root, matches) {
-  const identity = (skill) => {
-    try {
-      return fs.realpathSync(resolveInRoot(root, skill.path));
-    } catch {
-      return null;
-    }
-  };
-  const first = identity(matches[0]);
-  return first !== null && matches.every((skill) => identity(skill) === first);
 }
 
 export function describeTarget(target) {

--- a/src/target.js
+++ b/src/target.js
@@ -6,6 +6,7 @@ import { UserError, info } from "./logger.js";
 import { pointerImportPath, resolveMemoryFiles } from "./memory.js";
 import { pathInRoot, resolveInRoot } from "./scope.js";
 import { loadProjectSkills, resolveOverflowTarget } from "./skills.js";
+import { skillStagingRefusal } from "./workspace.js";
 
 /**
  * `--target`: one memory file or one skill instead of the whole surface.
@@ -68,6 +69,15 @@ export function resolveTarget(spec, scope) {
   }
   if (skillMatches.length) {
     const skill = skillMatches[0];
+    // A targeted run writes exactly one file, and staging is what decides whether that
+    // file can be in the copy at all. Ask it here so the refusal names its own cause.
+    const refusal = skillStagingRefusal(root, skill.path, { allowExternal: user });
+    if (refusal) {
+      throw new UserError(
+        `--target ${spec} is at ${skill.path}, which ${refusal}`,
+        "backpass loads and bills that skill but cannot write it there; edit it where it really lives, or point the link at a copy backpass can write",
+      );
+    }
     return { kind: "skill", path: skill.path, name: skill.name };
   }
   const memoryList = scope.memoryFiles.length ? scope.memoryFiles.join(", ") : "(none configured)";

--- a/src/target.js
+++ b/src/target.js
@@ -41,8 +41,13 @@ export function resolveTarget(spec, scope) {
   const normalized = pathInRoot(spec, root);
   const memoryMatches = scope.memoryFiles.filter((entry) => pathInRoot(entry, root) === normalized);
   const skillMatches = skills.filter((skill) => skill.name === spec);
+  // Several links to one library are several names for one file, and staging already
+  // resolves that layout by giving the first name the write. Only distinct files sharing
+  // a name are genuinely ambiguous - there, renaming really is the fix.
+  const aliased = skillMatches.length > 1 && sameFile(root, skillMatches);
+  const selected = aliased ? [skillMatches[0]] : skillMatches;
 
-  const found = memoryMatches.length + skillMatches.length;
+  const found = memoryMatches.length + selected.length;
   if (found > 1) {
     const names = [...memoryMatches, ...skillMatches.map((skill) => skill.path)];
     throw new UserError(
@@ -66,8 +71,8 @@ export function resolveTarget(spec, scope) {
     }
     return { kind: "memory", path: entry };
   }
-  if (skillMatches.length) {
-    const skill = skillMatches[0];
+  if (selected.length) {
+    const skill = selected[0];
     // The same path gate apply applies: a skill reached through a symlink out of the repo
     // is loaded and billed, but project scope can never write it - say so here rather than
     // staging nothing and failing the synthesis turn with an unrelated hint.
@@ -79,7 +84,10 @@ export function resolveTarget(spec, scope) {
         "project scope can read and bill that skill but never write it; edit it where it really lives, or run `--scope user`",
       );
     }
-    return { kind: "skill", path: skill.path, name: skill.name };
+    const aliases = aliased ? skillMatches.slice(1).map((other) => other.path) : [];
+    return aliases.length
+      ? { kind: "skill", path: skill.path, name: skill.name, aliases }
+      : { kind: "skill", path: skill.path, name: skill.name };
   }
   const memoryList = scope.memoryFiles.length ? scope.memoryFiles.join(", ") : "(none configured)";
   const skillList = skills.length ? skills.map((skill) => skill.name).join(", ") : "(none)";
@@ -87,6 +95,19 @@ export function resolveTarget(spec, scope) {
     `--target "${spec}" is not a configured memory file or a loaded skill in this ${user ? "user scope" : "repo"}`,
     `memory files: ${memoryList} · skills: ${skillList}`,
   );
+}
+
+/** True when every match is the same file on disk, reached under different names. */
+function sameFile(root, matches) {
+  const identity = (skill) => {
+    try {
+      return fs.realpathSync(resolveInRoot(root, skill.path));
+    } catch {
+      return null;
+    }
+  };
+  const first = identity(matches[0]);
+  return first !== null && matches.every((skill) => identity(skill) === first);
 }
 
 export function describeTarget(target) {
@@ -98,4 +119,7 @@ export function printTargetNote(target) {
   if (!target || target.kind === "surface") return;
   const rest = target.kind === "skill" ? "the memory file and other skills" : "existing skills";
   info(`targeting ${describeTarget(target)}; ${rest} are read-only this run`);
+  if (target.aliases?.length) {
+    info(`${target.name} is one file under ${target.aliases.length + 1} links; editing it as ${target.path}`);
+  }
 }

--- a/src/target.js
+++ b/src/target.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { userClaudeSkillsDir } from "./config.js";
 import { UserError, info } from "./logger.js";
-import { pointerImportPath, resolveMemoryFiles, resolveMemoryPath } from "./memory.js";
+import { pointerImportPath, readOnlyResolvedPath, resolveMemoryFiles, resolveMemoryPath } from "./memory.js";
 import { pathInRoot, resolveInRoot } from "./scope.js";
 import { loadProjectSkills, resolveOverflowTarget } from "./skills.js";
 
@@ -82,6 +82,15 @@ export function resolveTarget(spec, scope) {
       throw new UserError(
         `--target ${spec} is at ${skill.path}, which resolves outside the repository`,
         "project scope can read and bill that skill but never write it; edit it where it really lives, or run `--scope user`",
+      );
+    }
+    // The same probe staging and apply use: a skill that resolves into a store nothing may
+    // write is loaded and billed, but a run targeting it could only end in a refusal.
+    const unwritable = readOnlyResolvedPath(resolveInRoot(root, skill.path));
+    if (unwritable) {
+      throw new UserError(
+        `--target ${spec} is at ${skill.path}, which resolves to ${unwritable} and cannot be written`,
+        "edit the source that generates it, or point the link at a writable copy",
       );
     }
     if (aliased) {

--- a/src/target.js
+++ b/src/target.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { userClaudeSkillsDir } from "./config.js";
 import { UserError, info } from "./logger.js";
-import { pointerImportPath, resolveMemoryFiles } from "./memory.js";
+import { pointerImportPath, resolveMemoryFiles, resolveMemoryPath } from "./memory.js";
 import { pathInRoot, resolveInRoot } from "./scope.js";
 import { loadProjectSkills, resolveOverflowTarget } from "./skills.js";
 
@@ -68,6 +68,17 @@ export function resolveTarget(spec, scope) {
   }
   if (skillMatches.length) {
     const skill = skillMatches[0];
+    // The same path gate apply applies: a skill reached through a symlink out of the repo
+    // is loaded and billed, but project scope can never write it - say so here rather than
+    // staging nothing and failing the synthesis turn with an unrelated hint.
+    try {
+      resolveMemoryPath(root, skill.path, { allowExternal: user });
+    } catch {
+      throw new UserError(
+        `--target ${spec} is at ${skill.path}, which resolves outside the repository`,
+        "project scope can read and bill that skill but never write it; edit it where it really lives, or run `--scope user`",
+      );
+    }
     return { kind: "skill", path: skill.path, name: skill.name };
   }
   const memoryList = scope.memoryFiles.length ? scope.memoryFiles.join(", ") : "(none configured)";

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { anchoredHunks, countOccurrences, span } from "./diff.js";
 import { warn } from "./logger.js";
-import { parseMemoryUnits, resolveMemoryPath } from "./memory.js";
+import { parseMemoryUnits, readOnlyResolvedPath, resolveMemoryPath } from "./memory.js";
 import { isDirectoryEntry, parseFrontmatter, skillBody } from "./skills.js";
 import { sha256 } from "./state.js";
 
@@ -87,6 +87,13 @@ export function prepareWorkspace({
       const owner = identity && stagedIdentities.get(identity);
       if (owner) {
         unstageable.push({ path: logical, reason: `the same file is already staged as ${owner}` });
+        continue;
+      }
+      // Outside a repository a link can land in a store nothing may write - the layout
+      // this whole change exists to follow. Apply refuses such a path and that refusal
+      // drops the round, so staging declares it read-only instead of offering the edit.
+      if (allowExternal && readOnlyResolvedPath(from)) {
+        unstageable.push({ path: logical, reason: READ_ONLY_UNWRITABLE });
         continue;
       }
       const staged = path.posix.join(stagedDir, relative);
@@ -226,6 +233,7 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
 /** Why a loaded skill is absent from the staging copy: the skill index must say which. */
 const READ_ONLY_OUTSIDE_REPO = "resolves outside the repository";
 const READ_ONLY_UNREADABLE = "could not be read when the staging copy was built";
+const READ_ONLY_UNWRITABLE = "resolves to a location that cannot be written";
 
 /** Why measurement dropped a file the model wrote: the note the human reads must say which. */
 export const STRAY_OUTSIDE_SURFACE = "synthesis wrote it outside the memory file and skills";

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -79,23 +79,26 @@ export function prepareWorkspace({
     for (const relative of walkFiles(skillsSource, "", confineTo, confined)) {
       const from = path.join(skillsSource, relative);
       const logical = toLogical(relative);
-      if (stagedSkills && !stagedSkills.includes(logical)) continue;
-      // Two links to one library are two names the harness loads, so both are walked and
-      // both are billed - but one file cannot be two independently editable copies, and
-      // apply refuses a round whose targets collide. The first name owns the write.
       const identity = realPath(from);
-      const owner = identity && stagedIdentities.get(identity);
-      if (owner) {
-        unstageable.push({ path: logical, reason: `the same file is already staged as ${owner}` });
-        continue;
-      }
       // A link can land in a store nothing may write - the layout this whole change
       // exists to follow - and that is true of a vendored directory inside the repository
       // as much as of a nix store outside it. Apply refuses such a path and that refusal
       // drops the round, so staging declares it read-only instead of offering the edit.
+      // It is decided for every loaded skill, before a narrowed run drops the ones it does
+      // not write, so "backpass will never write this file" means the same thing on both.
       const refusal = stagingRefusal(from, confineTo);
       if (refusal) {
         unstageable.push({ path: logical, reason: refusal, identity });
+        continue;
+      }
+      if (stagedSkills && !stagedSkills.includes(logical)) continue;
+      // Two links to one library are two names the harness loads, so both are walked and
+      // both are billed - but one file cannot be two independently editable copies, and
+      // apply refuses a round whose targets collide. The first name owns the write. This
+      // one stays behind the narrowing: only a staged name can own anything.
+      const owner = identity && stagedIdentities.get(identity);
+      if (owner) {
+        unstageable.push({ path: logical, reason: `the same file is already staged as ${owner}` });
         continue;
       }
       const staged = path.posix.join(stagedDir, relative);

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -63,11 +63,14 @@ export function prepareWorkspace({
   // refusal there drops the whole round. Leaving it out of staging is what makes it
   // impossible for such a file to become an edit at all.
   const confineTo = allowExternal ? null : realPath(repo.root) || path.resolve(repo.root);
-  const skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) }));
+  const skillMappings = skillDirs.map((logical) => ({
+    logical,
+    staged: workspacePathFor(logical),
+    source: path.isAbsolute(logical) ? logical : path.join(repo.root, logical),
+  }));
   const unstageable = [];
   const stagedIdentities = new Map();
-  for (const { logical: sourceDir, staged: stagedDir } of skillMappings) {
-    const skillsSource = path.isAbsolute(sourceDir) ? sourceDir : path.join(repo.root, sourceDir);
+  for (const { logical: sourceDir, staged: stagedDir, source: skillsSource } of skillMappings) {
     if (!fs.existsSync(skillsSource) || !fs.statSync(skillsSource).isDirectory()) continue;
     const confined = [];
     const toLogical = (relative) =>
@@ -108,6 +111,7 @@ export function prepareWorkspace({
     originals,
     confineTo,
     unstageable,
+    stagedIdentities,
   };
 }
 
@@ -162,6 +166,11 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
   // link, a link back to an ancestor, or a mutual pair. The guard is ancestry, not a
   // global visited set - two separate links to one shared library are two directories
   // the harness really loads, and each must still be walked and billed.
+  //
+  // Leaf-only staging (below) currently keeps this dormant: a symlinked directory is
+  // never recursed into, and a real directory is always deeper than its ancestors, so the
+  // only live effect left is skipping a top-level self-link back to the skills root. It
+  // re-arms the moment subtree walking under a symlinked directory is restored.
   const chain = ancestors || new Set([realPath(dir)].filter(Boolean));
   // One rule for taking a file, wherever the walk reaches it: a path that resolves
   // outside the root is named for the caller instead of staged, so the containment
@@ -208,6 +217,7 @@ const READ_ONLY_OUTSIDE_REPO = "resolves outside the repository";
 /** Why measurement dropped a file the model wrote: the note the human reads must say which. */
 export const STRAY_OUTSIDE_SURFACE = "synthesis wrote it outside the memory file and skills";
 export const STRAY_OUTSIDE_REPO = "it resolves outside the repository, which project scope cannot write";
+export const strayAliasReason = (owner) => `it is the same file already staged as ${owner}`;
 
 /** A created file counts as a skill only in the layouts `loadSkills` reads. */
 export function isSkillFilePath(relative, skillsDir) {
@@ -365,6 +375,7 @@ export function measureWorkspace(workspace) {
     stagedPaths = new Map([...workspace.originals.keys()].map((file) => [file, workspacePathFor(file)])),
     originals,
     confineTo = null,
+    stagedIdentities = new Map(),
   } = workspace;
   /** @type {any[]} */
   const changes = [];
@@ -414,6 +425,14 @@ export function measureWorkspace(workspace) {
         stray.push({ file: logical, reason: STRAY_OUTSIDE_REPO });
         continue;
       }
+    }
+    // Staging gave one name of an aliased library the write; a file written at another of
+    // its names is that same file, and apply refuses a skill whose path already exists -
+    // a refusal that drops every other accepted edit with it.
+    const owner = mapping.source && stagedIdentities.get(realPath(path.join(mapping.source, inside)));
+    if (owner) {
+      stray.push({ file: logical, reason: strayAliasReason(owner) });
+      continue;
     }
     const text = fs.readFileSync(path.join(root, staged), "utf8");
     texts.set(logical, text);

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { anchoredHunks, countOccurrences, span } from "./diff.js";
+import { warn } from "./logger.js";
 import { parseMemoryUnits, resolveMemoryPath } from "./memory.js";
 import { isDirectoryEntry, parseFrontmatter, skillBody } from "./skills.js";
 import { sha256 } from "./state.js";
@@ -88,12 +89,23 @@ export function prepareWorkspace({
         unstageable.push({ path: logical, reason: `the same file is already staged as ${owner}` });
         continue;
       }
-      if (identity) stagedIdentities.set(identity, logical);
       const staged = path.posix.join(stagedDir, relative);
       const to = path.join(root, staged);
-      fs.mkdirSync(path.dirname(to), { recursive: true });
-      fs.copyFileSync(from, to);
-      originals.set(logical, fs.readFileSync(from, "utf8"));
+      // Following links means `from` can be any file in a foreign store, so a store this
+      // user cannot read is skipped and named the way `loadSkills` skips one - never an
+      // errno thrown out of workspace preparation.
+      try {
+        fs.mkdirSync(path.dirname(to), { recursive: true });
+        fs.copyFileSync(from, to);
+        originals.set(logical, fs.readFileSync(from, "utf8"));
+      } catch (err) {
+        fs.rmSync(to, { force: true });
+        originals.delete(logical);
+        unstageable.push({ path: logical, reason: READ_ONLY_UNREADABLE });
+        warn(`${logical} could not be read (${err.message}); it stays out of the staging copy`);
+        continue;
+      }
+      if (identity) stagedIdentities.set(identity, logical);
       stagedPaths.set(logical, staged);
     }
     unstageable.push(...confined.map((relative) => ({ path: toLogical(relative), reason: READ_ONLY_OUTSIDE_REPO })));
@@ -213,6 +225,7 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
 
 /** Why a loaded skill is absent from the staging copy: the skill index must say which. */
 const READ_ONLY_OUTSIDE_REPO = "resolves outside the repository";
+const READ_ONLY_UNREADABLE = "could not be read when the staging copy was built";
 
 /** Why measurement dropped a file the model wrote: the note the human reads must say which. */
 export const STRAY_OUTSIDE_SURFACE = "synthesis wrote it outside the memory file and skills";

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -93,7 +93,7 @@ export function prepareWorkspace({
       // this whole change exists to follow. Apply refuses such a path and that refusal
       // drops the round, so staging declares it read-only instead of offering the edit.
       if (allowExternal && readOnlyResolvedPath(from)) {
-        unstageable.push({ path: logical, reason: READ_ONLY_UNWRITABLE });
+        unstageable.push({ path: logical, reason: READ_ONLY_UNWRITABLE, identity });
         continue;
       }
       const staged = path.posix.join(stagedDir, relative);
@@ -239,6 +239,8 @@ const READ_ONLY_UNWRITABLE = "resolves to a location that cannot be written";
 export const STRAY_OUTSIDE_SURFACE = "synthesis wrote it outside the memory file and skills";
 export const STRAY_OUTSIDE_REPO = "it resolves outside the repository, which project scope cannot write";
 export const strayAliasReason = (owner) => `it is the same file already staged as ${owner}`;
+export const STRAY_UNWRITABLE =
+  "it resolves to a location that cannot be written, so staging withheld it from the copy";
 
 /** A created file counts as a skill only in the layouts `loadSkills` reads. */
 export function isSkillFilePath(relative, skillsDir) {
@@ -397,6 +399,7 @@ export function measureWorkspace(workspace) {
     originals,
     confineTo = null,
     stagedIdentities = new Map(),
+    unstageable = [],
   } = workspace;
   /** @type {any[]} */
   const changes = [];
@@ -450,9 +453,22 @@ export function measureWorkspace(workspace) {
     // Staging gave one name of an aliased library the write; a file written at another of
     // its names is that same file, and apply refuses a skill whose path already exists -
     // a refusal that drops every other accepted edit with it.
-    const owner = mapping.source && stagedIdentities.get(realPath(path.join(mapping.source, inside)));
+    const repoIdentity = mapping.source ? realPath(path.join(mapping.source, inside)) : null;
+    const owner = stagedIdentities.get(repoIdentity);
     if (owner) {
       stray.push({ file: logical, reason: strayAliasReason(owner) });
+      continue;
+    }
+    // Staging withheld this skill because a write to it could not land, and the skill
+    // index says so - but the model still has its path. Writing there re-creates a file
+    // apply refuses for already existing, and that refusal drops every accepted edit.
+    const withheld = unstageable.some(
+      (entry) =>
+        entry.reason === READ_ONLY_UNWRITABLE &&
+        (entry.path === logical || (entry.identity && entry.identity === repoIdentity)),
+    );
+    if (withheld) {
+      stray.push({ file: logical, reason: STRAY_UNWRITABLE });
       continue;
     }
     const text = fs.readFileSync(path.join(root, staged), "utf8");

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -106,6 +106,11 @@ export function prepareWorkspace({
       try {
         fs.mkdirSync(path.dirname(to), { recursive: true });
         fs.copyFileSync(from, to);
+        // The agent edits this copy in place, so it must be writable whatever the source's
+        // mode is - a store-managed library is commonly read-only. Only the copy is
+        // touched; the source keeps its own mode, and apply takes the mode it writes from
+        // the repository file rather than from here.
+        fs.chmodSync(to, (fs.statSync(from).mode & 0o777) | 0o600);
         originals.set(logical, fs.readFileSync(from, "utf8"));
       } catch (err) {
         fs.rmSync(to, { force: true });
@@ -175,7 +180,7 @@ function withinRoot(root, resolved) {
   return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
-function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors = null) {
+function walkFiles(dir, prefix = "", confineTo = null, confined = []) {
   const out = [];
   let entries;
   try {
@@ -183,16 +188,6 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
   } catch {
     return out;
   }
-  // Following directory links hands the walk cycles it must not recurse into: a self
-  // link, a link back to an ancestor, or a mutual pair. The guard is ancestry, not a
-  // global visited set - two separate links to one shared library are two directories
-  // the harness really loads, and each must still be walked and billed.
-  //
-  // Leaf-only staging (below) currently keeps this dormant: a symlinked directory is
-  // never recursed into, and a real directory is always deeper than its ancestors, so the
-  // only live effect left is skipping a top-level self-link back to the skills root. It
-  // re-arms the moment subtree walking under a symlinked directory is restored.
-  const chain = ancestors || new Set([realPath(dir)].filter(Boolean));
   // One rule for taking a file, wherever the walk reaches it: a path that resolves
   // outside the root is named for the caller instead of staged, so the containment
   // invariant cannot hold on one branch and not its sibling.
@@ -209,7 +204,7 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
     if (target === "dir") {
       const child = path.join(dir, entry.name);
       const identity = realPath(child);
-      if (!identity || chain.has(identity)) continue;
+      if (!identity) continue;
       // Pruned here, but named: the caller tells the model these are read-only rather
       // than letting a proposed edit to one be discarded without a reason.
       if (!withinRoot(confineTo, identity)) {
@@ -219,12 +214,19 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
       // A link may point at anything - in the layout that motivated following links at
       // all, a whole plugin repository. Only the file the skill layout loads is taken,
       // so the target's subtree is never walked, copied, or read.
+      //
+      // This is also the whole reason a cycle cannot be walked. A self link, a link back
+      // to an ancestor and a mutual pair are all directory links, and none of them is
+      // descended into; a real directory is always deeper than its parents, so ordinary
+      // recursion terminates. Anyone restoring subtree walking under a symlinked directory
+      // must reinstate cycle detection in the same change, or the walk recurses until the
+      // stack blows.
       if (entry.isSymbolicLink()) {
         const leaf = path.join(child, SKILL_FILENAME);
         if (prefix === "" && isFile(leaf)) take(leaf, path.posix.join(relative, SKILL_FILENAME));
         continue;
       }
-      out.push(...walkFiles(child, relative, confineTo, confined, new Set(chain).add(identity)));
+      out.push(...walkFiles(child, relative, confineTo, confined));
     } else if (target === "file") {
       take(path.join(dir, entry.name), relative);
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { anchoredHunks, countOccurrences, span } from "./diff.js";
-import { parseMemoryUnits } from "./memory.js";
+import { parseMemoryUnits, resolveMemoryPath } from "./memory.js";
 import { isDirectoryEntry, parseFrontmatter, skillBody } from "./skills.js";
 import { sha256 } from "./state.js";
 
@@ -65,6 +65,7 @@ export function prepareWorkspace({
   const confineTo = allowExternal ? null : realPath(repo.root) || path.resolve(repo.root);
   const skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) }));
   const unstageable = [];
+  const stagedIdentities = new Map();
   for (const { logical: sourceDir, staged: stagedDir } of skillMappings) {
     const skillsSource = path.isAbsolute(sourceDir) ? sourceDir : path.join(repo.root, sourceDir);
     if (!fs.existsSync(skillsSource) || !fs.statSync(skillsSource).isDirectory()) continue;
@@ -75,6 +76,16 @@ export function prepareWorkspace({
       const from = path.join(skillsSource, relative);
       const logical = toLogical(relative);
       if (stagedSkills && !stagedSkills.includes(logical)) continue;
+      // Two links to one library are two names the harness loads, so both are walked and
+      // both are billed - but one file cannot be two independently editable copies, and
+      // apply refuses a round whose targets collide. The first name owns the write.
+      const identity = realPath(from);
+      const owner = identity && stagedIdentities.get(identity);
+      if (owner) {
+        unstageable.push({ path: logical, reason: `the same file is already staged as ${owner}` });
+        continue;
+      }
+      if (identity) stagedIdentities.set(identity, logical);
       const staged = path.posix.join(stagedDir, relative);
       const to = path.join(root, staged);
       fs.mkdirSync(path.dirname(to), { recursive: true });
@@ -82,7 +93,7 @@ export function prepareWorkspace({
       originals.set(logical, fs.readFileSync(from, "utf8"));
       stagedPaths.set(logical, staged);
     }
-    unstageable.push(...confined.map(toLogical));
+    unstageable.push(...confined.map((relative) => ({ path: toLogical(relative), reason: READ_ONLY_OUTSIDE_REPO })));
   }
   fs.mkdirSync(path.join(root, workspacePathFor(skillsDir)), { recursive: true });
 
@@ -109,18 +120,6 @@ function realPath(file) {
   }
 }
 
-/**
- * Where a repo-relative target actually lands, following links on the part of it that
- * already exists - the question apply asks before it writes a file that is not there yet.
- */
-function resolvedTarget(root, logical) {
-  const absolute = path.isAbsolute(logical) ? logical : path.resolve(root, logical);
-  let existing = absolute;
-  while (!fs.existsSync(existing) && path.dirname(existing) !== existing) existing = path.dirname(existing);
-  const real = realPath(existing);
-  return real ? path.resolve(real, path.relative(existing, absolute)) : null;
-}
-
 /** "dir", "file", or null once symlinks are followed; a broken link is null, never a throw. */
 function entryKind(dir, entry) {
   if (isDirectoryEntry(dir, entry)) return "dir";
@@ -130,6 +129,16 @@ function entryKind(dir, entry) {
     return fs.statSync(path.join(dir, entry.name)).isFile() ? "file" : null;
   } catch {
     return null;
+  }
+}
+
+const SKILL_FILENAME = "SKILL.md";
+
+function isFile(file) {
+  try {
+    return fs.statSync(file).isFile();
+  } catch {
+    return false;
   }
 }
 
@@ -170,6 +179,15 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
         confined.push(relative);
         continue;
       }
+      // A link may point at anything - in the layout that motivated following links at
+      // all, a whole plugin repository. Only the file the skill layout loads is taken,
+      // so the target's subtree is never walked, copied, or read.
+      if (entry.isSymbolicLink()) {
+        if (prefix === "" && isFile(path.join(child, SKILL_FILENAME))) {
+          out.push(path.posix.join(relative, SKILL_FILENAME));
+        }
+        continue;
+      }
       out.push(...walkFiles(child, relative, confineTo, confined, new Set(chain).add(identity)));
     } else if (target === "file") {
       if (!confineTo || withinRoot(confineTo, realPath(path.join(dir, entry.name)))) out.push(relative);
@@ -178,6 +196,9 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
   }
   return out;
 }
+
+/** Why a loaded skill is absent from the staging copy: the skill index must say which. */
+const READ_ONLY_OUTSIDE_REPO = "resolves outside the repository";
 
 /** Why measurement dropped a file the model wrote: the note the human reads must say which. */
 export const STRAY_OUTSIDE_SURFACE = "synthesis wrote it outside the memory file and skills";
@@ -380,9 +401,14 @@ export function measureWorkspace(workspace) {
     }
     // Staging leaves out a skill that resolves outside the repository; measurement must
     // not carry one back in as a created file, which apply could never write either.
-    if (confineTo && !withinRoot(confineTo, resolvedTarget(confineTo, logical))) {
-      stray.push({ file: logical, reason: STRAY_OUTSIDE_REPO });
-      continue;
+    // The gate is apply's own, so the two can never disagree about what is reachable.
+    if (confineTo) {
+      try {
+        resolveMemoryPath(confineTo, logical);
+      } catch {
+        stray.push({ file: logical, reason: STRAY_OUTSIDE_REPO });
+        continue;
+      }
     }
     const text = fs.readFileSync(path.join(root, staged), "utf8");
     texts.set(logical, text);

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -63,7 +63,7 @@ export function prepareWorkspace({
   // project scope cannot write it - `resolveMemoryPath` refuses the path at apply, and a
   // refusal there drops the whole round. Leaving it out of staging is what makes it
   // impossible for such a file to become an edit at all.
-  const confineTo = allowExternal ? null : realPath(repo.root) || path.resolve(repo.root);
+  const confineTo = confinementRoot(repo.root, allowExternal);
   const skillMappings = skillDirs.map((logical) => ({
     logical,
     staged: workspacePathFor(logical),
@@ -93,8 +93,9 @@ export function prepareWorkspace({
       // exists to follow - and that is true of a vendored directory inside the repository
       // as much as of a nix store outside it. Apply refuses such a path and that refusal
       // drops the round, so staging declares it read-only instead of offering the edit.
-      if (readOnlyResolvedPath(from)) {
-        unstageable.push({ path: logical, reason: READ_ONLY_UNWRITABLE, identity });
+      const refusal = stagingRefusal(from, confineTo);
+      if (refusal) {
+        unstageable.push({ path: logical, reason: refusal, identity });
         continue;
       }
       const staged = path.posix.join(stagedDir, relative);
@@ -235,6 +236,27 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
 const READ_ONLY_OUTSIDE_REPO = "resolves outside the repository";
 const READ_ONLY_UNREADABLE = "could not be read when the staging copy was built";
 const READ_ONLY_UNWRITABLE = "resolves to a location that cannot be written";
+
+/** The root a project-scope walk may not leave; user scope owns files anywhere. */
+function confinementRoot(repoRoot, allowExternal) {
+  return allowExternal ? null : realPath(repoRoot) || path.resolve(repoRoot);
+}
+
+/** Why staging withholds a skill file from the copy, or null when it can stage it. */
+function stagingRefusal(absolute, confineTo) {
+  if (!withinRoot(confineTo, realPath(absolute))) return READ_ONLY_OUTSIDE_REPO;
+  return readOnlyResolvedPath(absolute) ? READ_ONLY_UNWRITABLE : null;
+}
+
+/**
+ * The one place outside staging that may ask staging's question: a run targeting a skill
+ * the copy will not hold could never emit an edit for it, so it is refused by name here
+ * rather than after a synthesis turn that was told the file is the one it may write.
+ */
+export function skillStagingRefusal(repoRoot, skillPath, { allowExternal = false } = {}) {
+  const absolute = path.isAbsolute(skillPath) ? skillPath : path.join(repoRoot, skillPath);
+  return stagingRefusal(absolute, confinementRoot(repoRoot, allowExternal));
+}
 
 /** Why measurement dropped a file the model wrote: the note the human reads must say which. */
 export const STRAY_OUTSIDE_SURFACE = "synthesis wrote it outside the memory file and skills";

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { anchoredHunks, countOccurrences, span } from "./diff.js";
 import { parseMemoryUnits } from "./memory.js";
-import { parseFrontmatter, skillBody } from "./skills.js";
+import { isDirectoryEntry, parseFrontmatter, skillBody } from "./skills.js";
 import { sha256 } from "./state.js";
 
 /**
@@ -36,7 +36,15 @@ export function workspacePathFor(file) {
  * narrows which existing skill files are copied (a targeted run stages only its write
  * surface); the skill-dir mappings stay, so a created SKILL.md is still measured.
  */
-export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs = [skillsDir], stagedSkills = null }) {
+export function prepareWorkspace({
+  state,
+  repo,
+  memoryFile,
+  skillsDir,
+  skillDirs = [skillsDir],
+  stagedSkills = null,
+  allowExternal = false,
+}) {
   const root = workspaceRoot(state);
   fs.rmSync(root, { recursive: true, force: true });
   fs.mkdirSync(root, { recursive: true });
@@ -50,11 +58,16 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs
   originals.set(memoryFile.path, memoryFile.text);
   stagedPaths.set(memoryFile.path, memoryWorkspacePath);
 
+  // A skill that resolves outside the repository is still loaded and still billed, but
+  // project scope cannot write it - `resolveMemoryPath` refuses the path at apply, and a
+  // refusal there drops the whole round. Leaving it out of staging is what makes it
+  // impossible for such a file to become an edit at all.
+  const confineTo = allowExternal ? null : repo.realRoot || realPath(repo.root) || path.resolve(repo.root);
   const skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) }));
   for (const { logical: sourceDir, staged: stagedDir } of skillMappings) {
     const skillsSource = path.isAbsolute(sourceDir) ? sourceDir : path.join(repo.root, sourceDir);
     if (!fs.existsSync(skillsSource) || !fs.statSync(skillsSource).isDirectory()) continue;
-    for (const relative of walkFiles(skillsSource)) {
+    for (const relative of walkFiles(skillsSource, "", confineTo)) {
       const from = path.join(skillsSource, relative);
       const logical = path.isAbsolute(sourceDir)
         ? path.join(sourceDir, relative)
@@ -79,32 +92,52 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs
     skillMappings,
     stagedPaths,
     originals,
+    confineTo,
   };
 }
 
-/** "dir", "file", or null once symlinks are followed; a broken link is null, never a throw. */
-/** Resolved identity of a directory, or null when it cannot be resolved (broken link). */
-function realDirectory(dir) {
+/** Resolved identity of a path, or null when it cannot be resolved (broken link). */
+function realPath(file) {
   try {
-    return fs.realpathSync(dir);
+    return fs.realpathSync(file);
   } catch {
     return null;
   }
 }
 
+/**
+ * Where a repo-relative target actually lands, following links on the part of it that
+ * already exists - the question apply asks before it writes a file that is not there yet.
+ */
+function resolvedTarget(root, logical) {
+  const absolute = path.isAbsolute(logical) ? logical : path.resolve(root, logical);
+  let existing = absolute;
+  while (!fs.existsSync(existing) && path.dirname(existing) !== existing) existing = path.dirname(existing);
+  const real = realPath(existing);
+  return real ? path.resolve(real, path.relative(existing, absolute)) : null;
+}
+
+/** "dir", "file", or null once symlinks are followed; a broken link is null, never a throw. */
 function entryKind(dir, entry) {
-  if (entry.isDirectory()) return "dir";
+  if (isDirectoryEntry(dir, entry)) return "dir";
   if (entry.isFile()) return "file";
   if (!entry.isSymbolicLink()) return null;
   try {
-    const stat = fs.statSync(path.join(dir, entry.name));
-    return stat.isDirectory() ? "dir" : stat.isFile() ? "file" : null;
+    return fs.statSync(path.join(dir, entry.name)).isFile() ? "file" : null;
   } catch {
     return null;
   }
 }
 
-function walkFiles(dir, prefix = "", ancestors = null) {
+/** True when an already-resolved path lies strictly inside `root`; a null root confines nothing. */
+function withinRoot(root, resolved) {
+  if (!root) return true;
+  if (!resolved) return false;
+  const relative = path.relative(root, resolved);
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function walkFiles(dir, prefix = "", confineTo = null, ancestors = null) {
   const out = [];
   let entries;
   try {
@@ -116,7 +149,7 @@ function walkFiles(dir, prefix = "", ancestors = null) {
   // link, a link back to an ancestor, or a mutual pair. The guard is ancestry, not a
   // global visited set - two separate links to one shared library are two directories
   // the harness really loads, and each must still be walked and billed.
-  const chain = ancestors || new Set([realDirectory(dir)].filter(Boolean));
+  const chain = ancestors || new Set([realPath(dir)].filter(Boolean));
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const relative = prefix ? path.posix.join(prefix, entry.name) : entry.name;
     // Follow symlinks: a skills directory is commonly a set of links into a shared
@@ -125,10 +158,12 @@ function walkFiles(dir, prefix = "", ancestors = null) {
     const target = entryKind(dir, entry);
     if (target === "dir") {
       const child = path.join(dir, entry.name);
-      const identity = realDirectory(child);
-      if (!identity || chain.has(identity)) continue;
-      out.push(...walkFiles(child, relative, new Set(chain).add(identity)));
-    } else if (target === "file") out.push(relative);
+      const identity = realPath(child);
+      if (!identity || chain.has(identity) || !withinRoot(confineTo, identity)) continue;
+      out.push(...walkFiles(child, relative, confineTo, new Set(chain).add(identity)));
+    } else if (target === "file") {
+      if (!confineTo || withinRoot(confineTo, realPath(path.join(dir, entry.name)))) out.push(relative);
+    }
   }
   return out;
 }
@@ -288,6 +323,7 @@ export function measureWorkspace(workspace) {
     skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) })),
     stagedPaths = new Map([...workspace.originals.keys()].map((file) => [file, workspacePathFor(file)])),
     originals,
+    confineTo = null,
   } = workspace;
   /** @type {any[]} */
   const changes = [];
@@ -324,6 +360,12 @@ export function measureWorkspace(workspace) {
       ? path.join(mapping.logical, inside)
       : path.posix.join(mapping.logical, inside);
     if (!isSkillFilePath(logical, skillDirs)) {
+      stray.push(staged);
+      continue;
+    }
+    // Staging leaves out a skill that resolves outside the repository; measurement must
+    // not carry one back in as a created file, which apply could never write either.
+    if (confineTo && !withinRoot(confineTo, resolvedTarget(confineTo, logical))) {
       stray.push(staged);
       continue;
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -82,6 +82,19 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs
   };
 }
 
+/** "dir", "file", or null once symlinks are followed; a broken link is null, never a throw. */
+function entryKind(dir, entry) {
+  if (entry.isDirectory()) return "dir";
+  if (entry.isFile()) return "file";
+  if (!entry.isSymbolicLink()) return null;
+  try {
+    const stat = fs.statSync(path.join(dir, entry.name));
+    return stat.isDirectory() ? "dir" : stat.isFile() ? "file" : null;
+  } catch {
+    return null;
+  }
+}
+
 function walkFiles(dir, prefix = "") {
   const out = [];
   let entries;
@@ -92,8 +105,12 @@ function walkFiles(dir, prefix = "") {
   }
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const relative = prefix ? path.posix.join(prefix, entry.name) : entry.name;
-    if (entry.isDirectory()) out.push(...walkFiles(path.join(dir, entry.name), relative));
-    else if (entry.isFile()) out.push(relative);
+    // Follow symlinks: a skills directory is commonly a set of links into a shared
+    // library, and those are the files the harness loads. Staging copies what it finds,
+    // so an edit lands in the staging copy and never writes through a link.
+    const target = entryKind(dir, entry);
+    if (target === "dir") out.push(...walkFiles(path.join(dir, entry.name), relative));
+    else if (target === "file") out.push(relative);
   }
   return out;
 }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -83,6 +83,15 @@ export function prepareWorkspace({ state, repo, memoryFile, skillsDir, skillDirs
 }
 
 /** "dir", "file", or null once symlinks are followed; a broken link is null, never a throw. */
+/** Resolved identity of a directory, or null when it cannot be resolved (broken link). */
+function realDirectory(dir) {
+  try {
+    return fs.realpathSync(dir);
+  } catch {
+    return null;
+  }
+}
+
 function entryKind(dir, entry) {
   if (entry.isDirectory()) return "dir";
   if (entry.isFile()) return "file";
@@ -95,7 +104,7 @@ function entryKind(dir, entry) {
   }
 }
 
-function walkFiles(dir, prefix = "") {
+function walkFiles(dir, prefix = "", ancestors = null) {
   const out = [];
   let entries;
   try {
@@ -103,14 +112,23 @@ function walkFiles(dir, prefix = "") {
   } catch {
     return out;
   }
+  // Following directory links hands the walk cycles it must not recurse into: a self
+  // link, a link back to an ancestor, or a mutual pair. The guard is ancestry, not a
+  // global visited set - two separate links to one shared library are two directories
+  // the harness really loads, and each must still be walked and billed.
+  const chain = ancestors || new Set([realDirectory(dir)].filter(Boolean));
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const relative = prefix ? path.posix.join(prefix, entry.name) : entry.name;
     // Follow symlinks: a skills directory is commonly a set of links into a shared
     // library, and those are the files the harness loads. Staging copies what it finds,
     // so an edit lands in the staging copy and never writes through a link.
     const target = entryKind(dir, entry);
-    if (target === "dir") out.push(...walkFiles(path.join(dir, entry.name), relative));
-    else if (target === "file") out.push(relative);
+    if (target === "dir") {
+      const child = path.join(dir, entry.name);
+      const identity = realDirectory(child);
+      if (!identity || chain.has(identity)) continue;
+      out.push(...walkFiles(child, relative, new Set(chain).add(identity)));
+    } else if (target === "file") out.push(relative);
   }
   return out;
 }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -62,16 +62,18 @@ export function prepareWorkspace({
   // project scope cannot write it - `resolveMemoryPath` refuses the path at apply, and a
   // refusal there drops the whole round. Leaving it out of staging is what makes it
   // impossible for such a file to become an edit at all.
-  const confineTo = allowExternal ? null : repo.realRoot || realPath(repo.root) || path.resolve(repo.root);
+  const confineTo = allowExternal ? null : realPath(repo.root) || path.resolve(repo.root);
   const skillMappings = skillDirs.map((logical) => ({ logical, staged: workspacePathFor(logical) }));
+  const unstageable = [];
   for (const { logical: sourceDir, staged: stagedDir } of skillMappings) {
     const skillsSource = path.isAbsolute(sourceDir) ? sourceDir : path.join(repo.root, sourceDir);
     if (!fs.existsSync(skillsSource) || !fs.statSync(skillsSource).isDirectory()) continue;
-    for (const relative of walkFiles(skillsSource, "", confineTo)) {
+    const confined = [];
+    const toLogical = (relative) =>
+      path.isAbsolute(sourceDir) ? path.join(sourceDir, relative) : path.posix.join(sourceDir, relative);
+    for (const relative of walkFiles(skillsSource, "", confineTo, confined)) {
       const from = path.join(skillsSource, relative);
-      const logical = path.isAbsolute(sourceDir)
-        ? path.join(sourceDir, relative)
-        : path.posix.join(sourceDir, relative);
+      const logical = toLogical(relative);
       if (stagedSkills && !stagedSkills.includes(logical)) continue;
       const staged = path.posix.join(stagedDir, relative);
       const to = path.join(root, staged);
@@ -80,6 +82,7 @@ export function prepareWorkspace({
       originals.set(logical, fs.readFileSync(from, "utf8"));
       stagedPaths.set(logical, staged);
     }
+    unstageable.push(...confined.map(toLogical));
   }
   fs.mkdirSync(path.join(root, workspacePathFor(skillsDir)), { recursive: true });
 
@@ -93,6 +96,7 @@ export function prepareWorkspace({
     stagedPaths,
     originals,
     confineTo,
+    unstageable,
   };
 }
 
@@ -137,7 +141,7 @@ function withinRoot(root, resolved) {
   return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
-function walkFiles(dir, prefix = "", confineTo = null, ancestors = null) {
+function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors = null) {
   const out = [];
   let entries;
   try {
@@ -159,14 +163,25 @@ function walkFiles(dir, prefix = "", confineTo = null, ancestors = null) {
     if (target === "dir") {
       const child = path.join(dir, entry.name);
       const identity = realPath(child);
-      if (!identity || chain.has(identity) || !withinRoot(confineTo, identity)) continue;
-      out.push(...walkFiles(child, relative, confineTo, new Set(chain).add(identity)));
+      if (!identity || chain.has(identity)) continue;
+      // Pruned here, but named: the caller tells the model these are read-only rather
+      // than letting a proposed edit to one be discarded without a reason.
+      if (!withinRoot(confineTo, identity)) {
+        confined.push(relative);
+        continue;
+      }
+      out.push(...walkFiles(child, relative, confineTo, confined, new Set(chain).add(identity)));
     } else if (target === "file") {
       if (!confineTo || withinRoot(confineTo, realPath(path.join(dir, entry.name)))) out.push(relative);
+      else confined.push(relative);
     }
   }
   return out;
 }
+
+/** Why measurement dropped a file the model wrote: the note the human reads must say which. */
+export const STRAY_OUTSIDE_SURFACE = "synthesis wrote it outside the memory file and skills";
+export const STRAY_OUTSIDE_REPO = "it resolves outside the repository, which project scope cannot write";
 
 /** A created file counts as a skill only in the layouts `loadSkills` reads. */
 export function isSkillFilePath(relative, skillsDir) {
@@ -352,7 +367,7 @@ export function measureWorkspace(workspace) {
     if (knownStaged.has(staged)) continue;
     const mapping = skillMappings.find(({ staged: dir }) => staged === dir || staged.startsWith(`${dir}/`));
     if (!mapping) {
-      stray.push(staged);
+      stray.push({ file: staged, reason: STRAY_OUTSIDE_SURFACE });
       continue;
     }
     const inside = staged.slice(mapping.staged.length).replace(/^\//, "");
@@ -360,13 +375,13 @@ export function measureWorkspace(workspace) {
       ? path.join(mapping.logical, inside)
       : path.posix.join(mapping.logical, inside);
     if (!isSkillFilePath(logical, skillDirs)) {
-      stray.push(staged);
+      stray.push({ file: staged, reason: STRAY_OUTSIDE_SURFACE });
       continue;
     }
     // Staging leaves out a skill that resolves outside the repository; measurement must
     // not carry one back in as a created file, which apply could never write either.
     if (confineTo && !withinRoot(confineTo, resolvedTarget(confineTo, logical))) {
-      stray.push(staged);
+      stray.push({ file: logical, reason: STRAY_OUTSIDE_REPO });
       continue;
     }
     const text = fs.readFileSync(path.join(root, staged), "utf8");

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -163,6 +163,13 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
   // global visited set - two separate links to one shared library are two directories
   // the harness really loads, and each must still be walked and billed.
   const chain = ancestors || new Set([realPath(dir)].filter(Boolean));
+  // One rule for taking a file, wherever the walk reaches it: a path that resolves
+  // outside the root is named for the caller instead of staged, so the containment
+  // invariant cannot hold on one branch and not its sibling.
+  const take = (absolute, relativePath) => {
+    if (!confineTo || withinRoot(confineTo, realPath(absolute))) out.push(relativePath);
+    else confined.push(relativePath);
+  };
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     const relative = prefix ? path.posix.join(prefix, entry.name) : entry.name;
     // Follow symlinks: a skills directory is commonly a set of links into a shared
@@ -183,15 +190,13 @@ function walkFiles(dir, prefix = "", confineTo = null, confined = [], ancestors 
       // all, a whole plugin repository. Only the file the skill layout loads is taken,
       // so the target's subtree is never walked, copied, or read.
       if (entry.isSymbolicLink()) {
-        if (prefix === "" && isFile(path.join(child, SKILL_FILENAME))) {
-          out.push(path.posix.join(relative, SKILL_FILENAME));
-        }
+        const leaf = path.join(child, SKILL_FILENAME);
+        if (prefix === "" && isFile(leaf)) take(leaf, path.posix.join(relative, SKILL_FILENAME));
         continue;
       }
       out.push(...walkFiles(child, relative, confineTo, confined, new Set(chain).add(identity)));
     } else if (target === "file") {
-      if (!confineTo || withinRoot(confineTo, realPath(path.join(dir, entry.name)))) out.push(relative);
-      else confined.push(relative);
+      take(path.join(dir, entry.name), relative);
     }
   }
   return out;

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -89,10 +89,11 @@ export function prepareWorkspace({
         unstageable.push({ path: logical, reason: `the same file is already staged as ${owner}` });
         continue;
       }
-      // Outside a repository a link can land in a store nothing may write - the layout
-      // this whole change exists to follow. Apply refuses such a path and that refusal
+      // A link can land in a store nothing may write - the layout this whole change
+      // exists to follow - and that is true of a vendored directory inside the repository
+      // as much as of a nix store outside it. Apply refuses such a path and that refusal
       // drops the round, so staging declares it read-only instead of offering the edit.
-      if (allowExternal && readOnlyResolvedPath(from)) {
+      if (readOnlyResolvedPath(from)) {
         unstageable.push({ path: logical, reason: READ_ONLY_UNWRITABLE, identity });
         continue;
       }
@@ -423,10 +424,19 @@ export function measureWorkspace(workspace) {
     }
   }
 
+  // The memory file's own staged directory is a mapping too: an absolute memory file
+  // stages under `.external/<hash>/`, and a file written beside it must be named where
+  // the user would look for it rather than by the hash.
+  const memoryStaged = stagedPaths.get(memoryPath) || workspacePathFor(memoryPath);
+  const dirMappings = [
+    ...skillMappings,
+    { logical: path.dirname(memoryPath), staged: path.posix.dirname(memoryStaged) },
+  ];
+
   const knownStaged = new Set(stagedPaths.values());
   for (const staged of [...present].sort()) {
     if (knownStaged.has(staged)) continue;
-    const mapping = skillMappings.find(({ staged: dir }) => staged === dir || staged.startsWith(`${dir}/`));
+    const mapping = dirMappings.find(({ staged: dir }) => staged === dir || staged.startsWith(`${dir}/`));
     if (!mapping) {
       stray.push({ file: staged, reason: STRAY_OUTSIDE_SURFACE });
       continue;

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -432,11 +432,13 @@ export function measureWorkspace(workspace) {
       continue;
     }
     const inside = staged.slice(mapping.staged.length).replace(/^\//, "");
+    // Every note names the path the reader knows - the repository path, or the real one a
+    // user-scope entry resolves to - never the `.external/<hash>` the staging copy uses.
     const logical = path.isAbsolute(mapping.logical)
       ? path.join(mapping.logical, inside)
       : path.posix.join(mapping.logical, inside);
     if (!isSkillFilePath(logical, skillDirs)) {
-      stray.push({ file: staged, reason: STRAY_OUTSIDE_SURFACE });
+      stray.push({ file: logical, reason: STRAY_OUTSIDE_SURFACE });
       continue;
     }
     // Staging leaves out a skill that resolves outside the repository; measurement must

--- a/test/helpers/staging.js
+++ b/test/helpers/staging.js
@@ -32,12 +32,18 @@ export function writeIn(root, relative, textOrFn) {
 }
 
 /**
- * @param {{ repo: any, memoryPath?: string, skillsDir?: string, edit: (workspaceRoot: string) => void }} options
+ * @param {{ repo: any, memoryPath?: string, skillsDir?: string, allowExternal?: boolean, edit: (workspaceRoot: string) => void }} options
  */
-export function stageAndMeasure({ repo, memoryPath = "AGENTS.md", skillsDir = ".agents/skills", edit }) {
+export function stageAndMeasure({
+  repo,
+  memoryPath = "AGENTS.md",
+  skillsDir = ".agents/skills",
+  allowExternal = false,
+  edit,
+}) {
   const memoryFile = readMemoryFile(repo.root, memoryPath);
   const state = new State(repo.root).ensure();
-  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir });
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir, allowExternal });
   edit(workspace.root);
   return { memoryFile, state, workspace, measured: measureWorkspace(workspace) };
 }

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -3123,6 +3123,71 @@ test("a skill-only shrink reports the remaining always-loaded overage", () => {
   assert.match(results.warnings[0], /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/);
 });
 
+test("two links to one library leave one writable copy, so an apply round is not refused for colliding targets", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT, "library/db/SKILL.md": skill });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(repo.root, "library", "db"), path.join(loaded, "db"));
+  fs.symlinkSync(path.join(repo.root, "library", "db"), path.join(loaded, "database"));
+
+  // The agent edits every skill copy its staging cwd holds, alongside the memory file.
+  const staged = stageAndMeasure({
+    repo,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text.replace("- Whenever a PR is mentioned, include its URL.", "- Always include the full PR URL."),
+      );
+      for (const name of ["db", "database"]) {
+        const copy = path.join(root, ".agents/skills", name, "SKILL.md");
+        if (fs.existsSync(copy)) fs.writeFileSync(copy, skill.replace("old trigger", "new trigger"));
+      }
+    },
+  });
+  assert.deepEqual(
+    [...new Set(staged.measured.changes.map((change) => change.file))],
+    ["AGENTS.md", ".agents/skills/database/SKILL.md"],
+    "one library file yields one editable path, whatever the harness calls it",
+  );
+
+  const built = buildProposal(
+    { edits: staged.measured.changes.map((change) => claim([change.id])) },
+    {
+      memoryFile: staged.memoryFile,
+      config: config(),
+      repo,
+      summary: {
+        analyzedSessions: 4,
+        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        instructions: Array.from({ length: 20 }, (_, i) => ({
+          instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+          positive: 0,
+          negative: 4,
+          harmSessions: 4,
+          sessions: 4,
+          relevance: 1,
+          quotes: [],
+        })),
+      },
+      measured: staged.measured,
+    },
+  );
+  assert.deepEqual(built.violations, []);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: Object.fromEntries(built.proposal.edits.map((edit) => [edit.id, "accepted"])),
+    repo,
+    state: staged.state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.failed, []);
+  assert.ok(results.written.some((entry) => entry.file === "AGENTS.md"));
+  assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /Always include the full PR URL/);
+  assert.match(fs.readFileSync(path.join(repo.root, "library/db/SKILL.md"), "utf8"), /new trigger/);
+});
+
 test("a skill symlinked out of the repo never joins a project apply round, so it cannot abort one", () => {
   const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
   const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-shared-skills-")));

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -16,13 +16,14 @@ import {
 } from "../src/proposal.js";
 import { foldEvidence, renderEvidenceForPrompt, renderEvidenceReport } from "../src/fold.js";
 import { estimateTokens } from "../src/tokens.js";
+import { loadProjectSkills, skillDescriptionTokens } from "../src/skills.js";
 import { parseMemoryUnits } from "../src/memory.js";
 import { isSuppressedByRejection, recordRejection, State } from "../src/state.js";
 import { applyDecisions } from "../src/apply/writer.js";
 import { injectPayload, parseDecisions, renderApplySurface } from "../src/apply/lavish.js";
 import { renderEdit } from "../src/apply/terminal.js";
 import { extractJson, parseTokenLine, stripAcpxNoise } from "../src/acpx.js";
-import { STRAY_OUTSIDE_REPO, STRAY_OUTSIDE_SURFACE } from "../src/workspace.js";
+import { STRAY_OUTSIDE_REPO, STRAY_OUTSIDE_SURFACE, strayAliasReason } from "../src/workspace.js";
 import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
 
 const MEMORY_TEXT = [
@@ -89,6 +90,21 @@ function gate({ text = MEMORY_TEXT, files = {}, edit, annotation, config: cfg = 
   });
   return { ...result, ...staged, repo };
 }
+
+/** Every instruction corroborated by enough harm-class sessions to clear the floors. */
+const aliasSummary = () => ({
+  analyzedSessions: 4,
+  totals: { positive: 3, negative: 2, gapClusters: 1 },
+  instructions: Array.from({ length: 20 }, (_, i) => ({
+    instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+    positive: 0,
+    negative: 4,
+    harmSessions: 4,
+    sessions: 4,
+    relevance: 1,
+    quotes: [],
+  })),
+});
 
 const memoryEdit = (fn) => (root) => writeIn(root, "AGENTS.md", fn);
 const claim = (changes, extra = {}) => ({
@@ -3186,6 +3202,128 @@ test("a skill linked out of the repo behind an in-repo library never reaches app
   assert.deepEqual(results.failed, []);
   assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /Always include the full PR URL/);
   assert.equal(fs.readFileSync(path.join(outside, "SKILL.md"), "utf8"), skill, "nothing outside the repository moved");
+});
+
+test("a file written at the unstaged alias becomes stray, so the round is not dropped", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT, "library/db/SKILL.md": skill });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(repo.root, "library", "db"), path.join(loaded, "db"));
+  fs.symlinkSync(path.join(repo.root, "library", "db"), path.join(loaded, "database"));
+
+  const extracted =
+    "---\nname: db\ndescription: Load before node work.\n---\n\n- Use Node 18 via nvm before running any script.\n";
+  const staged = stageAndMeasure({
+    repo,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) => text.replace("- Use Node 18 via nvm before running any script.\n", ""));
+      // The index marks `db` read-only, but its path is the one the model was shown.
+      writeIn(root, ".agents/skills/db/SKILL.md", extracted);
+    },
+  });
+  assert.deepEqual(staged.measured.stray, [
+    { file: ".agents/skills/db/SKILL.md", reason: strayAliasReason(".agents/skills/database/SKILL.md") },
+  ]);
+  assert.deepEqual(
+    staged.measured.changes.map((change) => change.file),
+    ["AGENTS.md"],
+    "the alias is not carried back in as a created file",
+  );
+
+  // Whatever measurement carried, the annotation claims it: an extract while the created
+  // alias survives, a plain removal once it does not.
+  const ids = staged.measured.changes.map((change) => change.id);
+  const created = staged.measured.changes.some((change) => change.kind === "created");
+  const built = buildProposal(
+    {
+      edits: [
+        created
+          ? claim(ids, { kind: "extract", title: "extract the node pin" })
+          : claim(ids, { kind: "remove", title: "drop the node pin" }),
+      ],
+    },
+    {
+      memoryFile: staged.memoryFile,
+      config: config(),
+      repo,
+      summary: aliasSummary(),
+      measured: staged.measured,
+    },
+  );
+  assert.deepEqual(built.violations, []);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: Object.fromEntries(built.proposal.edits.map((edit) => [edit.id, "accepted"])),
+    repo,
+    state: staged.state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.failed, []);
+  const written = fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8");
+  assert.ok(!written.includes("Node 18"), "the accepted memory edit still landed");
+  assert.equal(fs.readFileSync(path.join(repo.root, "library/db/SKILL.md"), "utf8"), skill);
+});
+
+test("a k-linked skill projects its description delta k times, matching the post-apply surface", () => {
+  const oldDescription = "old trigger";
+  const newDescription = "Load before touching the database or writing a migration";
+  const skill = `---\nname: db\ndescription: ${oldDescription}\n---\n\nbody\n`;
+  const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT, "library/db/SKILL.md": skill });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  // Three names for one file: the harness loads three description lines, so an edit to
+  // that line moves the always-loaded surface by three times its delta.
+  for (const name of ["db", "database", "sql"]) {
+    fs.symlinkSync(path.join(repo.root, "library", "db"), path.join(loaded, name));
+  }
+
+  const staged = stageAndMeasure({
+    repo,
+    edit: (root) => {
+      for (const name of ["db", "database", "sql"]) {
+        const copy = path.join(root, ".agents/skills", name, "SKILL.md");
+        if (fs.existsSync(copy)) fs.writeFileSync(copy, skill.replace(oldDescription, newDescription));
+      }
+    },
+  });
+  const built = buildProposal(
+    {
+      edits: [
+        claim(
+          staged.measured.changes.map((change) => change.id),
+          { title: "sharpen the trigger" },
+        ),
+      ],
+    },
+    {
+      memoryFile: staged.memoryFile,
+      config: config(),
+      repo,
+      summary: aliasSummary(),
+      measured: staged.measured,
+      skillFiles: loadProjectSkills(repo.root, ".agents/skills", []),
+    },
+  );
+  assert.deepEqual(built.violations, []);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: Object.fromEntries(built.proposal.edits.map((edit) => [edit.id, "accepted"])),
+    repo,
+    state: staged.state,
+    config: { budgetTokens: 5000 },
+  });
+  assert.deepEqual(results.failed, []);
+
+  // The projection the gate enforced must equal what a fresh measurement now reports.
+  const after =
+    estimateTokens(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8")) +
+    skillDescriptionTokens(loadProjectSkills(repo.root, ".agents/skills", []));
+  assert.equal(built.proposal.budget.projected, after);
+  assert.equal(built.proposal.budget.delta, 3 * (estimateTokens(newDescription) - estimateTokens(oldDescription)));
 });
 
 test("two links to one library leave one writable copy, so an apply round is not refused for colliding targets", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -3237,17 +3237,9 @@ test("re-creating a withheld unwritable skill is stray, so the round is not drop
       "the withheld skill is not carried back in as a created file",
     );
 
-    // An extract while the created file survives, a plain removal once it does not.
     const ids = staged.measured.changes.map((change) => change.id);
-    const created = staged.measured.changes.some((change) => change.kind === "created");
     const built = buildProposal(
-      {
-        edits: [
-          created
-            ? claim(ids, { kind: "extract", title: "extract the node pin" })
-            : claim(ids, { kind: "remove", title: "drop the node pin" }),
-        ],
-      },
+      { edits: [claim(ids, { kind: "remove", title: "drop the node pin" })] },
       {
         memoryFile: staged.memoryFile,
         config: config(),
@@ -3363,18 +3355,9 @@ test("a file written at the unstaged alias becomes stray, so the round is not dr
     "the alias is not carried back in as a created file",
   );
 
-  // Whatever measurement carried, the annotation claims it: an extract while the created
-  // alias survives, a plain removal once it does not.
   const ids = staged.measured.changes.map((change) => change.id);
-  const created = staged.measured.changes.some((change) => change.kind === "created");
   const built = buildProposal(
-    {
-      edits: [
-        created
-          ? claim(ids, { kind: "extract", title: "extract the node pin" })
-          : claim(ids, { kind: "remove", title: "drop the node pin" }),
-      ],
-    },
+    { edits: [claim(ids, { kind: "remove", title: "drop the node pin" })] },
     {
       memoryFile: staged.memoryFile,
       config: config(),

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -3123,6 +3123,71 @@ test("a skill-only shrink reports the remaining always-loaded overage", () => {
   assert.match(results.warnings[0], /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/);
 });
 
+test("a skill linked out of the repo behind an in-repo library never reaches apply, and nothing outside is written", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-outside-apply-")));
+  fs.writeFileSync(path.join(outside, "SKILL.md"), skill);
+
+  const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT });
+  fs.mkdirSync(path.join(repo.root, "library", "db"), { recursive: true });
+  fs.symlinkSync(path.join(outside, "SKILL.md"), path.join(repo.root, "library", "db", "SKILL.md"));
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(repo.root, "library", "db"), path.join(loaded, "db"));
+
+  const staged = stageAndMeasure({
+    repo,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text.replace("- Whenever a PR is mentioned, include its URL.", "- Always include the full PR URL."),
+      );
+      const copy = path.join(root, ".agents/skills/db/SKILL.md");
+      if (fs.existsSync(copy)) fs.writeFileSync(copy, skill.replace("old trigger", "new trigger"));
+    },
+  });
+  assert.deepEqual(
+    staged.measured.changes.map((change) => change.file),
+    ["AGENTS.md"],
+    "the out-of-repo skill file was never staged, so it cannot become an edit",
+  );
+
+  const built = buildProposal(
+    { edits: staged.measured.changes.map((change) => claim([change.id])) },
+    {
+      memoryFile: staged.memoryFile,
+      config: config(),
+      repo,
+      summary: {
+        analyzedSessions: 4,
+        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        instructions: Array.from({ length: 20 }, (_, i) => ({
+          instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+          positive: 0,
+          negative: 4,
+          harmSessions: 4,
+          sessions: 4,
+          relevance: 1,
+          quotes: [],
+        })),
+      },
+      measured: staged.measured,
+    },
+  );
+  assert.deepEqual(built.violations, []);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: Object.fromEntries(built.proposal.edits.map((edit) => [edit.id, "accepted"])),
+    repo,
+    state: staged.state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.failed, []);
+  assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /Always include the full PR URL/);
+  assert.equal(fs.readFileSync(path.join(outside, "SKILL.md"), "utf8"), skill, "nothing outside the repository moved");
+});
+
 test("two links to one library leave one writable copy, so an apply round is not refused for colliding targets", () => {
   const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
   const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT, "library/db/SKILL.md": skill });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -23,7 +23,7 @@ import { applyDecisions } from "../src/apply/writer.js";
 import { injectPayload, parseDecisions, renderApplySurface } from "../src/apply/lavish.js";
 import { renderEdit } from "../src/apply/terminal.js";
 import { extractJson, parseTokenLine, stripAcpxNoise } from "../src/acpx.js";
-import { STRAY_OUTSIDE_REPO, STRAY_OUTSIDE_SURFACE, strayAliasReason } from "../src/workspace.js";
+import { STRAY_OUTSIDE_REPO, STRAY_OUTSIDE_SURFACE, STRAY_UNWRITABLE, strayAliasReason } from "../src/workspace.js";
 import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
 
 const MEMORY_TEXT = [
@@ -3202,6 +3202,78 @@ test("a skill linked out of the repo behind an in-repo library never reaches app
   assert.deepEqual(results.failed, []);
   assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /Always include the full PR URL/);
   assert.equal(fs.readFileSync(path.join(outside, "SKILL.md"), "utf8"), skill, "nothing outside the repository moved");
+});
+
+test("re-creating a withheld unwritable skill is stray, so the round is not dropped", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-store-recreate-")));
+  fs.mkdirSync(path.join(store, "db"));
+  fs.writeFileSync(path.join(store, "db", "SKILL.md"), skill);
+
+  const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(store, "db"), path.join(loaded, "db"));
+  fs.chmodSync(path.join(store, "db"), 0o555);
+  fs.chmodSync(store, 0o555);
+
+  try {
+    const extracted =
+      "---\nname: db\ndescription: Load before node work.\n---\n\n- Use Node 18 via nvm before running any script.\n";
+    const staged = stageAndMeasure({
+      repo,
+      allowExternal: true,
+      edit: (root) => {
+        writeIn(root, "AGENTS.md", (text) => text.replace("- Use Node 18 via nvm before running any script.\n", ""));
+        // The index shows `db` read-only, but the model still has its path and the
+        // extraction rule points at the skill that already covers the lines.
+        writeIn(root, ".agents/skills/db/SKILL.md", extracted);
+      },
+    });
+    assert.deepEqual(staged.measured.stray, [{ file: ".agents/skills/db/SKILL.md", reason: STRAY_UNWRITABLE }]);
+    assert.deepEqual(
+      staged.measured.changes.map((change) => change.file),
+      ["AGENTS.md"],
+      "the withheld skill is not carried back in as a created file",
+    );
+
+    // An extract while the created file survives, a plain removal once it does not.
+    const ids = staged.measured.changes.map((change) => change.id);
+    const created = staged.measured.changes.some((change) => change.kind === "created");
+    const built = buildProposal(
+      {
+        edits: [
+          created
+            ? claim(ids, { kind: "extract", title: "extract the node pin" })
+            : claim(ids, { kind: "remove", title: "drop the node pin" }),
+        ],
+      },
+      {
+        memoryFile: staged.memoryFile,
+        config: config(),
+        repo,
+        summary: aliasSummary(),
+        measured: staged.measured,
+      },
+    );
+    assert.deepEqual(built.violations, []);
+
+    const results = applyDecisions({
+      proposal: { ...built.proposal, scope: "user" },
+      decisions: Object.fromEntries(built.proposal.edits.map((edit) => [edit.id, "accepted"])),
+      repo,
+      state: staged.state,
+      config: { budgetTokens: 5000 },
+    });
+
+    assert.deepEqual(results.failed, []);
+    const written = fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8");
+    assert.ok(!written.includes("Node 18"), "the accepted memory edit still landed");
+    assert.equal(fs.readFileSync(path.join(store, "db", "SKILL.md"), "utf8"), skill, "the store is untouched");
+  } finally {
+    fs.chmodSync(store, 0o755);
+    fs.chmodSync(path.join(store, "db"), 0o755);
+  }
 });
 
 test("a skill in a read-only store never joins a user-scope apply round, so the round still lands", () => {

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -3204,6 +3204,66 @@ test("a skill linked out of the repo behind an in-repo library never reaches app
   assert.equal(fs.readFileSync(path.join(outside, "SKILL.md"), "utf8"), skill, "nothing outside the repository moved");
 });
 
+test("a skill in a read-only store never joins a user-scope apply round, so the round still lands", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-store-apply-")));
+  fs.mkdirSync(path.join(store, "db"));
+  fs.writeFileSync(path.join(store, "db", "SKILL.md"), skill);
+
+  const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(store, "db"), path.join(loaded, "db"));
+  fs.chmodSync(path.join(store, "db"), 0o555);
+  fs.chmodSync(store, 0o555);
+
+  try {
+    const staged = stageAndMeasure({
+      repo,
+      allowExternal: true,
+      edit: (root) => {
+        writeIn(root, "AGENTS.md", (text) =>
+          text.replace("- Whenever a PR is mentioned, include its URL.", "- Always include the full PR URL."),
+        );
+        const copy = path.join(root, ".agents/skills/db/SKILL.md");
+        if (fs.existsSync(copy)) fs.writeFileSync(copy, skill.replace("old trigger", "new trigger"));
+      },
+    });
+    assert.deepEqual(
+      staged.measured.changes.map((change) => change.file),
+      ["AGENTS.md"],
+      "the store-backed skill was never staged, so it cannot become an edit",
+    );
+
+    const built = buildProposal(
+      { edits: staged.measured.changes.map((change) => claim([change.id])) },
+      {
+        memoryFile: staged.memoryFile,
+        config: config(),
+        repo,
+        summary: aliasSummary(),
+        measured: staged.measured,
+      },
+    );
+    assert.deepEqual(built.violations, []);
+
+    const results = applyDecisions({
+      proposal: { ...built.proposal, scope: "user" },
+      decisions: Object.fromEntries(built.proposal.edits.map((edit) => [edit.id, "accepted"])),
+      repo,
+      state: staged.state,
+      config: { budgetTokens: 5000 },
+    });
+
+    assert.deepEqual(results.failed, []);
+    assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /Always include the full PR URL/);
+    assert.equal(fs.readFileSync(path.join(store, "db", "SKILL.md"), "utf8"), skill, "the store is untouched");
+  } finally {
+    fs.chmodSync(store, 0o755);
+    fs.chmodSync(path.join(store, "db"), 0o755);
+  }
+});
+
 test("a file written at the unstaged alias becomes stray, so the round is not dropped", () => {
   const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
   const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT, "library/db/SKILL.md": skill });

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -22,6 +22,7 @@ import { applyDecisions } from "../src/apply/writer.js";
 import { injectPayload, parseDecisions, renderApplySurface } from "../src/apply/lavish.js";
 import { renderEdit } from "../src/apply/terminal.js";
 import { extractJson, parseTokenLine, stripAcpxNoise } from "../src/acpx.js";
+import { STRAY_OUTSIDE_REPO, STRAY_OUTSIDE_SURFACE } from "../src/workspace.js";
 import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
 
 const MEMORY_TEXT = [
@@ -1536,7 +1537,7 @@ test("a skill's description can be rewritten in place; deletions and stray files
     annotation: { edits: [claim(["H1"])] },
   });
   assert.deepEqual(stray.violations, []);
-  assert.ok(stray.proposal.notes.some((n) => /ignored notes\.md/.test(n)));
+  assert.ok(stray.proposal.notes.some((n) => n === `ignored notes.md: ${STRAY_OUTSIDE_SURFACE}`));
 });
 
 test("a previously rejected edit is suppressed until new evidence arrives", () => {
@@ -3152,7 +3153,7 @@ test("a skill symlinked out of the repo never joins a project apply round, so it
     ["AGENTS.md"],
     "the out-of-repo skill is neither staged nor measurable as a created file",
   );
-  assert.deepEqual(staged.measured.stray, [".agents/skills/db/SKILL.md"]);
+  assert.deepEqual(staged.measured.stray, [{ file: ".agents/skills/db/SKILL.md", reason: STRAY_OUTSIDE_REPO }]);
 
   const built = buildProposal(
     { edits: staged.measured.changes.map((change) => claim([change.id])) },
@@ -3177,6 +3178,10 @@ test("a skill symlinked out of the repo never joins a project apply round, so it
     },
   );
   assert.deepEqual(built.violations, []);
+  assert.ok(
+    built.proposal.notes.some((note) => note === `ignored .agents/skills/db/SKILL.md: ${STRAY_OUTSIDE_REPO}`),
+    `the note must name the real cause: ${built.proposal.notes.join(" | ")}`,
+  );
 
   const results = applyDecisions({
     proposal: built.proposal,

--- a/test/proposal.test.js
+++ b/test/proposal.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import vm from "node:vm";
 
@@ -3119,6 +3120,79 @@ test("a skill-only shrink reports the remaining always-loaded overage", () => {
   assert.ok(results.written[0].budget.delta < 0);
   assert.ok(results.written[0].budget.projected > 100);
   assert.match(results.warnings[0], /always-loaded surface \(AGENTS\.md \+ skill descriptions\)/);
+});
+
+test("a skill symlinked out of the repo never joins a project apply round, so it cannot abort one", () => {
+  const skill = "---\nname: db\ndescription: old trigger\n---\n\nbody\n";
+  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-shared-skills-")));
+  fs.mkdirSync(path.join(library, "db"));
+  fs.writeFileSync(path.join(library, "db", "SKILL.md"), skill);
+
+  const repo = makeRepo({ "AGENTS.md": MEMORY_TEXT });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(library, "db"), path.join(loaded, "db"));
+
+  // The synthesis agent edits whatever is in its staging cwd, so anything staged can
+  // become an accepted edit - and project scope cannot write a path that resolves
+  // outside the repository, which would drop the memory-file edits with it.
+  const staged = stageAndMeasure({
+    repo,
+    edit: (root) => {
+      writeIn(root, "AGENTS.md", (text) =>
+        text.replace("- Whenever a PR is mentioned, include its URL.", "- Always include the full PR URL."),
+      );
+      // Whether it edits the staged copy or writes the path fresh, the model reaches the
+      // same repository file - one apply could not write without dropping the round.
+      writeIn(root, ".agents/skills/db/SKILL.md", skill.replace("old trigger", "new trigger"));
+    },
+  });
+  assert.deepEqual(
+    staged.measured.changes.map((change) => change.file),
+    ["AGENTS.md"],
+    "the out-of-repo skill is neither staged nor measurable as a created file",
+  );
+  assert.deepEqual(staged.measured.stray, [".agents/skills/db/SKILL.md"]);
+
+  const built = buildProposal(
+    { edits: staged.measured.changes.map((change) => claim([change.id])) },
+    {
+      memoryFile: staged.memoryFile,
+      config: config(),
+      repo,
+      summary: {
+        analyzedSessions: 4,
+        totals: { positive: 3, negative: 2, gapClusters: 1 },
+        instructions: Array.from({ length: 20 }, (_, i) => ({
+          instruction: `AG-${String(i + 1).padStart(3, "0")}`,
+          positive: 0,
+          negative: 4,
+          harmSessions: 4,
+          sessions: 4,
+          relevance: 1,
+          quotes: [],
+        })),
+      },
+      measured: staged.measured,
+    },
+  );
+  assert.deepEqual(built.violations, []);
+
+  const results = applyDecisions({
+    proposal: built.proposal,
+    decisions: Object.fromEntries(built.proposal.edits.map((edit) => [edit.id, "accepted"])),
+    repo,
+    state: staged.state,
+    config: { budgetTokens: 5000 },
+  });
+
+  assert.deepEqual(results.failed, []);
+  assert.deepEqual(
+    results.written.map((entry) => entry.file),
+    ["AGENTS.md"],
+  );
+  assert.match(fs.readFileSync(path.join(repo.root, "AGENTS.md"), "utf8"), /Always include the full PR URL/);
+  assert.equal(fs.readFileSync(path.join(library, "db", "SKILL.md"), "utf8"), skill, "the shared library is untouched");
 });
 
 test("a skill file that changed after the proposal refuses the apply; unchanged, the edit lands", () => {

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -322,3 +322,28 @@ test("user apply links relocated Claude skills without relying on directory orde
     else process.env.CLAUDE_CONFIG_DIR = previous;
   }
 });
+
+test("a skill symlinked into the loaded directory is read, because that is what a harness loads", () => {
+  const root = tmpRepo();
+  const library = path.join(root, "library");
+  const loaded = path.join(root, ".claude", "skills");
+  fs.mkdirSync(path.join(library, "beads"), { recursive: true });
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.writeFileSync(
+    path.join(library, "beads", "SKILL.md"),
+    "---\nname: beads\ndescription: Use when tracking project work.\n---\n\n# Beads\n\nTrack work here.\n",
+  );
+  fs.writeFileSync(path.join(library, "solo.md"), "---\nname: solo\ndescription: A single-file skill.\n---\n\nBody.\n");
+  // How the user's machine is laid out: the library holds the content, the harness-loaded
+  // directory holds symlinks into it.
+  fs.symlinkSync(path.join(library, "beads"), path.join(loaded, "beads"));
+  fs.symlinkSync(path.join(library, "solo.md"), path.join(loaded, "solo.md"));
+  fs.symlinkSync(path.join(library, "missing"), path.join(loaded, "broken"));
+
+  const names = loadSkills(root, ".claude/skills").map((s) => s.name);
+  assert.deepEqual(names, ["beads", "solo"], "symlinked skills count; a broken symlink is skipped");
+
+  const beads = loadSkills(root, ".claude/skills").find((s) => s.name === "beads");
+  assert.match(beads.description, /tracking project work/);
+  assert.ok(beads.descriptionTokens > 0, "a symlinked skill's description is billed like any other");
+});

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -686,6 +686,32 @@ test("a skill target stages that skill alone; a staged write to AGENTS.md is ref
   await assert.rejects(direct.run(), /synthesis changed AGENTS\.md in the repository directly/);
 });
 
+test("an ordinary in-repo skill stays fingerprinted, whether or not the run narrows to it", async () => {
+  for (const target of [undefined, { kind: "memory", path: "AGENTS.md" }]) {
+    const guarded = setup({ edit: {} });
+    fs.mkdirSync(path.join(guarded.repo.root, ".agents/skills/db"), { recursive: true });
+    fs.writeFileSync(path.join(guarded.repo.root, ".agents/skills/db/SKILL.md"), DB_SKILL);
+    if (target) guarded.config.target = target;
+    fs.writeFileSync(
+      process.env.FAKE_ACPX_SCRIPT,
+      JSON.stringify({
+        edit: {
+          [path.join(guarded.repo.root, ".agents/skills/db/SKILL.md")]: {
+            replace: [["Keep transactions short.", "Keep every transaction short."]],
+          },
+        },
+        annotations: [{ reply: { edits: [] } }],
+      }),
+    );
+
+    await assert.rejects(guarded.run(), (err) => {
+      assert.ok(err instanceof UserError, `${target ? "targeted" : "surface"} run: ${err}`);
+      assert.match(err.message, /synthesis changed \.agents\/skills\/db\/SKILL\.md in the repository directly/);
+      return true;
+    });
+  }
+});
+
 test("a staged skill that resolves outside the repository is reported as such, not as a direct repo edit", async () => {
   const outside = setup({ edit: {} }, { scope: { kind: "user" }, externalSkills: true });
   const skillPath = path.join(outside.externalSkillsDir, "db/SKILL.md");

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -586,6 +586,41 @@ test("a memory-file target never stages existing skills, and the run proposes on
   assert.match(prompt, /This run targets `\.\/AGENTS\.md` only/);
 });
 
+test("a skill symlinked out of the repo is listed read-only, never offered as a writable path", async () => {
+  const { repo, config, run } = setup({
+    edit: { "AGENTS.md": { replace: [["- Keep this file short.\n", "- Keep this file short; point at files.\n"]] } },
+    annotations: [{ reply: { edits: [tighten(["H1"])] } }],
+  });
+  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-synth-library-")));
+  fs.mkdirSync(path.join(library, "beads"));
+  fs.writeFileSync(
+    path.join(library, "beads", "SKILL.md"),
+    "---\nname: beads\ndescription: Load before tracking project work.\n---\n\n- Track it in beads.\n",
+  );
+  fs.mkdirSync(path.join(repo.root, ".agents/skills/db"), { recursive: true });
+  fs.writeFileSync(path.join(repo.root, ".agents/skills/db/SKILL.md"), DB_SKILL);
+  fs.symlinkSync(path.join(library, "beads"), path.join(repo.root, ".agents/skills/beads"));
+
+  const { violations } = await run();
+  assert.deepEqual(violations, []);
+
+  const prompt = fs.readFileSync(path.join(config.state.root, "prompts/synthesis-edit.md"), "utf8");
+  // Present with its token costs - the coverage signal has to survive - but declared
+  // read-only with the reason, so nothing invites an edit that would be discarded.
+  assert.match(
+    prompt,
+    /- beads \(\.agents\/skills\/beads\/SKILL\.md; \d+ tok body, \d+ tok description; read-only, resolves outside the repository\) :: Load before tracking project work\./,
+  );
+  assert.match(prompt, /skills marked `read-only` above resolve outside this repository/);
+  assert.match(
+    prompt,
+    /- db \(\.agents\/skills\/db\/SKILL\.md; \d+ tok body, \d+ tok description\) :: Load for database work\./,
+    "an in-repo skill is still writable and carries no marker",
+  );
+  assert.equal(fs.existsSync(path.join(config.state.root, "synthesis/.agents/skills/db/SKILL.md")), true);
+  assert.equal(fs.existsSync(path.join(config.state.root, "synthesis/.agents/skills/beads/SKILL.md")), false);
+});
+
 test("a skill target in an absolute in-repo skills directory is staged under its repo-relative path", async () => {
   const targeted = setup({
     edit: {

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -611,7 +611,7 @@ test("a skill symlinked out of the repo is listed read-only, never offered as a 
     prompt,
     /- beads \(\.agents\/skills\/beads\/SKILL\.md; \d+ tok body, \d+ tok description; read-only, resolves outside the repository\) :: Load before tracking project work\./,
   );
-  assert.match(prompt, /skills marked `read-only` above resolve outside this repository/);
+  assert.match(prompt, /skills marked `read-only` above are not in your staging copy/);
   assert.match(
     prompt,
     /- db \(\.agents\/skills\/db\/SKILL\.md; \d+ tok body, \d+ tok description\) :: Load for database work\./,

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -685,3 +685,35 @@ test("a skill target stages that skill alone; a staged write to AGENTS.md is ref
   );
   await assert.rejects(direct.run(), /synthesis changed AGENTS\.md in the repository directly/);
 });
+
+test("a fingerprinted skill that resolves outside the repository is reported as such, not as a direct repo edit", async () => {
+  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fingerprint-library-")));
+  fs.mkdirSync(path.join(library, "beads"));
+  const skill = "---\nname: beads\ndescription: Load before tracking project work.\n---\n\n- Track it.\n";
+  fs.writeFileSync(path.join(library, "beads", "SKILL.md"), skill);
+
+  const outside = setup({ edit: {} });
+  fs.mkdirSync(path.join(outside.repo.root, ".agents/skills"), { recursive: true });
+  fs.symlinkSync(path.join(library, "beads"), path.join(outside.repo.root, ".agents/skills/beads"));
+  // The guard still fires - writing through the link to a skill declared read-only is
+  // exactly what it is for - but the file is not in the repository and the claim must
+  // not say it is.
+  fs.writeFileSync(
+    process.env.FAKE_ACPX_SCRIPT,
+    JSON.stringify({
+      edit: { [path.join(library, "beads", "SKILL.md")]: { replace: [["Track it.", "Track it in beads."]] } },
+      annotations: [{ reply: { edits: [] } }],
+    }),
+  );
+
+  await assert.rejects(outside.run(), (err) => {
+    assert.ok(err instanceof UserError);
+    assert.match(
+      err.message,
+      /\.agents\/skills\/beads\/SKILL\.md changed during synthesis; that path resolves outside the repository/,
+    );
+    assert.doesNotMatch(err.message, /in the repository directly/);
+    assert.match(err.hint, /another process changed the shared library mid-run/);
+    return true;
+  });
+});

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -686,18 +686,44 @@ test("a skill target stages that skill alone; a staged write to AGENTS.md is ref
   await assert.rejects(direct.run(), /synthesis changed AGENTS\.md in the repository directly/);
 });
 
-test("a fingerprinted skill that resolves outside the repository is reported as such, not as a direct repo edit", async () => {
-  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-fingerprint-library-")));
+test("a staged skill that resolves outside the repository is reported as such, not as a direct repo edit", async () => {
+  const outside = setup({ edit: {} }, { scope: { kind: "user" }, externalSkills: true });
+  const skillPath = path.join(outside.externalSkillsDir, "db/SKILL.md");
+  // User scope stages skills that live outside the repository, so they stay fingerprinted -
+  // writing through to one is exactly the betrayal this guard is for. But the file is not
+  // in the repository and the writer may have been another process, so the claim must not
+  // say it is.
+  fs.writeFileSync(
+    process.env.FAKE_ACPX_SCRIPT,
+    JSON.stringify({
+      edit: { [skillPath]: { replace: [["Keep transactions short.", "Keep every transaction short."]] } },
+      annotations: [{ reply: { edits: [] } }],
+    }),
+  );
+
+  await assert.rejects(outside.run(), (err) => {
+    assert.ok(err instanceof UserError);
+    assert.ok(
+      err.message.includes(`${skillPath} changed during synthesis; that path resolves outside the repository`),
+      err.message,
+    );
+    assert.doesNotMatch(err.message, /in the repository directly/);
+    assert.match(err.hint, /another process changed the shared library mid-run/);
+    return true;
+  });
+});
+
+test("a skill backpass withheld from staging is not fingerprinted, so a third party cannot abort the run", async () => {
+  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-withheld-library-")));
   fs.mkdirSync(path.join(library, "beads"));
   const skill = "---\nname: beads\ndescription: Load before tracking project work.\n---\n\n- Track it.\n";
   fs.writeFileSync(path.join(library, "beads", "SKILL.md"), skill);
 
-  const outside = setup({ edit: {} });
-  fs.mkdirSync(path.join(outside.repo.root, ".agents/skills"), { recursive: true });
-  fs.symlinkSync(path.join(library, "beads"), path.join(outside.repo.root, ".agents/skills/beads"));
-  // The guard still fires - writing through the link to a skill declared read-only is
-  // exactly what it is for - but the file is not in the repository and the claim must
-  // not say it is.
+  const withheld = setup({ edit: {}, annotations: [{ reply: { edits: [] } }] });
+  fs.mkdirSync(path.join(withheld.repo.root, ".agents/skills"), { recursive: true });
+  fs.symlinkSync(path.join(library, "beads"), path.join(withheld.repo.root, ".agents/skills/beads"));
+  // Project scope never stages this skill, so backpass has guaranteed it will never write
+  // it; another process touching it mid-run must not discard the measured memory-file work.
   fs.writeFileSync(
     process.env.FAKE_ACPX_SCRIPT,
     JSON.stringify({
@@ -706,14 +732,6 @@ test("a fingerprinted skill that resolves outside the repository is reported as 
     }),
   );
 
-  await assert.rejects(outside.run(), (err) => {
-    assert.ok(err instanceof UserError);
-    assert.match(
-      err.message,
-      /\.agents\/skills\/beads\/SKILL\.md changed during synthesis; that path resolves outside the repository/,
-    );
-    assert.doesNotMatch(err.message, /in the repository directly/);
-    assert.match(err.hint, /another process changed the shared library mid-run/);
-    return true;
-  });
+  const { violations } = await withheld.run();
+  assert.deepEqual(violations, []);
 });

--- a/test/synthesize.test.js
+++ b/test/synthesize.test.js
@@ -739,6 +739,43 @@ test("a staged skill that resolves outside the repository is reported as such, n
   });
 });
 
+test("a narrowed run does not fingerprint a skill linked into a store nothing may write", async () => {
+  const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-narrowed-store-")));
+  fs.mkdirSync(path.join(store, "db"));
+  const skill = "---\nname: db\ndescription: Load for database work.\n---\n\n- Keep transactions short.\n";
+  fs.writeFileSync(path.join(store, "db", "SKILL.md"), skill);
+
+  const narrowed = setup(
+    { edit: {}, annotations: [{ reply: { edits: [] } }] },
+    { scope: { kind: "user" }, externalSkills: true },
+  );
+  fs.rmSync(path.join(narrowed.externalSkillsDir, "db"), { recursive: true });
+  fs.symlinkSync(path.join(store, "db"), path.join(narrowed.externalSkillsDir, "db"));
+  fs.chmodSync(path.join(store, "db"), 0o555);
+  // Narrowing to the memory file stages no skill at all, but backpass has still guaranteed
+  // it will never write this one - so a home-manager rebuild touching it mid-run must not
+  // discard the memory-file work with a claim that the harness wrote to the repository.
+  narrowed.config.target = { kind: "memory", path: "AGENTS.md" };
+  fs.writeFileSync(
+    process.env.FAKE_ACPX_SCRIPT,
+    JSON.stringify({
+      edit: {
+        [path.join(store, "db", "SKILL.md")]: {
+          replace: [["Keep transactions short.", "Keep every transaction short."]],
+        },
+      },
+      annotations: [{ reply: { edits: [] } }],
+    }),
+  );
+
+  try {
+    const { violations } = await narrowed.run();
+    assert.deepEqual(violations, []);
+  } finally {
+    fs.chmodSync(path.join(store, "db"), 0o755);
+  }
+});
+
 test("a skill backpass withheld from staging is not fingerprinted, so a third party cannot abort the run", async () => {
   const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-withheld-library-")));
   fs.mkdirSync(path.join(library, "beads"));

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -84,6 +84,39 @@ test("a target validates every configured project memory path before narrowing",
   assert.throws(() => resolveTarget("AGENTS.md", scope), /private\.txt resolves outside the project root/);
 });
 
+test("one library under two links resolves to the first name; two distinct files still refuse", () => {
+  const { repo, scope } = projectScope();
+  const library = path.join(repo.root, "library", "db");
+  fs.mkdirSync(library, { recursive: true });
+  fs.writeFileSync(path.join(library, "SKILL.md"), DB);
+  fs.rmSync(path.join(repo.root, ".agents/skills/db"), { recursive: true });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.symlinkSync(library, path.join(loaded, "db"));
+  fs.symlinkSync(library, path.join(loaded, "database"));
+
+  // Both names are loaded and billed, so both match - but they are one file, and staging
+  // already gives the first name the write. Refusing here would contradict that.
+  assert.equal(loadProjectSkills(repo.root, ".agents/skills", []).filter((s) => s.name === "db").length, 2);
+  assert.deepEqual(resolveTarget("db", scope), {
+    kind: "skill",
+    path: ".agents/skills/database/SKILL.md",
+    name: "db",
+    aliases: [".agents/skills/db/SKILL.md"],
+  });
+
+  // Two genuinely different files under one frontmatter name: renaming is the fix.
+  const distinct = projectScope({ ".agents/skills/other/SKILL.md": DB.replace("transaction.", "transaction!") });
+  assert.throws(
+    () => resolveTarget("db", distinct.scope),
+    (err) =>
+      err instanceof UserError &&
+      /is ambiguous: it names \.agents\/skills\/db\/SKILL\.md and \.agents\/skills\/other\/SKILL\.md/.test(
+        err.message,
+      ) &&
+      /rename the skill so one name means one file/.test(err.hint),
+  );
+});
+
 test("a name that is both a skill and a memory file is refused, never picked", () => {
   const { scope } = projectScope({ ".agents/skills/agents/SKILL.md": DB.replace("name: db", "name: AGENTS.md") });
   assert.throws(() => resolveTarget("AGENTS.md", scope), /ambiguous: it names AGENTS\.md and \.agents\/skills\/agents/);

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -101,7 +101,6 @@ test("one library under two links resolves to the first name; two distinct files
     kind: "skill",
     path: ".agents/skills/database/SKILL.md",
     name: "db",
-    aliases: [".agents/skills/db/SKILL.md"],
   });
 
   // Two genuinely different files under one frontmatter name: renaming is the fix.

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -126,6 +126,58 @@ test("a name that is both a skill and a memory file is refused, never picked", (
   assert.throws(() => resolveTarget("AGENTS.md", scope), /ambiguous: it names AGENTS\.md and \.agents\/skills\/agents/);
 });
 
+test("--target refuses a skill staging will withhold, naming staging's own reason", () => {
+  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-library-")));
+  fs.mkdirSync(path.join(library, "beads"));
+  fs.writeFileSync(
+    path.join(library, "beads", "SKILL.md"),
+    "---\nname: beads\ndescription: Load before tracking work.\n---\n\n- Track it.\n",
+  );
+  const { repo, scope } = projectScope();
+  fs.symlinkSync(path.join(library, "beads"), path.join(repo.root, ".agents", "skills", "beads"));
+
+  // It is loaded and billed, so it is a name the user can plausibly type - but a targeted
+  // run on it could only end in zero edits, so it is refused before the synthesis turn.
+  const skills = loadProjectSkills(repo.root, ".agents/skills", []);
+  assert.ok(skills.some((skill) => skill.name === "beads" && skill.path === ".agents/skills/beads/SKILL.md"));
+  assert.throws(
+    () => resolveTarget("beads", scope),
+    (err) =>
+      err instanceof UserError &&
+      /--target beads is at \.agents\/skills\/beads\/SKILL\.md, which resolves outside the repository/.test(
+        err.message,
+      ) &&
+      /cannot write it there/.test(err.hint),
+  );
+
+  // The layout this change exists to support stays targetable: a link inside the repo.
+  fs.mkdirSync(path.join(repo.root, "library", "review"), { recursive: true });
+  fs.writeFileSync(path.join(repo.root, "library", "review", "SKILL.md"), REVIEW);
+  fs.symlinkSync(path.join(repo.root, "library", "review"), path.join(repo.root, ".agents", "skills", "review"));
+  assert.deepEqual(resolveTarget("review", scope), {
+    kind: "skill",
+    path: ".agents/skills/review/SKILL.md",
+    name: "review",
+  });
+  assert.deepEqual(resolveTarget("db", scope), { kind: "skill", path: ".agents/skills/db/SKILL.md", name: "db" });
+});
+
+test("--target refuses a skill that resolves into a directory nothing may write", () => {
+  const { repo, scope } = projectScope({ "vendor/beads/SKILL.md": REVIEW.replace("review", "beads") });
+  const vendor = path.join(repo.root, "vendor");
+  fs.symlinkSync(path.join(vendor, "beads"), path.join(repo.root, ".agents", "skills", "beads"));
+  fs.chmodSync(path.join(vendor, "beads"), 0o555);
+
+  try {
+    assert.throws(
+      () => resolveTarget("beads", scope),
+      /--target beads is at \.agents\/skills\/beads\/SKILL\.md, which resolves to a location that cannot be written/,
+    );
+  } finally {
+    fs.chmodSync(path.join(vendor, "beads"), 0o755);
+  }
+});
+
 test("user scope resolves against the user-level memory files and skill dirs", () => {
   const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-home-")));
   writeIn(home, ".agents/AGENTS.md", AGENTS);

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -84,7 +84,7 @@ test("a target validates every configured project memory path before narrowing",
   assert.throws(() => resolveTarget("AGENTS.md", scope), /private\.txt resolves outside the project root/);
 });
 
-test("one library under two links resolves to the first name; two distinct files still refuse", () => {
+test("--target refuses one name that names more than one file, however it got there", () => {
   const { repo, scope } = projectScope();
   const library = path.join(repo.root, "library", "db");
   fs.mkdirSync(library, { recursive: true });
@@ -94,18 +94,21 @@ test("one library under two links resolves to the first name; two distinct files
   fs.symlinkSync(library, path.join(loaded, "db"));
   fs.symlinkSync(library, path.join(loaded, "database"));
 
-  // Both names are loaded and billed, so both match - but they are one file, and staging
-  // already gives one name the write. Refusing here would contradict that. Each site picks
-  // deterministically from its own order - staging by directory-entry name, this by sorted
-  // path - and a targeted run stages only the name resolved here, so it owns its own write.
+  // Both names are loaded and billed, so both match. --target resolves exactly one file,
+  // and the hint must not tell someone to rename a file that already has only one name.
   assert.equal(loadProjectSkills(repo.root, ".agents/skills", []).filter((s) => s.name === "db").length, 2);
-  assert.deepEqual(resolveTarget("db", scope), {
-    kind: "skill",
-    path: ".agents/skills/database/SKILL.md",
-    name: "db",
-  });
+  assert.throws(
+    () => resolveTarget("db", scope),
+    (err) =>
+      err instanceof UserError &&
+      /is ambiguous: it names \.agents\/skills\/database\/SKILL\.md and \.agents\/skills\/db\/SKILL\.md/.test(
+        err.message,
+      ) &&
+      /one file under several links, or genuinely different files/.test(err.hint) &&
+      /needs a name that identifies exactly one file/.test(err.hint),
+  );
 
-  // Two genuinely different files under one frontmatter name: renaming is the fix.
+  // Two genuinely different files under one frontmatter name refuse the same way.
   const distinct = projectScope({ ".agents/skills/other/SKILL.md": DB.replace("transaction.", "transaction!") });
   assert.throws(
     () => resolveTarget("db", distinct.scope),
@@ -114,61 +117,13 @@ test("one library under two links resolves to the first name; two distinct files
       /is ambiguous: it names \.agents\/skills\/db\/SKILL\.md and \.agents\/skills\/other\/SKILL\.md/.test(
         err.message,
       ) &&
-      /rename the skill so one name means one file/.test(err.hint),
+      /needs a name that identifies exactly one file/.test(err.hint),
   );
 });
 
 test("a name that is both a skill and a memory file is refused, never picked", () => {
   const { scope } = projectScope({ ".agents/skills/agents/SKILL.md": DB.replace("name: db", "name: AGENTS.md") });
   assert.throws(() => resolveTarget("AGENTS.md", scope), /ambiguous: it names AGENTS\.md and \.agents\/skills\/agents/);
-});
-
-test("a skill symlinked out of the repo is refused as a project target, by the real cause", () => {
-  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-library-")));
-  fs.mkdirSync(path.join(library, "beads"));
-  fs.writeFileSync(
-    path.join(library, "beads", "SKILL.md"),
-    "---\nname: beads\ndescription: Load before tracking work.\n---\n\n- Track it.\n",
-  );
-  const { repo, scope } = projectScope();
-  fs.symlinkSync(path.join(library, "beads"), path.join(repo.root, ".agents", "skills", "beads"));
-
-  // It is loaded and billed, so it is a name the user can plausibly type.
-  const skills = loadProjectSkills(repo.root, ".agents/skills", []);
-  assert.ok(skills.some((skill) => skill.name === "beads" && skill.path === ".agents/skills/beads/SKILL.md"));
-
-  assert.throws(
-    () => resolveTarget("beads", scope),
-    (err) =>
-      err instanceof UserError &&
-      /--target beads is at \.agents\/skills\/beads\/SKILL\.md, which resolves outside the repository/.test(
-        err.message,
-      ) &&
-      /never write it/.test(err.hint),
-  );
-  // An in-repo skill in the same directory still resolves.
-  assert.deepEqual(resolveTarget("db", scope), { kind: "skill", path: ".agents/skills/db/SKILL.md", name: "db" });
-});
-
-test("a read-only skill file is still a target, because apply replaces it by rename", () => {
-  const { repo, scope } = projectScope({ "vendor/beads/SKILL.md": REVIEW.replace("review", "beads") });
-  const vendor = path.join(repo.root, "vendor");
-  fs.symlinkSync(path.join(vendor, "beads"), path.join(repo.root, ".agents", "skills", "beads"));
-  fs.chmodSync(path.join(vendor, "beads", "SKILL.md"), 0o444);
-
-  assert.deepEqual(resolveTarget("beads", scope), {
-    kind: "skill",
-    path: ".agents/skills/beads/SKILL.md",
-    name: "beads",
-  });
-
-  // The directory that receives the rename is what decides.
-  fs.chmodSync(path.join(vendor, "beads"), 0o555);
-  try {
-    assert.throws(() => resolveTarget("beads", scope), /resolves to .+ and cannot be written/);
-  } finally {
-    fs.chmodSync(path.join(vendor, "beads"), 0o755);
-  }
 });
 
 test("user scope resolves against the user-level memory files and skill dirs", () => {

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -89,6 +89,33 @@ test("a name that is both a skill and a memory file is refused, never picked", (
   assert.throws(() => resolveTarget("AGENTS.md", scope), /ambiguous: it names AGENTS\.md and \.agents\/skills\/agents/);
 });
 
+test("a skill symlinked out of the repo is refused as a project target, by the real cause", () => {
+  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-library-")));
+  fs.mkdirSync(path.join(library, "beads"));
+  fs.writeFileSync(
+    path.join(library, "beads", "SKILL.md"),
+    "---\nname: beads\ndescription: Load before tracking work.\n---\n\n- Track it.\n",
+  );
+  const { repo, scope } = projectScope();
+  fs.symlinkSync(path.join(library, "beads"), path.join(repo.root, ".agents", "skills", "beads"));
+
+  // It is loaded and billed, so it is a name the user can plausibly type.
+  const skills = loadProjectSkills(repo.root, ".agents/skills", []);
+  assert.ok(skills.some((skill) => skill.name === "beads" && skill.path === ".agents/skills/beads/SKILL.md"));
+
+  assert.throws(
+    () => resolveTarget("beads", scope),
+    (err) =>
+      err instanceof UserError &&
+      /--target beads is at \.agents\/skills\/beads\/SKILL\.md, which resolves outside the repository/.test(
+        err.message,
+      ) &&
+      /never write it/.test(err.hint),
+  );
+  // An in-repo skill in the same directory still resolves.
+  assert.deepEqual(resolveTarget("db", scope), { kind: "skill", path: ".agents/skills/db/SKILL.md", name: "db" });
+});
+
 test("user scope resolves against the user-level memory files and skill dirs", () => {
   const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-target-home-")));
   writeIn(home, ".agents/AGENTS.md", AGENTS);

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -95,7 +95,8 @@ test("one library under two links resolves to the first name; two distinct files
   fs.symlinkSync(library, path.join(loaded, "database"));
 
   // Both names are loaded and billed, so both match - but they are one file, and staging
-  // already gives the first name the write. Refusing here would contradict that.
+  // already gives the first name the write. Refusing here would contradict that. "First"
+  // is the path-sorted first at both sites, so the pick is the same on every filesystem.
   assert.equal(loadProjectSkills(repo.root, ".agents/skills", []).filter((s) => s.name === "db").length, 2);
   assert.deepEqual(resolveTarget("db", scope), {
     kind: "skill",

--- a/test/target.test.js
+++ b/test/target.test.js
@@ -95,8 +95,9 @@ test("one library under two links resolves to the first name; two distinct files
   fs.symlinkSync(library, path.join(loaded, "database"));
 
   // Both names are loaded and billed, so both match - but they are one file, and staging
-  // already gives the first name the write. Refusing here would contradict that. "First"
-  // is the path-sorted first at both sites, so the pick is the same on every filesystem.
+  // already gives one name the write. Refusing here would contradict that. Each site picks
+  // deterministically from its own order - staging by directory-entry name, this by sorted
+  // path - and a targeted run stages only the name resolved here, so it owns its own write.
   assert.equal(loadProjectSkills(repo.root, ".agents/skills", []).filter((s) => s.name === "db").length, 2);
   assert.deepEqual(resolveTarget("db", scope), {
     kind: "skill",
@@ -147,6 +148,27 @@ test("a skill symlinked out of the repo is refused as a project target, by the r
   );
   // An in-repo skill in the same directory still resolves.
   assert.deepEqual(resolveTarget("db", scope), { kind: "skill", path: ".agents/skills/db/SKILL.md", name: "db" });
+});
+
+test("a read-only skill file is still a target, because apply replaces it by rename", () => {
+  const { repo, scope } = projectScope({ "vendor/beads/SKILL.md": REVIEW.replace("review", "beads") });
+  const vendor = path.join(repo.root, "vendor");
+  fs.symlinkSync(path.join(vendor, "beads"), path.join(repo.root, ".agents", "skills", "beads"));
+  fs.chmodSync(path.join(vendor, "beads", "SKILL.md"), 0o444);
+
+  assert.deepEqual(resolveTarget("beads", scope), {
+    kind: "skill",
+    path: ".agents/skills/beads/SKILL.md",
+    name: "beads",
+  });
+
+  // The directory that receives the rename is what decides.
+  fs.chmodSync(path.join(vendor, "beads"), 0o555);
+  try {
+    assert.throws(() => resolveTarget("beads", scope), /resolves to .+ and cannot be written/);
+  } finally {
+    fs.chmodSync(path.join(vendor, "beads"), 0o755);
+  }
 });
 
 test("user scope resolves against the user-level memory files and skill dirs", () => {

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -35,42 +35,6 @@ test("user state creation tightens an existing directory to mode 0700", () => {
   assert.equal(fs.statSync(stateDir).mode & 0o777, 0o700);
 });
 
-test("apply refuses a user-level memory file that is a symlink to a read-only path", () => {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-home-"));
-  const source = path.join(home, "dotfiles", "AGENTS.md");
-  const link = path.join(home, ".agents", "AGENTS.md");
-  const text = "# User memory\n\n- Keep secrets out of prompts.\n";
-  fs.mkdirSync(path.dirname(source), { recursive: true });
-  fs.mkdirSync(path.dirname(link), { recursive: true });
-  fs.writeFileSync(source, text);
-  fs.chmodSync(source, 0o444);
-  fs.symlinkSync(source, link);
-
-  const state = new State(home, {
-    stateDir: path.join(home, ".config", "backpass", "user"),
-    mode: 0o700,
-    exclude: false,
-  }).ensure();
-  const results = applyDecisions({
-    proposal: {
-      memoryFile: { path: ".agents/AGENTS.md", hash: memoryTextHash(text), tokens: 20 },
-      edits: [{ id: "e1", kind: "rewrite", file: ".agents/AGENTS.md" }],
-      config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
-    },
-    decisions: { e1: "accepted" },
-    repo: { root: home, name: "user" },
-    state,
-    config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
-  });
-
-  assert.equal(results.written.length, 0);
-  assert.equal(results.rejectionsRecorded, false);
-  assert.equal(results.failed[0].error, readOnlySymlinkMessage(link, fs.realpathSync(source)));
-  assert.match(results.failed[0].error, /is a symlink to .+ which is not writable; edit the source that generates it/);
-  assert.equal(fs.readFileSync(source, "utf8"), text);
-  assert.equal(fs.readlinkSync(link), source);
-});
-
 test("apply names a symlink whose writable file is in a read-only store", () => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-store-"));
   const store = path.join(home, "readonly-store");
@@ -102,8 +66,14 @@ test("apply names a symlink whose writable file is in a read-only store", () => 
     });
 
     assert.equal(results.written.length, 0);
+    assert.equal(results.rejectionsRecorded, false);
     assert.equal(results.failed[0].error, readOnlySymlinkMessage(link, fs.realpathSync(source)));
+    assert.match(
+      results.failed[0].error,
+      /is a symlink to .+ which is not writable; edit the source that generates it/,
+    );
     assert.equal(fs.readFileSync(source, "utf8"), text);
+    assert.equal(fs.readlinkSync(link), source);
   } finally {
     fs.chmodSync(store, 0o755);
   }

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { applyDecisions, readOnlySymlinkMessage } from "../src/apply/writer.js";
+import { applyDecisions, readOnlySymlinkMessage, readOnlyTargetMessage } from "../src/apply/writer.js";
 import { cmdApply } from "../src/commands/apply.js";
 import { cmdInit } from "../src/commands/init.js";
 import { loadConfig } from "../src/config.js";
@@ -141,10 +141,13 @@ test("apply names the read-only store when the symlink is a directory on the way
     });
 
     assert.equal(results.written.length, 0);
+    // The leaf is a plain file, so the refusal names the resolved path rather than
+    // asserting a symlink that is not there.
     assert.equal(
       results.failed[0].error,
-      readOnlySymlinkMessage(path.join(home, ".agents", "AGENTS.md"), fs.realpathSync(source)),
+      readOnlyTargetMessage(path.join(home, ".agents", "AGENTS.md"), fs.realpathSync(source)),
     );
+    assert.doesNotMatch(results.failed[0].error, /is a symlink to/);
     assert.equal(fs.readFileSync(source, "utf8"), text);
   } finally {
     fs.chmodSync(store, 0o755);

--- a/test/user-apply.test.js
+++ b/test/user-apply.test.js
@@ -109,6 +109,48 @@ test("apply names a symlink whose writable file is in a read-only store", () => 
   }
 });
 
+test("apply names the read-only store when the symlink is a directory on the way to the file", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-uapply-dirlink-"));
+  const store = path.join(home, "readonly-store");
+  const source = path.join(store, "AGENTS.md");
+  // Nothing on the path lstats as a symlink except a directory, which is how a
+  // home-manager or nix layout generates the loaded tree.
+  const link = path.join(home, ".agents");
+  const text = "# User memory\n\n- Keep secrets out of prompts.\n";
+  fs.mkdirSync(store, { recursive: true });
+  fs.writeFileSync(source, text, { mode: 0o644 });
+  fs.symlinkSync(store, link, "dir");
+  fs.chmodSync(store, 0o555);
+
+  try {
+    const state = new State(home, {
+      stateDir: path.join(home, ".config", "backpass", "user"),
+      mode: 0o700,
+      exclude: false,
+    }).ensure();
+    const results = applyDecisions({
+      proposal: {
+        memoryFile: { path: ".agents/AGENTS.md", hash: memoryTextHash(text), tokens: 20 },
+        edits: [{ id: "e1", kind: "rewrite", file: ".agents/AGENTS.md" }],
+        config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+      },
+      decisions: { e1: "accepted" },
+      repo: { root: home, name: "user" },
+      state,
+      config: { budgetTokens: 5000, skillsDir: ".agents/skills" },
+    });
+
+    assert.equal(results.written.length, 0);
+    assert.equal(
+      results.failed[0].error,
+      readOnlySymlinkMessage(path.join(home, ".agents", "AGENTS.md"), fs.realpathSync(source)),
+    );
+    assert.equal(fs.readFileSync(source, "utf8"), text);
+  } finally {
+    fs.chmodSync(store, 0o755);
+  }
+});
+
 test("project apply refuses an external memory target", () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-project-apply-"));
   const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-apply-"));

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { readMemoryFile } from "../src/memory.js";
+import { loadSkills } from "../src/skills.js";
 import { State } from "../src/state.js";
 import {
   isSkillFilePath,
@@ -92,6 +93,7 @@ test("external user memory and skills use workspace-relative staging paths", () 
     memoryFile: readMemoryFile(repo.root, memoryPath, { allowExternal: true }),
     skillsDir,
     skillDirs: [skillsDir],
+    allowExternal: true,
   });
 
   assert.equal(path.isAbsolute(workspace.memoryWorkspacePath), false);
@@ -119,6 +121,7 @@ test("split external memory hunks retain their staged path", () => {
     memoryFile: readMemoryFile(repo.root, memoryPath, { allowExternal: true }),
     skillsDir,
     skillDirs: [skillsDir],
+    allowExternal: true,
   });
   writeIn(workspace.root, workspace.memoryWorkspacePath, (text) => text.replace("- carry\n- delete\n", ""));
   writeIn(
@@ -261,4 +264,46 @@ test("two links to one shared library are both staged: the guard is ancestry, no
 
   assert.ok(workspace.originals.has(".agents/skills/db/SKILL.md"));
   assert.ok(workspace.originals.has(".agents/skills/database/SKILL.md"));
+});
+
+test("project scope bills a skill symlinked out of the repo but never stages it", () => {
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  // The layout project scope cannot write: the loaded directory links into a library that
+  // lives outside the repository entirely.
+  const library = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-library-")));
+  fs.mkdirSync(path.join(library, "db"));
+  fs.writeFileSync(path.join(library, "db", "SKILL.md"), SKILL);
+  fs.writeFileSync(path.join(library, "solo.md"), "---\nname: solo\ndescription: Solo.\n---\n\nBody\n");
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(library, "db"), path.join(loaded, "db"));
+  fs.symlinkSync(path.join(library, "solo.md"), path.join(loaded, "solo.md"));
+  fs.mkdirSync(path.join(loaded, "local"));
+  fs.writeFileSync(path.join(loaded, "local", "SKILL.md"), SKILL.replace("name: db", "name: local"));
+
+  const loadedSkills = loadSkills(repo.root, ".agents/skills");
+  assert.deepEqual(
+    loadedSkills.map((s) => s.name).sort(),
+    ["db", "local", "solo"],
+    "the harness loads all three, so all three are billed",
+  );
+  assert.ok(
+    loadedSkills.find((s) => s.name === "db").descriptionTokens > 0,
+    "an out-of-repo skill still costs always-loaded tokens",
+  );
+
+  const state = new State(repo.root).ensure();
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills" });
+
+  assert.ok(workspace.originals.has(".agents/skills/local/SKILL.md"), "an in-repo skill is staged as before");
+  assert.equal(workspace.originals.has(".agents/skills/db/SKILL.md"), false);
+  assert.equal(workspace.originals.has(".agents/skills/solo.md"), false);
+  assert.equal(fs.existsSync(path.join(workspace.root, ".agents/skills/db")), false);
+  assert.equal(fs.existsSync(path.join(workspace.root, ".agents/skills/solo.md")), false);
+
+  // User scope owns files outside any repository, so there the same layout is editable.
+  const external = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills", allowExternal: true });
+  assert.equal(external.originals.get(".agents/skills/db/SKILL.md"), SKILL);
+  assert.ok(external.originals.has(".agents/skills/solo.md"));
 });

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -375,11 +375,14 @@ test("a skill linked into a store nothing may write is billed but never staged w
 
     assert.deepEqual([...workspace.originals.keys()], ["AGENTS.md", ".agents/skills/db/SKILL.md"]);
     assert.deepEqual(walkStaged(path.join(workspace.root, ".agents/skills")), ["db/SKILL.md"]);
-    assert.deepEqual(workspace.unstageable, [
-      { path: ".agents/skills/foo/SKILL.md", reason: "resolves to a location that cannot be written" },
-      { path: ".agents/skills/shared/SKILL.md", reason: "resolves to a location that cannot be written" },
-      { path: ".agents/skills/shared-alias/SKILL.md", reason: "resolves to a location that cannot be written" },
-    ]);
+    assert.deepEqual(
+      workspace.unstageable.map(({ path: p, reason }) => ({ path: p, reason })),
+      [
+        { path: ".agents/skills/foo/SKILL.md", reason: "resolves to a location that cannot be written" },
+        { path: ".agents/skills/shared/SKILL.md", reason: "resolves to a location that cannot be written" },
+        { path: ".agents/skills/shared-alias/SKILL.md", reason: "resolves to a location that cannot be written" },
+      ],
+    );
   } finally {
     fs.chmodSync(store, 0o755);
     fs.chmodSync(path.join(store, "foo"), 0o755);

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -335,6 +335,42 @@ test("a skill file linked out of the repo through an in-repo library is never st
   assert.equal(external.originals.get(".agents/skills/db/SKILL.md"), SKILL);
 });
 
+test("a skill in a store this user cannot read is skipped and named, not thrown", () => {
+  const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-locked-store-")));
+  fs.mkdirSync(path.join(store, "locked"));
+  const unreadable = path.join(store, "locked", "SKILL.md");
+  fs.writeFileSync(unreadable, SKILL);
+  fs.chmodSync(unreadable, 0o000);
+
+  const repo = makeRepo({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": SKILL });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.symlinkSync(path.join(store, "locked"), path.join(loaded, "locked"));
+
+  try {
+    const state = new State(repo.root).ensure();
+    const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+    // User scope, where an out-of-repo store is legitimately stageable - so nothing but
+    // the read failure itself can keep this file out.
+    const workspace = prepareWorkspace({
+      state,
+      repo,
+      memoryFile,
+      skillsDir: ".agents/skills",
+      allowExternal: true,
+    });
+
+    assert.deepEqual([...workspace.originals.keys()], ["AGENTS.md", ".agents/skills/db/SKILL.md"]);
+    assert.deepEqual(walkStaged(path.join(workspace.root, ".agents/skills")), ["db/SKILL.md"]);
+    assert.deepEqual(workspace.unstageable, [
+      { path: ".agents/skills/locked/SKILL.md", reason: "could not be read when the staging copy was built" },
+    ]);
+    // The readable skill beside it still measures normally.
+    assert.deepEqual(measureWorkspace(workspace).changes, []);
+  } finally {
+    fs.chmodSync(unreadable, 0o644);
+  }
+});
+
 test("a link to a whole repository stages only the skill file, never the tree behind it", () => {
   const repo = makeRepo({ "AGENTS.md": AGENTS });
   // The layout the finding names: a plugin repository linked in as a skill.

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -229,14 +229,16 @@ test("a symlinked skill is staged and measured, so a run can edit what the harne
   assert.equal(fs.readFileSync(path.join(library, "SKILL.md"), "utf8"), SKILL, "the library is untouched");
 });
 
-test("a cyclic skill symlink terminates instead of overflowing the traversal stack", () => {
+test("a symlinked skill directory is never recursed, so no cycle can be walked", () => {
   const repo = makeRepo({ "AGENTS.md": AGENTS });
   const loaded = path.join(repo.root, ".agents", "skills");
   const real = path.join(loaded, "db");
   fs.mkdirSync(real, { recursive: true });
   fs.writeFileSync(path.join(real, "SKILL.md"), SKILL);
-  // The three shapes a followed directory link can take: a self link, a link back to an
-  // ancestor, and a mutual pair. Each one revisits a directory the walk has already seen.
+  // The three shapes a directory link can take: a self link, a link back to an ancestor,
+  // and a mutual pair. Staging takes at most one leaf per link and never descends, so
+  // none of them can be entered. (The ancestry guard in walkFiles is a second line of
+  // defence for that; only the top-level self link still reaches it.)
   fs.symlinkSync(real, path.join(real, "self"));
   fs.symlinkSync(loaded, path.join(real, "up"));
   const a = path.join(loaded, "a");

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -11,6 +11,7 @@ import { State } from "../src/state.js";
 import {
   isSkillFilePath,
   STRAY_OUTSIDE_SURFACE,
+  STRAY_UNWRITABLE,
   measureWorkspace,
   parseSkillFile,
   prepareWorkspace,
@@ -440,13 +441,96 @@ test("a skill linked into a store nothing may write is billed but never staged w
   }
 });
 
+test("a read-only skill file in a writable directory is staged, because apply can write it", () => {
+  const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-readonly-file-")));
+  fs.mkdirSync(path.join(store, "foo"));
+  const foo = SKILL.replace("name: db", "name: foo");
+  const source = path.join(store, "foo", "SKILL.md");
+  fs.writeFileSync(source, foo);
+  // Apply never opens an existing target for writing: it creates a temp file in the
+  // directory and renames over it, so the file's own mode decides nothing.
+  fs.chmodSync(source, 0o444);
+
+  const repo = makeRepo({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": SKILL });
+  fs.symlinkSync(path.join(store, "foo"), path.join(repo.root, ".agents", "skills", "foo"));
+
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile: readMemoryFile(repo.root, "AGENTS.md"),
+    skillsDir: ".agents/skills",
+    allowExternal: true,
+  });
+
+  assert.deepEqual(workspace.unstageable, []);
+  assert.equal(workspace.originals.get(".agents/skills/foo/SKILL.md"), foo);
+});
+
+test("a skill linked into an unwritable directory inside the repository is withheld too", () => {
+  const repo = makeRepo({
+    "AGENTS.md": AGENTS,
+    ".agents/skills/keep/SKILL.md": SKILL.replace("name: db", "name: keep"),
+    "vendor/db/SKILL.md": SKILL,
+  });
+  const vendor = path.join(repo.root, "vendor");
+  fs.symlinkSync(path.join(vendor, "db"), path.join(repo.root, ".agents", "skills", "db"));
+  fs.chmodSync(path.join(vendor, "db"), 0o555);
+  fs.chmodSync(vendor, 0o555);
+
+  try {
+    // Project scope, where confinement passes: the link lands inside the repository, so
+    // only writability can keep it out - and the two scopes must agree about that.
+    const { workspace, measured } = stageAndMeasure({
+      repo,
+      edit: (root) => writeIn(root, ".agents/skills/db/SKILL.md", SKILL),
+    });
+
+    assert.deepEqual(
+      workspace.unstageable.map(({ path: file, reason }) => ({ path: file, reason })),
+      [{ path: ".agents/skills/db/SKILL.md", reason: "resolves to a location that cannot be written" }],
+    );
+    assert.equal(workspace.originals.has(".agents/skills/db/SKILL.md"), false);
+    // Re-creating it is the same unwritable path, not a new skill and not an out-of-repo one.
+    assert.deepEqual(measured.stray, [{ file: ".agents/skills/db/SKILL.md", reason: STRAY_UNWRITABLE }]);
+  } finally {
+    fs.chmodSync(vendor, 0o755);
+    fs.chmodSync(path.join(vendor, "db"), 0o755);
+  }
+});
+
+test("an ignored file beside an external memory file is named by the path the user knows", () => {
+  const repo = makeRepo({});
+  const external = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-memory-stray-")));
+  const memoryPath = path.join(external, "CLAUDE.md");
+  const skillsDir = path.join(external, "skills");
+  fs.writeFileSync(memoryPath, AGENTS);
+  fs.mkdirSync(skillsDir);
+
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile: readMemoryFile(repo.root, memoryPath, { allowExternal: true }),
+    skillsDir,
+    skillDirs: [skillsDir],
+    allowExternal: true,
+  });
+  // The memory file stages under `.external/<hash>/` too, so a scratch file written beside
+  // it matches no skill directory - and naming it by that hash tells the reader nothing.
+  writeIn(path.dirname(path.join(workspace.root, workspace.memoryWorkspacePath)), "CLAUDE.md.bak", "scratch");
+
+  assert.deepEqual(measureWorkspace(workspace).stray, [
+    { file: path.join(external, "CLAUDE.md.bak"), reason: STRAY_OUTSIDE_SURFACE },
+  ]);
+});
+
 test("a skill in a store this user cannot read is skipped and named, not thrown", () => {
   const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-locked-store-")));
   fs.mkdirSync(path.join(store, "locked"));
   const unreadable = path.join(store, "locked", "SKILL.md");
   fs.writeFileSync(unreadable, SKILL);
-  // Write-only: the writability probe accepts it, so only the read failure keeps it out.
-  fs.chmodSync(unreadable, 0o222);
+  // The writability probe looks at the directory, never at this file, so the read failure
+  // is the only thing that can keep it out.
+  fs.chmodSync(unreadable, 0o000);
 
   const repo = makeRepo({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": SKILL });
   const loaded = path.join(repo.root, ".agents", "skills");

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -263,8 +263,8 @@ test("a symlinked skill directory is never recursed, so no cycle can be walked",
   fs.writeFileSync(path.join(real, "SKILL.md"), SKILL);
   // The three shapes a directory link can take: a self link, a link back to an ancestor,
   // and a mutual pair. Staging takes at most one leaf per link and never descends, so
-  // none of them can be entered. (The ancestry guard in walkFiles is a second line of
-  // defence for that; only the top-level self link still reaches it.)
+  // none of them can be entered - which is the only thing standing between this layout
+  // and the RangeError it used to produce.
   fs.symlinkSync(real, path.join(real, "self"));
   fs.symlinkSync(loaded, path.join(real, "up"));
   const a = path.join(loaded, "a");
@@ -441,14 +441,14 @@ test("a skill linked into a store nothing may write is billed but never staged w
   }
 });
 
-test("a read-only skill file in a writable directory is staged, because apply can write it", () => {
+test("a read-only skill file in a writable directory is staged as an editable copy", () => {
   const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-readonly-file-")));
   fs.mkdirSync(path.join(store, "foo"));
   const foo = SKILL.replace("name: db", "name: foo");
   const source = path.join(store, "foo", "SKILL.md");
   fs.writeFileSync(source, foo);
   // Apply never opens an existing target for writing: it creates a temp file in the
-  // directory and renames over it, so the file's own mode decides nothing.
+  // directory and renames over it, so the file's own mode decides nothing there.
   fs.chmodSync(source, 0o444);
 
   const repo = makeRepo({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": SKILL });
@@ -464,6 +464,17 @@ test("a read-only skill file in a writable directory is staged, because apply ca
 
   assert.deepEqual(workspace.unstageable, []);
   assert.equal(workspace.originals.get(".agents/skills/foo/SKILL.md"), foo);
+
+  // Synthesis edits the staging copy in place, so a source mode that forbids writing must
+  // not travel with it - a skill staged unwritable can only ever measure as no change.
+  const staged = path.join(workspace.root, workspace.stagedPaths.get(".agents/skills/foo/SKILL.md"));
+  fs.writeFileSync(staged, foo.replace("Load before touching the database.", "Load before any database work."));
+  assert.deepEqual(
+    measureWorkspace(workspace).changes.map((change) => [change.kind, change.file]),
+    [["hunk", ".agents/skills/foo/SKILL.md"]],
+  );
+  assert.equal(fs.statSync(source).mode & 0o777, 0o444, "the source keeps its own mode");
+  assert.equal(fs.readFileSync(source, "utf8"), foo, "the source is never written through");
 });
 
 test("a skill linked into an unwritable directory inside the repository is withheld too", () => {

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -299,6 +299,40 @@ test("two links to one shared library are both billed, and exactly one of them i
   ]);
 });
 
+test("a skill file linked out of the repo through an in-repo library is never staged", () => {
+  const outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-outside-store-")));
+  fs.writeFileSync(path.join(outside, "SKILL.md"), SKILL);
+
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  // The library is inside the repository, so the directory link itself passes
+  // containment - but the file it holds is a link to something the repo does not own.
+  fs.mkdirSync(path.join(repo.root, "library", "db"), { recursive: true });
+  fs.symlinkSync(path.join(outside, "SKILL.md"), path.join(repo.root, "library", "db", "SKILL.md"));
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(path.join(repo.root, "library", "db"), path.join(loaded, "db"));
+
+  const state = new State(repo.root).ensure();
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills" });
+
+  assert.deepEqual([...workspace.originals.keys()], ["AGENTS.md"]);
+  assert.deepEqual(walkStaged(path.join(workspace.root, ".agents/skills")), []);
+  assert.deepEqual(workspace.unstageable, [
+    { path: ".agents/skills/db/SKILL.md", reason: "resolves outside the repository" },
+  ]);
+
+  // User scope owns files outside any repository, so there the same layout still stages.
+  const external = prepareWorkspace({
+    state,
+    repo,
+    memoryFile,
+    skillsDir: ".agents/skills",
+    allowExternal: true,
+  });
+  assert.equal(external.originals.get(".agents/skills/db/SKILL.md"), SKILL);
+});
+
 test("a link to a whole repository stages only the skill file, never the tree behind it", () => {
   const repo = makeRepo({ "AGENTS.md": AGENTS });
   // The layout the finding names: a plugin repository linked in as a skill.

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { readMemoryFile } from "../src/memory.js";
-import { loadSkills } from "../src/skills.js";
+import { loadSkills, skillDescriptionTokens } from "../src/skills.js";
 import { State } from "../src/state.js";
 import {
   isSkillFilePath,
@@ -19,6 +19,19 @@ import { makeRepo, stageAndMeasure, writeIn } from "./helpers/staging.js";
 
 const AGENTS = "# M\n\n- one\n- two\n";
 const SKILL = "---\nname: db\ndescription: Load before touching the database.\n---\n\n## Body\n";
+
+/** Every file actually present under a staging directory, relative to it. */
+function walkStaged(dir, prefix = "") {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) =>
+      entry.isDirectory()
+        ? walkStaged(path.join(dir, entry.name), path.posix.join(prefix, entry.name))
+        : [path.posix.join(prefix, entry.name)],
+    )
+    .sort();
+}
 
 function stage(files = {}) {
   const repo = makeRepo({ "AGENTS.md": AGENTS, ...files });
@@ -247,23 +260,72 @@ test("a cyclic skill symlink terminates instead of overflowing the traversal sta
   }
 });
 
-test("two links to one shared library are both staged: the guard is ancestry, not identity", () => {
+test("two links to one shared library are both billed, and exactly one of them is writable", () => {
   const repo = makeRepo({ "AGENTS.md": AGENTS });
   const library = path.join(repo.root, "library", "db");
   fs.mkdirSync(library, { recursive: true });
   fs.writeFileSync(path.join(library, "SKILL.md"), SKILL);
   const loaded = path.join(repo.root, ".agents", "skills");
   fs.mkdirSync(loaded, { recursive: true });
-  // The harness loads both names, so both cost description tokens and both must stage.
+  // The harness loads both names, so both cost description tokens.
   fs.symlinkSync(library, path.join(loaded, "db"));
   fs.symlinkSync(library, path.join(loaded, "database"));
+
+  const loadedSkills = loadSkills(repo.root, ".agents/skills");
+  assert.deepEqual(
+    loadedSkills.map((skill) => skill.path),
+    [".agents/skills/database/SKILL.md", ".agents/skills/db/SKILL.md"],
+    "both names are walked and loaded",
+  );
+  assert.equal(
+    skillDescriptionTokens(loadedSkills),
+    2 * loadedSkills[0].descriptionTokens,
+    "both descriptions are billed against the always-loaded budget",
+  );
 
   const state = new State(repo.root).ensure();
   const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
   const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills" });
 
-  assert.ok(workspace.originals.has(".agents/skills/db/SKILL.md"));
-  assert.ok(workspace.originals.has(".agents/skills/database/SKILL.md"));
+  // One file cannot be two independently editable copies: apply refuses a round whose
+  // accepted targets resolve to the same path, and that refusal drops every other edit.
+  assert.deepEqual([...workspace.originals.keys()], ["AGENTS.md", ".agents/skills/database/SKILL.md"]);
+  assert.equal(fs.existsSync(path.join(workspace.root, ".agents/skills/db/SKILL.md")), false);
+  assert.deepEqual(workspace.unstageable, [
+    {
+      path: ".agents/skills/db/SKILL.md",
+      reason: "the same file is already staged as .agents/skills/database/SKILL.md",
+    },
+  ]);
+});
+
+test("a link to a whole repository stages only the skill file, never the tree behind it", () => {
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  // The layout the finding names: a plugin repository linked in as a skill.
+  const plugin = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-plugin-repo-")));
+  fs.writeFileSync(path.join(plugin, "SKILL.md"), SKILL);
+  fs.writeFileSync(path.join(plugin, "README.md"), "# Plugin\n");
+  fs.mkdirSync(path.join(plugin, ".git", "objects"), { recursive: true });
+  fs.writeFileSync(path.join(plugin, ".git", "objects", "pack"), "binary");
+  fs.mkdirSync(path.join(plugin, "node_modules", "left-pad"), { recursive: true });
+  fs.writeFileSync(path.join(plugin, "node_modules", "left-pad", "index.js"), "module.exports = 1;\n");
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(plugin, path.join(loaded, "superpowers"));
+
+  const state = new State(repo.root).ensure();
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  // User scope: nothing confines the walk, so only the layout itself bounds what is taken.
+  const workspace = prepareWorkspace({
+    state,
+    repo,
+    memoryFile,
+    skillsDir: ".agents/skills",
+    allowExternal: true,
+  });
+
+  assert.deepEqual([...workspace.originals.keys()], ["AGENTS.md", ".agents/skills/superpowers/SKILL.md"]);
+  assert.deepEqual(walkStaged(path.join(workspace.root, ".agents/skills")), ["superpowers/SKILL.md"]);
 });
 
 test("project scope bills a skill symlinked out of the repo but never stages it", () => {

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -5,10 +5,12 @@ import os from "node:os";
 import path from "node:path";
 
 import { readMemoryFile } from "../src/memory.js";
-import { loadSkills, skillDescriptionTokens } from "../src/skills.js";
+import { loadProjectSkills, loadSkills, skillDescriptionTokens } from "../src/skills.js";
+import { estimateTokens } from "../src/tokens.js";
 import { State } from "../src/state.js";
 import {
   isSkillFilePath,
+  STRAY_OUTSIDE_SURFACE,
   measureWorkspace,
   parseSkillFile,
   prepareWorkspace,
@@ -90,6 +92,29 @@ test("an untouched workspace measures as no change, and ids are stable across re
   assert.equal(a.signature, b.signature);
   assert.equal(a.changes[1].skill.name, "new");
   assert.notEqual(first.signature, a.signature);
+});
+
+test("an ignored file in an external skills directory is named by the path the user knows", () => {
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  const skillsDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-external-stray-")));
+  fs.mkdirSync(path.join(skillsDir, "db"));
+  fs.writeFileSync(path.join(skillsDir, "db/SKILL.md"), SKILL);
+
+  const workspace = prepareWorkspace({
+    state: new State(repo.root).ensure(),
+    repo,
+    memoryFile: readMemoryFile(repo.root, "AGENTS.md"),
+    skillsDir,
+    skillDirs: [skillsDir],
+    allowExternal: true,
+  });
+  writeIn(path.join(workspace.root, workspacePathFor(skillsDir)), "notes.txt", "scratch");
+
+  // Staging hashes an absolute skills directory into `.external/<hash>/`, which tells the
+  // reader nothing about which file was ignored.
+  assert.deepEqual(measureWorkspace(workspace).stray, [
+    { file: path.join(skillsDir, "notes.txt"), reason: STRAY_OUTSIDE_SURFACE },
+  ]);
 });
 
 test("external user memory and skills use workspace-relative staging paths", () => {
@@ -262,6 +287,31 @@ test("a symlinked skill directory is never recursed, so no cycle can be walked",
   }
 });
 
+test("identity-based dedupe must never reach the always-loaded token count", () => {
+  // The bug this whole change exists to fix is an under-counted budget: half the real
+  // skill layer was invisible, so its description lines were never billed. A library
+  // reached through k links is k things the harness loads and k description lines it
+  // pays for every turn. Staging may pick one owner - that is a separate decision, pinned
+  // separately below - but no dedupe may ever reach this count.
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  const library = path.join(repo.root, "library", "db");
+  fs.mkdirSync(library, { recursive: true });
+  fs.writeFileSync(path.join(library, "SKILL.md"), SKILL);
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  for (const name of ["db", "database", "sql"]) fs.symlinkSync(library, path.join(loaded, name));
+
+  const one = estimateTokens("Load before touching the database.");
+  for (const skills of [loadSkills(repo.root, ".agents/skills"), loadProjectSkills(repo.root, ".agents/skills", [])]) {
+    assert.deepEqual(
+      skills.map((skill) => skill.path),
+      [".agents/skills/database/SKILL.md", ".agents/skills/db/SKILL.md", ".agents/skills/sql/SKILL.md"],
+      "every link is walked and loaded, and the order is by path rather than by readdir",
+    );
+    assert.equal(skillDescriptionTokens(skills), 3 * one, "three links cost three description lines");
+  }
+});
+
 test("two links to one shared library are both billed, and exactly one of them is writable", () => {
   const repo = makeRepo({ "AGENTS.md": AGENTS });
   const library = path.join(repo.root, "library", "db");
@@ -277,7 +327,7 @@ test("two links to one shared library are both billed, and exactly one of them i
   assert.deepEqual(
     loadedSkills.map((skill) => skill.path),
     [".agents/skills/database/SKILL.md", ".agents/skills/db/SKILL.md"],
-    "both names are walked and loaded",
+    "both names are walked and loaded, in path order on every filesystem",
   );
   assert.equal(
     skillDescriptionTokens(loadedSkills),

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -335,12 +335,65 @@ test("a skill file linked out of the repo through an in-repo library is never st
   assert.equal(external.originals.get(".agents/skills/db/SKILL.md"), SKILL);
 });
 
+test("a skill linked into a store nothing may write is billed but never staged writable", () => {
+  const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-readonly-store-")));
+  fs.mkdirSync(path.join(store, "foo"));
+  fs.writeFileSync(path.join(store, "foo", "SKILL.md"), SKILL.replace("name: db", "name: foo"));
+  fs.mkdirSync(path.join(store, "shared"));
+  fs.writeFileSync(path.join(store, "shared", "SKILL.md"), SKILL.replace("name: db", "name: shared"));
+
+  const repo = makeRepo({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": SKILL });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.symlinkSync(path.join(store, "foo"), path.join(loaded, "foo"));
+  // Two names for one unwritable library: neither may be staged, and the second must not
+  // be reported as an alias of a file that was never staged.
+  fs.symlinkSync(path.join(store, "shared"), path.join(loaded, "shared"));
+  fs.symlinkSync(path.join(store, "shared"), path.join(loaded, "shared-alias"));
+  fs.chmodSync(path.join(store, "foo"), 0o555);
+  fs.chmodSync(path.join(store, "shared"), 0o555);
+  fs.chmodSync(store, 0o555);
+
+  try {
+    // The harness loads them, so they cost description tokens whatever backpass may write.
+    assert.deepEqual(
+      loadSkills(repo.root, ".agents/skills")
+        .map((skill) => skill.name)
+        .sort(),
+      ["db", "foo", "shared", "shared"],
+    );
+
+    const state = new State(repo.root).ensure();
+    const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+    // User scope: nothing confines the walk, so only writability keeps these out.
+    const workspace = prepareWorkspace({
+      state,
+      repo,
+      memoryFile,
+      skillsDir: ".agents/skills",
+      allowExternal: true,
+    });
+
+    assert.deepEqual([...workspace.originals.keys()], ["AGENTS.md", ".agents/skills/db/SKILL.md"]);
+    assert.deepEqual(walkStaged(path.join(workspace.root, ".agents/skills")), ["db/SKILL.md"]);
+    assert.deepEqual(workspace.unstageable, [
+      { path: ".agents/skills/foo/SKILL.md", reason: "resolves to a location that cannot be written" },
+      { path: ".agents/skills/shared/SKILL.md", reason: "resolves to a location that cannot be written" },
+      { path: ".agents/skills/shared-alias/SKILL.md", reason: "resolves to a location that cannot be written" },
+    ]);
+  } finally {
+    fs.chmodSync(store, 0o755);
+    fs.chmodSync(path.join(store, "foo"), 0o755);
+    fs.chmodSync(path.join(store, "shared"), 0o755);
+  }
+});
+
 test("a skill in a store this user cannot read is skipped and named, not thrown", () => {
   const store = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "backpass-locked-store-")));
   fs.mkdirSync(path.join(store, "locked"));
   const unreadable = path.join(store, "locked", "SKILL.md");
   fs.writeFileSync(unreadable, SKILL);
-  fs.chmodSync(unreadable, 0o000);
+  // Write-only: the writability probe accepts it, so only the read failure keeps it out.
+  fs.chmodSync(unreadable, 0o222);
 
   const repo = makeRepo({ "AGENTS.md": AGENTS, ".agents/skills/db/SKILL.md": SKILL });
   const loaded = path.join(repo.root, ".agents", "skills");

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -212,3 +212,53 @@ test("a symlinked skill is staged and measured, so a run can edit what the harne
   assert.equal(hunks[0].kind, "hunk");
   assert.equal(fs.readFileSync(path.join(library, "SKILL.md"), "utf8"), SKILL, "the library is untouched");
 });
+
+test("a cyclic skill symlink terminates instead of overflowing the traversal stack", () => {
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  const loaded = path.join(repo.root, ".agents", "skills");
+  const real = path.join(loaded, "db");
+  fs.mkdirSync(real, { recursive: true });
+  fs.writeFileSync(path.join(real, "SKILL.md"), SKILL);
+  // The three shapes a followed directory link can take: a self link, a link back to an
+  // ancestor, and a mutual pair. Each one revisits a directory the walk has already seen.
+  fs.symlinkSync(real, path.join(real, "self"));
+  fs.symlinkSync(loaded, path.join(real, "up"));
+  const a = path.join(loaded, "a");
+  const b = path.join(loaded, "b");
+  fs.mkdirSync(a);
+  fs.mkdirSync(b);
+  fs.symlinkSync(b, path.join(a, "to-b"));
+  fs.symlinkSync(a, path.join(b, "to-a"));
+
+  const state = new State(repo.root).ensure();
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills" });
+
+  const staged = ".agents/skills/db/SKILL.md";
+  assert.ok(workspace.originals.has(staged), "the real skill behind the cycle is still staged");
+  assert.equal(workspace.originals.get(staged), SKILL);
+  // The cycle is pruned, not walked: no staged path may repeat a directory segment.
+  for (const p of workspace.originals.keys()) {
+    const segments = p.split("/").slice(0, -1);
+    assert.equal(new Set(segments).size, segments.length, `${p} revisits a directory`);
+  }
+});
+
+test("two links to one shared library are both staged: the guard is ancestry, not identity", () => {
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  const library = path.join(repo.root, "library", "db");
+  fs.mkdirSync(library, { recursive: true });
+  fs.writeFileSync(path.join(library, "SKILL.md"), SKILL);
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  // The harness loads both names, so both cost description tokens and both must stage.
+  fs.symlinkSync(library, path.join(loaded, "db"));
+  fs.symlinkSync(library, path.join(loaded, "database"));
+
+  const state = new State(repo.root).ensure();
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills" });
+
+  assert.ok(workspace.originals.has(".agents/skills/db/SKILL.md"));
+  assert.ok(workspace.originals.has(".agents/skills/database/SKILL.md"));
+});

--- a/test/workspace.test.js
+++ b/test/workspace.test.js
@@ -182,3 +182,33 @@ test("the repo fingerprint notices a changed or removed guarded file", () => {
   assert.notEqual(after["AGENTS.md"], before["AGENTS.md"]);
   assert.equal(after[".agents/skills/db/SKILL.md"], before[".agents/skills/db/SKILL.md"]);
 });
+
+test("a symlinked skill is staged and measured, so a run can edit what the harness actually loads", () => {
+  const repo = makeRepo({ "AGENTS.md": AGENTS });
+  // The library-plus-symlinks layout: content lives outside the loaded directory.
+  const library = path.join(repo.root, "library", "db");
+  fs.mkdirSync(library, { recursive: true });
+  fs.writeFileSync(path.join(library, "SKILL.md"), SKILL);
+  const loaded = path.join(repo.root, ".agents", "skills");
+  fs.mkdirSync(loaded, { recursive: true });
+  fs.symlinkSync(library, path.join(loaded, "db"));
+
+  const state = new State(repo.root).ensure();
+  const memoryFile = readMemoryFile(repo.root, "AGENTS.md");
+  const workspace = prepareWorkspace({ state, repo, memoryFile, skillsDir: ".agents/skills" });
+
+  const staged = ".agents/skills/db/SKILL.md";
+  assert.ok(workspace.originals.has(staged), "the symlinked skill is part of the staging copy");
+  assert.equal(workspace.originals.get(staged), SKILL);
+
+  const copy = path.join(workspace.root, workspace.stagedPaths.get(staged));
+  assert.ok(fs.existsSync(copy), "it is copied, not linked, so edits never reach the library");
+  assert.ok(!fs.lstatSync(copy).isSymbolicLink());
+
+  fs.writeFileSync(copy, SKILL.replace("Load before touching", "Load before migrating"));
+  const measured = measureWorkspace(workspace);
+  const hunks = measured.changes.filter((c) => c.file === staged);
+  assert.equal(hunks.length, 1, "an edit to the symlinked skill is measured as a change to it");
+  assert.equal(hunks[0].kind, "hunk");
+  assert.equal(fs.readFileSync(path.join(library, "SKILL.md"), "utf8"), SKILL, "the library is untouched");
+});


### PR DESCRIPTION
## Intent

Make backpass see and stage skills that are symlinked into the harness-loaded skills directory, then fix the symlink-cycle hazard that change introduced.

Background: backpass bills an always-loaded token budget made of the memory file plus every skill's description line. On a real machine 13 of 26 entries in the user's loaded skills directory were symlinks into a shared library. readdir reports a symlink as a symlink, never as its target, so entry.isDirectory() was false for those and both the loader (loadSkills in src/skills.js) and the staging walk (walkFiles in src/workspace.js) skipped them. Half the real skill layer was therefore unbilled against the budget and could not be staged for editing. The user's goal was that backpass measure and edit what the harness actually loads.

Decisions made along the way, which a reviewer reading only the diff would not know:

1. Both sites now stat the entry to follow the link. A broken, cyclic or otherwise unresolvable link is treated as absent rather than throwing, deliberately matching the fail-soft posture the surrounding discovery/skill code already has - an unreadable store warns and is skipped, never aborts a run.

2. Staging still COPIES what it finds rather than linking. This is deliberate and must not be 'simplified': an edit has to land in the staging copy and never write through a symlink back into the shared library. src/apply/writer.js is by design the only module that writes to the repo, and every other stage is read-only analysis.

3. The second commit fixes a P1 that Greptile reported on the existing PR: following directory links let walkFiles recurse into cycles (a self link, a link back to an ancestor, or a mutual pair) until workspace preparation died with RangeError: Maximum call stack size exceeded. This was reproduced by a test that took 56 seconds to blow the stack before the fix and runs in 26ms after it.

4. The cycle guard is ancestry-based, NOT a global visited set, and this tradeoff is the important one. A directory is pruned only when its resolved path already appears in its own chain of parents. Two separate symlinks pointing at one shared library are two directories the harness genuinely loads, so both must still be walked and billed; a global visited set would have silently under-counted them. That preserved behaviour is pinned by its own test so a later refactor cannot quietly switch to identity-based dedupe.

Constraints and context: the upstream maintainer already diff-reviewed the first commit, classified it contract-class 'restore', confirmed fork CI and Guard green, and explicitly said Greptile's cycle-walk note was not a gate - we fixed it anyway because it reproduced as a real crash. pnpm run check is green on this branch in isolation: 563 tests, lint, format:check, typecheck.

Delivery requirement: an open pull request already exists at kunchenguid/backpass#113, head sorcerai:fix/symlinked-skills, base kunchenguid:main. It was opened manually by mistake, against this repo's CONTRIBUTING.md which says not to open PRs by hand, so it lacks the head-SHA-bound pipeline attestation and require-no-mistakes is red. The attestation needs to land in that existing PR. Do not open a duplicate pull request against the fork's own main branch.

## What Changed

- `loadSkills` (`src/skills.js`) and the staging walk (`walkFiles` in `src/workspace.js`) now stat directory entries to follow symlinks, so a skill linked into the loaded directory is read, billed against the always-loaded budget, and staged for editing instead of being skipped; a broken or unresolvable link reads as absent rather than throwing. A symlinked skill directory is never descended into — only its top-level `SKILL.md` is taken — which is also what makes a self-link, ancestor link, or mutual pair impossible to recurse into.
- Staging withholds any loaded skill it could never write and names the reason in the skill index and synthesis prompt: resolving outside the repository in project scope, resolving into an unwritable store, unreadable at copy time, or being the same file as an already-staged link. Copies are chmod'd writable so a store-managed library is still editable in the staging copy; the repo fingerprint follows staging, `measureWorkspace` reports each dropped stray with its own reason instead of one generic note, and `--target` (`src/target.js`) refuses an unwritable skill up front via `skillStagingRefusal`.
- Description-line token deltas are multiplied by `loadedCopies` in both `buildProposal` and the writer's projection, since one library reached through k links is loaded and billed k times; the writer's read-only refusal now resolves the whole path (`readOnlyResolvedPath` in `src/memory.js`) so a link that is a directory on the way to the file is refused by name rather than surfacing a raw EROFS.

## Risk Assessment

⚠️ Medium: The change is large and heavily iterated (14 pipeline fix commits over 2 author commits) and carries one confirmed defect that drops an entire measured round plus one silent-link-replacement regression, but each round was author-authorized, the new tests drive real interfaces rather than asserting on source text, and neither defect corrupts file contents.

## Testing

<code>Ran the six test files this change touches (165 tests, all green) and then demonstrated the intent at the CLI itself: on a demo repo whose loaded skills directory is half symlinks, the base-commit tree reports `overflow: 1 skill(s) · 25 tok always loaded` while HEAD reports 4 skills and 115 tokens, with the always-loaded budget rising 170 -&gt; 260 on identical input; adding two more links to one shared library raises the count to 6, confirming k links stay billed k times. `--target` on a symlinked skill goes from &#34;not a configured memory file or a loaded skill&#34; at base to either a resolved write surface (in-repo library) or a specific &#34;loads and bills that skill but cannot write it there&#34; refusal (out-of-repo library). I also confirmed staging copies rather than links - editing the staged SKILL.md leaves the shared-library file byte-identical while the change is still measured against the symlinked path - and reproduced the cycle hazard end to end: the same layout crashes with RangeError after 24s at 955f17a and prepares in 13ms staging exactly the three real skills at HEAD. No visual artifact applies: backpass is a terminal CLI with no rendered UI surface, so the command transcripts are the end-user view. Temp fixtures were removed and the worktree is clean.</code>

<details>
<summary>Evidence: backpass status: 1 skill billed before, 4 after (same symlinked-skills repo)</summary>

<code>== BEFORE (base 713c362) ==&#10;$ backpass status&#10;BUDGET (always-loaded)&#10;AGENTS.md + skill descriptions [#...............................] 170 / 5,000 tok · 5 instructions&#10;overflow: 1 skill(s) in .agents/skills · 79 tok on trigger, 25 tok always loaded&#10;&#10;== AFTER (5c580b3) ==&#10;$ backpass status&#10;BUDGET (always-loaded)&#10;AGENTS.md + skill descriptions [##..............................] 260 / 5,000 tok · 5 instructions&#10;overflow: 4 skill(s) in .agents/skills · 327 tok on trigger, 115 tok always loaded</code>

```text
# backpass status - a loaded skills directory that is half symlinks

Fixture: /tmp/bp-demo/repo/.agents/skills holds one real skill directory (release)
and three symlinks into a shared library outside the repo (db, deploy, review) -
the library-plus-symlinks layout the change exists to follow.

$ ls -l .agents/skills
total 0
lrwxr-xr-x@ 1 ariapramesi  wheel  36 Sep  7 00:08 db -> /tmp/bp-demo/shared-skill-library/db
lrwxr-xr-x@ 1 ariapramesi  wheel  40 Sep  7 00:08 deploy -> /tmp/bp-demo/shared-skill-library/deploy
drwxr-xr-x@ 3 ariapramesi  wheel  96 Sep  7 00:08 release
lrwxr-xr-x@ 1 ariapramesi  wheel  40 Sep  7 00:08 review -> /tmp/bp-demo/shared-skill-library/review

== BEFORE (base 713c362): readdir reports a symlink as a symlink, so three of the four skills are invisible ==
$ backpass status
repo /private/tmp/bp-demo/repo

BUDGET (always-loaded)
  AGENTS.md + skill descriptions [#...............................] 170 / 5,000 tok · 5 instructions
  overflow: 1 skill(s) in .agents/skills · 79 tok on trigger, 25 tok always loaded


== AFTER (5c580b3): all four loaded skills are seen and billed against the always-loaded budget ==
$ backpass status
repo /private/tmp/bp-demo/repo

BUDGET (always-loaded)
  AGENTS.md + skill descriptions [##..............................] 260 / 5,000 tok · 5 instructions
  overflow: 4 skill(s) in .agents/skills · 327 tok on trigger, 115 tok always loaded


== Appendix: k links to ONE library are k things the harness loads, and are billed k times ==
   (added .agents/skills/database and .agents/skills/sql, both pointing at the same db library)
$ backpass status
BUDGET (always-loaded)
  AGENTS.md + skill descriptions [##..............................] 322 / 5,000 tok · 5 instructions
  overflow: 6 skill(s) in .agents/skills · 493 tok on trigger, 177 tok always loaded
```
</details>
<details>
<summary>Evidence: backpass propose --target &lt;symlinked skill&gt;: unseen before, resolved or named-refusal after</summary>

<code># in-repo library link&#10;$ backpass propose --target lint --dry-run # base 713c362&#10;error --target &#34;lint&#34; is not a configured memory file or a loaded skill in this repo&#10;memory files: AGENTS.md, CLAUDE.md · skills: (none)&#10;&#10;$ backpass propose --target lint --dry-run # 5c580b3&#10;targeting skill lint (.agents/skills/lint/SKILL.md); the memory file and other skills are read-only this run&#10;&#10;# out-of-repo library link&#10;$ backpass propose --target db --dry-run # 5c580b3&#10;error --target db is at .agents/skills/db/SKILL.md, which resolves outside the repository&#10;backpass loads and bills that skill but cannot write it there; edit it where it really lives, or point the link at a copy backpass can write</code>

```text
# --target on a symlinked skill: backpass now sees it, and says exactly what it may write

## Case A - .agents/skills/lint -> shared/lint, both inside the repo (writable)
$ backpass propose --target lint --dry-run   # base 713c362
error --target "lint" is not a configured memory file or a loaded skill in this repo
  memory files: AGENTS.md, CLAUDE.md · skills: (none)

$ backpass propose --target lint --dry-run   # 5c580b3
targeting skill lint (.agents/skills/lint/SKILL.md); the memory file and other skills are read-only this run
error no loss calculated yet: nothing to run gradient descent on
  run `backpass analyze` first, or `backpass` for the full pass
  (the trailing error is only 'no analysis yet' - this fixture has no transcripts)

## Case B - .agents/skills/db -> a library outside the repo (project scope cannot write it)
$ backpass propose --target db --dry-run   # base 713c362
error --target "db" is not a configured memory file or a loaded skill in this repo
  memory files: AGENTS.md, CLAUDE.md · skills: release

$ backpass propose --target db --dry-run   # 5c580b3
error --target db is at .agents/skills/db/SKILL.md, which resolves outside the repository
  backpass loads and bills that skill but cannot write it there; edit it where it really lives, or point the link at a copy backpass can write
```
</details>
<details>
<summary>Evidence: Staging copies the followed link; an edit never reaches the shared library</summary>

<code>the symlinked skill is in the staging copy as .agents/skills/lint/SKILL.md&#10;it is a regular file, not a link back into the repo: regular file&#10;after the synthesis agent edits the staging copy, the shared library file is UNCHANGED&#10;measured change H1: hunk in .agents/skills/lint/SKILL.md</code>

```text
# Staging copies the followed link; an edit never writes through into the shared library

prepareWorkspace/measureWorkspace on the repo whose .agents/skills/lint is a symlink to shared/lint:

the symlinked skill is in the staging copy as    .agents/skills/lint/SKILL.md
it is a regular file, not a link back into the repo: regular file
after the synthesis agent edits the staging copy, the shared library file is UNCHANGED
measured change H1: hunk in .agents/skills/lint/SKILL.md
  - description: Use when a lint or format check fails in CI: which rule owns which directory and how to fix rather than suppress.
  + description: Use when a lint or format check fails in CI: which rule owns which directory and how to fix rather than suppress, and the one rule that is allowed to be disabled inline.
```
</details>
<details>
<summary>Evidence: Symlink cycle: RangeError after 24s before the fix, 13ms after</summary>

<code>== BEFORE the cycle fix (955f17a) ==&#10;[955f17a] layout: .agents/skills with a self link, a link back to the skills dir, and a mutual a&lt;-&gt;b pair&#10;[955f17a] CRASHED after 24020 ms: RangeError: Maximum call stack size exceeded&#10;&#10;== AFTER (5c580b3) ==&#10;[5c580b3] workspace prepared in 13 ms&#10;[5c580b3] staged skill files: .agents/skills/a/SKILL.md, .agents/skills/alpha/SKILL.md, .agents/skills/b/SKILL.md</code>

```text
# The symlink-cycle hazard that following links introduced

Layout (all inside one loaded skills directory): a self link (alpha/self -> alpha),
a link back to an ancestor (alpha/up -> .agents/skills), and a mutual pair (a/to-b -> b, b/to-a -> a).

== BEFORE the cycle fix (955f17a, the first commit of this branch) ==
[955f17a  before the cycle fix] layout: .agents/skills with a self link, a link back to the skills dir, and a mutual a<->b pair
[955f17a  before the cycle fix] CRASHED after 24020 ms: RangeError: Maximum call stack size exceeded

== AFTER (5c580b3) ==
[5c580b3  after the fix] layout: .agents/skills with a self link, a link back to the skills dir, and a mutual a<->b pair
[5c580b3  after the fix] workspace prepared in 13 ms
[5c580b3  after the fix] staged skill files: .agents/skills/a/SKILL.md, .agents/skills/alpha/SKILL.md, .agents/skills/b/SKILL.md

Only the three real skills are staged; a symlinked directory is never descended into,
so the walk terminates. Both runs used the same script and the same layout.

Reproduce: materialize each tree with `git archive <sha> | tar -x -C <dir>` (backpass has zero
runtime dependencies, so an extracted tree runs without node_modules) and pass the directory to
repro-symlink-cycle.js. Run the before-case with the default stack size: raising it with
--stack-size=2000 trades the RangeError for ~127s spent staging thousands of duplicate
to-b/to-a/to-b/... copies into the staging tree - a garbage workspace rather than a clean crash.
```
</details>
<details>
<summary>Evidence: Reproduction scripts for the four manual checks (fixtures, cycle, staging)</summary>

```text
// Reproduces the symlink-cycle hazard against any backpass tree.
//
//   mkdir -p /tmp/bp-955  && git archive 955f17a | tar -x -C /tmp/bp-955   # before the fix
//   mkdir -p /tmp/bp-head && git archive 5c580b3 | tar -x -C /tmp/bp-head  # after the fix
//   node repro-symlink-cycle.js /tmp/bp-955  "before"
//   node repro-symlink-cycle.js /tmp/bp-head "after"
//
// backpass has zero runtime dependencies, so an extracted tree runs without node_modules.
// Run the "before" case with the DEFAULT stack size: raising it (--stack-size) trades the
// RangeError for ~127s of staging thousands of to-b/to-a/... duplicate copies instead.

import fs from "node:fs";
import path from "node:path";

const tree = process.argv[2];
const label = process.argv[3];
const { prepareWorkspace } = await import(path.join(tree, "src/workspace.js"));

const repoRoot = fs.mkdtempSync("/tmp/bp-cycle-");
const skills = path.join(repoRoot, ".agents", "skills");
const alpha = path.join(skills, "alpha");
fs.mkdirSync(alpha, { recursive: true });
fs.writeFileSync(path.join(alpha, "SKILL.md"), "---\nname: alpha\ndescription: A real skill behind the cycle.\n---\n\nbody\n");
// The three shapes a directory link can take inside a loaded skills directory.
fs.symlinkSync(alpha, path.join(alpha, "self"));
fs.symlinkSync(skills, path.join(alpha, "up"));
const a = path.join(skills, "a");
const b = path.join(skills, "b");
fs.mkdirSync(a); fs.mkdirSync(b);
fs.writeFileSync(path.join(a, "SKILL.md"), "---\nname: a\ndescription: one half of a mutual pair.\n---\n\nbody\n");
fs.writeFileSync(path.join(b, "SKILL.md"), "---\nname: b\ndescription: the other half of a mutual pair.\n---\n\nbody\n");
fs.symlinkSync(b, path.join(a, "to-b"));
fs.symlinkSync(a, path.join(b, "to-a"));

const state = { root: path.join(repoRoot, ".backpass") };
fs.mkdirSync(state.root, { recursive: true });

console.log(`[${label}] layout: .agents/skills with a self link, a link back to the skills dir, and a mutual a<->b pair`);
const started = Date.now();
try {
  const ws = prepareWorkspace({
    state,
    repo: { root: repoRoot },
    memoryFile: { path: "AGENTS.md", text: "# memory\n\nan instruction.\n" },
    skillsDir: ".agents/skills",
  });
  console.log(`[${label}] workspace prepared in ${Date.now() - started} ms`);
  console.log(`[${label}] staged skill files: ${[...ws.stagedPaths.keys()].filter((p) => p !== "AGENTS.md").sort().join(", ")}`);
} catch (err) {
  console.log(`[${label}] CRASHED after ${Date.now() - started} ms: ${err.constructor.name}: ${err.message}`);
  process.exitCode = 1;
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"19c80655dbea7fabf76e0c2bc1a8eeda61fc7fe4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

_... (15 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 5 issues (3 warnings, 2 infos)</summary>

🔧 Fix: withhold skills that resolve into unwritable stores
1 warning still open:

- ⚠️ `src/workspace.js:453` - The round-8 withholding closes staging but not measurement, so the failure it was authorized to fix is still reachable by one step. `prepareWorkspace` now pushes an unwritable skill onto `unstageable` and does NOT record its identity in `stagedIdentities` (src/workspace.js:96 `continue`s before src/workspace.js:115). `measureWorkspace` guards a re-created skill file only two ways: the `confineTo` check (project scope only, and `confineTo` is null exactly when `allowExternal` is set, i.e. the only scope where the unwritable reason fires) and the alias check at src/workspace.js:453, which reads `stagedIdentities` and therefore misses the withheld file. So the withheld path falls through to `changes.push({ kind: &#34;created&#34;, ... })` at src/workspace.js:459. Concrete sequence, user scope: `~/.claude/skills/db -&gt; /nix/store/.../db` (0o555). `loadSkills` reads it, so it IS in `skillFiles` and its row is rendered in the skill index with `read-only, resolves to a location that cannot be written`. The fold&#39;s `failedTriggerSkill` machinery actively directs synthesis at that skill (&#34;synthesis fixes the description with real cross-session evidence&#34;), and the extraction prompt directs moving memory-file text into the skill that covers it. The model, unable to edit a file that is not in its staging copy, writes `.agents/skills/db/SKILL.md` (or `.claude/skills/db/SKILL.md`) into staging carrying the memory lines it removes, and claims it as `kind: &#34;extract&#34;`. That passes every extract gate in `buildProposal` (frontmatter present, memory removal present, removed lines carried), and the `clash` gate at src/proposal.js:414 that would catch a created file colliding with an existing skill path is inside `if (target.kind !== &#34;surface&#34;)`, so a default surface run has no such gate. At apply, src/apply/writer.js:427 `fs.existsSync(absolute)` is true (the symlink resolves), pushes `already exists; nothing was written`, and src/apply/writer.js:438 `return results` discards the memory-file edit and every other accepted edit in the round - the exact dropped-round outcome the previous finding was authorized to prevent. Remedy at the same boundary that already guards the alias case: record the withheld file&#39;s resolved identity (and/or its logical path) alongside `stagedIdentities`, and have `measureWorkspace` push it to `stray` with its `unstageable` reason instead of emitting a `created` change, so staging and measurement cannot disagree about what is reachable. The UNREADABLE reason needs no such guard - `loadSkills` drops an unreadable file (src/skills.js:74-78), so it never enters `skillFiles`, never appears in the index, and the model has no path string to re-create.

🔧 Fix: ignore re-created writes at withheld unwritable skill paths
3 issues (2 warnings, 1 info) still open:

- ⚠️ `src/target.js:47` - `resolveTarget`&#39;s alias pick is nondeterministic and does not necessarily agree with the staging owner its own comment cites. The comment at src/target.js:44-46 says &#34;staging already resolves that layout by giving the first name the write&#34;, but the two sites define &#34;first&#34; differently. `walkFiles` (src/workspace.js:184) sorts entries explicitly with `entries.sort((a, b) =&gt; a.name.localeCompare(b.name))`, so `prepareWorkspace` always makes the alphabetically-first link the staged owner. `loadSkills` (src/skills.js:94) ends with `skills.sort((a, b) =&gt; a.name.localeCompare(b.name))` keyed on the frontmatter `name` - two aliases of one library share that name, the comparator returns 0, and V8&#39;s stable sort therefore preserves `fs.readdirSync` insertion order, which is filesystem-dependent (creation order on Linux tmpfs, hash order on ext4 with dir_index and on APFS). So `skillMatches[0]` is whichever link readdir happened to return first. Concrete trace: `.agents/skills/db -&gt; library/db` and `.agents/skills/database -&gt; library/db`. On a creation-order filesystem `--target db` returns `.agents/skills/db/SKILL.md`; on a hash-order filesystem it returns `.agents/skills/database/SKILL.md`. Same repo, same command, different proposal path, different `info(...)` line at src/target.js:96. The run does not break - `prepareWorkspace` applies the `stagedSkills` filter (src/workspace.js:81) before registering identities, so the target&#39;s own path always wins the write whichever one was picked - so this is a determinism defect, not a correctness break. The two new tests encode the arbitrary order as the expected answer and are order-dependent in the same way: test/target.test.js:87 creates `db` then `database` and asserts the result is `.agents/skills/database/SKILL.md`, and test/workspace.test.js:265 asserts `loadSkills(...).map(s =&gt; s.path)` deepEquals `[&#34;.agents/skills/database/SKILL.md&#34;, &#34;.agents/skills/db/SKILL.md&#34;]` - both would fail on a filesystem that returns creation order. Remedy is one line at the earliest shared point: break the tie on `skill.path` (either sort `skillMatches` by path before taking `[0]`, or make `loadSkills`&#39;s comparator fall back to path), which makes `resolveTarget` and `walkFiles` agree by construction and makes both tests order-independent. No new state, no scope change.
- ⚠️ `test/workspace.test.js:265` - A pipeline fix round deleted the regression pin the author installed specifically to prevent the refactor that was then made, and replaced it with an assertion of the opposite outcome. The intent states: &#34;Two separate symlinks pointing at one shared library are two directories the harness genuinely loads, so both must still be walked and billed; a global visited set would have silently under-counted them. That preserved behaviour is pinned by its own test so a later refactor cannot quietly switch to identity-based dedupe.&#34; The author&#39;s commit 6685d81 added `test(&#34;two links to one shared library are both staged: the guard is ancestry, not identity&#34;)`, asserting `workspace.originals.has(&#34;.agents/skills/db/SKILL.md&#34;)` AND `workspace.originals.has(&#34;.agents/skills/database/SKILL.md&#34;)`. That test no longer exists. In its place, test/workspace.test.js:265 is `test(&#34;two links to one shared library are both billed, and exactly one of them is writable&#34;)`, which asserts `[...workspace.originals.keys()]` deepEquals `[&#34;AGENTS.md&#34;, &#34;.agents/skills/database/SKILL.md&#34;]` and that `.agents/skills/db/SKILL.md` is absent from the staging copy - i.e. exactly the identity-based dedupe (`stagedIdentities`, src/workspace.js:72/85-89) the pin was written to catch. To be fair to the delivered code: the intent&#39;s stated requirement is that both links be &#34;walked and billed&#34;, and both still are - `walkFiles` returns both relative paths and the dedupe happens afterwards in `prepareWorkspace`; `loadSkills` bills both descriptions; and `loadedCopies` (src/skills.js:155) multiplies a description-line delta by k on both the proposal (src/proposal.js:692) and apply (src/apply/writer.js:446) sides, verified equal to a fresh post-apply measurement by the new k-linked test. So I am not claiming a required behavior was lost. What needs the author&#39;s decision is that a guard they explicitly installed against this exact refactor was removed by the pipeline rather than by them. The smallest honest remedy is not to revert the dedupe (apply refuses a round whose accepted targets resolve to one file, so staging one owner is defensible) but to restore an explicit pin for whatever the author now wants pinned - most likely that both links are walked and billed k times, asserted on `loadSkills`/`skillDescriptionTokens` rather than on staging.
- ℹ️ `src/workspace.js:431` - `measureWorkspace` now reports two of its four stray reasons with the logical repository path and two with the staging path. The three new branches push `{ file: logical, ... }` (src/workspace.js:448, 458, 468) while the two `STRAY_OUTSIDE_SURFACE` branches keep the pre-existing `{ file: staged, ... }` (src/workspace.js:431, 439). These coincide only when the skills directory is repo-relative. In user scope the skill dirs are absolute, so `workspacePathFor` maps them to `.external/&lt;sha256-prefix&gt;/...`, and the note rendered at src/proposal.js:750 reads `ignored .external/9f3c.../notes.md: synthesis wrote it outside the memory file and skills` - a hash the reader cannot map back to a real path, where the new reasons would have said `~/.claude/skills/foo/notes.md`. The old behavior is unchanged by this diff (it was `stray.push(staged)` before), so this is pre-existing rather than introduced; noting it only because the change made the two halves diverge and the one-line fix (compute `logical` before the `isSkillFilePath` check and use it for all four) is now trivial.

🔧 Fix: sort skills by path; name ignored files recognisably
4 issues (2 warnings, 2 infos) still open:

- ⚠️ `src/workspace.js:431` - The round-10 fix implemented only half of the author&#39;s instruction that &#34;all four stray reasons report the same kind of path&#34;. Line 441 now reports the logical path, but line 431 - the branch for a file matching no skill mapping - still pushes `staged`. Concrete reachable case, user scope: the memory file is absolute, so it stages at `.external/&lt;sha256-prefix&gt;/CLAUDE.md`, and the synthesis agent is told to edit `./.external/&lt;hash&gt;/CLAUDE.md`. A model that writes a sibling scratch or `.bak` file there produces a path matching no `skillMappings` entry, so `buildProposal` (src/proposal.js:750) emits `ignored .external/9f3c.../CLAUDE.md.bak: synthesis wrote it outside the memory file and skills` - the exact unrecognisable message the author rejected. Project scope is unaffected: a relative memory file stages at the repo-relative path, and a stray at the workspace root is already named recognisably, so no change is needed for that case. Remedy: make the memory file&#39;s own staged directory resolvable back to its logical directory before the mapping lookup (its logical/staged pair is already available via `memoryPath` and `stagedPaths`), keeping each reason&#39;s own named cause.
- ⚠️ `src/memory.js:344` - `readOnlyResolvedPath` declares a path unwritable when `fs.accessSync(real, W_OK)` fails, but no backpass write path opens an existing target for writing: `atomicReplace` (src/apply/writer.js:170) does `statSync` (read), `openSync(temp, &#34;wx&#34;)` in the parent directory, then `renameSync` - all of which need only the parent directory&#39;s W_OK|X_OK - and `writeSkill` is only ever called with `exclusive: true` (src/apply/writer.js:481), which is `openSync(target, &#34;wx&#34;)`, also directory-only. At base this predicate was inert: it only decorated the message of a write that had already failed. The fix rounds gave it two proactive consumers, so it now decides work that never gets attempted. Concrete case: a skills directory containing `foo -&gt; /shared/skills/foo` where `/shared/skills/foo/SKILL.md` is mode 444 in a writable directory. `prepareWorkspace` (src/workspace.js:95) withholds it as `resolves to a location that cannot be written`, the skill index tells the model it is read-only, and `--target foo` hard-errors with `resolves to /shared/skills/foo/SKILL.md and cannot be written` (src/target.js:88-93) - all for a file `atomicReplace` would in fact rewrite successfully. The label is wrong and reachable work is refused. The remedy, not the defect, needs authorization: either (a) drop the file-level W_OK check so the predicate matches what the write path actually needs, or (b) keep it and reword the reason to &#34;is marked read-only&#34; if a 444 file is intended as a hands-off signal. Choosing between them is a product call about what backpass should treat as off-limits.
- ℹ️ `src/workspace.js:95` - The unwritable probe runs only when `allowExternal` is true, but `confineTo` - the only gate covering project scope - checks location, not writability. Traced: `.agents/skills/db -&gt; ../../vendor/db` with `vendor/` at mode 555 and the repo in project scope. `walkFiles` resolves the link to `&lt;repo&gt;/vendor/db`, `withinRoot` passes (it is inside the repo), the leaf `SKILL.md` is readable so `copyFileSync` succeeds, and the skill is staged and offered for editing. At apply, `atomicReplace` tries to create its temp file in `&lt;repo&gt;/vendor/db` and fails with EACCES, which per the writer&#39;s contract fails the file and drops every other accepted edit in the round - precisely the outcome the `READ_ONLY_UNWRITABLE` machinery exists to prevent. The comment above the gate justifies only the user-scope case (&#34;Outside a repository a link can land in a store nothing may write&#34;), so the asymmetry reads as unintentional rather than chosen. Non-blocking: the chmod layout is unusual. The smallest remedy is dropping the `allowExternal &amp;&amp;` guard so the probe covers both scopes; note this interacts with the finding above about what the probe considers unwritable, so resolve that one first.
- ℹ️ `test/target.test.js:99` - The comment added this round claims &#34;&#39;First&#39; is the path-sorted first at both sites&#34;, but `walkFiles` (src/workspace.js:201) sorts directory entries by `entry.name`, not by path, and the two orders disagree: `&#34;db/SKILL.md&#34;.localeCompare(&#34;db-x/SKILL.md&#34;)` returns 1, so for links named `db` and `db-x`, staging makes `db` the owner while `loadProjectSkills`/`resolveTarget` pick `db-x`. This is harmless today because a targeted run sets `stagedSkills = [target.path]` and that filter runs before identity registration (src/workspace.js:82), so the target always wins its own write - but in a file whose comments are load-bearing invariant statements, an asserted invariant that does not hold is worth correcting to what is actually true (each site is independently deterministic).

🔧 Fix: probe write directories, not file modes; name strays recognisably
5 issues (3 warnings, 2 infos) still open:

- ⚠️ `src/memory.js:328` - The doc comment on `readOnlyResolvedPath` states &#34;The probe is what `atomicReplace` needs and nothing more: the directory that receives the rename.&#34; That is false whenever the leaf itself is the link. Trace the layout `test/user-apply.test.js:41-77` builds: `~/.agents/AGENTS.md` is a symlink to `&lt;store&gt;/AGENTS.md` with `&lt;store&gt;` chmod 0555 and `~/.agents` an ordinary writable directory. The probe realpaths to `&lt;store&gt;/AGENTS.md`, tests `dirname(real)` = `&lt;store&gt;` (EACCES) and refuses. `atomicReplace` (src/apply/writer.js:170) would instead create its temp in `path.dirname(target)` = `~/.agents` (writable), `fchmod` it, and `renameSync` over the link path - which succeeds, replacing the symlink with a regular file and leaving the store source untouched. So the probe deliberately refuses MORE than `atomicReplace` needs, and the test asserts exactly that (`fs.readlinkSync(link) === source`, i.e. the link survives). The behavior is right; only the comment is wrong, and this is the same class the author escalated from no-op to a fix last round (&#34;a comment that states an invariant the code does not have is worse than no comment&#34;). Correct it to say the probe refuses when the directory the resolved location sits in is unwritable - which covers both a symlinked directory component and a leaf link into a read-only store, the latter on purpose so a rename cannot silently swap the link for a private copy.
- ⚠️ `src/target.js:44` - `sameFile` (src/target.js:110) plus the `aliased`/`selected` branch (src/target.js:44-48), the new `resolveTarget` skill-path gates, and the `info(&#34;... is one file under N links; targeting it as ...&#34;)` line (src/target.js:96-119) were introduced by fix round 5, not by the change author. They convert what was a hard `--target &#34;db&#34; is ambiguous: it names A and B` refusal into a silent first-match pick whenever every match realpaths to the same file. The stated intent covers exactly two things - make backpass see and stage skills symlinked into the harness-loaded skills directory, and fix the symlink-cycle hazard that introduced - and says nothing about `--target`. AGENTS.md&#39;s own sharp edge frames `--target` as exact-match-only, and the surviving error hint still reads &#34;rename the skill so one name means one file&#34;, which now contradicts the new branch. The component, not a defect inside it, is what needs authorization: the smallest honest remedy is to delete `sameFile`/`aliased`/`selected` and let the pre-existing ambiguity error stand (it needs no new code), accepting that a skill reachable under k links cannot be named by `--target` until one of its names is unique. Keeping it is defensible - the layout this change enables is what creates the duplicate names in the first place - but that is the author&#39;s call, not the fixer&#39;s.
- ⚠️ `src/synthesize.js:545` - `repoFingerprint(repo, [memoryFile.path, ...skillFiles.map((s) =&gt; s.path)])` now covers skills that `loadSkills` only sees because this change follows symlinks - including ones `prepareWorkspace` deliberately withheld. Concrete project-scope sequence: `.agents/skills/beads -&gt; ~/lib/skills/beads`. `loadProjectSkills` (src/synthesize.js:218) includes it, so line 545 hashes the shared library&#39;s contents through the link. `prepareWorkspace` refuses to stage it (src/workspace.js:119, reason `resolves outside the repository`) and the prompt marks it read-only, so backpass will never write it. If any other process - a second agent session, a dotfiles/home-manager rebuild, the user&#39;s editor - touches that file during the multi-minute synthesis turn, `assertRepoUntouched` (src/synthesize.js:347/375) throws and the entire run is discarded with `nothing was proposed`, including unrelated memory-file work that was already measured. Before this change symlinked skills were not loaded at all, so this abort path did not exist for project scope. The narrowing needs no new state: `workspace` (with `stagedPaths` and `unstageable`) exists from src/synthesize.js:500, 45 lines before the fingerprint is taken, so restricting the fingerprint to paths staging actually staged is a smaller change, not a bigger one. It is ask-user because the abort competes with an intended purpose: the round-7 hint text (&#34;either the synthesis harness wrote through the link to a skill it was told is read-only, or another process changed the shared library mid-run&#34;) shows the author wants some detection for writes through a read-only link, and narrowing the set trades that detection away.
- ℹ️ `test/workspace.test.js:258` - Intent decision 4 says the ancestry-based cycle guard is &#34;pinned by its own test so a later refactor cannot quietly switch to identity-based dedupe.&#34; Half of that holds and half does not, and the difference is worth recording rather than acting on. The anti-dedupe invariant IS genuinely pinned: &#34;identity-based dedupe must never reach the always-loaded token count&#34; (test/workspace.test.js:307) and &#34;two links to one shared library are both billed&#34; (test/workspace.test.js:333) both fail if a global visited set is introduced. The cycle CRASH is not: &#34;a symlinked skill directory is never recursed, so no cycle can be walked&#34; asserts only that no staged path repeats a directory segment, which the leaf-only rule added by a later fix round (src/workspace.js:221-225 - a symlinked directory contributes just its `SKILL.md` and is never descended) guarantees on its own. Delete `chain`/`ancestors` from `walkFiles` and that test still passes; it cannot fail before the fix it claims to pin. The code comment at src/workspace.js:190-193 already says as much (&#34;Leaf-only staging currently keeps this dormant&#34;). Do NOT remove the guard - intent decisions 3 and 4 require it and require it be ancestry-based rather than identity-based; this is recorded only so nobody later reads the test name as proof the RangeError is covered.
- ℹ️ `test/proposal.test.js:3242` - In &#34;re-creating a withheld unwritable skill is stray&#34; (test/proposal.test.js:3242) and &#34;a file written at the unstaged alias becomes stray&#34; (test/proposal.test.js:3369), `const created = staged.measured.changes.some((change) =&gt; change.kind === &#34;created&#34;)` is always false: the immediately preceding `assert.deepEqual(staged.measured.changes.map((c) =&gt; c.file), [&#34;AGENTS.md&#34;])` already pins that no created change exists. The `claim(ids, { kind: &#34;extract&#34; })` branch is therefore unreachable, and the comment above it (&#34;an extract while the created alias survives, a plain removal once it does not&#34;) describes a case the test cannot reach. It is not a coverage hole - the deepEqual is the real assertion - but the conditional makes the test read as if it tolerates either outcome, which is the opposite of what it pins. Collapse both to the unconditional `remove` claim and drop `created`.

🔧 Fix: narrow synthesis fingerprint to staged paths; drop target alias pick
2 issues (1 warning, 1 info) still open:

- ⚠️ `src/target.js:69` - `resolveTarget` now returns a skill target for a skill that `prepareWorkspace` is guaranteed to withhold, producing a run that cannot possibly emit an edit. Round 11 ordered the `resolveMemoryPath` / `readOnlyResolvedPath` gates in this branch deleted; that decision&#39;s stated consequence was only the ALIAS case (&#34;a skill reachable under k links cannot be named by --target until one of its names is unique&#34;). The uniquely-named out-of-repo / unwritable skill is a different case it did not cover, and it is only reachable because this change made symlinked skills visible to `loadSkills` at all -- before the change `--target beads` errored immediately with &#34;not a valid target&#34;.

Verified by running the real modules on two constructed layouts:
- Project scope, `.agents/skills/beads -&gt; &lt;lib&gt;/beads`: `resolveTarget(&#34;beads&#34;)` returns `{kind:&#34;skill&#34;, path:&#34;.agents/skills/beads/SKILL.md&#34;}`; `prepareWorkspace({stagedSkills:[that path]})` yields `stagedPaths = [&#34;AGENTS.md&#34;]` and `unstageable = [{path:&#34;.agents/skills/beads&#34;, reason:&#34;resolves outside the repository&#34;}]`. The target file does not exist in the staging copy.
- User scope, `~/.claude/skills/beads -&gt; &lt;store&gt;/beads` with the store&#39;s leaf directory mode 0555 (the author&#39;s own reported layout: 13 of 26 entries symlinked into a shared library): `allowExternal` skips confinement but `readOnlyResolvedPath` still withholds -- `stagedPaths = [&#34;AGENTS.md&#34;]`, `unstageable = [{reason:&#34;resolves to a location that cannot be written&#34;}]`.

The failure is deterministic, not model-dependent: any write at that path is classified stray by `measureWorkspace`&#39;s `confineTo` / `withheld` gates (src/workspace.js:454,481), and `buildProposal`&#39;s targeted gate (src/proposal.js:405) rejects an edit to any other file, so zero edits is the only outcome. The run burns the full `ANNOTATE_TURNS` budget and fails with a `synthesisFailureHint` naming an unrelated cause. Source-provable with no model reasoning: `targetRule` (src/synthesize.js:184) emits &#34;**This run targets `./.agents/skills/beads/SKILL.md` only.** It is the one staged file.&#34; for a path absent from `workspace.stagedPaths`, while `renderSkillIndex` marks that same skill `read-only, resolves outside the repository` in the index directly above it -- two contradictory statements in one prompt.

The remedy, not the defect, is what needs authorization: correcting this means re-adding a refusal gate that round 11 explicitly ordered deleted, which grows the change rather than shrinking it. The narrowest form would be a single check in this branch that the chosen skill is one staging can stage, refusing with the reason `prepareWorkspace` would record. Accepting the dead end as-is is also a defensible call -- it is the author&#39;s, not the fixer&#39;s.
- ℹ️ `src/synthesize.js:546` - The round-11 instruction was followed literally -- the fingerprint is now restricted to &#34;the paths staging actually staged&#34; -- but the consequence reaches further than the rationale that motivated it. That rationale was about files backpass has guaranteed it will never write (out-of-repo / unwritable skills). On a `--target` run, `stagedSkills` is `[]` (memory target) or `[target.path]` (skill target), so NO in-repo skill file is staged, and the fingerprint collapses to the memory file alone. Those skills are perfectly ordinary writable repo files; they are merely out of scope for this run.

Concrete sequence: `backpass propose --target AGENTS.md` on a repo with `.agents/skills/db/SKILL.md`. Before this change the fingerprint covered that file, so a synthesis harness that wrote to it in the repo instead of the staging copy aborted the run loudly via `assertRepoUntouched`. Now the write is neither detected nor reported, and no apply gate covers it either (`proposal.targetFiles` only hashes files an accepted edit targets). AGENTS.md states the invariant as &#34;the repo is fingerprinted and a harness that writes there fails the run loudly.&#34;

I verified the default path is unaffected: on a surface run with a relative in-repo skills dir, `skillFiles` paths and `stagedPaths` keys are both repo-relative posix, so the filter keeps every in-repo skill (`fingerprint list: [&#34;AGENTS.md&#34;, &#34;.agents/skills/db/SKILL.md&#34;]`). The loss is confined to targeted runs. Note also that no test pins &#34;an in-repo skill is still fingerprinted on a surface run,&#34; so a future key-format drift between `loadSkills` and `prepareWorkspace` would silently empty this list on every run rather than failing CI.

If the reach is unwanted, the narrower form is to exclude only paths that appear in `workspace.unstageable` rather than every path staging did not stage -- but that reverses part of a decision made one round ago, so it is the author&#39;s call.

🔧 Fix: refuse unstageable skill targets; fingerprint in-repo skills
2 warnings still open:

- ⚠️ `src/workspace.js:108` - `fs.copyFileSync(from, to)` reproduces the source file&#39;s permission bits, so a skill whose SKILL.md is mode 0444 in a *writable* directory is staged as a copy the synthesis agent cannot write. This layout is now reachable precisely because the change follows symlinks: store-managed shared libraries (nix, home-manager, a `chmod -R a-w` dotfiles checkout) are the motivating case, and `readOnlyResolvedPath` deliberately stopped probing the file&#39;s own mode (round 11: &#34;no write path opens it for writing&#34;), which is true for apply&#39;s rename but false for the staging copy the model edits.

Verified by running the real modules on a project-scope repo with `.agents/skills/db -&gt; &lt;repo&gt;/library/db` and `library/db/SKILL.md` at 0444 in a 0755 directory:
  loaded skills: [&#39;.agents/skills/db/SKILL.md&#39;]
  stagedPaths:   [&#39;AGENTS.md&#39;, &#39;.agents/skills/db/SKILL.md&#39;]
  unstageable:   []
  staged mode:   444
  agent write:   FAILED EACCES
Separately confirmed `copyFileSync` copies mode and that a 0444 destination rejects `writeFileSync` with EACCES.

The source-provable consequence is the dead end round 12 ordered closed, reached through a different door: `skillStagingRefusal` returns null for this layout (dirname of the resolved path is writable), so `--target db` is accepted; staging then copies the file at 0444; `targetRule` tells the model &#34;**This run targets `./.agents/skills/db/SKILL.md` only.** It is the one staged file&#34;; `renderSkillIndex` shows no read-only marker; and no measured change for that file can ever exist. On a surface run the same skill is silently unmodifiable with nothing in `stray` or the notes to say why.

Coverage that would have caught it was removed in the same round: `test/target.test.js`&#39;s &#34;a read-only skill file is still a target, because apply replaces it by rename&#34; was replaced by a test covering only the unwritable-*directory* case, and `test/workspace.test.js:444` (&#34;a read-only skill file in a writable directory is staged, because apply can write it&#34;) asserts the right decision -- stage it, do not withhold it -- but only checks `unstageable` is empty and the content was copied, never that the staged copy is writable.

Remedy is mechanical and contained: make the staging copy user-writable after copying (e.g. `fs.chmodSync(to, 0o644)`, or write it via `readFileSync`/`writeFileSync`) and extend that test to assert the staged image is writable. It cannot leak into the repo: `atomicReplace` (src/apply/writer.js:172) takes `mode` from `fs.statSync(target)` -- the repo file -- not from the staged image, so the repo file keeps its original 0444 after apply.
- ⚠️ `src/workspace.js:195` - The User intent names the ancestry-based cycle guard as required, deliberately-chosen behavior: &#34;The cycle guard is ancestry-based, NOT a global visited set, and this tradeoff is the important one... That preserved behaviour is pinned by its own test so a later refactor cannot quietly switch to identity-based dedupe.&#34; A later fix round (leaf-only staging for symlinked directories) has since stranded most of that machinery, and the code says so itself at src/workspace.js:190-194: &#34;Leaf-only staging (below) currently keeps this dormant... the only live effect left is skipping a top-level self-link back to the skills root.&#34;

I confirmed the reach. `walkFiles` never recurses into a symlinked directory (line 220-225 takes at most `&lt;link&gt;/SKILL.md` and `continue`s), and a real directory&#39;s realpath is always strictly deeper than its ancestors&#39;, so `chain.has(identity)` can only fire for a top-level entry whose realpath equals the skills root. The `ancestors` parameter and the `new Set(chain).add(identity)` propagation at line 227 are unreachable. The original RangeError no longer depends on the guard either: deleting `chain` entirely would still not recurse into any of the three cycle shapes.

The test that the intent says pins this has been rewritten to match: `test/workspace.test.js:258` is now &#34;a symlinked skill directory is never recursed, so no cycle can be walked&#34; and its own comment demotes the guard to &#34;a second line of defence... only the top-level self link still reaches it.&#34; It asserts staging completes and no staged path repeats a directory segment -- which passes whether or not the guard exists. The intent&#39;s substantive requirement (two links to one library are both loaded and both billed, never identity-deduped) IS still pinned, correctly, at test/workspace.test.js:291 and :316 through `loadSkills`/`skillDescriptionTokens`; note that `stagedIdentities` is a global visited set, but it governs only which name owns the write, not billing.

This is a Simplification-pass item: the guard is a component the change no longer needs in its current shape, and it was ordered in rather than ordered away, so removing it is not something I should decide. The remedy is the author&#39;s call between the two the code itself names -- delete `ancestors`/`chain` as dead code and let the leaf-only rule be the single stated defence, or restore subtree walking under a symlinked directory, which &#34;re-arms&#34; the guard. Either way the intent&#39;s description of what is pinned and why should be reconciled with what the tests now assert.

🔧 Fix: stage read-only skills writable; delete stranded cycle guard
1 warning still open:

- ⚠️ `src/workspace.js:82` - On a narrowed run (`--target &lt;memory file&gt;` or `--target &lt;other skill&gt;`), `unstageable` is not computed for the skills the run skips, so `synthesize.js:549` fingerprints files backpass has guaranteed it will never write — the exact opposite of what a surface run does, and the opposite of what the comment at `synthesize.js:139-147` says the fingerprint means (&#34;Only skills staging withheld are left out. Such a file is one backpass has guaranteed it will never write, so aborting a run over a third party&#39;s edit to it would discard measured work for nothing&#34;).

Root cause: `if (stagedSkills &amp;&amp; !stagedSkills.includes(logical)) continue;` at line 82 short-circuits before both the alias check (line 86) and `stagingRefusal` (line 96), so neither the READ_ONLY_UNWRITABLE nor the alias entry is ever recorded. Only the confined (outside-repo) entries survive narrowing, because `walkFiles` populates `confined` before the filter.

Verified by running the real module on a user-scope layout — `.agents/skills/db -&gt; &lt;store&gt;/db` with `&lt;store&gt;` and `&lt;store&gt;/db` at 0555:
  SURFACE unstageable: [{ path: &#39;.agents/skills/db/SKILL.md&#39;, reason: &#39;resolves to a location that cannot be written&#39;, identity: ... }]
  MEMORY-TARGET unstageable: []

Concrete failure: `backpass --scope user --target AGENTS.md` on the motivating machine (13 links into a shared library). The store skills are fingerprinted; a home-manager/nix rebuild touching one mid-run makes `assertRepoUntouched` throw, and because `insideRepo` is true for a `~/.claude/skills/...` path under the synthetic homedir repo, the user is told &#34;synthesis changed ... in the repository directly instead of the staging copy&#34; with the hint &#34;a harness that edits outside its cwd cannot be trusted with the synthesis role&#34; — a wrong accusation against the harness, and the measured memory-file work is discarded. The same surface-scope run completes. `test/synthesize.test.js`&#39;s &#34;a skill backpass withheld from staging is not fingerprinted&#34; covers only project scope with an outside-repo link, which is the one withholding reason that survives narrowing, so it passes either way.

Reachability is narrow: it needs a narrowed run, a skill withheld for unwritability or aliasing (not for resolving outside the repo), and that skill&#39;s bytes changing during the run.

The remedy, not the defect, is what needs authorization. The obvious repair — move the `stagedSkills` filter past the refusal checks — is not mechanical: `stagedIdentities` only registers identities for files that were actually copied, so on a narrowed run the alias branch would report &#34;the same file is already staged as X&#34; against a name that was never staged. Making that correct extends the round-12/13 fingerprint machinery rather than correcting what it does. The alternatives (compute refusals in a separate pass, or accept the inconsistency and narrow the comment&#39;s claim to surface runs) are author calls.

🔧 Fix: record unwritable skill refusals before narrowing
5 issues (3 warnings, 2 infos) still open:

- ⚠️ `src/workspace.js:506` - The re-creation guard in `measureWorkspace` only matches one of the three reasons staging records in `unstageable`. `READ_ONLY_UNREADABLE` (pushed at src/workspace.js:121 from the copyFileSync/readFileSync catch) is not matched, and that push also omits the `identity` field the guard&#39;s second branch needs.

Concrete sequence, using the layout the change&#39;s own new test builds (test/workspace.test.js:512, &#34;a skill in a store this user cannot read is skipped and named, not thrown&#34;), user scope:
1. `.agents/skills/locked -&gt; &lt;store&gt;/locked` with `SKILL.md` at mode 000. `loadSkills` skips it, but `walkFiles` returns it, `stagingRefusal` returns null (the writability probe never opens the file), and the copy throws -&gt; `unstageable.push({ path: &#39;.agents/skills/locked/SKILL.md&#39;, reason: READ_ONLY_UNREADABLE })`, no `identity`.
2. `renderSkillIndex` shows it marked read-only, so the model has its path.
3. The model writes `SKILL.md` at that path in the staging copy (or cites it as an extract&#39;s skill).
4. `measureWorkspace`: the skills mapping matches, `isSkillFilePath` is true, `confineTo` is null in user scope so the outside-repo gate is skipped, the alias branch misses (nothing was staged under that identity), and the `withheld` check at line 506 misses on the reason filter. The file is emitted as `kind: &#34;created&#34;`.
5. `applyDecisions` (src/apply/writer.js:426): `fs.existsSync(absolute)` is true -&gt; `&#34;&lt;path&gt; already exists; nothing was written&#34;` -&gt; `if (results.failed.length) return results;` drops every accepted edit, including the memory file.

That is the exact outcome the comment above the guard says it prevents (&#34;Writing there re-creates a file apply refuses for already existing, and that refusal drops every accepted edit&#34;). The remedy is a correction inside existing machinery, not an extension: drop the reason filter so any `unstageable` entry matching by path or identity means staging withheld the file, and add `identity` to the catch-block push at line 121 so the identity branch works there too.
- ⚠️ `src/memory.js:349` - `readOnlyResolvedPath` replaced the old `refuseReadOnlySymlink` probe and dropped its `fs.accessSync(real, fs.constants.W_OK)` check, keeping only `accessSync(path.dirname(real), W_OK | X_OK)`.

The doc comment at src/memory.js:326-334 states the probe is deliberately STRICTER than `atomicReplace` needs, specifically so the rename cannot &#34;swap the link for a private copy and leave the store source behind, silently unlinking the file from what generates it.&#34; The implementation does not hold that invariant: it only prevents the swap when `dirname(real)` happens to be unwritable. For a leaf symlink into a writable location the swap proceeds unchecked.

Concrete sequence: `~/.agents/AGENTS.md -&gt; ~/dotfiles/AGENTS.md`, with `~/dotfiles` writable and the source file at mode 0444 (a stow/dotfiles guard). Base commit: `refuseReadOnlySymlink` hits `accessSync(real, W_OK)`, fails, and returns `readOnlySymlinkMessage` — apply refuses by name and the link survives. Current HEAD: `real !== path.resolve(absolute)`, `dirname(real)` is writable, so the probe returns null; `atomicReplace` (src/apply/writer.js:170) creates a temp in `dirname(absolute)` and renames it over the symlink, replacing the link with a regular file. The dotfiles source is left stale and the user&#39;s link is silently broken with no message.

This is not merely hypothetical coverage loss: test/user-apply.test.js&#39;s &#34;apply refuses a user-level memory file that is a symlink to a read-only path&#34; (which built exactly that 0444-source-in-writable-dir layout) was rewritten in this change into a read-only-STORE layout, so nothing exercises the dropped branch any more.

Marked ask-user because the author documented the mode-independence as a deliberate decision; the choice between restoring the file-mode check, refusing leaf links generally (the swap happens for writable targets too), and narrowing the comment&#39;s claim is a product call.
- ⚠️ `src/target.js:51` - Following symlinks makes it ordinary for one library to be loaded under k names, and `skillMatches` filters on `skill.name` (the frontmatter name), which is identical for every link. So `--target db` with two links to one library always hits the `found &gt; 1` branch.

The hint was changed from &#34;rename the skill so one name means one file&#34; to &#34;those may be one file under several links, or genuinely different files; --target needs a name that identifies exactly one file&#34;. Per AGENTS.md and this file&#39;s own header, `--target` accepts only an exact configured memory-file entry or an exact loaded skill name — never a path, basename, directory, or glob. There is therefore no name the user can type that identifies exactly one of the two links, so the hint asks for something the flag cannot accept. test/target.test.js:87 pins this wording while also asserting that both matches share the name, which makes the contradiction explicit rather than catching it.

The actionable remedies the hint should name instead are: rename one of the skills&#39; frontmatter `name`, or remove one of the links from the loaded directory. Marked ask-user because the wording was chosen deliberately in an earlier fix round.
- ℹ️ `src/workspace.js:225` - The stated intent&#39;s decision 4 describes an ancestry-based cycle guard as the important preserved tradeoff, &#34;pinned by its own test so a later refactor cannot quietly switch to identity-based dedupe&#34;. That guard no longer exists: round 13&#39;s explicit author instruction deleted the `ancestors` parameter and `chain` set, and leaf-only staging (src/workspace.js:216-226) is now the single stated defence. I verified the required accompanying comment IS present, including the &#34;must reinstate cycle detection in the same change&#34; clause, and that the substantive requirement (k links to one library are both loaded and both billed, never identity-deduped) is still pinned at test/workspace.test.js:320 and :344 through `loadSkills`/`skillDescriptionTokens`.

No action on the code — the author reversed this deliberately. Flagging only because that intent text will likely be carried into the PR body, where it would describe machinery the diff does not contain.
- ℹ️ `test/workspace.test.js:405` - Several tests establish their premise with `chmod 0555` and rely on `fs.accessSync(dir, W_OK)` failing (test/workspace.test.js:403-405 and :488-489, test/target.test.js:169, test/synthesize.test.js:754, test/user-apply.test.js:48 and :93). Under a root uid — common in container CI — `access(W_OK)` succeeds regardless of mode, so `readOnlyResolvedPath` returns null and these tests fail rather than skip, with a failure message that points at the probe instead of at the environment.

The pattern originates in earlier fix rounds (8-11), not only the last two commits, so this is one consolidated note rather than per-test findings. A `process.getuid?.() === 0` guard that skips with a reason would make the dependency explicit.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/workspace.test.js test/skills.test.js` - 34 tests, all pass (staging walk, link following, billing, cycle pruning)</code>
- <code>`node --test test/target.test.js test/synthesize.test.js test/user-apply.test.js test/proposal.test.js` - 131 tests, all pass</code>
- <code>Manual: built a demo repo with `.agents/skills/` = one real skill dir + three symlinks into an out-of-repo shared library; ran `backpass status` from the base tree (`git archive 713c362`) and from HEAD, comparing the always-loaded budget row and the `overflow:` line</code>
- <code>Manual: appended two additional symlinks pointing at the SAME library and re-ran `backpass status` to confirm k links are billed k times rather than identity-deduped</code>
- <code>Manual: `backpass propose --target lint --dry-run` on a repo whose `.agents/skills/lint` links to an in-repo `shared/lint`, base vs HEAD</code>
- <code>Manual: `backpass propose --target db --dry-run` on the out-of-repo-library fixture, base vs HEAD</code>
- <code>Manual: drove `prepareWorkspace` + `measureWorkspace` on the symlinked-skill fixture, edited the staged `SKILL.md`, and asserted the shared-library source file was byte-identical afterwards</code>
- <code>Manual: ran a cycle layout (self link, link back to an ancestor, mutual a&lt;-&gt;b pair) through `prepareWorkspace` against `955f17a` (pre-cycle-fix) and against HEAD, with the default V8 stack size</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

