### PR TITLE
fix(analyze): discard evidence quotes that do not appear in the distilled trace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,15 @@ list` only sees this clone. `attachSiblingClones` in `src/repo.js` also searches
   negative (`harm` / `non-compliance` / `irrelevant`, `sanitizeEvidence` drops other
   values) and `renderEvidenceForPrompt` renders the class AND the `effect` text with each
   quote. Records from before the class existed carry none, and none never counts as harm.
+- **A quote must be findable in the trace it claims to come from.** `sanitizeEvidence`
+  (`src/analyze.js`) drops any evidence item whose quote is not a whitespace-folded
+  substring of the distilled trace, counting the drops into `summary.quotesNotInTrace` so a
+  paraphrasing model reads as that rather than as a clean repo. Only the literal boolean
+  `usedRawTranscript === true` opts out, because then the quote may come from text the
+  distiller elided. Consequence for tests: a fake agent must quote real text from the
+  session it analyzes - invented quotes are exactly what the gate rejects. Analysis
+  semantics changed, so `ANALYSIS_INDEX_VERSION` (`src/state.js`) was bumped; bump it again
+  for any future change to what analysis accepts.
 - **Skill target/load-layout rules live in `src/skills.js`.** Preserve an existing configured
   harness-loaded directory; a bare `skills/` directory is never auto-detected. A harness loads
   what a path resolves to, so a symlinked directory under the loaded dir is a skill: entry types

--- a/README.md
+++ b/README.md
@@ -259,10 +259,16 @@ orchestrating tool) - and the
 analysis is shown the ledger's open gaps so it can cite an existing gap id instead of
 coining a paraphrase of it.
 
-**Every claim must carry a verbatim quote.** Quoteless items are discarded - the single
-most important defence against a model confabulating influence. Negative evidence is
-weighted highest, but its class determines what it supports: non-compliance supports
-reinforcement, while only harm supports removal.
+**Every claim must carry a verbatim quote, and the quote must be in the trace.** Quoteless
+items are discarded - the single most important defence against a model confabulating
+influence - and so are quotes that do not actually appear in the distilled trace they claim
+to come from, compared whitespace-folded so the trace's line wrapping never rejects a real
+quote. A paraphrase is a claim without evidence. The check is skipped only when the analysis
+reports `usedRawTranscript`, because then the quote may legitimately come from text the
+distiller truncated or elided. When a run discards quotes this way it says so on stderr:
+a model that paraphrases instead of copying produces fewer findings, not cleaner ones.
+Negative evidence is weighted highest, but its class determines what it supports:
+non-compliance supports reinforcement, while only harm supports removal.
 
 To avoid smearing evidence across a large prose blob, backpass splits eligible prose
 paragraphs above 120 tokens at high-confidence sentence boundaries for attribution only.
@@ -698,7 +704,8 @@ For the user-scope state location and isolation contract, see
 ## Limitations
 
 - **Causal attribution is genuinely hard.** A model can confabulate influence. The
-  mitigations are structural - mandatory verbatim quotes, the two-session rule, negative
+  mitigations are structural - mandatory verbatim quotes checked against the trace they
+  claim to come from, the two-session rule, negative
   evidence weighted highest, and a human gate - but read the evidence, not just the title.
 - **Transcript formats are undocumented** and can change without notice. Each adapter is
   pinned by a golden fixture and fails soft.

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -40,13 +40,30 @@ function noteOnce(note) {
 /** Negative evidence carries one of these classes; anything else is dropped as unjudged. */
 export const NEGATIVE_CLASSES = ["harm", "non-compliance", "irrelevant"];
 
-/** Evidence items without a verbatim quote are dropped - the rubric's central rule. */
-export function sanitizeEvidence(parsed, memoryFile = null) {
+/** Whitespace-insensitive form used to check a quote against the trace it claims to come from. */
+function foldSpace(text) {
+  return String(text).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Evidence items without a verbatim quote are dropped - the rubric's central rule.
+ *
+ * When `trace` is supplied and the model did not open the raw transcript, a quote must
+ * also appear in that trace (whitespace folded). A quote that is long enough but not in
+ * the trace is a paraphrase, and a paraphrase is a claim without evidence. When the model
+ * reports `usedRawTranscript`, the quote may come from text the distiller truncated or
+ * elided, so the substring check is skipped rather than punishing the honest path.
+ */
+export function sanitizeEvidence(parsed, memoryFile = null, trace = null) {
   const clean = { positive: [], negative: [], gaps: [], usedRawTranscript: Boolean(parsed?.usedRawTranscript) };
   if (!parsed || typeof parsed !== "object") return clean;
 
   const validInstructions = memoryFile ? new Set(instructionUnits(memoryFile).map((unit) => unit.id)) : null;
-  const hasQuote = (item) => typeof item?.quote === "string" && item.quote.trim().length >= 8;
+  const foldedTrace = typeof trace === "string" && !clean.usedRawTranscript ? foldSpace(trace) : null;
+  const hasQuote = (item) => {
+    if (typeof item?.quote !== "string" || item.quote.trim().length < 8) return false;
+    return foldedTrace === null || foldedTrace.includes(foldSpace(item.quote));
+  };
 
   for (const key of ["positive", "negative"]) {
     for (const item of Array.isArray(parsed[key]) ? parsed[key] : []) {
@@ -195,7 +212,7 @@ async function analyzeOne({
 
   return {
     status: "ok",
-    evidence: sanitizeEvidence(parsed, memoryFile),
+    evidence: sanitizeEvidence(parsed, memoryFile, distilled.trace),
     usage: usageRecord(ranWith, result),
     distilled,
   };

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -52,17 +52,30 @@ function foldSpace(text) {
  * also appear in that trace (whitespace folded). A quote that is long enough but not in
  * the trace is a paraphrase, and a paraphrase is a claim without evidence. When the model
  * reports `usedRawTranscript`, the quote may come from text the distiller truncated or
- * elided, so the substring check is skipped rather than punishing the honest path.
+ * elided, so the substring check is skipped rather than punishing the honest path. Only
+ * the literal boolean opts out: a model that answers `"false"` must still anchor its
+ * quotes, or a stringly-typed reply would disable the check it is meant to fail.
+ *
+ * `quotesNotInTrace` counts what the trace check rejected, so a run whose analysis model
+ * paraphrases everything reads as that rather than as a clean repo.
  */
 export function sanitizeEvidence(parsed, memoryFile = null, trace = null) {
-  const clean = { positive: [], negative: [], gaps: [], usedRawTranscript: Boolean(parsed?.usedRawTranscript) };
+  const clean = {
+    positive: [],
+    negative: [],
+    gaps: [],
+    usedRawTranscript: parsed?.usedRawTranscript === true,
+    quotesNotInTrace: 0,
+  };
   if (!parsed || typeof parsed !== "object") return clean;
 
   const validInstructions = memoryFile ? new Set(instructionUnits(memoryFile).map((unit) => unit.id)) : null;
   const foldedTrace = typeof trace === "string" && !clean.usedRawTranscript ? foldSpace(trace) : null;
   const hasQuote = (item) => {
     if (typeof item?.quote !== "string" || item.quote.trim().length < 8) return false;
-    return foldedTrace === null || foldedTrace.includes(foldSpace(item.quote));
+    if (foldedTrace === null || foldedTrace.includes(foldSpace(item.quote))) return true;
+    clean.quotesNotInTrace += 1;
+    return false;
   };
 
   for (const key of ["positive", "negative"]) {
@@ -258,6 +271,7 @@ export async function analyzeTranscripts({
     failed: 0,
     usage: [],
     staleMemoryHash: 0,
+    quotesNotInTrace: 0,
   };
   const priorHashes = new Set();
   const transcriptMetadata = (transcript) => ({
@@ -383,6 +397,7 @@ export async function analyzeTranscripts({
         evidenceTotals.positive += result.evidence.positive.length;
         evidenceTotals.negative += result.evidence.negative.length;
         evidenceTotals.gaps += result.evidence.gaps.length;
+        summary.quotesNotInTrace += result.evidence.quotesNotInTrace;
         emitProgress("analyze:evidence", { ...evidenceTotals });
       }
     } catch (err) {
@@ -405,6 +420,14 @@ export async function analyzeTranscripts({
       }
     }
   });
+
+  if (summary.quotesNotInTrace) {
+    warn(
+      `${summary.quotesNotInTrace} quote(s) were discarded because they do not appear in the ` +
+        `distilled trace they claim to come from; a model that paraphrases instead of copying ` +
+        `produces fewer findings, not cleaner ones - consider a stronger analysis model`,
+    );
+  }
 
   emitProgress("analyze:done", summary);
   return summary;

--- a/src/state.js
+++ b/src/state.js
@@ -225,7 +225,7 @@ function migrateEvidenceRecord(record, transcript, identity) {
   };
 }
 
-export const ANALYSIS_INDEX_VERSION = 2;
+export const ANALYSIS_INDEX_VERSION = 3;
 
 /**
  * Cache key for a transcript's analysis: its content signature, the memory-surface hash,

--- a/test/analyze-reuse.test.js
+++ b/test/analyze-reuse.test.js
@@ -47,9 +47,9 @@ if (argv.includes("config") && argv.includes("show")) {
 }
 if (argv.includes("--file")) {
   process.stdout.write(JSON.stringify({
-    positive: [{ instruction: "AG-001", moment: "start", effect: "followed it", quote: "followed the build rule exactly as written" }],
+    positive: [{ instruction: "AG-001", moment: "start", effect: "followed it", quote: "Ran make build as instructed." }],
     negative: [],
-    gaps: [{ mistake: "skipped lint", proposedInstruction: "Always run lint before pushing.", recurrenceRisk: "high", quote: "skipped lint entirely this time" }],
+    gaps: [{ mistake: "skipped lint", proposedInstruction: "Always run lint before pushing.", recurrenceRisk: "high", quote: "Now run the tests too." }],
   }) + "\\n");
   process.exit(0);
 }

--- a/test/distill.test.js
+++ b/test/distill.test.js
@@ -157,6 +157,37 @@ test("split paragraphs accept only sentence-part attribution targets", () => {
   );
 });
 
+test("a quote that is not in the distilled trace is a paraphrase and is discarded", () => {
+  const trace = "turn 3\n  the agent posted the full URL\n\nturn 4\n  it used a  bare #2731\n  reference\n";
+  const clean = sanitizeEvidence(
+    {
+      positive: [
+        { instruction: "AG-001", quote: "the agent posted the full URL" },
+        { instruction: "AG-002", quote: "the agent shared the complete link" },
+      ],
+      negative: [{ instruction: "AG-004", quote: "it used a bare #2731 reference" }],
+      gaps: [{ proposedInstruction: "Post full URLs.", quote: "posted the full URL" }],
+    },
+    null,
+    trace,
+  );
+  assert.deepEqual(
+    clean.positive.map((item) => item.instruction),
+    ["AG-001"],
+  );
+  assert.equal(clean.negative.length, 1, "whitespace and line breaks fold before matching");
+  assert.equal(clean.gaps.length, 1);
+});
+
+test("the trace check is skipped when the model read the raw transcript", () => {
+  const clean = sanitizeEvidence(
+    { positive: [{ instruction: "AG-001", quote: "text the distiller elided" }], usedRawTranscript: true },
+    null,
+    "nothing here matches",
+  );
+  assert.equal(clean.positive.length, 1);
+});
+
 test("sanitizeEvidence tolerates a malformed model response", () => {
   const clean = sanitizeEvidence(null);
   assert.deepEqual(clean, { positive: [], negative: [], gaps: [], usedRawTranscript: false });

--- a/test/distill.test.js
+++ b/test/distill.test.js
@@ -179,6 +179,23 @@ test("a quote that is not in the distilled trace is a paraphrase and is discarde
   assert.equal(clean.gaps.length, 1);
 });
 
+test("only a literal true opts out of the trace check, and rejections are counted", () => {
+  const clean = sanitizeEvidence(
+    {
+      positive: [
+        { instruction: "AG-001", quote: "text the distiller elided" },
+        { instruction: "AG-002", quote: "another invented sentence" },
+      ],
+      usedRawTranscript: "false",
+    },
+    null,
+    "nothing here matches",
+  );
+  assert.equal(clean.usedRawTranscript, false);
+  assert.deepEqual(clean.positive, []);
+  assert.equal(clean.quotesNotInTrace, 2);
+});
+
 test("the trace check is skipped when the model read the raw transcript", () => {
   const clean = sanitizeEvidence(
     { positive: [{ instruction: "AG-001", quote: "text the distiller elided" }], usedRawTranscript: true },
@@ -190,7 +207,7 @@ test("the trace check is skipped when the model read the raw transcript", () => 
 
 test("sanitizeEvidence tolerates a malformed model response", () => {
   const clean = sanitizeEvidence(null);
-  assert.deepEqual(clean, { positive: [], negative: [], gaps: [], usedRawTranscript: false });
+  assert.deepEqual(clean, { positive: [], negative: [], gaps: [], usedRawTranscript: false, quotesNotInTrace: 0 });
   assert.deepEqual(sanitizeEvidence({ positive: "not an array" }).positive, []);
 });
 

--- a/test/gap-domain-cli.test.js
+++ b/test/gap-domain-cli.test.js
@@ -59,13 +59,13 @@ if (argv.includes("--file")) {
         proposedInstruction: ${JSON.stringify(ORCHESTRATION_GAP)},
         recurrenceRisk: "high",
         domain: "orchestration",
-        quote: "opened a PR during a scout task",
+        quote: "Please build the project.",
       },
       {
         mistake: "skipped lint",
         proposedInstruction: ${JSON.stringify(UNLABELLED_GAP)},
         recurrenceRisk: "high",
-        quote: "skipped lint entirely this time",
+        quote: "Now run the tests too.",
       },
     ],
   }) + "\\n");
@@ -102,7 +102,7 @@ if (argv.includes("--file")) {
         proposedInstruction: ${JSON.stringify(ORCHESTRATOR_REPO_GAP)},
         recurrenceRisk: "high",
         domain: "project",
-        quote: "opened a PR during a scout task",
+        quote: "Please build the project.",
       },
     ],
   }) + "\\n");


### PR DESCRIPTION
## Intent

Fix a real gap in backpass evidence validation: sanitizeEvidence accepted any string of 8+ chars as a verbatim quote, so a paraphrased quote could enter the gap ledger with no anchor in the trace, contradicting VISION.md (a claim without a quote is discarded, not softened). Decision: require each quote to be a substring of the distilled trace, whitespace-folded so line-wrapping in the distilled trace does not reject a real quote. Deliberate exemption: when the model sets usedRawTranscript, the quote may come from text the distiller truncated or elided, so the check is skipped for that path. Deliberately NOT adding a passed-trajectory gate on skill extraction: extract is a move and VISION.md exempts it from the evidence floor by design. Test fixtures in analyze-reuse and gap-domain-cli returned invented quotes not present in the session; they now quote real session text, since invented quotes are exactly what the gate rejects. Pre-existing failure on this machine (self-session: the exclusion survives the scan cache) is unrelated and fails on base too. A manual PR #118 already exists on kunchenguid/backpass for this branch; the pipeline should attest/update it rather than duplicate. Motivation: Mem0 'Self Evolving Harness With Memory' — store the exact sentence, not an inferred fact.

## What Changed

- `sanitizeEvidence` in `src/analyze.js` now takes the distilled trace and drops any positive, negative, or gap quote that is not a whitespace-folded substring of it, so a paraphrase can no longer pass the 8-character verbatim-quote check. The check is skipped only when the model reports the literal boolean `usedRawTranscript === true`, since the quote may then come from text the distiller truncated or elided; a stringly-typed `"false"` still has to anchor.
- Rejections are counted into `summary.quotesNotInTrace` and rolled up in `analyzeTranscripts`, which warns at the end of a run that a paraphrasing analysis model produces fewer findings rather than a cleaner repo. `ANALYSIS_INDEX_VERSION` is bumped to 3 (`src/state.js`) because cached evidence was accepted under the old rule.
- Added trace-check tests in `test/distill.test.js` (paraphrase discarded, literal-`true` opt-out with counting, raw-transcript path exempt) and fixed the fake agents in `test/analyze-reuse.test.js` and `test/gap-domain-cli.test.js` to quote real session text instead of invented lines. README and AGENTS.md record the gate.

## Risk Assessment

✅ Low: A tightly scoped, well-tested validation gate that fails closed in the safe direction, with correct ordering of the usedRawTranscript exemption, real before/after regression tests, and fixtures corrected to quote genuine session text; the only consequence worth noting is an authorized one-time reanalysis cost.

## Testing

I drove the real `backpass analyze` CLI in isolated temp repos, stubbing only the external model binary, across seven scenarios covering the trace gate and its exemptions. A paraphrased gap quote and a paraphrased instruction-level negative are both discarded and the run prints the new "N quote(s) were discarded because they do not appear in the distilled trace" warning, with `summary.quotesNotInTrace: 2` in `--json` on the fresh run; verbatim and line-wrapped-verbatim quotes still record evidence, so the whitespace fold does not reject real quotes. Adversarially, `usedRawTranscript: "false"` does not disable the check (quotes discarded), while a literal `true` does exempt it, matching the intent. The upgrade path is proven live: evidence cached by the base commit under `analysis-index-v2` holds a paraphrased gap and re-runs as `cached`, but the new build re-analyzes both transcripts under `v3` and the gaps drop to zero. The three touched test files pass. No UI surface is involved, so evidence is CLI transcripts rather than screenshots. I did not run the full suite; remote CI owns that.

- Live validation: ✅ go - 8 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A paraphrased gap quote is discarded and the run says so instead of reading as a clean repo | ✅ pass | live | `backpass analyze` with a model answer quoting &#34;the user asked me to build the thing&#34; (absent from the session): both sessions record gaps=0 and stderr warns &#34;2 quote(s) were discarded because they do… |
| A verbatim quote from the session still records its gap | ✅ pass | live | Same run shape quoting the real user turn &#34;Please build the project.&#34;: both sessions record gaps=1 with that quote and quotesNotInTrace stays 0 (analyze-trace-gate.txt, scenario verbatim-quote) |
| Line-wrapping in the distilled trace does not reject a real quote | ✅ pass | live | Model answer returns the quote broken across a newline and indentation (&#34;Please build\n the project.&#34;); both sessions still record gaps=1, no warning (analyze-trace-gate.txt, scenario wrapped-quote) |
| usedRawTranscript exempts a quote the distiller could have elided | ✅ pass | live | With `usedRawTranscript: true`, the same out-of-trace quote is kept: gaps=1, usedRawTranscript=true, no warning (analyze-trace-gate.txt, scenario raw-transcript-exemption) |
| Adversarial: a stringly-typed &#34;false&#34; cannot switch the gate off | ✅ pass | live | With `usedRawTranscript: &#34;false&#34;`, the out-of-trace quote is still discarded: gaps=0, usedRawTranscript=false, warning printed for 2 quotes (analyze-trace-gate.txt, scenario stringly-false-usedraw) |
| The gate covers instruction-level negatives, not just gaps | ✅ pass | live | A `non-compliance` negative on AG-001 quoting real session text records negatives=1; the same negative with a paraphrased quote records negatives=0 and warns (analyze-trace-gate.txt, scenarios verbati… |
| Upgrading over an existing evidence cache purges pre-fix paraphrased evidence | ✅ pass | live | Base commit analyze records gaps=1 under key analysis-index-v2 and re-runs as cached=2; the new build over that same repo re-analyzes both (analyzed=2, cached=0), reports quotesNotInTrace=2, and leave… |
| The run&#39;s per-run rejection count is machine-readable in the JSON summary | ✅ pass | live | `backpass analyze --json` on a first (uncached) run emits `&#34;quotesNotInTrace&#34;: 2` in summary (analyze-trace-gate-json.txt) |

<details>
<summary>Evidence: CLI transcripts: trace gate across seven analyze scenarios</summary>

```text
=== scenario: verbatim-quote ===
--- quote the model returned ---
{"quote":"Please build the project."}
--- backpass analyze (human output, exit 0) ---
analyzed against AGENTS.md (1 instructions, 15 tok)
  2 newly analyzed · 0 cached · 0 skipped (too short) · 0 failed

  tier-1 tokens: not reported by pi
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-b: gaps=1 "Please build the project." usedRawTranscript=false
pi-session-a: gaps=1 "Please build the project." usedRawTranscript=false
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-GvbBbd

=== scenario: paraphrased-quote ===
--- quote the model returned ---
{"quote":"the user asked me to build the thing"}
--- backpass analyze (human output, exit 0) ---
analyzed against AGENTS.md (1 instructions, 15 tok)
  2 newly analyzed · 0 cached · 0 skipped (too short) · 0 failed

  tier-1 tokens: not reported by pi
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
warn 2 quote(s) were discarded because they do not appear in the distilled trace they claim to come from; a model that paraphrases instead of copying produces fewer findings, not cleaner ones - consider a stronger analysis model
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-a: gaps=0  usedRawTranscript=false
pi-session-b: gaps=0  usedRawTranscript=false
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-1qoi7v

=== scenario: raw-transcript-exemption ===
--- quote the model returned ---
{"quote":"the user asked me to build the thing","usedRawTranscript":true}
--- backpass analyze (human output, exit 0) ---
analyzed against AGENTS.md (1 instructions, 15 tok)
  2 newly analyzed · 0 cached · 0 skipped (too short) · 0 failed

  tier-1 tokens: not reported by pi
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-a: gaps=1 "the user asked me to build the thing" usedRawTranscript=true
pi-session-b: gaps=1 "the user asked me to build the thing" usedRawTranscript=true
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-L3iXhf

=== scenario: stringly-false-usedraw ===
--- quote the model returned ---
{"quote":"the user asked me to build the thing","usedRawTranscript":"false"}
--- backpass analyze (human output, exit 0) ---
analyzed against AGENTS.md (1 instructions, 15 tok)
  2 newly analyzed · 0 cached · 0 skipped (too short) · 0 failed

  tier-1 tokens: not reported by pi
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
warn 2 quote(s) were discarded because they do not appear in the distilled trace they claim to come from; a model that paraphrases instead of copying produces fewer findings, not cleaner ones - consider a stronger analysis model
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-b: gaps=0  usedRawTranscript=false
pi-session-a: gaps=0  usedRawTranscript=false
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-qMBNNw

=== scenario: wrapped-quote ===
--- quote the model returned ---
{"quote":"Please build\n   the project."}
--- backpass analyze (human output, exit 0) ---
analyzed against AGENTS.md (1 instructions, 15 tok)
  2 newly analyzed · 0 cached · 0 skipped (too short) · 0 failed

  tier-1 tokens: not reported by pi
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-b: gaps=1 "Please build\n   the project." usedRawTranscript=false
pi-session-a: gaps=1 "Please build\n   the project." usedRawTranscript=false
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-1UbC1k

=== scenario: verbatim-negative ===
--- quote the model returned ---
{"quote":"Now run the tests too.","negative":true}
--- backpass analyze (human output, exit 0) ---
analyzed against AGENTS.md (1 instructions, 15 tok)
  2 newly analyzed · 0 cached · 0 skipped (too short) · 0 failed

  tier-1 tokens: not reported by pi
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-a: negatives=1 "Now run the tests too." gaps=0  usedRawTranscript=false
pi-session-b: negatives=1 "Now run the tests too." gaps=0  usedRawTranscript=false
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-xPw3gX
=== scenario: paraphrased-negative ===
--- quote the model returned ---
{"quote":"the user asked me to build the thing","negative":true}
--- backpass analyze (human output, exit 0) ---
analyzed against AGENTS.md (1 instructions, 15 tok)
  2 newly analyzed · 0 cached · 0 skipped (too short) · 0 failed

  tier-1 tokens: not reported by pi
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
warn 2 quote(s) were discarded because they do not appear in the distilled trace they claim to come from; a model that paraphrases instead of copying produces fewer findings, not cleaner ones - consider a stronger analysis model
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-a: negatives=0  gaps=0  usedRawTranscript=false
pi-session-b: negatives=0  gaps=0  usedRawTranscript=false
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-wArGzy
```
</details>
<details>
<summary>Evidence: analyze --json on a fresh run reporting quotesNotInTrace: 2</summary>

```text
=== scenario: paraphrased-quote ===
--- quote the model returned ---
{"quote":"the user asked me to build the thing"}
--- backpass analyze (human output, exit 0) ---
{
  "memoryFile": "AGENTS.md",
  "transcripts": 2,
  "summary": {
    "total": 2,
    "cached": 0,
    "analyzed": 2,
    "skipped": 0,
    "failed": 0,
    "usage": [
      {
        "agent": "pi",
        "usage": null
      },
      {
        "agent": "pi",
        "usage": null
      }
    ],
    "staleMemoryHash": 0,
    "quotesNotInTrace": 2
  }
}
· analyzing 2 transcript(s) with pi effort=medium at jobs=1
  2/2 analyzed
warn 2 quote(s) were discarded because they do not appear in the distilled trace they claim to come from; a model that paraphrases instead of copying produces fewer findings, not cleaner ones - consider a stronger analysis model
--- summary.quotesNotInTrace: 0 (cached=2) ---
--- recorded evidence per session ---
pi-session-b: gaps=0  usedRawTranscript=false
pi-session-a: gaps=0  usedRawTranscript=false
--- repo dir: /private/var/folders/l3/n9p4jk8j6qb453hmbr_pj_dr0000gn/T/bp-repo-zNF1p3
```
</details>
<details>
<summary>Evidence: Base-commit cache re-analyzed by the new build (v2 -&gt; v3)</summary>

<code>1. base commit (pre-fix) analyze: {&#34;analyzed&#34;:2,&#34;cached&#34;:0}&#10;evidence: pi-session-b: gaps=1 key=analysis-index-v2 | pi-session-a: gaps=1 key=analysis-index-v2&#10;2. base commit re-run (cache proves itself): {&#34;analyzed&#34;:0,&#34;cached&#34;:2}&#10;3. upgraded build analyze over that same cache: {&#34;analyzed&#34;:2,&#34;cached&#34;:0,&#34;quotesNotInTrace&#34;:2}&#10;evidence: pi-session-b: gaps=0 key=analysis-index-v3 | pi-session-a: gaps=0 key=analysis-index-v3</code>

```text
1. base commit (pre-fix) analyze: {"analyzed":2,"cached":0}
   evidence: pi-session-b: gaps=1 key=analysis-index-v2 | pi-session-a: gaps=1 key=analysis-index-v2
2. base commit re-run (cache proves itself): {"analyzed":0,"cached":2}
3. upgraded build analyze over that same cache: {"analyzed":2,"cached":0,"quotesNotInTrace":2}
   evidence: pi-session-b: gaps=0 key=analysis-index-v3 | pi-session-a: gaps=0 key=analysis-index-v3
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"abb33fb18c26bc919f72d80914438c7a002baead","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/analyze.js:58` - `Boolean(parsed?.usedRawTranscript)` now gates the new trace check, so any truthy non-boolean the model emits disables it entirely. Concrete case: the model returns `&#34;usedRawTranscript&#34;: &#34;false&#34;` (or &#34;no&#34;) — a common JSON-from-LLM shape — `Boolean(&#34;false&#34;)` is `true`, `foldedTrace` stays `null` (line 62), and every paraphrased quote passes straight into the gap ledger, which is exactly the failure this change targets. The coercion predates the change but was previously only a fold counter; the change made it load-bearing. Fix mechanically: `parsed?.usedRawTranscript === true` (the prompt schema at src/prompts/analysis.md:49 already specifies a boolean, and fold&#39;s `usedRawCount` stays correct).
- ⚠️ `src/analyze.js:215` - `ANALYSIS_INDEX_VERSION` (src/state.js:228) is documented as the knob that invalidates evidence when analysis semantics change, and it was not bumped. `isEvidenceFresh` therefore keeps every pre-change evidence record fresh, so on any repo with an existing `.backpass/evidence` cache the paraphrased quotes already recorded continue to fold and to feed the gap ledger unchanged — the authorized failure remains reachable for existing users until the memory surface happens to change. Note the remedy needs authorization, not the defect: bumping the version forces a full paid reanalysis of every cached transcript, and it still would not purge quotes already persisted in `.backpass/gap-ledger.json` (pruned only by age/coverage), so the owner should decide whether to bump, to prune the ledger, or to accept that the gate applies to new analyses only.
- ⚠️ `src/analyze.js:65` - A quote rejected by the trace check is dropped with no counter, warning, or note, and the match is exact apart from whitespace — so a model that normalizes typography while copying (curly quotes, an en dash, a trailing period) has its otherwise-valid evidence discarded. Concrete case: a weaker analysis model paraphrases lightly across a whole run; every item is discarded, the run reports zero gaps, and that is indistinguishable from a genuinely clean repo. The strictness itself is the intent&#39;s explicit decision and should not be loosened, but the silence is new: the remedy is a per-run count of quotes rejected as not-in-trace (there is a `noteOnce`/`warn` channel at src/analyze.js:34 and a `summary.totals` surface it could ride). That adds a counter beyond the change&#39;s stated scope, so it needs the owner&#39;s call rather than an in-place fix.

🔧 Fix applied.
1 info still open:

- ℹ️ `src/state.js:228` - Bumping ANALYSIS_INDEX_VERSION to 3 invalidates every cached evidence record, so each existing user&#39;s next run pays for a full corpus reanalysis. The explanatory path at src/analyze.js:311 only fires when `existing.memoryHash !== memoryHash`, which is false here (the memory file did not change), so the run reports `N newly analyzed · 0 cached` with no reason — the same reading as a broken cache that AGENTS.md&#39;s staleMemoryHash entry exists to prevent. This is authorized (the bump was explicitly requested) and matches the precedent of the only prior bump (8c040dc, which also added no messaging), so no change is needed; noting the cost consequence only. Adding a version-invalidation counter/message would be new machinery beyond this change&#39;s scope.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 8 of 8 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A paraphrased gap quote is discarded and the run says so instead of reading as a clean repo | ✅ pass | live | `backpass analyze` with a model answer quoting &#34;the user asked me to build the thing&#34; (absent from the session): both sessions record gaps=0 and stderr warns &#34;2 quote(s) were discarded because they do… |
| A verbatim quote from the session still records its gap | ✅ pass | live | Same run shape quoting the real user turn &#34;Please build the project.&#34;: both sessions record gaps=1 with that quote and quotesNotInTrace stays 0 (analyze-trace-gate.txt, scenario verbatim-quote) |
| Line-wrapping in the distilled trace does not reject a real quote | ✅ pass | live | Model answer returns the quote broken across a newline and indentation (&#34;Please build\n the project.&#34;); both sessions still record gaps=1, no warning (analyze-trace-gate.txt, scenario wrapped-quote) |
| usedRawTranscript exempts a quote the distiller could have elided | ✅ pass | live | With `usedRawTranscript: true`, the same out-of-trace quote is kept: gaps=1, usedRawTranscript=true, no warning (analyze-trace-gate.txt, scenario raw-transcript-exemption) |
| Adversarial: a stringly-typed &#34;false&#34; cannot switch the gate off | ✅ pass | live | With `usedRawTranscript: &#34;false&#34;`, the out-of-trace quote is still discarded: gaps=0, usedRawTranscript=false, warning printed for 2 quotes (analyze-trace-gate.txt, scenario stringly-false-usedraw) |
| The gate covers instruction-level negatives, not just gaps | ✅ pass | live | A `non-compliance` negative on AG-001 quoting real session text records negatives=1; the same negative with a paraphrased quote records negatives=0 and warns (analyze-trace-gate.txt, scenarios verbati… |
| Upgrading over an existing evidence cache purges pre-fix paraphrased evidence | ✅ pass | live | Base commit analyze records gaps=1 under key analysis-index-v2 and re-runs as cached=2; the new build over that same repo re-analyzes both (analyzed=2, cached=0), reports quotesNotInTrace=2, and leave… |
| The run&#39;s per-run rejection count is machine-readable in the JSON summary | ✅ pass | live | `backpass analyze --json` on a first (uncached) run emits `&#34;quotesNotInTrace&#34;: 2` in summary (analyze-trace-gate-json.txt) |

- <code>`node /tmp/bp-drive/drive.mjs &lt;worktree&gt; &lt;scenario&gt;` — real `bin/backpass.js analyze --harness pi --since all --analysis-agent pi --jobs 1` runs in temp git repos with temp `$HOME` Pi sessions and a stub acpx; scenarios: verbatim-quote, paraphrased-quote, wrapped-quote, raw-transcript-exemption, stringly-false-usedraw, verbatim-negative, paraphrased-negative</code>
- <code>`node /tmp/bp-drive/cache.mjs &lt;worktree&gt;` — analyze with the base commit (`git archive dc4855f`) then with the change over the same `.backpass/evidence` cache, comparing analyzed/cached counts and the `analysis-index-vN` cache key</code>
- <code>`node --test test/distill.test.js test/analyze-reuse.test.js test/gap-domain-cli.test.js` — the three test files this change touches, including the CLI-driven gap-domain test whose fixtures now quote real session text</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `src/prompts/analysis.md:57` - The analysis prompt still describes the quote rule as advisory (&#34;Items without a real quote are discarded downstream&#34;) and does not tell the model that a quote which is not a substring of the distilled trace is now mechanically rejected, nor that setting usedRawTranscript to anything other than the literal boolean true keeps the check on. The prompt is not wrong, so nothing was edited: it is a model-facing input, and strengthening it would change run behavior, which is outside this documentation phase. Worth a follow-up by the author if weaker analysis models are seen losing findings to the gate.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
